### PR TITLE
feat: leak Npmrc, remove cloning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1219,6 +1219,7 @@ dependencies = [
  "node-semver",
  "pacquet_registry",
  "pacquet_tarball",
+ "pipe-trait",
  "project-root",
  "reqwest",
  "tempfile",
@@ -1295,6 +1296,7 @@ name = "pacquet_npmrc"
 version = "0.0.1"
 dependencies = [
  "home",
+ "pipe-trait",
  "pretty_assertions",
  "serde",
  "serde_ini",

--- a/crates/cli/src/commands/add.rs
+++ b/crates/cli/src/commands/add.rs
@@ -61,7 +61,7 @@ impl PackageManager {
     pub async fn add(&mut self, args: &AddCommandArgs) -> Result<(), PackageManagerError> {
         let latest_version = fetch_package_version_directly(
             &self.tarball_cache,
-            &self.config,
+            self.config,
             &self.http_client,
             &args.package,
             "latest",
@@ -143,6 +143,7 @@ mod tests {
     use std::{env, fs};
 
     use crate::fs::get_filenames_in_folder;
+    use pacquet_npmrc::current_npmrc;
     use pacquet_package_json::{DependencyGroup, PackageJson};
     use pretty_assertions::assert_eq;
     use tempfile::tempdir;
@@ -156,7 +157,7 @@ mod tests {
         let current_directory = env::current_dir().unwrap();
         env::set_current_dir(&dir).unwrap();
         let package_json = dir.path().join("package.json");
-        let mut manager = PackageManager::new(&package_json).unwrap();
+        let mut manager = PackageManager::new(&package_json, current_npmrc().leak()).unwrap();
 
         // It should create a package_json if not exist
         assert!(package_json.exists());
@@ -197,7 +198,7 @@ mod tests {
         let current_directory = env::current_dir().unwrap();
         env::set_current_dir(&dir).unwrap();
         let package_json = dir.path().join("package.json");
-        let mut manager = PackageManager::new(&package_json).unwrap();
+        let mut manager = PackageManager::new(&package_json, current_npmrc().leak()).unwrap();
 
         let args = AddCommandArgs {
             package: "is-odd".to_string(),
@@ -228,7 +229,7 @@ mod tests {
         let current_directory = env::current_dir().unwrap();
         env::set_current_dir(&dir).unwrap();
         let package_json = dir.path().join("package.json");
-        let mut manager = PackageManager::new(&package_json).unwrap();
+        let mut manager = PackageManager::new(&package_json, current_npmrc().leak()).unwrap();
 
         let args = AddCommandArgs {
             package: "is-odd".to_string(),
@@ -252,7 +253,7 @@ mod tests {
         let current_directory = env::current_dir().unwrap();
         env::set_current_dir(&dir).unwrap();
         let package_json = dir.path().join("package.json");
-        let mut manager = PackageManager::new(&package_json).unwrap();
+        let mut manager = PackageManager::new(&package_json, current_npmrc().leak()).unwrap();
 
         let args = AddCommandArgs {
             package: "is-odd".to_string(),
@@ -276,7 +277,7 @@ mod tests {
         let current_directory = env::current_dir().unwrap();
         env::set_current_dir(&dir).unwrap();
         let package_json = dir.path().join("package.json");
-        let mut manager = PackageManager::new(&package_json).unwrap();
+        let mut manager = PackageManager::new(&package_json, current_npmrc().leak()).unwrap();
 
         let args = AddCommandArgs {
             package: "is-odd".to_string(),

--- a/crates/cli/src/commands/add.rs
+++ b/crates/cli/src/commands/add.rs
@@ -143,7 +143,7 @@ mod tests {
     use std::{env, fs};
 
     use crate::fs::get_filenames_in_folder;
-    use pacquet_npmrc::current_npmrc;
+    use pacquet_npmrc::Npmrc;
     use pacquet_package_json::{DependencyGroup, PackageJson};
     use pretty_assertions::assert_eq;
     use tempfile::tempdir;
@@ -157,7 +157,7 @@ mod tests {
         let current_directory = env::current_dir().unwrap();
         env::set_current_dir(&dir).unwrap();
         let package_json = dir.path().join("package.json");
-        let mut manager = PackageManager::new(&package_json, current_npmrc().leak()).unwrap();
+        let mut manager = PackageManager::new(&package_json, Npmrc::current().leak()).unwrap();
 
         // It should create a package_json if not exist
         assert!(package_json.exists());
@@ -198,7 +198,7 @@ mod tests {
         let current_directory = env::current_dir().unwrap();
         env::set_current_dir(&dir).unwrap();
         let package_json = dir.path().join("package.json");
-        let mut manager = PackageManager::new(&package_json, current_npmrc().leak()).unwrap();
+        let mut manager = PackageManager::new(&package_json, Npmrc::current().leak()).unwrap();
 
         let args = AddCommandArgs {
             package: "is-odd".to_string(),
@@ -229,7 +229,7 @@ mod tests {
         let current_directory = env::current_dir().unwrap();
         env::set_current_dir(&dir).unwrap();
         let package_json = dir.path().join("package.json");
-        let mut manager = PackageManager::new(&package_json, current_npmrc().leak()).unwrap();
+        let mut manager = PackageManager::new(&package_json, Npmrc::current().leak()).unwrap();
 
         let args = AddCommandArgs {
             package: "is-odd".to_string(),
@@ -253,7 +253,7 @@ mod tests {
         let current_directory = env::current_dir().unwrap();
         env::set_current_dir(&dir).unwrap();
         let package_json = dir.path().join("package.json");
-        let mut manager = PackageManager::new(&package_json, current_npmrc().leak()).unwrap();
+        let mut manager = PackageManager::new(&package_json, Npmrc::current().leak()).unwrap();
 
         let args = AddCommandArgs {
             package: "is-odd".to_string(),
@@ -277,7 +277,7 @@ mod tests {
         let current_directory = env::current_dir().unwrap();
         env::set_current_dir(&dir).unwrap();
         let package_json = dir.path().join("package.json");
-        let mut manager = PackageManager::new(&package_json, current_npmrc().leak()).unwrap();
+        let mut manager = PackageManager::new(&package_json, Npmrc::current().leak()).unwrap();
 
         let args = AddCommandArgs {
             package: "is-odd".to_string(),

--- a/crates/cli/src/commands/install.rs
+++ b/crates/cli/src/commands/install.rs
@@ -107,7 +107,7 @@ mod tests {
     use crate::commands::install::InstallCommandArgs;
     use crate::fs::get_all_folders;
     use crate::package_manager::PackageManager;
-    use pacquet_npmrc::current_npmrc;
+    use pacquet_npmrc::Npmrc;
     use pacquet_package_json::{DependencyGroup, PackageJson};
     use pretty_assertions::assert_eq;
     use tempfile::tempdir;
@@ -183,7 +183,7 @@ mod tests {
         package_json.save().unwrap();
 
         let package_manager =
-            PackageManager::new(&package_json_path, current_npmrc().leak()).unwrap();
+            PackageManager::new(&package_json_path, Npmrc::current().leak()).unwrap();
         let args = InstallCommandArgs { prod: false, dev: false, no_optional: false };
         package_manager.install(&args).await.unwrap();
 

--- a/crates/cli/src/commands/install.rs
+++ b/crates/cli/src/commands/install.rs
@@ -57,7 +57,7 @@ impl PackageManager {
             .map(|(name, version)| async {
                 let dependency = find_package_version_from_registry(
                     &self.tarball_cache,
-                    &self.config,
+                    self.config,
                     &self.http_client,
                     name,
                     version,
@@ -82,7 +82,7 @@ impl PackageManager {
             .map(|(name, version)| async move {
                 let dependency = find_package_version_from_registry(
                     &self.tarball_cache,
-                    &self.config,
+                    self.config,
                     &self.http_client,
                     name,
                     version,
@@ -107,6 +107,7 @@ mod tests {
     use crate::commands::install::InstallCommandArgs;
     use crate::fs::get_all_folders;
     use crate::package_manager::PackageManager;
+    use pacquet_npmrc::current_npmrc;
     use pacquet_package_json::{DependencyGroup, PackageJson};
     use pretty_assertions::assert_eq;
     use tempfile::tempdir;
@@ -181,7 +182,8 @@ mod tests {
 
         package_json.save().unwrap();
 
-        let package_manager = PackageManager::new(&package_json_path).unwrap();
+        let package_manager =
+            PackageManager::new(&package_json_path, current_npmrc().leak()).unwrap();
         let args = InstallCommandArgs { prod: false, dev: false, no_optional: false };
         package_manager.install(&args).await.unwrap();
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -14,14 +14,14 @@ use pacquet_diagnostics::{
     miette::{set_panic_hook, IntoDiagnostic, Result, WrapErr},
 };
 use pacquet_executor::execute_shell;
-use pacquet_npmrc::{current_npmrc, Npmrc};
+use pacquet_npmrc::Npmrc;
 use pacquet_package_json::PackageJson;
 
 pub async fn run_cli() -> Result<()> {
     enable_tracing_by_env();
     set_panic_hook();
     let cli = Cli::parse();
-    let config = current_npmrc().leak();
+    let config = Npmrc::current().leak();
     run_commands(cli, config).await
 }
 
@@ -113,7 +113,7 @@ mod tests {
     async fn init_command_should_create_package_json() {
         let parent_folder = tempdir().unwrap();
         let cli = Cli::parse_from(["", "-C", parent_folder.path().to_str().unwrap(), "init"]);
-        run_commands(cli, current_npmrc().leak()).await.unwrap();
+        run_commands(cli, Npmrc::current().leak()).await.unwrap();
         assert!(parent_folder.path().join("package.json").exists());
     }
 
@@ -124,7 +124,7 @@ mod tests {
         file.write_all("{}".as_bytes()).unwrap();
         assert!(parent_folder.path().join("package.json").exists());
         let cli = Cli::parse_from(["", "-C", parent_folder.path().to_str().unwrap(), "init"]);
-        run_commands(cli, current_npmrc().leak()).await.expect_err("should have thrown");
+        run_commands(cli, Npmrc::current().leak()).await.expect_err("should have thrown");
     }
 
     #[tokio::test]
@@ -132,6 +132,6 @@ mod tests {
         let parent_folder = tempdir().unwrap();
         let cli =
             Cli::parse_from(["", "-C", parent_folder.path().to_str().unwrap(), "store", "path"]);
-        run_commands(cli, current_npmrc().leak()).await.unwrap();
+        run_commands(cli, Npmrc::current().leak()).await.unwrap();
     }
 }

--- a/crates/cli/src/package_manager.rs
+++ b/crates/cli/src/package_manager.rs
@@ -4,7 +4,7 @@ use pacquet_diagnostics::{
     miette::{self, Diagnostic},
     thiserror::{self, Error},
 };
-use pacquet_npmrc::{current_npmrc, Npmrc};
+use pacquet_npmrc::Npmrc;
 use pacquet_package_json::PackageJson;
 use pacquet_tarball::Cache;
 
@@ -50,16 +50,19 @@ pub enum PackageManagerError {
 }
 
 pub struct PackageManager {
-    pub config: Npmrc,
+    pub config: &'static Npmrc,
     pub package_json: PackageJson,
     pub http_client: reqwest::Client,
     pub(crate) tarball_cache: Cache,
 }
 
 impl PackageManager {
-    pub fn new<P: Into<PathBuf>>(package_json_path: P) -> Result<Self, PackageManagerError> {
+    pub fn new<P: Into<PathBuf>>(
+        package_json_path: P,
+        config: &'static Npmrc,
+    ) -> Result<Self, PackageManagerError> {
         Ok(PackageManager {
-            config: current_npmrc(),
+            config,
             package_json: PackageJson::create_if_needed(package_json_path.into())?,
             http_client: reqwest::Client::new(),
             tarball_cache: Cache::new(),

--- a/crates/npmrc/Cargo.toml
+++ b/crates/npmrc/Cargo.toml
@@ -11,9 +11,10 @@ license.workspace     = true
 repository.workspace  = true
 
 [dependencies]
-home      = { workspace = true }
-serde     = { workspace = true }
-serde_ini = { workspace = true }
+home       = { workspace = true }
+pipe-trait = { workspace = true }
+serde      = { workspace = true }
+serde_ini  = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/crates/npmrc/src/lib.rs
+++ b/crates/npmrc/src/lib.rs
@@ -157,6 +157,26 @@ impl Npmrc {
         config
     }
 
+    /// Try loading `.npmrc` in the current directory.
+    /// If fails, try in the home directory.
+    /// If fails again, return the default.
+    pub fn current() -> Self {
+        let path = match env::current_dir() {
+            Ok(dir) => Some(dir.join(".npmrc")),
+            _ => home::home_dir().map(|dir| dir.join(".npmrc")),
+        };
+
+        if let Some(file) = path {
+            if let Ok(content) = fs::read_to_string(file) {
+                if let Ok(npmrc) = serde_ini::from_str(&content) {
+                    return npmrc;
+                }
+            }
+        }
+
+        Npmrc::default()
+    }
+
     /// Persist the config data until the program terminates.
     pub fn leak(self) -> &'static mut Self {
         self.pipe(Box::new).pipe(Box::leak)
@@ -167,24 +187,6 @@ impl Default for Npmrc {
     fn default() -> Self {
         Self::new()
     }
-}
-
-pub fn current_npmrc() -> Npmrc {
-    // Look for current folder `.npmrc` and if not found, look for home directory.
-    let path = match env::current_dir() {
-        Ok(dir) => Some(dir.join(".npmrc")),
-        _ => home::home_dir().map(|dir| dir.join(".npmrc")),
-    };
-
-    if let Some(file) = path {
-        if let Ok(content) = fs::read_to_string(file) {
-            if let Ok(npmrc) = serde_ini::from_str(&content) {
-                return npmrc;
-            }
-        }
-    }
-
-    Npmrc::new()
 }
 
 #[cfg(test)]
@@ -250,7 +252,7 @@ mod tests {
 
     #[test]
     pub fn should_return_npmrc() {
-        let value = current_npmrc();
+        let value = Npmrc::current();
         assert!(value.symlink);
     }
 
@@ -286,7 +288,7 @@ mod tests {
         let mut f = fs::File::create(tmp.path().join(".npmrc")).expect("Unable to create file");
         f.write_all(b"symlink=false").unwrap();
         env::set_current_dir(tmp.path()).unwrap();
-        let config = current_npmrc();
+        let config = Npmrc::current();
         assert!(!config.symlink);
         env::set_current_dir(current_directory).unwrap();
     }
@@ -299,7 +301,7 @@ mod tests {
         // write invalid utf-8 value to npmrc
         f.write_all(b"Hello \xff World").unwrap();
         env::set_current_dir(tmp.path()).unwrap();
-        let config = current_npmrc();
+        let config = Npmrc::current();
         assert!(config.symlink);
         env::set_current_dir(current_directory).unwrap();
     }

--- a/crates/npmrc/src/lib.rs
+++ b/crates/npmrc/src/lib.rs
@@ -1,5 +1,6 @@
 mod custom_deserializer;
 
+use pipe_trait::Pipe;
 use serde::Deserialize;
 use std::{env, fs, path::PathBuf};
 
@@ -154,6 +155,11 @@ impl Npmrc {
     pub fn new() -> Self {
         let config: Npmrc = serde_ini::from_str("").unwrap(); // TODO: derive `SmartDefault` for `Npmrc and call `Npmrc::default()`
         config
+    }
+
+    /// Persist the config data until the program terminates.
+    pub fn leak(self) -> &'static mut Self {
+        self.pipe(Box::new).pipe(Box::leak)
     }
 }
 

--- a/tasks/benchmark/Cargo.toml
+++ b/tasks/benchmark/Cargo.toml
@@ -19,6 +19,7 @@ criterion    = { workspace = true }
 mockito      = { workspace = true }
 tokio        = { workspace = true }
 tempfile     = { workspace = true }
+pipe-trait   = { workspace = true }
 project-root = { workspace = true }
 reqwest      = { workspace = true }
 node-semver  = { workspace = true }


### PR DESCRIPTION
By leaking `Npmrc`, all its data become `'static`, allowing `store_dir` to be passed to another thread without `.clone()`.

Closes https://github.com/pnpm/pacquet/pull/101