### PR TITLE
perf: Increase the size of rayon threadpool for syscalls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,16 +507,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
-name = "dudy-malloc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7693457240fabab8f300db030cd86e969944089971c31654e4e2a9c255ebd369"
-dependencies = [
- "mimalloc-rust",
- "tikv-jemallocator",
-]
-
-[[package]]
 name = "dunce"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,12 +607,6 @@ checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1347,7 +1331,6 @@ dependencies = [
  "clap",
  "command-extra",
  "derive_more",
- "dudy-malloc",
  "dunce",
  "home",
  "insta",
@@ -1367,6 +1350,7 @@ dependencies = [
  "pretty_assertions",
  "reqwest",
  "serde_json",
+ "swc_malloc",
  "tempfile",
  "tokio",
  "walkdir",
@@ -2198,6 +2182,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "swc_malloc"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a279493814466a779ac93921b8a88fbd9f9162807e564d64dbbae2edee00c8a"
+dependencies = [
+ "mimalloc-rust",
+ "tikv-jemallocator",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2297,20 +2291,19 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.4.3+5.2.1-patched.2"
+version = "0.5.4+5.3.0-patched"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1792ccb507d955b46af42c123ea8863668fae24d03721e40cad6a41773dbb49"
+checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
 dependencies = [
  "cc",
- "fs_extra",
  "libc",
 ]
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.4.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5b7bcecfafe4998587d636f9ae9d55eb9d0499877b88757767c346875067098"
+checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,6 +438,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cty"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,6 +505,16 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "dudy-malloc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7693457240fabab8f300db030cd86e969944089971c31654e4e2a9c255ebd369"
+dependencies = [
+ "mimalloc-rust",
+ "tikv-jemallocator",
+]
 
 [[package]]
 name = "dunce"
@@ -601,6 +617,12 @@ checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1081,6 +1103,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "mimalloc-rust"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb726c8298efb4010b2c46d8050e4be36cf807b9d9e98cb112f830914fc9bbe"
+dependencies = [
+ "cty",
+ "mimalloc-rust-sys",
+]
+
+[[package]]
+name = "mimalloc-rust-sys"
+version = "1.7.9-source"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6413e13241a9809f291568133eca6694572cf528c1a6175502d090adce5dd5db"
+dependencies = [
+ "cc",
+ "cty",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1305,6 +1347,7 @@ dependencies = [
  "clap",
  "command-extra",
  "derive_more",
+ "dudy-malloc",
  "dunce",
  "home",
  "insta",
@@ -2250,6 +2293,27 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.4.3+5.2.1-patched.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1792ccb507d955b46af42c123ea8863668fae24d03721e40cad6a41773dbb49"
+dependencies = [
+ "cc",
+ "fs_extra",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5b7bcecfafe4998587d636f9ae9d55eb9d0499877b88757767c346875067098"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1335,6 +1335,7 @@ dependencies = [
  "home",
  "insta",
  "miette",
+ "num_cpus",
  "pacquet-diagnostics",
  "pacquet-executor",
  "pacquet-fs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1348,6 +1348,7 @@ dependencies = [
  "pacquet-testing-utils",
  "pipe-trait",
  "pretty_assertions",
+ "rayon",
  "reqwest",
  "serde_json",
  "swc_malloc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ command-extra      = { version = "1.0.0" }
 base64             = { version = "0.21.5" }
 dashmap            = { version = "5.5.3" }
 derive_more        = { version = "1.0.0-beta.3", features = ["full"] }
-dudy-malloc       = { version = "0.1.0" }
 dunce              = { version = "1.0.4" }
 home               = { version = "0.5.5" }
 insta              = { version = "1.32.0", features = ["yaml", "glob", "walkdir"] }
@@ -55,6 +54,7 @@ sha2               = { version = "0.10.8" }
 split-first-char   = { version = "0.0.0" }
 ssri               = { version = "9.0.0" }
 strum              = { version = "0.25.0", features = ["derive"] }
+swc_malloc         = { version = "0.5.9" }
 tar                = { version = "0.4.40" }
 text-block-macros  = { version = "0.1.1" }
 tracing            = { version = "0.1.37" }
@@ -81,7 +81,7 @@ lto           = "fat"
 codegen-units = 1
 # strip         = "symbols"
 # debug         = false
-panic         = "abort"   # Let it crash and force ourselves to write safe Rust.
+panic = "abort" # Let it crash and force ourselves to write safe Rust.
 
 # Use the `--profile release-debug` flag to show symbols in release mode.
 # e.g. `cargo build --profile release-debug`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ command-extra      = { version = "1.0.0" }
 base64             = { version = "0.21.5" }
 dashmap            = { version = "5.5.3" }
 derive_more        = { version = "1.0.0-beta.3", features = ["full"] }
+dudy-malloc       = { version = "0.1.0" }
 dunce              = { version = "1.0.4" }
 home               = { version = "0.5.5" }
 insta              = { version = "1.32.0", features = ["yaml", "glob", "walkdir"] }
@@ -78,8 +79,8 @@ allow_branch = "main"
 opt-level     = 3
 lto           = "fat"
 codegen-units = 1
-strip         = "symbols"
-debug         = false
+# strip         = "symbols"
+# debug         = false
 panic         = "abort"   # Let it crash and force ourselves to write safe Rust.
 
 # Use the `--profile release-debug` flag to show symbols in release mode.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ reflink-copy       = { version = "0.1.9" }
 junction           = { version = "1.0.0" }
 reqwest            = { version = "0.11", default-features = false, features = ["json", "native-tls-vendored"] }
 node-semver        = { version = "2.1.0" }
+num_cpus           = { version = "1.16.0" }
 pipe-trait         = { version = "0.4.0" }
 rayon              = { version = "1.8.0" }
 serde              = { version = "1.0.188", features = ["derive"] }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -32,7 +32,7 @@ miette      = { workspace = true }
 reqwest     = { workspace = true }
 pipe-trait  = { workspace = true }
 tokio       = { workspace = true }
-dudy-malloc = { workspace = true }
+swc_malloc  = { workspace = true }
 
 [dev-dependencies]
 pacquet-store-dir     = { workspace = true }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -34,6 +34,7 @@ pipe-trait  = { workspace = true }
 tokio       = { workspace = true }
 swc_malloc  = { workspace = true }
 rayon       = { workspace = true }
+num_cpus    = { workspace = true }
 
 [dev-dependencies]
 pacquet-store-dir     = { workspace = true }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -32,6 +32,7 @@ miette      = { workspace = true }
 reqwest     = { workspace = true }
 pipe-trait  = { workspace = true }
 tokio       = { workspace = true }
+dudy-malloc = { workspace = true }
 
 [dev-dependencies]
 pacquet-store-dir     = { workspace = true }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -33,6 +33,7 @@ reqwest     = { workspace = true }
 pipe-trait  = { workspace = true }
 tokio       = { workspace = true }
 swc_malloc  = { workspace = true }
+rayon       = { workspace = true }
 
 [dev-dependencies]
 pacquet-store-dir     = { workspace = true }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -11,6 +11,10 @@ use state::State;
 
 pub async fn main() -> miette::Result<()> {
     // We use rayon only for blocking syscalls, so we multiply the number of threads by 3.
+    //
+    // If we are going to use rayon for CPU-bound tasks,
+    // we should create an extra threadpool for IO-bound tasks,
+    // and use the global theadpool for CPU-bound tasks.
     rayon::ThreadPoolBuilder::new()
         .num_threads(num_cpus::get() * 3)
         .build_global()

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate dudy_malloc;
+
 mod cli_args;
 mod state;
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -10,6 +10,12 @@ use pacquet_diagnostics::enable_tracing_by_env;
 use state::State;
 
 pub async fn main() -> miette::Result<()> {
+    // We use rayon only for blocking syscalls, so we multiply the number of threads by 3.
+    rayon::ThreadPoolBuilder::new()
+        .num_threads(num_cpus::get() * 3)
+        .build_global()
+        .expect("build rayon thread pool");
+
     enable_tracing_by_env();
     set_panic_hook();
     CliArgs::parse().run().await

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,4 +1,4 @@
-extern crate dudy_malloc;
+extern crate swc_malloc;
 
 mod cli_args;
 mod state;


### PR DESCRIPTION
I found that rayon is used only for syscalls. rayon is built for CPU-heavy tasks, but, it can still be used for syscalls. But we need one more patch to make it faster. 1x CPU count is too small because of *blocking*. There will be some idle threads.
I also wrote a comment about future improvements.



Blocked by
 - https://github.com/pnpm/pacquet/pull/188