### PR TITLE
ci: clippy and doc on all platforms

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,3 @@
 [alias]
 # Do not append `--` or it will break IDEs
-ck = "check --workspace --all-targets --all-features --locked"
-lint = "clippy --workspace --all-targets --all-features"
 codecov = "llvm-cov nextest --workspace --ignore-filename-regex tasks"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,34 +89,6 @@ jobs:
 
       - run: cargo fmt --all -- --check
 
-  lint:
-    name: Clippy
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust
-        uses: ./.github/actions/rustup
-        with:
-          clippy: true
-
-      - name: Run Clippy
-        run: cargo lint -- -D warnings
-
-  doc:
-    name: Doc
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust
-        uses: ./.github/actions/rustup
-        with:
-          docs: true
-
-      - name: Run doc
-        run: RUSTDOCFLAGS='-D warnings' cargo doc -p pacquet_cli
-
   test:
     name: Test
     strategy:
@@ -132,6 +104,12 @@ jobs:
 
       - name: Install Rust Toolchain
         uses: ./.github/actions/rustup
+        with:
+          docs: true
+          clippy: true
+
+      - run: cargo clippy -- -D warnings
+      - run: RUSTDOCFLAGS='-D warnings' cargo doc
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@cargo-nextest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ concurrency:
   cancel-in-progress: ${{ github.ref_name != 'main' }}
 
 jobs:
-  cache: # Warm cache factory for all other CI jobs
-    name: Check and Build
+  test:
+    name: Lint and Test
     strategy:
       fail-fast: false
       matrix:
@@ -33,17 +33,20 @@ jobs:
       - name: Install Rust Toolchain
         uses: ./.github/actions/rustup
         with:
+          docs: true
+          clippy: true
           save-cache: ${{ github.ref_name == 'main' }}
+
+      - name: Clippy
+        run: cargo clippy -- -D warnings
+
+      - name: Doc
+        run: RUSTDOCFLAGS='-D warnings' cargo doc
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@cargo-nextest
 
-      - name: Cargo check
-        run: cargo ck
-
-      - name: Build cache by Cargo Check and Cargo Test
-        run: |
-          cargo nextest run --workspace --all-targets --all-features --no-run
+      - run: cargo nextest run
 
   typos:
     name: Spell Check
@@ -88,30 +91,3 @@ jobs:
           restore-cache: false
 
       - run: cargo fmt --all -- --check
-
-  test:
-    name: Test
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: windows-latest
-          - os: ubuntu-latest
-          - os: macos-latest
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust Toolchain
-        uses: ./.github/actions/rustup
-        with:
-          docs: true
-          clippy: true
-
-      - run: cargo clippy -- -D warnings
-      - run: RUSTDOCFLAGS='-D warnings' cargo doc
-
-      - name: Install cargo-nextest
-        uses: taiki-e/install-action@cargo-nextest
-
-      - run: cargo nextest run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           save-cache: ${{ github.ref_name == 'main' }}
 
       - name: Clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --locked -- -D warnings
 
       - name: Doc
         run: RUSTDOCFLAGS='-D warnings' cargo doc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,9 @@ jobs:
         run: cargo clippy --locked -- -D warnings
 
       - name: Doc
-        run: RUSTDOCFLAGS='-D warnings' cargo doc
+        env:
+          RUSTDOCFLAGS: '-D warnings'
+        run: cargo doc
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@cargo-nextest

--- a/crates/cli/src/fs.rs
+++ b/crates/cli/src/fs.rs
@@ -1,8 +1,8 @@
-use std::{io, os, path::Path};
+use std::{io, path::Path};
 
 #[cfg(unix)]
 pub fn symlink_dir(original: &Path, link: &Path) -> io::Result<()> {
-    os::unix::fs::symlink(original, link)
+    std::os::unix::fs::symlink(original, link)
 }
 
 #[cfg(windows)]

--- a/crates/npmrc/src/custom_deserializer.rs
+++ b/crates/npmrc/src/custom_deserializer.rs
@@ -34,9 +34,9 @@ fn get_drive_letter(current_dir: &Path) -> Option<char> {
 #[cfg(windows)]
 fn default_store_dir_windows(home_dir: &Path, current_dir: &Path) -> PathBuf {
     let current_drive =
-        get_drive_letter(&current_dir).expect("current dir is an absolute path with drive letter");
+        get_drive_letter(current_dir).expect("current dir is an absolute path with drive letter");
     let home_drive =
-        get_drive_letter(&home_dir).expect("home dir is an absolute path with drive letter");
+        get_drive_letter(home_dir).expect("home dir is an absolute path with drive letter");
 
     if current_drive == home_drive {
         return home_dir.join("AppData/Local/pacquet/store");

--- a/justfile
+++ b/justfile
@@ -49,7 +49,7 @@ test:
 
 # Lint the whole project
 lint:
-  cargo clippy -- --deny warnings
+  cargo clippy --locked -- --deny warnings
 
 # Get code coverage
 codecov:

--- a/justfile
+++ b/justfile
@@ -41,7 +41,7 @@ fmt:
 
 # Run cargo check
 check:
-  cargo ck
+  cargo check --locked
 
 # Run all the tests
 test:
@@ -49,7 +49,7 @@ test:
 
 # Lint the whole project
 lint:
-  cargo lint -- --deny warnings
+  cargo clippy -- --deny warnings
 
 # Get code coverage
 codecov:

--- a/tasks/integrated-benchmark/src/work_env.rs
+++ b/tasks/integrated-benchmark/src/work_env.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 use os_display::Quotable;
 use pipe_trait::Pipe;
 use std::{
-    fs::{self, File, Permissions},
+    fs::{self, File},
     io::Write,
     iter,
     path::{Path, PathBuf},
@@ -230,7 +230,7 @@ fn create_install_script(dir: &Path, scenario: BenchmarkScenario, for_pnpm: bool
 
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
+        use std::{fs::Permissions, os::unix::fs::PermissionsExt};
         let permissions = Permissions::from_mode(0o777);
         fs::set_permissions(path, permissions).expect("make the script executable");
     }


### PR DESCRIPTION
Fixes https://github.com/pnpm/pacquet/issues/152

I also remove `ck` and `lint` from cargo aliases. Currently, `pacquet` doesn't use any feature flag, and even if we are to add them in the future, we would have to use cargo-hack instead.