### PR TITLE
chore: add bug-report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -1,0 +1,68 @@
+name: Bug Report 🐛
+description: Create a bug report for pacquet
+labels: ["type: bug"]
+body:
+  - type: checkboxes
+    attributes:
+      label: Verify latest release
+      description: "Please try the latest version of pacquet. Some issues may already be fixed in the latest release, so please verify that your issue reproduces before opening a new issue."
+      options:
+        - label: I verified that the issue exists in the latest pacquet release
+  - type: dropdown
+    attributes:
+      label: Which area(s) of pacquet are affected? (leave empty if unsure)
+      multiple: true
+      options:
+        - "Dependencies resolver"
+        - "CLI"
+        - "Lockfile"
+        - "Store"
+        - "Package manager compatibility"
+        - "Operating System (Windows, MacOS, Linux)"
+        - "Hooks"
+  - type: input
+    attributes:
+      label: Link to the code that reproduces this issue or a replay of the bug
+      description: |
+        A link to a GitHub repository minimal reproduction. If a minimal reproduction can't be created please share a replay of the bug which doesn't require sharing a private repo.
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      description: "How do you trigger this bug? Please walk us through it step by step."
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: ----------------------------
+  - type: textarea
+    attributes:
+      label: Describe the Bug
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: ----------------------------
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: A clear and concise description of what you expected to happen.
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: ----------------------------
+  - type: checkboxes
+    id: operating-systems
+    attributes:
+      label: Which operating systems have you used?
+      description: You may select more than one.
+      options:
+        - label: macOS
+        - label: Windows
+        - label: Linux
+  - type: input
+    attributes:
+      label: If your OS is a Linux based, which one it is? (Include the version if relevant)
+      placeholder: Linux, Ubuntu, Debian...

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true


### PR DESCRIPTION
Adapted the bug-report template from the pnpm repository.
We could also setup the feature-request and regression-report templates but it feels a bit early.
Closes #144