### PR TITLE
fix(tarball): use rwlock instead of dashmap to avoid potential deadlock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,19 +448,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.0",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "derive_more"
 version = "1.0.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1536,7 +1523,6 @@ name = "pacquet-tarball"
 version = "0.0.1"
 dependencies = [
  "base64",
- "dashmap",
  "derive_more",
  "miette",
  "pacquet-diagnostics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ async-recursion    = { version = "1.0.5" }
 clap               = { version = "4", features = ["derive", "string"] }
 command-extra      = { version = "1.0.0" }
 base64             = { version = "0.21.5" }
-dashmap            = { version = "5.5.3" }
 derive_more        = { version = "1.0.0-beta.3", features = ["full"] }
 dunce              = { version = "1.0.4" }
 home               = { version = "0.5.5" }

--- a/crates/cli/src/state.rs
+++ b/crates/cli/src/state.rs
@@ -6,7 +6,6 @@ use pacquet_package_manifest::{PackageManifest, PackageManifestError};
 use pacquet_tarball::MemCache;
 use pipe_trait::Pipe;
 use reqwest::Client;
-use std::collections::HashMap;
 use std::path::PathBuf;
 
 /// Application state when running `pacquet run` or `pacquet install`.
@@ -45,7 +44,7 @@ impl State {
             lockfile: call_load_lockfile(config.lockfile, Lockfile::load_from_current_dir)
                 .map_err(InitStateError::LoadLockfile)?,
             http_client: Client::new(),
-            tarball_mem_cache: MemCache::new(HashMap::new()),
+            tarball_mem_cache: MemCache::default(),
         })
     }
 }

--- a/crates/cli/src/state.rs
+++ b/crates/cli/src/state.rs
@@ -6,6 +6,7 @@ use pacquet_package_manifest::{PackageManifest, PackageManifestError};
 use pacquet_tarball::MemCache;
 use pipe_trait::Pipe;
 use reqwest::Client;
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 /// Application state when running `pacquet run` or `pacquet install`.
@@ -44,7 +45,7 @@ impl State {
             lockfile: call_load_lockfile(config.lockfile, Lockfile::load_from_current_dir)
                 .map_err(InitStateError::LoadLockfile)?,
             http_client: Client::new(),
-            tarball_mem_cache: MemCache::new(),
+            tarball_mem_cache: MemCache::new(HashMap::new()),
         })
     }
 }

--- a/crates/cli/tests/install.rs
+++ b/crates/cli/tests/install.rs
@@ -5,7 +5,7 @@ use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pacquet_testing_utils::{
     bin::{AddMockedRegistry, CommandTempCwd},
-    fs::{get_all_files, get_all_folders, is_symlink_or_junction}, 
+    fs::{get_all_files, get_all_folders, is_symlink_or_junction},
     panic_after,
 };
 use pipe_trait::Pipe;
@@ -136,7 +136,7 @@ fn should_install_index_files() {
 #[test]
 fn should_install_duplicated_dependencies() {
     let CommandTempCwd { pacquet, root, workspace, .. } =
-        CommandTempCwd::init().add_default_npmrc();
+        CommandTempCwd::init().add_mocked_registry();
 
     eprintln!("Creating package.json...");
     let manifest_path = workspace.join("package.json");

--- a/crates/cli/tests/install.rs
+++ b/crates/cli/tests/install.rs
@@ -135,8 +135,9 @@ fn should_install_index_files() {
 
 #[test]
 fn should_install_duplicated_dependencies() {
-    let CommandTempCwd { pacquet, root, workspace, .. } =
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
 
     eprintln!("Creating package.json...");
     let manifest_path = workspace.join("package.json");
@@ -158,6 +159,5 @@ fn should_install_duplicated_dependencies() {
         assert!(is_symlink_or_junction(&workspace.join("node_modules/express")).unwrap());
         assert!(workspace.join("node_modules/.pnpm/express@4.18.2").exists());
     });
-
-    drop(root); // cleanup
+    drop((root, mock_instance)); // cleanup
 }

--- a/crates/cli/tests/install.rs
+++ b/crates/cli/tests/install.rs
@@ -5,10 +5,11 @@ use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pacquet_testing_utils::{
     bin::{AddMockedRegistry, CommandTempCwd},
-    fs::{get_all_files, get_all_folders, is_symlink_or_junction},
+    fs::{get_all_files, get_all_folders, is_symlink_or_junction}, 
+    panic_after,
 };
 use pipe_trait::Pipe;
-use std::fs;
+use std::{fs, thread, time::Duration};
 
 #[test]
 fn should_install_dependencies() {
@@ -130,4 +131,33 @@ fn should_install_index_files() {
     insta::assert_yaml_snapshot!(index_file_contents);
 
     drop((root, mock_instance)); // cleanup
+}
+
+#[test]
+fn should_install_duplicated_dependencies() {
+    let CommandTempCwd { pacquet, root, workspace, .. } =
+        CommandTempCwd::init().add_default_npmrc();
+
+    eprintln!("Creating package.json...");
+    let manifest_path = workspace.join("package.json");
+    let package_json_content = serde_json::json!({
+        "dependencies": {
+            "express": "4.18.2",
+        },
+        "devDependencies": {
+            "express": "4.18.2",
+        },
+    });
+    fs::write(manifest_path, package_json_content.to_string()).expect("write to package.json");
+
+    panic_after(Duration::from_secs(30), move || {
+        thread::sleep(Duration::from_millis(200));
+        eprintln!("Executing command...");
+        pacquet.with_arg("install").assert().success();
+        eprintln!("Make sure the package is installed");
+        assert!(is_symlink_or_junction(&workspace.join("node_modules/express")).unwrap());
+        assert!(workspace.join("node_modules/.pnpm/express@4.18.2").exists());
+    });
+
+    drop(root); // cleanup
 }

--- a/crates/cli/tests/install.rs
+++ b/crates/cli/tests/install.rs
@@ -6,7 +6,7 @@ use command_extra::CommandExtra;
 use pacquet_testing_utils::{
     bin::{AddMockedRegistry, CommandTempCwd},
     fs::{get_all_files, get_all_folders, is_symlink_or_junction},
-    panic_after,
+    misc::panic_after,
 };
 use pipe_trait::Pipe;
 use std::{fs, thread, time::Duration};

--- a/crates/tarball/Cargo.toml
+++ b/crates/tarball/Cargo.toml
@@ -16,7 +16,6 @@ pacquet-fs          = { workspace = true }
 pacquet-store-dir   = { workspace = true }
 
 base64       = { workspace = true }
-dashmap      = { workspace = true }
 derive_more  = { workspace = true }
 miette       = { workspace = true }
 pipe-trait   = { workspace = true }

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -2,7 +2,6 @@ use std::{
     collections::HashMap,
     ffi::OsString,
     io::{Cursor, Read},
-    mem::drop,
     path::PathBuf,
     sync::Arc,
     time::UNIX_EPOCH,

--- a/crates/testing-utils/src/lib.rs
+++ b/crates/testing-utils/src/lib.rs
@@ -1,22 +1,3 @@
-use std::{sync::mpsc, thread, time::Duration};
 pub mod bin;
 pub mod fs;
-
-pub fn panic_after<T, F>(d: Duration, f: F) -> T
-where
-    T: Send + 'static,
-    F: FnOnce() -> T,
-    F: Send + 'static,
-{
-    let (done_tx, done_rx) = mpsc::channel();
-    let handle = thread::spawn(move || {
-        let val = f();
-        done_tx.send(()).expect("Unable to send completion signal");
-        val
-    });
-
-    match done_rx.recv_timeout(d) {
-        Ok(_) => handle.join().expect("test panicked"),
-        Err(_) => panic!("test timeout"),
-    }
-}
+pub mod misc;

--- a/crates/testing-utils/src/lib.rs
+++ b/crates/testing-utils/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{ thread, sync::mpsc, time::Duration};
+use std::{sync::mpsc, thread, time::Duration};
 pub mod bin;
 pub mod fs;
 

--- a/crates/testing-utils/src/lib.rs
+++ b/crates/testing-utils/src/lib.rs
@@ -1,2 +1,22 @@
+use std::{ thread, sync::mpsc, time::Duration};
 pub mod bin;
 pub mod fs;
+
+pub fn panic_after<T, F>(d: Duration, f: F) -> T
+where
+    T: Send + 'static,
+    F: FnOnce() -> T,
+    F: Send + 'static,
+{
+    let (done_tx, done_rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        let val = f();
+        done_tx.send(()).expect("Unable to send completion signal");
+        val
+    });
+
+    match done_rx.recv_timeout(d) {
+        Ok(_) => handle.join().expect("test panicked"),
+        Err(_) => panic!("test timeout"),
+    }
+}

--- a/crates/testing-utils/src/misc.rs
+++ b/crates/testing-utils/src/misc.rs
@@ -1,0 +1,20 @@
+use std::{sync::mpsc, thread, time::Duration};
+
+pub fn panic_after<T, F>(d: Duration, f: F) -> T
+where
+    T: Send + 'static,
+    F: FnOnce() -> T,
+    F: Send + 'static,
+{
+    let (done_tx, done_rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        let val = f();
+        done_tx.send(()).expect("Unable to send completion signal");
+        val
+    });
+
+    match done_rx.recv_timeout(d) {
+        Ok(_) => handle.join().expect("test panicked"),
+        Err(_) => panic!("test timeout"),
+    }
+}


### PR DESCRIPTION
Let's say we have a project that has `express` in dependencies and devDependencies:

```
// package.json
  "dependencies": {
    "express": "^4.18.2"
  },
  "devDependencies": {
    "express": "^4.18.2"
  }
```

Running `pacquet/target/debug/pacquet install` over and over again under this project sometimes hangs forever.

Inspect thread's backtrace using rust-lldb you can see that there seems to be a deadlock in the dashmap:

```
(lldb) thread list
Process 19187 stopped
* thread #1: tid = 0x1c7fe, 0x00007ff80c7670ee libsystem_kernel.dylib`__psynch_cvwait + 10, name = 'main', queue = 'com.apple.main-thread', stop reason = signal SIGSTOP
  thread #2: tid = 0x1c80b, 0x00007ff80c7670ee libsystem_kernel.dylib`__psynch_cvwait + 10, name = 'tokio-runtime-worker'
  thread #3: tid = 0x1c80c, 0x00007ff80c7670ee libsystem_kernel.dylib`__psynch_cvwait + 10, name = 'tokio-runtime-worker'
  thread #4: tid = 0x1c80d, 0x00007ff80c7670ee libsystem_kernel.dylib`__psynch_cvwait + 10, name = 'tokio-runtime-worker'
  thread #5: tid = 0x1c80e, 0x00007ff80c7670ee libsystem_kernel.dylib`__psynch_cvwait + 10, name = 'tokio-runtime-worker'
  thread #6: tid = 0x1c80f, 0x00007ff80c7670ee libsystem_kernel.dylib`__psynch_cvwait + 10, name = 'tokio-runtime-worker'
  thread #7: tid = 0x1c810, 0x00007ff80c7670ee libsystem_kernel.dylib`__psynch_cvwait + 10, name = 'tokio-runtime-worker'
  thread #8: tid = 0x1c811, 0x00007ff80c7670ee libsystem_kernel.dylib`__psynch_cvwait + 10, name = 'tokio-runtime-worker'
  thread #9: tid = 0x1c812, 0x00007ff80c7670ee libsystem_kernel.dylib`__psynch_cvwait + 10, name = 'tokio-runtime-worker'
  thread #10: tid = 0x1c813, 0x00007ff80c7670ee libsystem_kernel.dylib`__psynch_cvwait + 10, name = 'tokio-runtime-worker'
  thread #11: tid = 0x1c814, 0x00007ff80c7691ee libsystem_kernel.dylib`kevent + 10, name = 'tokio-runtime-worker'
  thread #12: tid = 0x1c815, 0x00007ff80c7670ee libsystem_kernel.dylib`__psynch_cvwait + 10, name = 'tokio-runtime-worker'
  thread #13: tid = 0x1c816, 0x00007ff80c7670ee libsystem_kernel.dylib`__psynch_cvwait + 10, name = 'tokio-runtime-worker'
  thread #14: tid = 0x1c8c7, 0x0000000000000000
(lldb) thread backtrace
* thread #1, name = 'main', queue = 'com.apple.main-thread', stop reason = signal SIGSTOP
  * frame #0: 0x00007ff80c7670ee libsystem_kernel.dylib`__psynch_cvwait + 10
    frame #1: 0x00007ff80c7a3758 libsystem_pthread.dylib`_pthread_cond_wait + 1242
    frame #2: 0x0000000101f8885a pacquet`_$LT$parking_lot_core..thread_parker..imp..ThreadParker$u20$as$u20$parking_lot_core..thread_parker..ThreadParkerT$GT$::park::h901dec8d6c82d511(self=0x00007fd753904620) at unix.rs:77:21
    frame #3: 0x0000000101f8681d pacquet`parking_lot_core::parking_lot::park::_$u7b$$u7b$closure$u7d$$u7d$::hf6f0000f30670c25(thread_data=0x00007fd753904620) at parking_lot.rs:635:17
    frame #4: 0x0000000101f85a7a pacquet`parking_lot_core::parking_lot::park::h7573f0f4d6138281 at parking_lot.rs:207:5
    frame #5: 0x0000000101f8599f pacquet`parking_lot_core::parking_lot::park::h7573f0f4d6138281(key=140562837595088, validate={closure_env#0} @ 0x00007ff7be08f878, before_sleep={closure_env#1} @ 0x00007ff7be08f886, timed_out={closure_env#2} @ 0x00007ff7be08f887, park_token=ParkToken @ 0x00007ff7be08f840, timeout=Option<std::time::Instant> @ 0x00007ff7be08f848) at parking_lot.rs:600:5
    frame #6: 0x0000000102b04394 pacquet`dashmap::lock::RawRwLock::lock_exclusive_slow::hf285450ddd71acbc(self=0x00007fd75600e3d0) at lock.rs:127:21
    frame #7: 0x0000000101ee3ce5 pacquet`_$LT$dashmap..lock..RawRwLock$u20$as$u20$lock_api..rwlock..RawRwLock$GT$::lock_exclusive::h759a7154a4d567da(self=0x00007fd75600e3d0) at lock.rs:39:13
    frame #8: 0x0000000101ee3ae5 pacquet`lock_api::rwlock::RwLock$LT$R$C$T$GT$::write::h815e856b6c8b2ff2(self=0x00007fd75600e3d0) at rwlock.rs:480:9
    frame #9: 0x0000000101ecbcb5 pacquet`_$LT$dashmap..DashMap$LT$K$C$V$C$S$GT$$u20$as$u20$dashmap..t..Map$LT$K$C$V$C$S$GT$$GT$::_yield_write_shard::hc66de80739a70aa5(self=0x00007ff7be0a0c18, i=54) at lib.rs:897:9
    frame #10: 0x0000000101ecbf0f pacquet`_$LT$dashmap..DashMap$LT$K$C$V$C$S$GT$$u20$as$u20$dashmap..t..Map$LT$K$C$V$C$S$GT$$GT$::_insert::h00b54d0a5a90f554(self=0x00007ff7be0a0c18, key="https://registry.npmjs.org/etag/-/etag-1.8.1.tgz", value=strong=2, weak=0) at lib.rs:923:34
    frame #11: 0x0000000101ecbb05 pacquet`dashmap::DashMap$LT$K$C$V$C$S$GT$::insert::h1a302dff1cb874ef(self=0x00007ff7be0a0c18, key=<unavailable>, value=strong=2, weak=0) at lib.rs:459:9
    frame #12: 0x0000000101f0a0b9 pacquet`pacquet_tarball::DownloadTarballToStore::run_with_mem_cache::_$u7b$$u7b$closure$u7d$$u7d$::h3f64b7dfdb11ee17((null)=0x00007ff7be096750) at lib.rs:155:16
    frame #13: 0x0000000101f06eb0 pacquet`pacquet_package_manager::install_package_from_registry::InstallPackageFromRegistry::install_package_version::_$u7b$$u7b$closure$u7d$$u7d$::h39469df5cf1dd94c((null)=0x00007ff7be096750) at install_package_from_registry.rs:93:10
    frame #14: 0x0000000101f068d8 pacquet`pacquet_package_manager::install_package_from_registry::InstallPackageFromRegistry::run::_$u7b$$u7b$closure$u7d$$u7d$::h353ed9cd774f2404((null)=0x00007ff7be096750) at install_package_from_registry.rs:61:59
    frame #15: 0x0000000101f28c03 pacquet`pacquet_package_manager::install_without_lockfile::InstallWithoutLockfile$LT$$LP$$RP$$GT$::install_dependencies_from_registry::_$u7b$$u7b$closure$u7d$$u7d$::_$u7b$$u7b$closure$u7d$$u7d$::_$u7b$$u7b$closure$u7d$$u7d$::h80c7f76aaa118353((null)=0x00007ff7be096750) at install_without_lockfile.rs:100:18
    frame #16: 0x0000000101efef7d pacquet`_$LT$futures_util..stream..futures_ordered..OrderWrapper$LT$T$GT$$u20$as$u20$core..future..future..Future$GT$::poll::h331dc0890632c4ce(self=Pin<&mut futures_util::stream::futures_ordered::OrderWrapper<pacquet_package_manager::install_without_lockfile::{impl#1}::install_dependencies_from_registry::{async_block#0}::{closure#0}::{async_block_env#0}>> @ 0x00007ff7be096510, cx=0x00007ff7be096750) at futures_ordered.rs:55:9
    frame #17: 0x0000000101ed3fc5 pacquet`_$LT$futures_util..stream..futures_unordered..FuturesUnordered$LT$Fut$GT$$u20$as$u20$futures_core..stream..Stream$GT$::poll_next::hbe129c38375cab09(self=Pin<&mut futures_util::stream::futures_unordered::FuturesUnordered<futures_util::stream::futures_ordered::OrderWrapper<pacquet_package_manager::install_without_lockfile::{impl#1}::install_dependencies_from_registry::{async_block#0}::{closure#0}::{async_block_env#0}>>> @ 0x00007ff7be096650, cx=0x00007ff7be098970) at mod.rs:518:17
    frame #18: 0x0000000101ed5c01 pacquet`futures_util::stream::stream::StreamExt::poll_next_unpin::hc09dfe6a154413a8(self=0x0000600002ab8778, cx=0x00007ff7be098970) at mod.rs:1632:9
    frame #19: 0x0000000101eff183 pacquet`_$LT$futures_util..stream..futures_ordered..FuturesOrdered$LT$Fut$GT$$u20$as$u20$futures_core..stream..Stream$GT$::poll_next::hb951f6867c98c605(self=Pin<&mut futures_util::stream::futures_ordered::FuturesOrdered<pacquet_package_manager::install_without_lockfile::{impl#1}::install_dependencies_from_registry::{async_block#0}::{closure#0}::{async_block_env#0}>> @ 0x00007ff7be096868, cx=0x00007ff7be098970) at futures_ordered.rs:190:26
    frame #20: 0x0000000101f29604 pacquet`_$LT$futures_util..stream..stream..collect..Collect$LT$St$C$C$GT$$u20$as$u20$core..future..future..Future$GT$::poll::hb5fafae2ec03e571(self=Pin<&mut futures_util::stream::stream::collect::Collect<futures_util::stream::futures_ordered::FuturesOrdered<pacquet_package_manager::install_without_lockfile::{impl#1}::install_dependencies_from_registry::{async_block#0}::{closure#0}::{async_block_env#0}>, alloc::vec::Vec<(), alloc::alloc::Global>>> @ 0x00007ff7be096918, cx=0x00007ff7be098970) at collect.rs:50:26
    frame #21: 0x0000000101ef7657 pacquet`_$LT$futures_util..future..join_all..JoinAll$LT$F$GT$$u20$as$u20$core..future..future..Future$GT$::poll::h039afb5b7efc154e(self=Pin<&mut futures_util::future::join_all::JoinAll<pacquet_package_manager::install_without_lockfile::{impl#1}::install_dependencies_from_registry::{async_block#0}::{closure#0}::{async_block_env#0}>> @ 0x00007ff7be096a20, cx=0x00007ff7be098970) at join_all.rs:157:41
    frame #22: 0x0000000101f2822e pacquet`pacquet_package_manager::install_without_lockfile::InstallWithoutLockfile$LT$$LP$$RP$$GT$::install_dependencies_from_registry::_$u7b$$u7b$closure$u7d$$u7d$::hbffb66c18bd4a4e7((null)=0x00007ff7be098970) at install_without_lockfile.rs:105:14
    frame #23: 0x0000000101ed6f20 pacquet`_$LT$core..pin..Pin$LT$P$GT$$u20$as$u20$core..future..future..Future$GT$::poll::h59adedcf45602e2c(self=Pin<&mut core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output=()> + core::marker::Send), alloc::alloc::Global>>> @ 0x00007ff7be0975f8, cx=0x00007ff7be098970) at future.rs:125:9
    frame #24: 0x0000000101ea906d pacquet`pacquet_package_manager::install_without_lockfile::InstallWithoutLockfile$LT$DependencyGroupList$GT$::run::_$u7b$$u7b$closure$u7d$$u7d$::_$u7b$$u7b$closure$u7d$$u7d$::_$u7b$$u7b$closure$u7d$$u7d$::h764f14b1de4dc53d((null)=0x00007ff7be098970) at install_without_lockfile.rs:67:18
    frame #25: 0x0000000101ea24ad pacquet`_$LT$futures_util..stream..futures_ordered..OrderWrapper$LT$T$GT$$u20$as$u20$core..future..future..Future$GT$::poll::h15ec92cc022ac7e1(self=Pin<&mut futures_util::stream::futures_ordered::OrderWrapper<pacquet_package_manager::install_without_lockfile::{impl#0}::run::{async_fn#0}::{closure#0}::{async_block_env#0}<core::iter::adapters::chain::Chain<core::iter::adapters::chain::Chain<core::iter::adapters::chain::Chain<core::iter::sources::empty::Empty<pacquet_package_manifest::DependencyGroup>, core::option::IntoIter<pacquet_package_manifest::DependencyGroup>>, core::option::IntoIter<pacquet_package_manifest::DependencyGroup>>, core::option::IntoIter<pacquet_package_manifest::DependencyGroup>>>>> @ 0x00007ff7be098730, cx=0x00007ff7be098970) at futures_ordered.rs:55:9
    frame #26: 0x0000000101e74515 pacquet`_$LT$futures_util..stream..futures_unordered..FuturesUnordered$LT$Fut$GT$$u20$as$u20$futures_core..stream..Stream$GT$::poll_next::h1be25d9d3cf19b96(self=Pin<&mut futures_util::stream::futures_unordered::FuturesUnordered<futures_util::stream::futures_ordered::OrderWrapper<pacquet_package_manager::install_without_lockfile::{impl#0}::run::{async_fn#0}::{closure#0}::{async_block_env#0}<core::iter::adapters::chain::Chain<core::iter::adapters::chain::Chain<core::iter::adapters::chain::Chain<core::iter::sources::empty::Empty<pacquet_package_manifest::DependencyGroup>, core::option::IntoIter<pacquet_package_manifest::DependencyGroup>>, core::option::IntoIter<pacquet_package_manifest::DependencyGroup>>, core::option::IntoIter<pacquet_package_manifest::DependencyGroup>>>>>> @ 0x00007ff7be098870, cx=0x00007ff7be0a07e8) at mod.rs:518:17
    frame #27: 0x0000000101e7a6f1 pacquet`futures_util::stream::stream::StreamExt::poll_next_unpin::h66befaa29111ca72(self=0x00007ff7be0a0b60, cx=0x00007ff7be0a07e8) at mod.rs:1632:9
    frame #28: 0x0000000101ea27b3 pacquet`_$LT$futures_util..stream..futures_ordered..FuturesOrdered$LT$Fut$GT$$u20$as$u20$futures_core..stream..Stream$GT$::poll_next::hb7e87eab8b6cc693(self=Pin<&mut futures_util::stream::futures_ordered::FuturesOrdered<pacquet_package_manager::install_without_lockfile::{impl#0}::run::{async_fn#0}::{closure#0}::{async_block_env#0}<core::iter::adapters::chain::Chain<core::iter::adapters::chain::Chain<core::iter::adapters::chain::Chain<core::iter::sources::empty::Empty<pacquet_package_manifest::DependencyGroup>, core::option::IntoIter<pacquet_package_manifest::DependencyGroup>>, core::option::IntoIter<pacquet_package_manifest::DependencyGroup>>, core::option::IntoIter<pacquet_package_manifest::DependencyGroup>>>>> @ 0x00007ff7be098a88, cx=0x00007ff7be0a07e8) at futures_ordered.rs:190:26
    frame #29: 0x0000000101e97804 pacquet`_$LT$futures_util..stream..stream..collect..Collect$LT$St$C$C$GT$$u20$as$u20$core..future..future..Future$GT$::poll::h475c0329ed622f55(self=Pin<&mut futures_util::stream::stream::collect::Collect<futures_util::stream::futures_ordered::FuturesOrdered<pacquet_package_manager::install_without_lockfile::{impl#0}::run::{async_fn#0}::{closure#0}::{async_block_env#0}<core::iter::adapters::chain::Chain<core::iter::adapters::chain::Chain<core::iter::adapters::chain::Chain<core::iter::sources::empty::Empty<pacquet_package_manifest::DependencyGroup>, core::option::IntoIter<pacquet_package_manifest::DependencyGroup>>, core::option::IntoIter<pacquet_package_manifest::DependencyGroup>>, core::option::IntoIter<pacquet_package_manifest::DependencyGroup>>>>, alloc::vec::Vec<(), alloc::alloc::Global>>> @ 0x00007ff7be098b38, cx=0x00007ff7be0a07e8) at collect.rs:50:26
    frame #30: 0x0000000101e5f347 pacquet`_$LT$futures_util..future..join_all..JoinAll$LT$F$GT$$u20$as$u20$core..future..future..Future$GT$::poll::h2004fdfddbbd37f7(self=Pin<&mut futures_util::future::join_all::JoinAll<pacquet_package_manager::install_without_lockfile::{impl#0}::run::{async_fn#0}::{closure#0}::{async_block_env#0}<core::iter::adapters::chain::Chain<core::iter::adapters::chain::Chain<core::iter::adapters::chain::Chain<core::iter::sources::empty::Empty<pacquet_package_manifest::DependencyGroup>, core::option::IntoIter<pacquet_package_manifest::DependencyGroup>>, core::option::IntoIter<pacquet_package_manifest::DependencyGroup>>, core::option::IntoIter<pacquet_package_manifest::DependencyGroup>>>>> @ 0x00007ff7be098c40, cx=0x00007ff7be0a07e8) at join_all.rs:157:41
    frame #31: 0x0000000101ea8278 pacquet`pacquet_package_manager::install_without_lockfile::InstallWithoutLockfile$LT$DependencyGroupList$GT$::run::_$u7b$$u7b$closure$u7d$$u7d$::h5279e414d3ac9c8f((null)=0x00007ff7be0a07e8) at install_without_lockfile.rs:70:14
    frame #32: 0x0000000101e5d52c pacquet`pacquet_package_manager::install::Install$LT$DependencyGroupList$GT$::run::_$u7b$$u7b$closure$u7d$$u7d$::hdd263e747923347f((null)=0x00007ff7be0a07e8) at install.rs:51:18
    frame #33: 0x0000000101e5dffd pacquet`pacquet_cli::cli_args::install::InstallArgs::run::_$u7b$$u7b$closure$u7d$$u7d$::h1d5e5bc4af22f316((null)=0x00007ff7be0a07e8) at install.rs:65:10
    frame #34: 0x0000000101e611cc pacquet`pacquet_cli::cli_args::CliArgs::run::_$u7b$$u7b$closure$u7d$$u7d$::he0259bf7ff7d4fdb((null)=0x00007ff7be0a07e8) at cli_args.rs:65:61
    frame #35: 0x0000000101e822d6 pacquet`pacquet_cli::main::_$u7b$$u7b$closure$u7d$$u7d$::h72ed04d395be81e4((null)=0x00007ff7be0a07e8) at lib.rs:13:28
    frame #36: 0x0000000101e5b8a3 pacquet`pacquet::main::_$u7b$$u7b$closure$u7d$$u7d$::h5b27071a787da554((null)=0x00007ff7be0a07e8) at main.rs:3:25
    frame #37: 0x0000000101e83002 pacquet`tokio::runtime::park::CachedParkThread::block_on::_$u7b$$u7b$closure$u7d$$u7d$::hddb7a5e4f7256cf4 at park.rs:283:63
    frame #38: 0x0000000101e82e31 pacquet`tokio::runtime::park::CachedParkThread::block_on::h5ffbb6a446bf7df4 at coop.rs:107:5
    frame #39: 0x0000000101e82dc7 pacquet`tokio::runtime::park::CachedParkThread::block_on::h5ffbb6a446bf7df4 [inlined] tokio::runtime::coop::budget::heca54b564cf92ee2(f={closure_env#0}<pacquet::main::{async_block_env#0}> @ 0x00007ff7be0a1548) at coop.rs:73:5
    frame #40: 0x0000000101e82d43 pacquet`tokio::runtime::park::CachedParkThread::block_on::h5ffbb6a446bf7df4(self=0x00007ff7be0a15df, f={async_block_env#0} @ 0x00007ff7be0a15e0) at park.rs:283:31
    frame #41: 0x0000000101e7a8c1 pacquet`tokio::runtime::context::blocking::BlockingRegionGuard::block_on::h8c9921ac00e5e534(self=0x00007ff7be0a3048, f={async_block_env#0} @ 0x00007ff7be0a22f8) at blocking.rs:66:9
    frame #42: 0x0000000101e801f0 pacquet`tokio::runtime::scheduler::multi_thread::MultiThread::block_on::_$u7b$$u7b$closure$u7d$$u7d$::h1e04f13f5ef259a1(blocking=0x00007ff7be0a3048) at mod.rs:87:13
    frame #43: 0x0000000101e98a64 pacquet`tokio::runtime::context::runtime::enter_runtime::h633aa6f4b970d737(handle=0x00007ff7be0a7268, allow_block_in_place=true, f={closure_env#0}<pacquet::main::{async_block_env#0}> @ 0x00007ff7be0a3dc0) at runtime.rs:65:16
    frame #44: 0x0000000101e8019b pacquet`tokio::runtime::scheduler::multi_thread::MultiThread::block_on::h840ca0aa5089a8b0(self=0x00007ff7be0a7240, handle=0x00007ff7be0a7268, future=<unavailable>) at mod.rs:86:9
    frame #45: 0x0000000101e7fcde pacquet`tokio::runtime::runtime::Runtime::block_on::hef52f1f93b1039a7(self=0x00007ff7be0a7238, future={async_block_env#0} @ 0x00007ff7be0a7398) at runtime.rs:313:45
    frame #46: 0x0000000101e9e47f pacquet`pacquet::main::h75bb93d8b2c5adcc at main.rs:3:5
    frame #47: 0x0000000101e6db6e pacquet`core::ops::function::FnOnce::call_once::hc6ed0eaeaead1dbf((null)=(pacquet`pacquet::main::h75bb93d8b2c5adcc at main.rs:2), (null)=<unavailable>) at function.rs:250:5
    frame #48: 0x0000000101e7df91 pacquet`std::sys_common::backtrace::__rust_begin_short_backtrace::heeac9e61e07c83b4(f=(pacquet`pacquet::main::h75bb93d8b2c5adcc at main.rs:2)) at backtrace.rs:154:18
    frame #49: 0x0000000101e9e364 pacquet`std::rt::lang_start::_$u7b$$u7b$closure$u7d$$u7d$::h85e885c88739b978 at rt.rs:166:18
    frame #50: 0x0000000102ac5a4a pacquet`std::rt::lang_start_internal::h54faea1e36783632 [inlined] core::ops::function::impls::_$LT$impl$u20$core..ops..function..FnOnce$LT$A$GT$$u20$for$u20$$RF$F$GT$::call_once::hcfff0e1d84ed81c5 at function.rs:284:13 [opt]
    frame #51: 0x0000000102ac5a3d pacquet`std::rt::lang_start_internal::h54faea1e36783632 [inlined] std::panicking::try::do_call::hbabf83ee9c686a7b at panicking.rs:502:40 [opt]
    frame #52: 0x0000000102ac5a3d pacquet`std::rt::lang_start_internal::h54faea1e36783632 [inlined] std::panicking::try::he3e9a1c93c50f591 at panicking.rs:466:19 [opt]
    frame #53: 0x0000000102ac5a3d pacquet`std::rt::lang_start_internal::h54faea1e36783632 [inlined] std::panic::catch_unwind::ha18733e497b82774 at panic.rs:142:14 [opt]
    frame #54: 0x0000000102ac5a3d pacquet`std::rt::lang_start_internal::h54faea1e36783632 [inlined] std::rt::lang_start_internal::_$u7b$$u7b$closure$u7d$$u7d$::hfb6977160fe64fc0 at rt.rs:148:48 [opt]
    frame #55: 0x0000000102ac5a3d pacquet`std::rt::lang_start_internal::h54faea1e36783632 [inlined] std::panicking::try::do_call::h385fcb260f1f324b at panicking.rs:502:40 [opt]
    frame #56: 0x0000000102ac5a3d pacquet`std::rt::lang_start_internal::h54faea1e36783632 [inlined] std::panicking::try::h3734e87bdbb1b067 at panicking.rs:466:19 [opt]
    frame #57: 0x0000000102ac5a3d pacquet`std::rt::lang_start_internal::h54faea1e36783632 [inlined] std::panic::catch_unwind::hc13dbc187cd64fe1 at panic.rs:142:14 [opt]
    frame #58: 0x0000000102ac5a3d pacquet`std::rt::lang_start_internal::h54faea1e36783632 at rt.rs:148:20 [opt]
    frame #59: 0x0000000101e9e337 pacquet`std::rt::lang_start::hd05a88e7ef5041fc(main=(pacquet`pacquet::main::h75bb93d8b2c5adcc at main.rs:2), argc=2, argv=0x00007ff7be0a84d0, sigpipe='\0') at rt.rs:165:17
    frame #60: 0x0000000101e9e518 pacquet`main + 24
    frame #61: 0x00007ff80c44941f dyld`start + 1903
```

It looks like dashmap [doesn't recommend keeping references across `.await`](https://github.com/xacrimon/dashmap/issues/150#issuecomment-1030858774), which should also be the cause of the deadlock here, if I understand correctly.

Since I'm new to Rust, I'm not sure if there's a better way to solve this problem, I tried replacing the dashmap with `RwLock` like in this PR and it seems to work fine.



