### PR TITLE
fix(ci): micro-benchmark

### DIFF
--- a/.github/workflows/micro-benchmark.yml
+++ b/.github/workflows/micro-benchmark.yml
@@ -39,7 +39,7 @@ jobs:
         run: sleep 15s
 
       - name: Run Bench on Main Branch
-        run: cargo micro-benchmark --save-baseline main
+        run: cargo run --bin=micro-benchmark --release --save-baseline main
 
       - name: Checkout PR Branch
         uses: actions/checkout@v4
@@ -55,7 +55,7 @@ jobs:
         run: sleep 15s
 
       - name: Run Bench on PR Branch
-        run: cargo micro-benchmark --save-baseline pr
+        run: cargo run --bin=micro-benchmark --release --save-baseline pr
 
       - name: Upload benchmark results
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
I forgot to change the CI when I remove `micro-benchmark` from `.cargo/config.toml`.

And since it was expected for the CI to fail, I didn't bother to check the error message.