### PR TITLE
feat: Implement `ls` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1228,6 +1228,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "termtree",
  "tokio",
  "walkdir",
 ]
@@ -1902,6 +1903,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "textwrap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,9 @@ license     = "MIT"
 repository  = "https://github.com/anonrig/pacquet"
 
 [workspace.dependencies]
-# Crates
-pacquet_cli          = { path = "crates/cli" }
 pacquet_registry     = { path = "crates/registry" }
 pacquet_tarball      = { path = "crates/tarball" }
 pacquet_package_json = { path = "crates/package_json" }
-pacquet_lockfile     = { path = "crates/lockfile" }
 pacquet_npmrc        = { path = "crates/npmrc" }
 pacquet_executor     = { path = "crates/executor" }
 pacquet_cafs         = { path = "crates/cafs" }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -32,6 +32,7 @@ node-semver  = { workspace = true }
 serde        = { workspace = true }
 serde_json   = { workspace = true }
 tokio        = { workspace = true }
+termtree = "0.4.1"
 
 [dev-dependencies]
 insta    = { workspace = true }

--- a/crates/cli/src/commands/list.rs
+++ b/crates/cli/src/commands/list.rs
@@ -1,0 +1,107 @@
+use std::path::{ MAIN_SEPARATOR, PathBuf };
+
+use clap::Parser;
+use serde_json::{json, Map, Value};
+
+use pacquet_package_json::{DependencyGroup, PackageJson};
+
+use crate::package_manager::{PackageManager, PackageManagerError};
+
+#[derive(Parser, Debug)]
+pub struct ListArgs {
+    /// Perform the command on every package subdirectories
+    /// or on every workspace
+    #[arg(long = "recursive", short = 'r')]
+    pub recursive: bool,
+    /// Log the output as JSON
+    #[arg(long = "json")]
+    pub json: bool,
+    /// Show the extended information
+    #[arg(long = "long")]
+    pub long: bool,
+    /// Outputs the package directories into a parseable format
+    #[arg(long = "parseable")]
+    pub parseable: bool,
+    /// List the package in the global install directory instead of the
+    /// current project
+    #[arg(long = "global", short = 'g')]
+    pub global: bool,
+    /// Max display depth of the dependency tree
+    #[arg(long = "depth")]
+    pub depth: u32,
+    /// Display only dependencies within dependencies or optionalDependencies
+    #[arg(long = "prod", short = 'p')]
+    pub prod: bool,
+    /// Display only dependencies within devDependencies
+    #[arg(long = "dev", short = 'd')]
+    pub dev: bool,
+    /// Omit packages from optionalDependencies
+    #[arg(long = "no-optional")]
+    pub no_opts: bool,
+    /// Display only depndencies that are also projects within the workspace
+    #[arg(long = "only-projects")]
+    pub projects_only: bool,
+    /// Display the dependencies from a given subset of dependencies
+    #[arg(long = "filter", short = 'f')]
+    pub filter: String,
+}
+
+impl ListArgs {
+    pub fn get_scope(&self) -> DependencyGroup {
+        if self.dev {
+            DependencyGroup::Dev
+        } else {
+            DependencyGroup::Default
+        }
+    }
+
+    pub fn get_depth(&self) -> u32 {
+        let mut depth: u32 = 1;
+        self.depth.clone_into(&mut depth);
+
+        depth
+    }
+}
+
+impl PackageManager {
+    pub fn list(
+        &self,
+        package_json: &PackageJson,
+        dependency_group: DependencyGroup,
+        node_modules_path: &PathBuf,
+        depth: u32,
+    ) -> Result<String, PackageManagerError> {
+        let mut scope: String = String::new();
+        match dependency_group {
+            DependencyGroup::Default => {
+                let dependencies = package_json.get_dependencies(vec![DependencyGroup::Default]);
+                
+                for (name, version) in &dependencies {
+                    scope = format!("{} - {}\n", name, version);
+
+                    if depth > 1 {
+                        let path = format!("{}{}{}", &name, MAIN_SEPARATOR, "package.json");
+                        let pjson = PackageJson::from_path(&node_modules_path.join(path))?;
+                        let n_dependencies = self.list(&pjson, DependencyGroup::Default, node_modules_path, depth - 1)?;
+                        // TODO: fix format
+                        scope = format!("\n\t{}", n_dependencies)
+                    }
+                }
+            }
+            DependencyGroup::Dev => scope = "dependencies".to_string(),
+            _ => scope = "all".to_string(),
+        }
+
+        // let binding = Value::default();
+        // let mut dependencies = self.value.get(scope).unwrap_or(&binding).as_object().into_iter();
+
+        // let mut dep = dependencies.next();
+        // while !dep.is_none() {
+        //     println!("{:?}", dep);
+        //     dep = dependencies.next();
+        // }
+
+        println!("{}", scope);
+        Ok(scope.clone())
+    }
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -1,12 +1,14 @@
 pub mod add;
 pub mod install;
+pub mod list;
 pub mod run;
 pub mod store;
 
 use std::{env, ffi::OsString, path::PathBuf};
 
 use crate::commands::{
-    add::AddCommandArgs, install::InstallCommandArgs, run::RunCommandArgs, store::StoreSubcommands,
+    add::AddCommandArgs, install::InstallCommandArgs, list::ListArgs, run::RunCommandArgs,
+    store::StoreSubcommands,
 };
 use clap::{Parser, Subcommand};
 
@@ -46,4 +48,6 @@ pub enum Subcommands {
     /// Managing the package store.
     #[clap(subcommand)]
     Store(StoreSubcommands),
+    /// List all dependencies installed based on package.json
+    List(ListArgs),
 }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -25,6 +25,7 @@ pub async fn run_cli() -> Result<()> {
 
 async fn run_commands(cli: Cli) -> Result<()> {
     let package_json_path = cli.current_dir.join("package.json");
+    let node_modules_path = cli.current_dir.join("node_modules");
 
     match &cli.subcommand {
         Subcommands::Init => {
@@ -100,7 +101,8 @@ async fn run_commands(cli: Cli) -> Result<()> {
         Subcommands::List(args) => {
             let group = args.get_scope();
             let depth = args.get_depth();
-            PackageJson::from_path(&package_json_path)?.list(group, &node_modules_path, depth)?;
+            let manager = PackageManager::new(&package_json_path)?;
+            manager.list(&manager.package_json, group, &node_modules_path, depth)?;
         }
     }
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -97,6 +97,9 @@ async fn run_commands(cli: Cli) -> Result<()> {
                 }
             }
         }
+        Subcommands::ListCommand((args)) => {
+            println!("Command goes here")
+        }
     }
 
     Ok(())

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -97,8 +97,10 @@ async fn run_commands(cli: Cli) -> Result<()> {
                 }
             }
         }
-        Subcommands::ListCommand((args)) => {
-            println!("Command goes here")
+        Subcommands::List(args) => {
+            let group = args.get_scope();
+            let depth = args.get_depth();
+            PackageJson::from_path(&package_json_path)?.list(group, &node_modules_path, depth)?;
         }
     }
 

--- a/crates/package_json/src/lib.rs
+++ b/crates/package_json/src/lib.rs
@@ -197,55 +197,6 @@ impl PackageJson {
             Err(PackageJsonError::NoScript(command.to_string()))
         }
     }
-
-    pub fn list(&self, dependency_group: DependencyGroup, node_modules_path: &PathBuf, depth: u32) -> Result<String, PackageJsonError> { 
-        let mut scope: String = String::new();
-        let default = Value::default();
-        match dependency_group {
-            DependencyGroup::Dev => {
-                let mut dependencies = self
-                    .value
-                    .get("devDependencies")
-                    .unwrap_or(&default)
-                    .as_object()
-                    .into_iter();
-
-                let dep = dependencies.next();
-                while !dep.is_none() {
-                   let tree: String =  dep.unwrap()
-                        .into_iter()
-                        .map(|(name, version)| {
-                            let mut res = format!("{}@{}", name, version);
-
-                            if depth > 1 {
-                                let nested = PackageJson::from_path(&node_modules_path.join(name))
-                                    .unwrap();
-                                let unwraped = nested.list(DependencyGroup::Dev, node_modules_path, depth);
-                                res = format!("\n\t{}", unwraped.unwrap())
-                            }
-
-                            res
-                        }).collect();
-                        scope = format!("{:?}\n", tree);
-                }
-
-            },
-            DependencyGroup::Default => scope = "dependencies".to_string(),
-            _ => scope = "all".to_string()
-        }
-
-        // let binding = Value::default();
-        // let mut dependencies = self.value.get(scope).unwrap_or(&binding).as_object().into_iter();
-
-        // let mut dep = dependencies.next();
-        // while !dep.is_none() {
-        //     println!("{:?}", dep);
-        //     dep = dependencies.next();
-        // }
-
-        Ok(scope.clone())
-    }
-
 }
 
 #[cfg(test)]

--- a/crates/package_json/src/lib.rs
+++ b/crates/package_json/src/lib.rs
@@ -197,6 +197,27 @@ impl PackageJson {
             Err(PackageJsonError::NoScript(command.to_string()))
         }
     }
+
+    pub fn list(&self, dependency_group: DependencyGroup, node_modules_path: &PathBuf, depth: u32) -> Result<(), PackageJsonError> {
+        
+        let scope: &str;
+        match dependency_group {
+            DependencyGroup::Dev => scope = "devDependencies",
+            DependencyGroup::Default => scope = "dependencies",
+            _ => scope = "dependencies"
+        }
+
+        let binding = Value::default();
+        let mut dependencies = self.value.get(scope).unwrap_or(&binding).as_object().into_iter();
+
+        let dep = dependencies.next();
+        // while !dep.is_none() {
+        
+        // }
+
+        Ok(())
+    }
+
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR attempts to introduce the `ls` command, similar to `npm` and `pnpm` versions.
Its initial version aims for simplicity and just provides a tree-like representation of the modules installed based on the `package.json` manifest with options to omit `dev` or `dependencies` accordingly.

> __Note__: I just opened this PR as most likely will require some early feedback, I'll be pushing more changes soon 🙂 