### PR TITLE
ci: pin typos version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: crate-ci/typos@master
+      - uses: crate-ci/typos@v1.16.22
         with:
           files: .
 


### PR DESCRIPTION
Just a few seconds ago, when CI for https://github.com/pnpm/pacquet/pull/166 was being run, `typos` [errored](https://github.com/pnpm/pacquet/actions/runs/6723936052/job/18275105882?pr=166). This is due to `typos` pushing commits to `master` before its binary has been uploaded to the release page, and my CI run just happens to coincide with this narrow window of time. In order to prevent unnecessary confusion in the future, I propose pinning typos to a fixed released version.