### PR TITLE
perf: Use faster `malloc`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1185,6 +1185,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1300,6 +1309,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3627c4272df786b9260cabaa46aec1d59c93ede723d4c3ef646c503816b0640"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -1572,6 +1590,7 @@ dependencies = [
  "pipe-trait",
  "pretty_assertions",
  "serde_json",
+ "swc_malloc",
  "tempfile",
  "tokio",
  "walkdir",
@@ -2589,6 +2608,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
+name = "swc_malloc"
+version = "1.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d222be9e55e86fd6ee32e97c7b12829692329ac8bbed652dcd6c2e1d488af935"
+dependencies = [
+ "mimalloc",
+ "tikv-jemallocator",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2736,6 +2765,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1575,6 +1575,7 @@ dependencies = [
  "home",
  "insta",
  "miette 7.6.0",
+ "mimalloc",
  "pacquet-diagnostics",
  "pacquet-executor",
  "pacquet-fs",
@@ -1590,7 +1591,6 @@ dependencies = [
  "pipe-trait",
  "pretty_assertions",
  "serde_json",
- "swc_malloc",
  "tempfile",
  "tokio",
  "walkdir",
@@ -2608,16 +2608,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
-name = "swc_malloc"
-version = "1.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d222be9e55e86fd6ee32e97c7b12829692329ac8bbed652dcd6c2e1d488af935"
-dependencies = [
- "mimalloc",
- "tikv-jemallocator",
-]
-
-[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2765,26 +2755,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "tikv-jemalloc-sys"
-version = "0.5.4+5.3.0-patched"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "tikv-jemallocator"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
-dependencies = [
- "libc",
- "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ sha2               = { version = "0.10.9" }                                     
 split-first-char   = { version = "2.0.1" }
 ssri               = { version = "9.2.0" }
 strum              = { version = "0.28.0", features = ["derive"] }
+swc_malloc         = { version = "1.2.5" }
 sysinfo            = { version = "0.38.4" }
 tar                = { version = "0.4.45" }
 text-block-macros  = { version = "0.2.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ sha2               = { version = "0.10.9" }                                     
 split-first-char   = { version = "2.0.1" }
 ssri               = { version = "9.2.0" }
 strum              = { version = "0.28.0", features = ["derive"] }
-swc_malloc         = { version = "1.2.5" }
+mimalloc           = { version = "0.1.50" }
 sysinfo            = { version = "0.38.4" }
 tar                = { version = "0.4.45" }
 text-block-macros  = { version = "0.2.0" }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -31,6 +31,7 @@ derive_more = { workspace = true }
 home        = { workspace = true }
 miette      = { workspace = true }
 pipe-trait  = { workspace = true }
+swc_malloc  = { workspace = true }
 tokio       = { workspace = true }
 
 [dev-dependencies]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -29,9 +29,9 @@ pacquet-diagnostics      = { workspace = true }
 clap        = { workspace = true }
 derive_more = { workspace = true }
 home        = { workspace = true }
+mimalloc    = { workspace = true }
 miette      = { workspace = true }
 pipe-trait  = { workspace = true }
-swc_malloc  = { workspace = true }
 tokio       = { workspace = true }
 
 [dev-dependencies]

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,13 +1,11 @@
-// Swap the default system allocator for `swc_malloc`, which pulls
-// in mimalloc on macOS / Windows and jemalloc on Linux. A package
+// Swap the default system allocator for `mimalloc`. A package
 // manager fan-outs thousands of short-lived `Vec<u8>` / `String` /
 // `HashMap` allocations per install (tar entry buffers, CAFS
-// paths, snapshot IDs, …); the system allocators on macOS and
-// glibc are noticeably slower than mimalloc / jemalloc on that
-// workload. Activating the crate via `extern crate` is enough —
-// `swc_malloc` embeds the `#[global_allocator]` declaration
-// itself and picks the per-target backend at compile time.
-extern crate swc_malloc;
+// paths, snapshot IDs, …); mimalloc's per-thread free lists and
+// small-object fast path are a better match for that shape than
+// the default system allocator on macOS and glibc-Linux.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 mod cli_args;
 mod state;

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,3 +1,14 @@
+// Swap the default system allocator for `swc_malloc`, which pulls
+// in mimalloc on macOS / Windows and jemalloc on Linux. A package
+// manager fan-outs thousands of short-lived `Vec<u8>` / `String` /
+// `HashMap` allocations per install (tar entry buffers, CAFS
+// paths, snapshot IDs, …); the system allocators on macOS and
+// glibc are noticeably slower than mimalloc / jemalloc on that
+// workload. Activating the crate via `extern crate` is enough —
+// `swc_malloc` embeds the `#[global_allocator]` declaration
+// itself and picks the per-target backend at compile time.
+extern crate swc_malloc;
+
 mod cli_args;
 mod state;
 


### PR DESCRIPTION
Hi. I'm the creator of SWC, and I'm working to improve performance.

`swc_malloc` is a utility crate that configures global malloc with the best one for each platform. I made it mainly for benchmarks, but I found it useful so I'm also using it for the official node bindings (including extra bindings - CSS/HTML/XML)

If you want, you can store it inline, but with this crate you don't need to maintain it.
