### PR TITLE
perf(tarball): use tokio::task::spawn_blocking

### DIFF
--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -200,7 +200,7 @@ impl<'a> DownloadTarballToStore<'a> {
             Checksum(ssri::Error),
             Other(TarballError),
         }
-        let cas_paths = tokio::task::spawn(async move {
+        let cas_paths = tokio::task::spawn_blocking(move || {
             verify_checksum(&response, package_integrity.clone()).map_err(TaskError::Checksum)?;
 
             // TODO: move tarball extraction to its own function

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -17,7 +17,7 @@ use pacquet_store_dir::{
 };
 use pipe_trait::Pipe;
 use reqwest::Client;
-use ssri::{Integrity, IntegrityChecker};
+use ssri::Integrity;
 use tar::Archive;
 use tokio::sync::{Notify, RwLock};
 use tracing::instrument;
@@ -101,11 +101,6 @@ fn decompress_gzip(gz_data: &[u8], unpacked_size: Option<usize>) -> Result<Vec<u
     DeflateDecoder::new_with_options(gz_data, options)
         .decode_gzip()
         .map_err(TarballError::DecodeGzip)
-}
-
-#[instrument(skip(data), fields(data_len = data.len()))]
-fn verify_checksum(data: &[u8], integrity: Integrity) -> Result<ssri::Algorithm, ssri::Error> {
-    integrity.pipe(IntegrityChecker::new).chain(data).result()
 }
 
 /// This subroutine downloads and extracts a tarball to the store directory.
@@ -201,7 +196,7 @@ impl<'a> DownloadTarballToStore<'a> {
             Other(TarballError),
         }
         let cas_paths = tokio::task::spawn(async move {
-            verify_checksum(&response, package_integrity.clone()).map_err(TaskError::Checksum)?;
+            package_integrity.check(&response).map_err(TaskError::Checksum)?;
 
             // TODO: move tarball extraction to its own function
             // TODO: test it


### PR DESCRIPTION
Thanks @TmLev for the [suggestion](https://github.com/pnpm/pacquet/commit/09521309d668dc5533e55d9137e50a8388bde379#r132721109).

The benchmark proved that `spawn_blocking` does improve the performance, even if it's only slightly.