### PR TITLE
refactor: remove pico_args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1213,12 +1213,12 @@ checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 name = "pacquet_benchmark"
 version = "0.0.0"
 dependencies = [
+ "clap",
  "criterion",
  "mockito",
  "node-semver",
  "pacquet_registry",
  "pacquet_tarball",
- "pico-args",
  "project-root",
  "reqwest",
  "tempfile",
@@ -1374,12 +1374,6 @@ name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
-
-[[package]]
-name = "pico-args"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project-lite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,6 @@ pretty_assertions = { version = "1.4.0" }
 project-root      = { version = "0.2.2" }
 tempfile          = { version = "3.8.0" }
 mockito           = { version = "1.1.0" }
-pico-args         = { version = "0.5.0" }
 
 [workspace.metadata.workspaces]
 allow_branch = "main"

--- a/tasks/benchmark/Cargo.toml
+++ b/tasks/benchmark/Cargo.toml
@@ -14,11 +14,11 @@ repository.workspace  = true
 pacquet_registry = { workspace = true }
 pacquet_tarball  = { workspace = true }
 
+clap         = { workspace = true }
 criterion    = { workspace = true }
 mockito      = { workspace = true }
 tokio        = { workspace = true }
 tempfile     = { workspace = true }
-pico-args    = { workspace = true }
 project-root = { workspace = true }
 reqwest      = { workspace = true }
 node-semver  = { workspace = true }


### PR DESCRIPTION
There is no reason to use 2 argument parsers in one project.