### PR TITLE
test(lib): use registry-mock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1453,6 +1453,7 @@ dependencies = [
  "pacquet-npmrc",
  "pacquet-package-manifest",
  "pacquet-registry",
+ "pacquet-registry-mock",
  "pacquet-store-dir",
  "pacquet-tarball",
  "pacquet-testing-utils",

--- a/crates/package-manager/Cargo.toml
+++ b/crates/package-manager/Cargo.toml
@@ -31,6 +31,7 @@ miette          = { workspace = true }
 
 [dev-dependencies]
 pacquet-store-dir     = { workspace = true }
+pacquet-registry-mock = { workspace = true }
 pacquet-testing-utils = { workspace = true }
 
 node-semver       = { workspace = true }

--- a/crates/package-manager/src/install.rs
+++ b/crates/package-manager/src/install.rs
@@ -78,12 +78,15 @@ mod tests {
     use super::*;
     use pacquet_npmrc::Npmrc;
     use pacquet_package_manifest::{DependencyGroup, PackageManifest};
+    use pacquet_registry_mock::AutoMockInstance;
     use pacquet_testing_utils::fs::{get_all_folders, is_symlink_or_junction};
     use std::env;
     use tempfile::tempdir;
 
     #[tokio::test]
     async fn should_install_dependencies() {
+        let mock_instance = AutoMockInstance::load_or_init();
+
         let dir = tempdir().unwrap();
         let store_dir = dir.path().join("pacquet-store");
         let project_root = dir.path().join("project");
@@ -104,6 +107,7 @@ mod tests {
         config.store_dir = store_dir.into();
         config.modules_dir = modules_dir.to_path_buf();
         config.virtual_store_dir = virtual_store_dir.to_path_buf();
+        config.registry = mock_instance.url();
         let config = config.leak();
 
         Install {
@@ -138,5 +142,7 @@ mod tests {
             .is_dir());
 
         insta::assert_debug_snapshot!(get_all_folders(&project_root));
+
+        drop((dir, mock_instance)); // cleanup
     }
 }

--- a/crates/package-manager/src/install.rs
+++ b/crates/package-manager/src/install.rs
@@ -96,10 +96,10 @@ mod tests {
         let manifest_path = dir.path().join("package.json");
         let mut manifest = PackageManifest::create_if_needed(manifest_path.clone()).unwrap();
 
-        manifest.add_dependency("is-odd", "3.0.1", DependencyGroup::Prod).unwrap();
         manifest
-            .add_dependency("fast-decode-uri-component", "1.0.1", DependencyGroup::Dev)
+            .add_dependency("@pnpm.e2e/hello-world-js-bin", "1.0.0", DependencyGroup::Prod)
             .unwrap();
+        manifest.add_dependency("@pnpm/xyz", "1.0.0", DependencyGroup::Dev).unwrap();
 
         manifest.save().unwrap();
 
@@ -127,19 +127,15 @@ mod tests {
         .await;
 
         // Make sure the package is installed
-        assert!(is_symlink_or_junction(&project_root.join("node_modules/is-odd")).unwrap());
-        assert!(project_root.join("node_modules/.pacquet/is-odd@3.0.1").exists());
-        // Make sure it installs direct dependencies
-        assert!(!project_root.join("node_modules/is-number").exists());
-        assert!(project_root.join("node_modules/.pacquet/is-number@6.0.0").exists());
+        let path = project_root.join("node_modules/@pnpm.e2e/hello-world-js-bin");
+        assert!(is_symlink_or_junction(&path).unwrap());
+        let path = project_root.join("node_modules/.pacquet/@pnpm.e2e+hello-world-js-bin@1.0.0");
+        assert!(path.exists());
         // Make sure we install dev-dependencies as well
-        assert!(is_symlink_or_junction(
-            &project_root.join("node_modules/fast-decode-uri-component")
-        )
-        .unwrap());
-        assert!(project_root
-            .join("node_modules/.pacquet/fast-decode-uri-component@1.0.1")
-            .is_dir());
+        let path = project_root.join("node_modules/@pnpm/xyz");
+        assert!(is_symlink_or_junction(&path).unwrap());
+        let path = project_root.join("node_modules/.pacquet/@pnpm+xyz@1.0.0");
+        assert!(path.is_dir());
 
         insta::assert_debug_snapshot!(get_all_folders(&project_root));
 

--- a/crates/package-manager/src/snapshots/pacquet_package_manager__install__tests__should_install_dependencies.snap
+++ b/crates/package-manager/src/snapshots/pacquet_package_manager__install__tests__should_install_dependencies.snap
@@ -1,21 +1,36 @@
 ---
-source: crates/package_manager/src/install.rs
-assertion_line: 184
+source: crates/package-manager/src/install.rs
+assertion_line: 140
 expression: get_all_folders(&project_root)
 ---
 [
     "node_modules",
     "node_modules/.pacquet",
-    "node_modules/.pacquet/fast-decode-uri-component@1.0.1",
-    "node_modules/.pacquet/fast-decode-uri-component@1.0.1/node_modules",
-    "node_modules/.pacquet/fast-decode-uri-component@1.0.1/node_modules/fast-decode-uri-component",
-    "node_modules/.pacquet/is-number@6.0.0",
-    "node_modules/.pacquet/is-number@6.0.0/node_modules",
-    "node_modules/.pacquet/is-number@6.0.0/node_modules/is-number",
-    "node_modules/.pacquet/is-odd@3.0.1",
-    "node_modules/.pacquet/is-odd@3.0.1/node_modules",
-    "node_modules/.pacquet/is-odd@3.0.1/node_modules/is-number",
-    "node_modules/.pacquet/is-odd@3.0.1/node_modules/is-odd",
-    "node_modules/fast-decode-uri-component",
-    "node_modules/is-odd",
+    "node_modules/.pacquet/@pnpm+x@1.0.0",
+    "node_modules/.pacquet/@pnpm+x@1.0.0/node_modules",
+    "node_modules/.pacquet/@pnpm+x@1.0.0/node_modules/@pnpm",
+    "node_modules/.pacquet/@pnpm+x@1.0.0/node_modules/@pnpm/x",
+    "node_modules/.pacquet/@pnpm+xyz@1.0.0",
+    "node_modules/.pacquet/@pnpm+xyz@1.0.0/node_modules",
+    "node_modules/.pacquet/@pnpm+xyz@1.0.0/node_modules/@pnpm",
+    "node_modules/.pacquet/@pnpm+xyz@1.0.0/node_modules/@pnpm/x",
+    "node_modules/.pacquet/@pnpm+xyz@1.0.0/node_modules/@pnpm/xyz",
+    "node_modules/.pacquet/@pnpm+xyz@1.0.0/node_modules/@pnpm/y",
+    "node_modules/.pacquet/@pnpm+xyz@1.0.0/node_modules/@pnpm/z",
+    "node_modules/.pacquet/@pnpm+y@1.0.0",
+    "node_modules/.pacquet/@pnpm+y@1.0.0/node_modules",
+    "node_modules/.pacquet/@pnpm+y@1.0.0/node_modules/@pnpm",
+    "node_modules/.pacquet/@pnpm+y@1.0.0/node_modules/@pnpm/y",
+    "node_modules/.pacquet/@pnpm+z@1.0.0",
+    "node_modules/.pacquet/@pnpm+z@1.0.0/node_modules",
+    "node_modules/.pacquet/@pnpm+z@1.0.0/node_modules/@pnpm",
+    "node_modules/.pacquet/@pnpm+z@1.0.0/node_modules/@pnpm/z",
+    "node_modules/.pacquet/@pnpm.e2e+hello-world-js-bin@1.0.0",
+    "node_modules/.pacquet/@pnpm.e2e+hello-world-js-bin@1.0.0/node_modules",
+    "node_modules/.pacquet/@pnpm.e2e+hello-world-js-bin@1.0.0/node_modules/@pnpm.e2e",
+    "node_modules/.pacquet/@pnpm.e2e+hello-world-js-bin@1.0.0/node_modules/@pnpm.e2e/hello-world-js-bin",
+    "node_modules/@pnpm",
+    "node_modules/@pnpm/xyz",
+    "node_modules/@pnpm.e2e",
+    "node_modules/@pnpm.e2e/hello-world-js-bin",
 ]


### PR DESCRIPTION
I forgot that the workspace member `package-manager` also has a test that relies on the registry.