### PR TITLE
feat: remove intermediate HashMap

### DIFF
--- a/crates/cli/src/commands/add.rs
+++ b/crates/cli/src/commands/add.rs
@@ -75,7 +75,6 @@ impl PackageManager {
 
         let direct_dependency_handles = latest_version
             .get_dependencies(self.config.auto_install_peers)
-            .iter()
             .map(|(name, version)| {
                 find_package_version_from_registry(config, http_client, name, version, path)
             })
@@ -95,7 +94,6 @@ impl PackageManager {
 
                 let handles = dependency
                     .get_dependencies(self.config.auto_install_peers)
-                    .iter()
                     .map(|(name, version)| {
                         find_package_version_from_registry(
                             config,

--- a/crates/cli/src/commands/install.rs
+++ b/crates/cli/src/commands/install.rs
@@ -61,7 +61,6 @@ impl PackageManager {
 
                 let handles = dependency
                     .get_dependencies(self.config.auto_install_peers)
-                    .iter()
                     .map(|(name, version)| async {
                         find_package_version_from_registry(
                             config,

--- a/crates/registry/src/package.rs
+++ b/crates/registry/src/package.rs
@@ -89,11 +89,13 @@ mod tests {
             peer_dependencies: Some(peer_dependencies),
         };
 
-        assert!(version.get_dependencies(false).contains_key("fastify"));
-        assert!(!version.get_dependencies(false).contains_key("fast-querystring"));
-        assert!(version.get_dependencies(true).contains_key("fastify"));
-        assert!(version.get_dependencies(true).contains_key("fast-querystring"));
-        assert!(!version.get_dependencies(true).contains_key("hello-world"));
+        let get_dependencies = |peer| version.get_dependencies(peer).collect::<HashMap<_, _>>();
+
+        assert!(get_dependencies(false).contains_key("fastify"));
+        assert!(!get_dependencies(false).contains_key("fast-querystring"));
+        assert!(get_dependencies(true).contains_key("fastify"));
+        assert!(get_dependencies(true).contains_key("fast-querystring"));
+        assert!(!get_dependencies(true).contains_key("hello-world"));
     }
 
     #[test]

--- a/crates/registry/src/package_version.rs
+++ b/crates/registry/src/package_version.rs
@@ -47,24 +47,21 @@ impl PackageVersion {
         self.dist.tarball.as_str()
     }
 
-    pub fn get_dependencies(&self, with_peer_dependencies: bool) -> HashMap<&str, &str> {
-        let mut dependencies = HashMap::<&str, &str>::new();
+    pub fn get_dependencies(
+        &self,
+        with_peer_dependencies: bool,
+    ) -> impl Iterator<Item = (&'_ str, &'_ str)> {
+        let dependencies = self.dependencies.iter().flatten();
 
-        if let Some(deps) = self.dependencies.as_ref() {
-            for dep in deps {
-                dependencies.insert(dep.0.as_str(), dep.1.as_str());
-            }
-        }
-
-        if with_peer_dependencies {
-            if let Some(deps) = self.peer_dependencies.as_ref() {
-                for dep in deps {
-                    dependencies.insert(dep.0.as_str(), dep.1.as_str());
-                }
-            }
-        }
+        let peer_dependencies = with_peer_dependencies
+            .then_some(&self.peer_dependencies)
+            .into_iter()
+            .flatten()
+            .flatten();
 
         dependencies
+            .chain(peer_dependencies)
+            .map(|(name, version)| (name.as_str(), version.as_str()))
     }
 
     pub fn serialize(&self, save_exact: bool) -> String {


### PR DESCRIPTION
The `HashMap` is an unnecessary allocation when every instance of its use is to call `.iter()` again.