### PR TITLE
fix: share the http client between requests

### DIFF
--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -115,6 +115,7 @@ fn verify_checksum(data: &[u8], integrity: Integrity) -> Result<ssri::Algorithm,
 #[instrument(skip(cache), fields(cache_len = cache.len()))]
 pub async fn download_tarball_to_store(
     cache: &Cache,
+    http_client: &Client,
     store_dir: &'static Path,
     package_integrity: &str,
     package_unpacked_size: Option<usize>,
@@ -145,7 +146,7 @@ pub async fn download_tarball_to_store(
     }
 
     let network_error = |error| NetworkError { url: package_url.to_string(), error };
-    let response = Client::new()
+    let response = http_client
         .get(package_url)
         .send()
         .await
@@ -239,6 +240,7 @@ mod tests {
         let (store_dir, store_path) = tempdir_with_leaked_path();
         let cas_files = download_tarball_to_store(
             &Default::default(),
+            &Client::new(),
             store_path,
             "sha512-dj7vjIn1Ar8sVXj2yAXiMNCJDmS9MQ9XMlIecX2dIzzhjSHCyKo4DdXjXMs7wKW2kj6yvVRSpuQjOZ3YLrh56w==",
             Some(16697),
@@ -277,6 +279,7 @@ mod tests {
         let (store_dir, store_path) = tempdir_with_leaked_path();
         download_tarball_to_store(
             &Default::default(),
+            &Client::new(),
             store_path,
             "sha512-aaaan1Ar8sVXj2yAXiMNCJDmS9MQ9XMlIecX2dIzzhjSHCyKo4DdXjXMs7wKW2kj6yvVRSpuQjOZ3YLrh56w==",
             Some(16697),

--- a/tasks/benchmark/src/main.rs
+++ b/tasks/benchmark/src/main.rs
@@ -6,6 +6,7 @@ use mockito::ServerGuard;
 use pacquet_tarball::download_tarball_to_store;
 use pipe_trait::Pipe;
 use project_root::get_project_root;
+use reqwest::Client;
 use tempfile::tempdir;
 
 #[derive(Debug, Parser)]
@@ -28,10 +29,12 @@ fn bench_tarball(c: &mut Criterion, server: &mut ServerGuard, fixtures_folder: &
         b.to_async(&rt).iter(|| async {
             // NOTE: the tempdir is being leaked, meaning the cleanup would be postponed until the end of the benchmark
             let dir = tempdir().unwrap().pipe(Box::new).pipe(Box::leak);
+            let http_client = Client::new();
 
             let cas_map =
                 download_tarball_to_store(
                     &Default::default(),
+                    &http_client,
                     dir.path(),
                     "sha512-dj7vjIn1Ar8sVXj2yAXiMNCJDmS9MQ9XMlIecX2dIzzhjSHCyKo4DdXjXMs7wKW2kj6yvVRSpuQjOZ3YLrh56w==",
                     Some(16697),


### PR DESCRIPTION
This fixes the "failed to lookup address information: nodename nor servname provided, or not known" error that happens on macOS.