### PR TITLE
feat: add support for CoW in Win Dev Drives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1598,9 +1598,9 @@ dependencies = [
 
 [[package]]
 name = "reflink-copy"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e3947399fd46f412918bafde71ec68f9b3505f11ef082eeb80bc7fdf4d7caf"
+checksum = "d7e3e017e993f86feeddf8a7fb609ca49f89082309e328e27aefd4a25bb317a4"
 dependencies = [
  "cfg-if",
  "ioctl-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,6 +923,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "junction"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca39ef0d69b18e6a2fd14c2f0a1d593200f4a4ed949b240b5917ab51fac754cb"
+dependencies = [
+ "scopeguard",
+ "winapi",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1284,6 +1294,7 @@ dependencies = [
  "clap",
  "futures-util",
  "insta",
+ "junction",
  "node-semver",
  "pacquet_cafs",
  "pacquet_diagnostics",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,13 +1587,12 @@ dependencies = [
 
 [[package]]
 name = "reflink-copy"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e062faffd49af27131ed7fa8fcb8a777dec096932c4f1751bc1c0e61c797907"
+checksum = "f9e3947399fd46f412918bafde71ec68f9b3505f11ef082eeb80bc7fdf4d7caf"
 dependencies = [
  "cfg-if",
  "ioctl-sys",
- "libc",
  "windows",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ itertools          = { version = "0.11.0" }
 futures-util       = { version = "0.3.28" }
 miette             = { version = "5.9.0", features = ["fancy"] }
 os_display         = { version = "0.1.3" }
-reflink-copy       = { version = "0.1.8" }
+reflink-copy       = { version = "0.1.9" }
 junction           = { version = "1.0.0" }
 reqwest            = { version = "0.11", default-features = false, features = ["json", "native-tls-vendored"] }
 node-semver        = { version = "2.1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ futures-util       = { version = "0.3.28" }
 miette             = { version = "5.9.0", features = ["fancy"] }
 os_display         = { version = "0.1.3" }
 reflink-copy       = { version = "0.1.8" }
+junction           = { version = "1.0.0" }
 reqwest            = { version = "0.11", default-features = false, features = ["json", "native-tls-vendored"] }
 node-semver        = { version = "2.1.0" }
 pipe-trait         = { version = "0.4.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ itertools          = { version = "0.11.0" }
 futures-util       = { version = "0.3.28" }
 miette             = { version = "5.9.0", features = ["fancy"] }
 os_display         = { version = "0.1.3" }
-reflink-copy       = { version = "0.1.7" }
+reflink-copy       = { version = "0.1.8" }
 reqwest            = { version = "0.11", default-features = false, features = ["json", "native-tls-vendored"] }
 node-semver        = { version = "2.1.0" }
 pipe-trait         = { version = "0.4.0" }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -29,6 +29,7 @@ clap            = { workspace = true }
 futures-util    = { workspace = true }
 rayon           = { workspace = true }
 reflink-copy    = { workspace = true }
+junction        = { workspace = true }
 reqwest         = { workspace = true }
 node-semver     = { workspace = true }
 pipe-trait      = { workspace = true }

--- a/crates/cli/src/commands/install.rs
+++ b/crates/cli/src/commands/install.rs
@@ -223,7 +223,7 @@ mod tests {
     fn is_symlink_or_junction(path: std::path::PathBuf) -> Result<bool> {
         #[cfg(windows)]
         return junction::exists(&path);
-    
+
         #[cfg(not(windows))]
         return Ok(path.is_symlink());
     }

--- a/crates/cli/src/commands/install.rs
+++ b/crates/cli/src/commands/install.rs
@@ -222,14 +222,9 @@ mod tests {
     // Helper function to check if a path is a symlink or junction
     fn is_symlink_or_junction(path: std::path::PathBuf) -> Result<bool> {
         #[cfg(windows)]
-        {
-            junction::exists(&path)
-        }
-
+        junction::exists(&path);
         #[cfg(not(windows))]
-        {
-            Ok(path.is_symlink())
-        }
+        return Ok(path.is_symlink());
     }
 
     #[test]

--- a/crates/cli/src/commands/install.rs
+++ b/crates/cli/src/commands/install.rs
@@ -222,7 +222,8 @@ mod tests {
     // Helper function to check if a path is a symlink or junction
     fn is_symlink_or_junction(path: std::path::PathBuf) -> Result<bool> {
         #[cfg(windows)]
-        junction::exists(&path);
+        return junction::exists(&path);
+    
         #[cfg(not(windows))]
         return Ok(path.is_symlink());
     }

--- a/crates/cli/src/commands/install.rs
+++ b/crates/cli/src/commands/install.rs
@@ -209,6 +209,7 @@ impl PackageManager {
 #[cfg(test)]
 mod tests {
     use std::env;
+    use std::io::Result;
 
     use crate::commands::install::{CliDependencyOptions, InstallCommandArgs};
     use crate::fs::get_all_folders;
@@ -217,6 +218,19 @@ mod tests {
     use pacquet_package_json::{DependencyGroup, PackageJson};
     use pretty_assertions::assert_eq;
     use tempfile::tempdir;
+
+    // Helper function to check if a path is a symlink or junction
+    fn is_symlink_or_junction(path: std::path::PathBuf) -> Result<bool> {
+        #[cfg(windows)]
+        {
+            junction::exists(&path)
+        }
+
+        #[cfg(not(windows))]
+        {
+            Ok(path.is_symlink())
+        }
+    }
 
     #[test]
     fn install_args_to_dependency_groups() {
@@ -301,13 +315,14 @@ mod tests {
         package_manager.install(&args).await.unwrap();
 
         // Make sure the package is installed
-        assert!(dir.path().join("node_modules/is-odd").is_symlink());
+        assert!(is_symlink_or_junction(dir.path().join("node_modules/is-odd")).unwrap());
         assert!(dir.path().join("node_modules/.pacquet/is-odd@3.0.1").exists());
         // Make sure it installs direct dependencies
         assert!(!dir.path().join("node_modules/is-number").exists());
         assert!(dir.path().join("node_modules/.pacquet/is-number@6.0.0").exists());
         // Make sure we install dev-dependencies as well
-        assert!(dir.path().join("node_modules/fast-decode-uri-component").is_symlink());
+        assert!(is_symlink_or_junction(dir.path().join("node_modules/fast-decode-uri-component"))
+            .unwrap());
         assert!(dir.path().join("node_modules/.pacquet/fast-decode-uri-component@1.0.1").is_dir());
 
         insta::assert_debug_snapshot!(get_all_folders(dir.path()));

--- a/crates/cli/src/fs.rs
+++ b/crates/cli/src/fs.rs
@@ -7,6 +7,7 @@ pub fn symlink_dir(original: &Path, link: &Path) -> io::Result<()> {
 
 #[cfg(windows)]
 pub fn symlink_dir(original: &Path, link: &Path) -> io::Result<()> {
+    // In Windows, we use junctions instead of symlinks because symlinks may require elevated privileges.
     junction::create(original, link)
 }
 

--- a/crates/cli/src/fs.rs
+++ b/crates/cli/src/fs.rs
@@ -1,4 +1,4 @@
-use std::{io, path::Path};
+use std::{io, os, path::Path};
 
 #[cfg(unix)]
 pub fn symlink_dir(original: &Path, link: &Path) -> io::Result<()> {

--- a/crates/cli/src/fs.rs
+++ b/crates/cli/src/fs.rs
@@ -15,14 +15,10 @@ pub fn symlink_dir(original: &Path, link: &Path) -> io::Result<()> {
         Err(e) => {
             match e.raw_os_error() {
                 // If we don't have the privilege to create a symlink, we can try to create a junction instead.
-                Some(ERROR_PRIVILEGE_NOT_HELD) => {
-                    junction::create(original, link)
-                },
-                _ => {
-                    Err(e)
-                }
+                Some(ERROR_PRIVILEGE_NOT_HELD) => junction::create(original, link),
+                _ => Err(e),
             }
-        },
+        }
     }
 }
 

--- a/crates/cli/src/fs.rs
+++ b/crates/cli/src/fs.rs
@@ -1,25 +1,13 @@
 use std::{io, path::Path};
 
-#[cfg(windows)]
-const ERROR_PRIVILEGE_NOT_HELD: i32 = 1314;
-
 #[cfg(unix)]
 pub fn symlink_dir(original: &Path, link: &Path) -> io::Result<()> {
-    std::os::unix::fs::symlink(original, link)
+    os::unix::fs::symlink(original, link)
 }
 
 #[cfg(windows)]
 pub fn symlink_dir(original: &Path, link: &Path) -> io::Result<()> {
-    match std::os::windows::fs::symlink_dir(original, link) {
-        Ok(_) => Ok(()),
-        Err(e) => {
-            match e.raw_os_error() {
-                // If we don't have the privilege to create a symlink, we can try to create a junction instead.
-                Some(ERROR_PRIVILEGE_NOT_HELD) => junction::create(original, link),
-                _ => Err(e),
-            }
-        }
-    }
+    junction::create(original, link)
 }
 
 #[cfg(test)]

--- a/crates/npmrc/src/custom_deserializer.rs
+++ b/crates/npmrc/src/custom_deserializer.rs
@@ -29,7 +29,6 @@ fn get_drive_letter(current_dir: &Path) -> Option<String> {
     None
 }
 
-#[cfg(windows)]
 fn default_store_dir_windows(home_dir: &Path) -> PathBuf {
     let current_dir = env::current_dir().expect("Current directory is not available");
     let current_drive = get_drive_letter(&current_dir).unwrap_or_default();

--- a/crates/npmrc/src/custom_deserializer.rs
+++ b/crates/npmrc/src/custom_deserializer.rs
@@ -29,8 +29,8 @@ fn get_drive_letter(current_dir: &Path) -> Option<char> {
 
 fn default_store_dir_windows(home_dir: PathBuf) -> PathBuf {
     let current_dir = env::current_dir().expect("Current directory is not available");
-    let current_drive = get_drive_letter(&current_dir).unwrap_or_default();
-    let home_drive = get_drive_letter(&home_dir).unwrap_or_default();
+    let current_drive = get_drive_letter(&current_dir).expect("current dir is an absolute path with drive letter");
+    let home_drive = get_drive_letter(&home_dir).expect("home dir is an absolute path with drive letter");
 
     if current_drive == home_drive {
         return home_dir.join("AppData/Local/pacquet/store");

--- a/crates/npmrc/src/custom_deserializer.rs
+++ b/crates/npmrc/src/custom_deserializer.rs
@@ -32,8 +32,7 @@ fn get_drive_letter(current_dir: &Path) -> Option<char> {
 }
 
 #[cfg(windows)]
-fn default_store_dir_windows(home_dir: PathBuf) -> PathBuf {
-    let current_dir = env::current_dir().expect("Current directory is not available");
+fn default_store_dir_windows(home_dir: PathBuf, current_dir: PathBuf) -> PathBuf {
     let current_drive =
         get_drive_letter(&current_dir).expect("current dir is an absolute path with drive letter");
     let home_drive =
@@ -67,7 +66,8 @@ pub fn default_store_dir() -> PathBuf {
 
     #[cfg(windows)]
     if cfg!(windows) {
-        return default_store_dir_windows(home_dir);
+        let current_dir = env::current_dir().expect("current directory is unavailable");
+        return default_store_dir_windows(home_dir, current_dir);
     }
 
     // https://doc.rust-lang.org/std/env/consts/constant.OS.html
@@ -173,18 +173,14 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn test_default_store_dir_with_windows() {
-        let current_dir = env::current_dir().expect("Current directory is not available");
-        let home_dir = home::home_dir().expect("Home directory is not available");
-        let store_dir = default_store_dir();
+        let mocked_current_dir = Path::new("D:\\Users\\user\\project");
+        let mocked_home_dir = Path::new("C:\\Users\\user");
 
-        let current_drive = get_drive_letter(&current_dir).unwrap_or_default();
-        let home_drive = get_drive_letter(&home_dir).unwrap_or_default();
-        let store_drive = get_drive_letter(&store_dir).unwrap_or_default();
+        let store_dir = default_store_dir_windows(mocked_home_dir.to_path_buf(), mocked_current_dir.to_path_buf());
 
-        if current_drive == home_drive {
-            assert_eq!(store_drive, home_drive);
-        } else {
-            assert_eq!(store_drive, current_drive);
-        }
+        let current_drive = get_drive_letter(mocked_current_dir);
+        let store_drive = get_drive_letter(&store_dir);
+
+        assert_eq!(current_drive, Some(store_drive.unwrap()));
     }
 }

--- a/crates/npmrc/src/custom_deserializer.rs
+++ b/crates/npmrc/src/custom_deserializer.rs
@@ -172,11 +172,21 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
-    fn test_default_store_dir_with_windows() {
+    fn test_default_store_dir_with_windows_diff_drive() {
         let current_dir = Path::new("D:\\Users\\user\\project");
         let home_dir = Path::new("C:\\Users\\user");
 
         let store_dir = default_store_dir_windows(&home_dir, &current_dir);
         assert_eq!(store_dir, Path::new("D:\\.pacquet-store"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_dynamic_default_store_dir_with_windows_same_drive() {
+        let current_dir = Path::new("C:\\Users\\user\\project");
+        let home_dir = Path::new("C:\\Users\\user");
+
+        let store_dir = default_store_dir_windows(&home_dir, &current_dir);
+        assert_eq!(store_dir, Path::new("C:\\Users\\user\\AppData\\Local\\pacquet\\store"));
     }
 }

--- a/crates/npmrc/src/custom_deserializer.rs
+++ b/crates/npmrc/src/custom_deserializer.rs
@@ -17,7 +17,6 @@ pub fn default_public_hoist_pattern() -> Vec<String> {
 }
 
 // Get the drive letter from a path on Windows. If it's not a Windows path, return None.
-#[cfg(windows)]
 fn get_drive_letter(current_dir: &Path) -> Option<String> {
     for component in current_dir.components() {
         if let Component::Prefix(prefix_component) = component {

--- a/crates/npmrc/src/custom_deserializer.rs
+++ b/crates/npmrc/src/custom_deserializer.rs
@@ -149,4 +149,30 @@ mod tests {
         assert_eq!(store_dir, Path::new("/tmp/xdg_data_home/pacquet/store"));
         env::remove_var("XDG_DATA_HOME");
     }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn test_should_get_the_correct_drive_letter() {
+        let current_dir = Path::new("C:\\Users\\user\\project");
+        let drive_letter = get_drive_letter(current_dir);
+        assert_eq!(drive_letter, Some("C".to_string()));
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn test_default_store_dir_with_windows() {
+        let current_dir = env::current_dir().expect("Current directory is not available");
+        let home_dir = home::home_dir().expect("Home directory is not available");
+        let store_dir = default_store_dir();
+
+        let current_drive = get_drive_letter(&current_dir).unwrap_or_default();
+        let home_drive = get_drive_letter(&home_dir).unwrap_or_default();
+        let store_drive = get_drive_letter(&store_dir).unwrap_or_default();
+
+        if current_drive == home_drive {
+            assert_eq!(store_drive, home_drive);
+        } else {
+            assert_eq!(store_drive, current_drive);
+        }
+    }
 }

--- a/crates/npmrc/src/custom_deserializer.rs
+++ b/crates/npmrc/src/custom_deserializer.rs
@@ -35,8 +35,8 @@ fn default_store_dir_windows(home_dir: PathBuf) -> PathBuf {
 
     if current_drive == home_drive {
         return home_dir.join("AppData/Local/pacquet/store");
-    } 
-    
+    }
+
     PathBuf::from(format!("{}:\\.pacquet-store", current_drive))
 }
 

--- a/crates/npmrc/src/custom_deserializer.rs
+++ b/crates/npmrc/src/custom_deserializer.rs
@@ -1,5 +1,8 @@
 use serde::{de, Deserialize, Deserializer};
-use std::{env, path::Component, path::Path, path::PathBuf, str::FromStr};
+use std::{env, path::PathBuf, str::FromStr};
+
+#[cfg(windows)]
+use std::{path::Component, path::Path};
 
 // This needs to be implemented because serde doesn't support default = "true" as
 // a valid option, and throws  "failed to parse" error.

--- a/crates/npmrc/src/custom_deserializer.rs
+++ b/crates/npmrc/src/custom_deserializer.rs
@@ -173,14 +173,10 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn test_default_store_dir_with_windows() {
-        let mocked_current_dir = Path::new("D:\\Users\\user\\project");
-        let mocked_home_dir = Path::new("C:\\Users\\user");
+        let current_dir = Path::new("D:\\Users\\user\\project");
+        let home_dir = Path::new("C:\\Users\\user");
 
-        let store_dir = default_store_dir_windows(mocked_home_dir.to_path_buf(), mocked_current_dir.to_path_buf());
-
-        let current_drive = get_drive_letter(mocked_current_dir);
-        let store_drive = get_drive_letter(&store_dir);
-
-        assert_eq!(current_drive, Some(store_drive.unwrap()));
+        let store_dir = default_store_dir_windows(home_dir, current_dir);
+        assert_eq!(store_dir, Path::new("D:\\.pacquet-store"));
     }
 }

--- a/crates/npmrc/src/custom_deserializer.rs
+++ b/crates/npmrc/src/custom_deserializer.rs
@@ -163,7 +163,7 @@ mod tests {
         assert_eq!(drive_letter, Some("C".to_string()));
     }
 
-    #[cfg(target_os = "windows")]
+    #[cfg(windows)]
     #[test]
     fn test_default_store_dir_with_windows() {
         let current_dir = env::current_dir().expect("Current directory is not available");

--- a/crates/npmrc/src/custom_deserializer.rs
+++ b/crates/npmrc/src/custom_deserializer.rs
@@ -42,7 +42,7 @@ fn default_store_dir_windows(home_dir: &Path, current_dir: &Path) -> PathBuf {
         return home_dir.join("AppData/Local/pacquet/store");
     }
 
-    PathBuf::from(format!("{}:\\.pacquet-store", current_drive))
+    PathBuf::from(format!("{current_drive}:\\.pacquet-store"))
 }
 
 /// If the $PACQUET_HOME env variable is set, then $PACQUET_HOME/store

--- a/crates/npmrc/src/custom_deserializer.rs
+++ b/crates/npmrc/src/custom_deserializer.rs
@@ -67,7 +67,7 @@ pub fn default_store_dir() -> PathBuf {
     #[cfg(windows)]
     if cfg!(windows) {
         let current_dir = env::current_dir().expect("current directory is unavailable");
-        return default_store_dir_windows(home_dir, current_dir);
+        return default_store_dir_windows(&home_dir, &current_dir);
     }
 
     // https://doc.rust-lang.org/std/env/consts/constant.OS.html

--- a/crates/npmrc/src/custom_deserializer.rs
+++ b/crates/npmrc/src/custom_deserializer.rs
@@ -28,16 +28,16 @@ fn get_drive_letter(current_dir: &Path) -> Option<String> {
     None
 }
 
-fn default_store_dir_windows(home_dir: &Path) -> PathBuf {
+fn default_store_dir_windows(home_dir: PathBuf) -> PathBuf {
     let current_dir = env::current_dir().expect("Current directory is not available");
     let current_drive = get_drive_letter(&current_dir).unwrap_or_default();
     let home_drive = get_drive_letter(&home_dir).unwrap_or_default();
 
     if current_drive == home_drive {
         return home_dir.join("AppData/Local/pacquet/store");
-    } else {
-        return PathBuf::from(format!("{}:\\.pacquet-store", current_drive));
-    }
+    } 
+    
+    PathBuf::from(format!("{}:\\.pacquet-store", current_drive))
 }
 
 /// If the $PACQUET_HOME env variable is set, then $PACQUET_HOME/store
@@ -60,7 +60,7 @@ pub fn default_store_dir() -> PathBuf {
     let home_dir = home::home_dir().expect("Home directory is not available");
 
     if cfg!(windows) {
-        return default_store_dir_windows(&home_dir);
+        return default_store_dir_windows(home_dir);
     }
 
     // https://doc.rust-lang.org/std/env/consts/constant.OS.html

--- a/crates/npmrc/src/custom_deserializer.rs
+++ b/crates/npmrc/src/custom_deserializer.rs
@@ -32,7 +32,7 @@ fn get_drive_letter(current_dir: &Path) -> Option<char> {
 }
 
 #[cfg(windows)]
-fn default_store_dir_windows(home_dir: PathBuf, current_dir: PathBuf) -> PathBuf {
+fn default_store_dir_windows(home_dir: &Path, current_dir: &Path) -> PathBuf {
     let current_drive =
         get_drive_letter(&current_dir).expect("current dir is an absolute path with drive letter");
     let home_drive =

--- a/crates/npmrc/src/custom_deserializer.rs
+++ b/crates/npmrc/src/custom_deserializer.rs
@@ -16,6 +16,7 @@ pub fn default_public_hoist_pattern() -> Vec<String> {
 }
 
 // Get the drive letter from a path on Windows. If it's not a Windows path, return None.
+#[cfg(windows)]
 fn get_drive_letter(current_dir: &Path) -> Option<char> {
     if let Some(Component::Prefix(prefix_component)) = current_dir.components().next() {
         if let std::path::Prefix::Disk(disk_byte) | std::path::Prefix::VerbatimDisk(disk_byte) =
@@ -27,6 +28,7 @@ fn get_drive_letter(current_dir: &Path) -> Option<char> {
     None
 }
 
+#[cfg(windows)]
 fn default_store_dir_windows(home_dir: PathBuf) -> PathBuf {
     let current_dir = env::current_dir().expect("Current directory is not available");
     let current_drive =
@@ -60,6 +62,7 @@ pub fn default_store_dir() -> PathBuf {
     // needs to be resolved into an absolute path.
     let home_dir = home::home_dir().expect("Home directory is not available");
 
+    #[cfg(windows)]
     if cfg!(windows) {
         return default_store_dir_windows(home_dir);
     }

--- a/crates/npmrc/src/custom_deserializer.rs
+++ b/crates/npmrc/src/custom_deserializer.rs
@@ -30,10 +30,9 @@ fn get_drive_letter(current_dir: &Path) -> Option<String> {
 }
 
 #[cfg(windows)]
-fn default_store_dir_windows() -> PathBuf {
+fn default_store_dir_windows(home_dir: &Path) -> PathBuf {
     let current_dir = env::current_dir().expect("Current directory is not available");
     let current_drive = get_drive_letter(&current_dir).unwrap_or_default();
-    let home_dir = home::home_dir().expect("Home directory is not available");
     let home_drive = get_drive_letter(&home_dir).unwrap_or_default();
 
     if current_drive == home_drive {
@@ -58,19 +57,15 @@ pub fn default_store_dir() -> PathBuf {
         return PathBuf::from(xdg_data_home).join("pacquet/store");
     }
 
-    if cfg!(windows) {
-        return default_store_dir_windows();
-    }
-
     // Using ~ (tilde) for defining home path is not supported in Rust and
     // needs to be resolved into an absolute path.
     let home_dir = home::home_dir().expect("Home directory is not available");
 
-    // Check if we are on the same drive as the home directory
     // https://doc.rust-lang.org/std/env/consts/constant.OS.html
     match env::consts::OS {
         "linux" => home_dir.join(".local/share/pacquet/store"),
         "macos" => home_dir.join("Library/pacquet/store"),
+        "windows" => default_store_dir_windows(&home_dir),
         _ => panic!("unsupported operating system: {}", env::consts::OS),
     }
 }

--- a/crates/npmrc/src/custom_deserializer.rs
+++ b/crates/npmrc/src/custom_deserializer.rs
@@ -1,4 +1,4 @@
-use std::{env, path::Component, path::PathBuf, str::FromStr};
+use std::{env, path::Component, path::Path, path::PathBuf, str::FromStr};
 
 use serde::{de, Deserialize, Deserializer};
 
@@ -17,11 +17,11 @@ pub fn default_public_hoist_pattern() -> Vec<String> {
 }
 
 // Get the drive letter from a path on Windows. If it's not a Windows path, return None.
-fn get_drive_letter(current_dir: &PathBuf) -> Option<String> {
+fn get_drive_letter(current_dir: &Path) -> Option<String> {
     for component in current_dir.components() {
         if let Component::Prefix(prefix_component) = component {
             return Some(
-                prefix_component.as_os_str().to_str().unwrap().replace(":", "").to_string(),
+                prefix_component.as_os_str().to_str().unwrap().replace(':', "").to_string(),
             );
         }
     }

--- a/crates/npmrc/src/custom_deserializer.rs
+++ b/crates/npmrc/src/custom_deserializer.rs
@@ -176,7 +176,7 @@ mod tests {
         let current_dir = Path::new("D:\\Users\\user\\project");
         let home_dir = Path::new("C:\\Users\\user");
 
-        let store_dir = default_store_dir_windows(home_dir, current_dir);
+        let store_dir = default_store_dir_windows(&home_dir, &current_dir);
         assert_eq!(store_dir, Path::new("D:\\.pacquet-store"));
     }
 }

--- a/crates/npmrc/src/custom_deserializer.rs
+++ b/crates/npmrc/src/custom_deserializer.rs
@@ -29,8 +29,10 @@ fn get_drive_letter(current_dir: &Path) -> Option<char> {
 
 fn default_store_dir_windows(home_dir: PathBuf) -> PathBuf {
     let current_dir = env::current_dir().expect("Current directory is not available");
-    let current_drive = get_drive_letter(&current_dir).expect("current dir is an absolute path with drive letter");
-    let home_drive = get_drive_letter(&home_dir).expect("home dir is an absolute path with drive letter");
+    let current_drive =
+        get_drive_letter(&current_dir).expect("current dir is an absolute path with drive letter");
+    let home_drive =
+        get_drive_letter(&home_dir).expect("home dir is an absolute path with drive letter");
 
     if current_drive == home_drive {
         return home_dir.join("AppData/Local/pacquet/store");

--- a/crates/npmrc/src/custom_deserializer.rs
+++ b/crates/npmrc/src/custom_deserializer.rs
@@ -61,11 +61,14 @@ pub fn default_store_dir() -> PathBuf {
     // needs to be resolved into an absolute path.
     let home_dir = home::home_dir().expect("Home directory is not available");
 
+    if cfg!(windows) {
+        return default_store_dir_windows(&home_dir);
+    }
+
     // https://doc.rust-lang.org/std/env/consts/constant.OS.html
     match env::consts::OS {
         "linux" => home_dir.join(".local/share/pacquet/store"),
         "macos" => home_dir.join("Library/pacquet/store"),
-        "windows" => default_store_dir_windows(&home_dir),
         _ => panic!("unsupported operating system: {}", env::consts::OS),
     }
 }

--- a/crates/npmrc/src/custom_deserializer.rs
+++ b/crates/npmrc/src/custom_deserializer.rs
@@ -159,7 +159,7 @@ mod tests {
     fn test_should_get_the_correct_drive_letter() {
         let current_dir = Path::new("C:\\Users\\user\\project");
         let drive_letter = get_drive_letter(current_dir);
-        assert_eq!(drive_letter.as_deref(), Some("C"));
+        assert_eq!(drive_letter, Some('C'));
     }
 
     #[cfg(windows)]

--- a/crates/npmrc/src/custom_deserializer.rs
+++ b/crates/npmrc/src/custom_deserializer.rs
@@ -1,5 +1,4 @@
 use serde::{de, Deserialize, Deserializer};
-use std::borrow::Cow;
 use std::{env, path::Component, path::Path, path::PathBuf, str::FromStr};
 
 // This needs to be implemented because serde doesn't support default = "true" as
@@ -17,12 +16,12 @@ pub fn default_public_hoist_pattern() -> Vec<String> {
 }
 
 // Get the drive letter from a path on Windows. If it's not a Windows path, return None.
-fn get_drive_letter(current_dir: &Path) -> Option<Cow<'_, str>> {
+fn get_drive_letter(current_dir: &Path) -> Option<char> {
     if let Some(Component::Prefix(prefix_component)) = current_dir.components().next() {
         if let std::path::Prefix::Disk(disk_byte) | std::path::Prefix::VerbatimDisk(disk_byte) =
             prefix_component.kind()
         {
-            return Some(Cow::Owned((disk_byte as char).to_string()));
+            return Some(disk_byte as char);
         }
     }
     None
@@ -160,7 +159,7 @@ mod tests {
     fn test_should_get_the_correct_drive_letter() {
         let current_dir = Path::new("C:\\Users\\user\\project");
         let drive_letter = get_drive_letter(current_dir);
-        assert_eq!(drive_letter, Some(Cow::Borrowed("C")));
+        assert_eq!(drive_letter.as_deref(), Some("C"));
     }
 
     #[cfg(windows)]


### PR DESCRIPTION
Bump the `reflink-copy` dependency version to `0.1.8` as it supports now Copy-on-Write on the new Windows Dev Drives.

Keeping it as draft for now until I can test it in a Dev Drive later today.

Reference: [https://github.com/cargo-bins/reflink-copy/pull/28](https://github.com/cargo-bins/reflink-copy/pull/28)