### PR TITLE
refactor: parse integrity eagerly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1382,6 +1382,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "split-first-char",
+ "ssri",
  "text-block-macros",
 ]
 
@@ -1399,6 +1400,7 @@ dependencies = [
  "pipe-trait",
  "project-root",
  "reqwest",
+ "ssri",
  "tempfile",
  "tokio",
 ]
@@ -1473,6 +1475,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "ssri",
  "tempfile",
  "tokio",
 ]

--- a/crates/lockfile/Cargo.toml
+++ b/crates/lockfile/Cargo.toml
@@ -19,6 +19,7 @@ node-semver      = { workspace = true }
 pipe-trait       = { workspace = true }
 serde            = { workspace = true }
 serde_yaml       = { workspace = true }
+ssri             = { workspace = true }
 split-first-char = { workspace = true }
 
 [dev-dependencies]

--- a/crates/lockfile/src/resolution.rs
+++ b/crates/lockfile/src/resolution.rs
@@ -49,7 +49,7 @@ impl LockfileResolution {
     pub fn integrity(&self) -> Option<&'_ Integrity> {
         match self {
             LockfileResolution::Tarball(resolution) => resolution.integrity.as_ref(),
-            LockfileResolution::Registry(resolution) => resolution.integrity.pipe_ref(Some),
+            LockfileResolution::Registry(resolution) => Some(&resolution.integrity),
             LockfileResolution::Directory(_) | LockfileResolution::Git(_) => None,
         }
     }

--- a/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/crates/package-manager/src/install_package_by_snapshot.rs
@@ -41,7 +41,7 @@ impl<'a> InstallPackageBySnapshot<'a> {
 
         let (tarball_url, integrity) = match resolution {
             LockfileResolution::Tarball(tarball_resolution) => {
-                let integrity = tarball_resolution.integrity.as_deref().unwrap_or_else(|| {
+                let integrity = tarball_resolution.integrity.as_ref().unwrap_or_else(|| {
                     // TODO: how to handle the absent of integrity field?
                     panic!("Current implementation requires integrity, but {dependency_path} doesn't have it");
                 });
@@ -54,7 +54,7 @@ impl<'a> InstallPackageBySnapshot<'a> {
                 let version = ver_peer.version();
                 let bare_name = name.bare.as_str();
                 let tarball_url = format!("{registry}/{name}/-/{bare_name}-{version}.tgz");
-                let integrity = registry_resolution.integrity.as_str();
+                let integrity = &registry_resolution.integrity;
                 (Cow::Owned(tarball_url), integrity)
             }
             LockfileResolution::Directory(_) | LockfileResolution::Git(_) => {

--- a/crates/registry/Cargo.toml
+++ b/crates/registry/Cargo.toml
@@ -19,6 +19,7 @@ node-semver = { workspace = true }
 pipe-trait  = { workspace = true }
 serde       = { workspace = true }
 serde_json  = { workspace = true }
+ssri        = { workspace = true }
 tokio       = { workspace = true }
 miette      = { workspace = true }
 

--- a/crates/registry/src/package_distribution.rs
+++ b/crates/registry/src/package_distribution.rs
@@ -1,9 +1,10 @@
 use serde::{Deserialize, Serialize};
+use ssri::Integrity;
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct PackageDistribution {
-    pub integrity: Option<String>,
+    pub integrity: Option<Integrity>,
     pub shasum: Option<String>,
     pub tarball: String,
     pub file_count: Option<usize>,

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -190,7 +190,6 @@ impl<'a> DownloadTarballToStore<'a> {
         // TODO: Cloning here is less than desirable, there are 2 possible solutions for this problem:
         // 1. Use an Arc and convert this line to Arc::clone.
         // 2. Replace ssri with base64 and serde magic (which supports Copy).
-        // 3. Use move somehow.
         let package_integrity = package_integrity.clone();
 
         #[derive(Debug, From)]

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -189,7 +189,7 @@ impl<'a> DownloadTarballToStore<'a> {
 
         // TODO: Cloning here is less than desirable, there are 2 possible solutions for this problem:
         // 1. Use an Arc and convert this line to Arc::clone.
-        // 2. Replace ssri with base64 and serde magic.
+        // 2. Replace ssri with base64 and serde magic (which supports Copy).
         // 3. Use move somehow.
         let package_integrity = package_integrity.clone();
 

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -31,15 +31,6 @@ pub struct NetworkError {
 }
 
 #[derive(Debug, Display, Error, Diagnostic)]
-#[display("Cannot parse {integrity:?} from {url} as an integrity: {error}")]
-pub struct ParseIntegrityError {
-    pub url: String,
-    pub integrity: String,
-    #[error(source)]
-    pub error: ssri::Error,
-}
-
-#[derive(Debug, Display, Error, Diagnostic)]
 #[display("Failed to verify the integrity of {url}: {error}")]
 pub struct VerifyChecksumError {
     pub url: String,
@@ -56,9 +47,6 @@ pub enum TarballError {
     #[from(ignore)]
     #[diagnostic(code(pacquet_tarball::io_error))]
     ReadTarballEntries(std::io::Error),
-
-    #[diagnostic(code(pacquet_tarball::parse_integrity_error))]
-    ParseIntegrity(ParseIntegrityError),
 
     #[diagnostic(code(pacquet_tarball::verify_checksum_error))]
     Checksum(VerifyChecksumError),
@@ -128,7 +116,7 @@ pub struct DownloadTarballToStore<'a> {
     pub tarball_cache: &'a Cache,
     pub http_client: &'a Client,
     pub store_dir: &'static StoreDir,
-    pub package_integrity: &'a str,
+    pub package_integrity: &'a Integrity,
     pub package_unpacked_size: Option<usize>,
     pub package_url: &'a str,
 }
@@ -199,12 +187,12 @@ impl<'a> DownloadTarballToStore<'a> {
 
         tracing::info!(target: "pacquet::download", ?package_url, "Download completed");
 
-        let package_integrity: Integrity =
-            package_integrity.parse().map_err(|error| ParseIntegrityError {
-                url: package_url.to_string(),
-                integrity: package_integrity.to_string(),
-                error,
-            })?;
+        // TODO: Cloning here is less than desirable, there are 2 possible solutions for this problem:
+        // 1. Use an Arc and convert this line to Arc::clone.
+        // 2. Replace ssri with base64 and serde magic.
+        // 3. Use move somehow.
+        let package_integrity = package_integrity.clone();
+
         #[derive(Debug, From)]
         enum TaskError {
             Checksum(ssri::Error),
@@ -303,6 +291,10 @@ mod tests {
 
     use super::*;
 
+    fn integrity(integrity_str: &str) -> Integrity {
+        integrity_str.parse().expect("parse integrity string")
+    }
+
     /// **Problem:**
     /// The tested function requires `'static` paths, leaking would prevent
     /// temporary files from being cleaned up.
@@ -328,7 +320,7 @@ mod tests {
             tarball_cache: &Default::default(),
             http_client: &Default::default(),
             store_dir: store_path,
-            package_integrity: "sha512-dj7vjIn1Ar8sVXj2yAXiMNCJDmS9MQ9XMlIecX2dIzzhjSHCyKo4DdXjXMs7wKW2kj6yvVRSpuQjOZ3YLrh56w==",
+            package_integrity: &integrity("sha512-dj7vjIn1Ar8sVXj2yAXiMNCJDmS9MQ9XMlIecX2dIzzhjSHCyKo4DdXjXMs7wKW2kj6yvVRSpuQjOZ3YLrh56w=="),
             package_unpacked_size: Some(16697),
             package_url: "https://registry.npmjs.org/@fastify/error/-/error-3.3.0.tgz"
         }
@@ -368,7 +360,7 @@ mod tests {
             tarball_cache: &Default::default(),
             http_client: &Default::default(),
             store_dir: store_path,
-            package_integrity: "sha512-aaaan1Ar8sVXj2yAXiMNCJDmS9MQ9XMlIecX2dIzzhjSHCyKo4DdXjXMs7wKW2kj6yvVRSpuQjOZ3YLrh56w==",
+            package_integrity: &integrity("sha512-aaaan1Ar8sVXj2yAXiMNCJDmS9MQ9XMlIecX2dIzzhjSHCyKo4DdXjXMs7wKW2kj6yvVRSpuQjOZ3YLrh56w=="),
             package_unpacked_size: Some(16697),
             package_url: "https://registry.npmjs.org/@fastify/error/-/error-3.3.0.tgz",
         }

--- a/tasks/micro-benchmark/Cargo.toml
+++ b/tasks/micro-benchmark/Cargo.toml
@@ -27,4 +27,5 @@ tempfile     = { workspace = true }
 pipe-trait   = { workspace = true }
 project-root = { workspace = true }
 reqwest      = { workspace = true }
+ssri         = { workspace = true }
 node-semver  = { workspace = true }


### PR DESCRIPTION
The parsing of integrity has been moved from tarball to serde.