### PR TITLE
refactor: rewrite the `bin` functions into a struct

### DIFF
--- a/crates/cli/tests/_utils.rs
+++ b/crates/cli/tests/_utils.rs
@@ -1,7 +1,7 @@
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pacquet_store_dir::{PackageFileInfo, PackageFilesIndex};
-use pacquet_testing_utils::bin::pacquet_with_temp_cwd;
+use pacquet_testing_utils::bin::CommandTempCwd;
 use pipe_trait::Pipe;
 use std::{
     collections::BTreeMap,
@@ -17,7 +17,13 @@ where
     Args: IntoIterator,
     Args::Item: AsRef<OsStr>,
 {
-    let (command, root, workspace) = pacquet_with_temp_cwd(create_npmrc);
+    let env = CommandTempCwd::create();
+    let (command, root, workspace) = if create_npmrc {
+        let CommandTempCwd { pacquet, root, workspace, .. } = env.add_default_npmrc();
+        (pacquet, root, workspace)
+    } else {
+        (env.pacquet, env.root, env.workspace)
+    };
     command.with_args(args).assert().success();
     (root, workspace)
 }

--- a/crates/cli/tests/_utils.rs
+++ b/crates/cli/tests/_utils.rs
@@ -19,8 +19,8 @@ where
 {
     let env = CommandTempCwd::create();
     let (command, root, workspace) = if create_npmrc {
-        let CommandTempCwd { pacquet, root, workspace, .. } = env.add_default_npmrc();
-        (pacquet, root, workspace)
+        let env = env.add_default_npmrc();
+        (env.pacquet, env.root, env.workspace)
     } else {
         (env.pacquet, env.root, env.workspace)
     };

--- a/crates/cli/tests/_utils.rs
+++ b/crates/cli/tests/_utils.rs
@@ -17,7 +17,7 @@ where
     Args: IntoIterator,
     Args::Item: AsRef<OsStr>,
 {
-    let env = CommandTempCwd::create();
+    let env = CommandTempCwd::init();
     let (command, root, workspace) = if create_npmrc {
         let env = env.add_default_npmrc();
         (env.pacquet, env.root, env.workspace)

--- a/crates/cli/tests/init.rs
+++ b/crates/cli/tests/init.rs
@@ -25,7 +25,7 @@ fn should_create_package_json() {
 
 #[test]
 fn should_throw_on_existing_file() {
-    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::create();
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
 
     let manifest_path = workspace.join("package.json");
     dbg!(&manifest_path);

--- a/crates/cli/tests/init.rs
+++ b/crates/cli/tests/init.rs
@@ -2,7 +2,7 @@ pub mod _utils;
 pub use _utils::*;
 
 use command_extra::CommandExtra;
-use pacquet_testing_utils::{bin::pacquet_with_temp_cwd, fs::get_filenames_in_folder};
+use pacquet_testing_utils::{bin::CommandTempCwd, fs::get_filenames_in_folder};
 use pretty_assertions::assert_eq;
 use std::{env, fs};
 
@@ -25,7 +25,7 @@ fn should_create_package_json() {
 
 #[test]
 fn should_throw_on_existing_file() {
-    let (command, root, workspace) = pacquet_with_temp_cwd(false);
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::create();
 
     let manifest_path = workspace.join("package.json");
     dbg!(&manifest_path);
@@ -34,7 +34,7 @@ fn should_throw_on_existing_file() {
     fs::write(&manifest_path, "{}").expect("write to package.json");
 
     eprintln!("Executing pacquet init...");
-    let output = command.with_arg("init").output().expect("execute pacquet init");
+    let output = pacquet.with_arg("init").output().expect("execute pacquet init");
     dbg!(&output);
 
     eprintln!("Exit status code");

--- a/crates/cli/tests/install.rs
+++ b/crates/cli/tests/install.rs
@@ -13,7 +13,7 @@ use std::fs;
 #[test]
 fn should_install_dependencies() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
-        CommandTempCwd::create().add_default_npmrc();
+        CommandTempCwd::init().add_default_npmrc();
     let AddDefaultNpmrcInfo { store_dir, .. } = npmrc_info;
 
     eprintln!("Creating package.json...");
@@ -56,7 +56,7 @@ fn should_install_dependencies() {
 #[test]
 fn should_install_exec_files() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
-        CommandTempCwd::create().add_default_npmrc();
+        CommandTempCwd::init().add_default_npmrc();
     let AddDefaultNpmrcInfo { store_dir, .. } = npmrc_info;
 
     eprintln!("Creating package.json...");
@@ -116,7 +116,7 @@ fn should_install_exec_files() {
 #[test]
 fn should_install_index_files() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
-        CommandTempCwd::create().add_default_npmrc();
+        CommandTempCwd::init().add_default_npmrc();
     let AddDefaultNpmrcInfo { store_dir, .. } = npmrc_info;
 
     eprintln!("Creating package.json...");

--- a/crates/cli/tests/pnpm_compatibility.rs
+++ b/crates/cli/tests/pnpm_compatibility.rs
@@ -16,7 +16,7 @@ use std::fs;
 #[ignore = "requires metadata cache feature which pacquet doesn't yet have"]
 fn store_usable_by_pnpm_offline() {
     let CommandTempCwd { pacquet, pnpm, root, workspace, .. } =
-        CommandTempCwd::create().add_default_npmrc();
+        CommandTempCwd::init().add_default_npmrc();
 
     eprintln!("Creating package.json...");
     let manifest_path = workspace.join("package.json");
@@ -43,7 +43,7 @@ fn store_usable_by_pnpm_offline() {
 #[test]
 fn same_file_structure() {
     let CommandTempCwd { pacquet, pnpm, root, workspace, npmrc_info } =
-        CommandTempCwd::create().add_default_npmrc();
+        CommandTempCwd::init().add_default_npmrc();
     let AddDefaultNpmrcInfo { store_dir, .. } = npmrc_info;
 
     let modules_dir = workspace.join("node_modules");
@@ -86,7 +86,7 @@ fn same_file_structure() {
 #[test]
 fn same_index_file_contents() {
     let CommandTempCwd { pacquet, pnpm, root, workspace, npmrc_info } =
-        CommandTempCwd::create().add_default_npmrc();
+        CommandTempCwd::init().add_default_npmrc();
     let AddDefaultNpmrcInfo { store_dir, .. } = npmrc_info;
 
     let modules_dir = workspace.join("node_modules");

--- a/crates/cli/tests/pnpm_compatibility.rs
+++ b/crates/cli/tests/pnpm_compatibility.rs
@@ -4,7 +4,10 @@ pub use _utils::*;
 
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
-use pacquet_testing_utils::{bin::pacquet_and_pnpm_with_temp_cwd, fs::get_all_files};
+use pacquet_testing_utils::{
+    bin::{AddDefaultNpmrcInfo, CommandTempCwd},
+    fs::get_all_files,
+};
 use pipe_trait::Pipe;
 use pretty_assertions::assert_eq;
 use std::fs;
@@ -12,7 +15,8 @@ use std::fs;
 #[test]
 #[ignore = "requires metadata cache feature which pacquet doesn't yet have"]
 fn store_usable_by_pnpm_offline() {
-    let (pacquet, pnpm, root, workspace) = pacquet_and_pnpm_with_temp_cwd(true);
+    let CommandTempCwd { pacquet, pnpm, root, workspace, .. } =
+        CommandTempCwd::create().add_default_npmrc();
 
     eprintln!("Creating package.json...");
     let manifest_path = workspace.join("package.json");
@@ -38,9 +42,10 @@ fn store_usable_by_pnpm_offline() {
 
 #[test]
 fn same_file_structure() {
-    let (pacquet, pnpm, root, workspace) = pacquet_and_pnpm_with_temp_cwd(true);
+    let CommandTempCwd { pacquet, pnpm, root, workspace, npmrc_info } =
+        CommandTempCwd::create().add_default_npmrc();
+    let AddDefaultNpmrcInfo { store_dir, .. } = npmrc_info;
 
-    let store_dir = root.path().join("pacquet-store");
     let modules_dir = workspace.join("node_modules");
     let cleanup = || {
         eprintln!("Cleaning up...");
@@ -80,9 +85,10 @@ fn same_file_structure() {
 
 #[test]
 fn same_index_file_contents() {
-    let (pacquet, pnpm, root, workspace) = pacquet_and_pnpm_with_temp_cwd(true);
+    let CommandTempCwd { pacquet, pnpm, root, workspace, npmrc_info } =
+        CommandTempCwd::create().add_default_npmrc();
+    let AddDefaultNpmrcInfo { store_dir, .. } = npmrc_info;
 
-    let store_dir = root.path().join("pacquet-store");
     let modules_dir = workspace.join("node_modules");
     let cleanup = || {
         eprintln!("Cleaning up...");

--- a/crates/cli/tests/store.rs
+++ b/crates/cli/tests/store.rs
@@ -1,5 +1,5 @@
 use command_extra::CommandExtra;
-use pacquet_testing_utils::bin::pacquet_with_temp_cwd;
+use pacquet_testing_utils::bin::CommandTempCwd;
 use pipe_trait::Pipe;
 use pretty_assertions::assert_eq;
 use std::{
@@ -20,13 +20,13 @@ fn canonicalize(path: &Path) -> PathBuf {
 
 #[test]
 fn store_path_should_return_store_dir_from_npmrc() {
-    let (command, root, workspace) = pacquet_with_temp_cwd(false);
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::create();
 
     eprintln!("Creating .npmrc...");
     fs::write(workspace.join(".npmrc"), "store-dir=foo/bar").expect("write to .npmrc");
 
     eprintln!("Executing pacquet store path...");
-    let output = command.with_args(["store", "path"]).output().expect("run pacquet store path");
+    let output = pacquet.with_args(["store", "path"]).output().expect("run pacquet store path");
     dbg!(&output);
 
     eprintln!("Exit status code");

--- a/crates/cli/tests/store.rs
+++ b/crates/cli/tests/store.rs
@@ -20,7 +20,7 @@ fn canonicalize(path: &Path) -> PathBuf {
 
 #[test]
 fn store_path_should_return_store_dir_from_npmrc() {
-    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::create();
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
 
     eprintln!("Creating .npmrc...");
     fs::write(workspace.join(".npmrc"), "store-dir=foo/bar").expect("write to .npmrc");

--- a/crates/testing-utils/src/bin.rs
+++ b/crates/testing-utils/src/bin.rs
@@ -1,47 +1,62 @@
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
-use std::{
-    fs,
-    path::{Path, PathBuf},
-    process::Command,
-};
+use std::{fs, path::PathBuf, process::Command};
 use tempfile::{tempdir, TempDir};
 use text_block_macros::text_block_fnl;
 
-const DEFAULT_NPMRC: &str = text_block_fnl! {
-    "store-dir=../pacquet-store"
-    "cache-dir=../pacquet-cache"
-};
-
-fn create_default_npmrc(workspace: &Path) {
-    fs::write(workspace.join(".npmrc"), DEFAULT_NPMRC).expect("write to .npmrc");
+/// Assets for an integration test involving spawning `pacquet` and/or `pnpm` as
+/// sub-process(es) in a temporary directory.
+pub struct CommandTempCwd<NpmrcInfo> {
+    /// Command of `pacquet` with [`Self::workspace`] as working directory.
+    pub pacquet: Command,
+    /// Command of `pnpm` with [`Self::workspace`] as working directory.
+    pub pnpm: Command,
+    /// Temporary directory that contains all other paths.
+    pub root: TempDir,
+    /// The `workspace` sub-directory.
+    pub workspace: PathBuf,
+    /// Optional info regarding the creation of `.npmrc`.
+    pub npmrc_info: NpmrcInfo,
 }
 
-// TODO: convert this into a struct, add workspace and store_dir fields, make use of them
-pub fn pacquet_with_temp_cwd(create_npmrc: bool) -> (Command, TempDir, PathBuf) {
-    let root = tempdir().expect("create temporary directory");
-    let workspace = root.path().join("workspace");
-    fs::create_dir(&workspace).expect("create temporary workspace for pacquet");
-    if create_npmrc {
-        create_default_npmrc(&workspace)
+impl CommandTempCwd<()> {
+    /// Creates a temporary directory, a `workspace` sub-directory, a `pacquet` command,
+    /// and a `pnpm` command with current dir set to the `workspace` sub-directory.
+    pub fn create() -> Self {
+        let root = tempdir().expect("create temporary directory");
+        let workspace = root.path().join("workspace");
+        fs::create_dir(&workspace).expect("create temporary workspace for the commands");
+        let pacquet = Command::cargo_bin("pacquet")
+            .expect("find the pacquet binary")
+            .with_current_dir(&workspace);
+        let pnpm = Command::new("pnpm").with_current_dir(&workspace);
+        CommandTempCwd { pacquet, pnpm, root, workspace, npmrc_info: () }
     }
-    let command = Command::cargo_bin("pacquet")
-        .expect("find the pacquet binary")
-        .with_current_dir(&workspace);
-    (command, root, workspace)
 }
 
-// TODO: convert this into a struct, add workspace and store_dir fields, make use of them
-pub fn pacquet_and_pnpm_with_temp_cwd(create_npmrc: bool) -> (Command, Command, TempDir, PathBuf) {
-    let root = tempdir().expect("create temporary directory");
-    let workspace = root.path().join("workspace");
-    fs::create_dir(&workspace).expect("create temporary workspace for pacquet");
-    if create_npmrc {
-        create_default_npmrc(&workspace)
+/// Information after the creation of an `.npmrc` file from assets provided by [`CommandTempCwd`].
+pub struct AddDefaultNpmrcInfo {
+    /// Path to the created `.npmrc` file.
+    pub npmrc_path: PathBuf,
+    /// Absolute path to the store directory as defined by the `.npmrc` file.
+    pub store_dir: PathBuf,
+    /// Absolute path to the cache directory as defined by the `.npmrc` file.
+    pub cache_dir: PathBuf,
+}
+
+impl CommandTempCwd<()> {
+    /// Create a `.npmrc` file that defines `store-dir` and `cache-dir`.
+    pub fn add_default_npmrc(self) -> CommandTempCwd<AddDefaultNpmrcInfo> {
+        let store_dir = self.root.path().join("pacquet-store");
+        let cache_dir = self.root.path().join("pacquet-cache");
+        let npmrc_path = self.workspace.join(".npmrc");
+        let npmrc_text = text_block_fnl! {
+            "store-dir=../pacquet-store"
+            "cache-dir=../pacquet-cache"
+        };
+        fs::write(&npmrc_path, npmrc_text).expect("write to .npmrc");
+        let npmrc_info = AddDefaultNpmrcInfo { npmrc_path, store_dir, cache_dir };
+        let CommandTempCwd { pacquet, pnpm, root, workspace, npmrc_info: () } = self;
+        CommandTempCwd { pacquet, pnpm, root, workspace, npmrc_info }
     }
-    let pacquet = Command::cargo_bin("pacquet")
-        .expect("find the pacquet binary")
-        .with_current_dir(&workspace);
-    let pnpm = Command::new("pnpm").with_current_dir(&workspace);
-    (pacquet, pnpm, root, workspace)
 }

--- a/crates/testing-utils/src/bin.rs
+++ b/crates/testing-utils/src/bin.rs
@@ -20,7 +20,7 @@ pub struct CommandTempCwd<NpmrcInfo> {
 }
 
 impl CommandTempCwd<()> {
-    /// Creates a temporary directory, a `workspace` sub-directory, a `pacquet` command,
+    /// Create a temporary directory, a `workspace` sub-directory, a `pacquet` command,
     /// and a `pnpm` command with current dir set to the `workspace` sub-directory.
     pub fn init() -> Self {
         let root = tempdir().expect("create temporary directory");

--- a/crates/testing-utils/src/bin.rs
+++ b/crates/testing-utils/src/bin.rs
@@ -22,7 +22,7 @@ pub struct CommandTempCwd<NpmrcInfo> {
 impl CommandTempCwd<()> {
     /// Creates a temporary directory, a `workspace` sub-directory, a `pacquet` command,
     /// and a `pnpm` command with current dir set to the `workspace` sub-directory.
-    pub fn create() -> Self {
+    pub fn init() -> Self {
         let root = tempdir().expect("create temporary directory");
         let workspace = root.path().join("workspace");
         fs::create_dir(&workspace).expect("create temporary workspace for the commands");


### PR DESCRIPTION
* It was ambiguous to pass a `bool` argument to a function.
* The tuples were terrible:
  - The returning tuples were too long.
  - The members inside the tuples share type, leading to ambiguity.
* The path to store dir was calculated downstream.
