### PR TITLE
refactor: replace `alias` with `rename_all`

### DIFF
--- a/crates/lockfile/src/lib.rs
+++ b/crates/lockfile/src/lib.rs
@@ -39,19 +39,17 @@ pub struct LockfilePeerDependencyMeta {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct LockfileSettings {
-    #[serde(alias = "autoInstallPeers")]
     auto_install_peers: bool,
-    #[serde(alias = "excludeLinksFromLockfile")]
     exclude_links_from_lockfile: bool,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Lockfile {
-    #[serde(alias = "lockFileVersion")]
     pub lock_file_version: String,
     pub settings: Option<LockfileSettings>,
-    #[serde(alias = "neverBuiltDependencies")]
     pub never_built_dependencies: Option<Vec<String>>,
     pub overrides: Option<HashMap<String, String>>,
     pub dependencies: Option<HashMap<String, LockfileDependency>>,

--- a/crates/lockfile/src/package.rs
+++ b/crates/lockfile/src/package.rs
@@ -11,6 +11,7 @@ pub struct LockfilePackageResolution {
 
 // Reference: https://github.com/pnpm/pnpm/blob/main/lockfile/lockfile-file/src/sortLockfileKeys.ts#L5
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct LockfilePackage {
     resolution: LockfilePackageResolution,
     id: Option<String>,
@@ -23,22 +24,17 @@ pub struct LockfilePackage {
     os: Option<Vec<String>>,
     // TODO: Add `libc`
     deprecated: Option<bool>,
-    #[serde(alias = "hasBin")]
     has_bin: Option<bool>,
     // TODO: Add `prepare`
-    #[serde(alias = "requiresBuild")]
     requires_build: Option<bool>,
 
     // TODO: Add `bundleDependencies`
-    #[serde(alias = "peerDependencies")]
     peer_dependencies: Option<HashMap<String, String>>,
-    #[serde(alias = "peerDependenciesMeta")]
     peer_dependencies_meta: Option<HashMap<String, LockfilePeerDependencyMeta>>,
 
     dependencies: Option<HashMap<String, String>>,
     optional_dependencies: Option<HashMap<String, String>>,
 
-    #[serde(alias = "transitivePeerDependencies")]
     transitive_peer_dependencies: Option<Vec<String>>,
     dev: bool,
     optional: Option<bool>,

--- a/crates/registry/src/package.rs
+++ b/crates/registry/src/package.rs
@@ -10,7 +10,7 @@ use crate::{package_version::PackageVersion, RegistryError};
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Package {
     pub name: String,
-    #[serde(alias = "dist-tags")]
+    #[serde(rename = "dist-tags")]
     dist_tags: HashMap<String, String>,
     pub versions: HashMap<String, PackageVersion>,
 

--- a/crates/registry/src/package_distribution.rs
+++ b/crates/registry/src/package_distribution.rs
@@ -1,13 +1,12 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct PackageDistribution {
     pub integrity: String,
     pub shasum: String,
     pub tarball: String,
-    #[serde(alias = "fileCount")]
     pub file_count: Option<usize>,
-    #[serde(alias = "unpackedSize")]
     pub unpacked_size: Option<usize>,
 }
 

--- a/crates/registry/src/package_version.rs
+++ b/crates/registry/src/package_version.rs
@@ -6,14 +6,13 @@ use crate::package_distribution::PackageDistribution;
 use crate::RegistryError;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct PackageVersion {
     pub name: String,
     pub version: node_semver::Version,
     pub dist: PackageDistribution,
     pub dependencies: Option<HashMap<String, String>>,
-    #[serde(alias = "devDependencies")]
     pub dev_dependencies: Option<HashMap<String, String>>,
-    #[serde(alias = "peerDependencies")]
     pub peer_dependencies: Option<HashMap<String, String>>,
 }
 


### PR DESCRIPTION
`alias` is actually different from `rename`: `rename` changes the name, but there's still only one name. `alias` however adds another name, and when serde serializes the type to JSON, it will not choose the alias.