### PR TITLE
refactor: use utf8 strings as mem cache keys

### DIFF
--- a/crates/cli/tests/install.rs
+++ b/crates/cli/tests/install.rs
@@ -12,7 +12,6 @@ use pipe_trait::Pipe;
 use std::{
     fs::{self, OpenOptions},
     io::Write,
-    path::Path,
 };
 
 #[test]
@@ -165,6 +164,8 @@ fn frozen_lockfile_should_be_able_to_handle_big_lockfile() {
 
     eprintln!("Executing command...");
     pacquet.with_args(["install", "--frozen-lockfile"]).assert().success();
+
+    drop((root, mock_instance)); // cleanup
 }
 
 #[test]

--- a/crates/package-manager/src/create_cas_files.rs
+++ b/crates/package-manager/src/create_cas_files.rs
@@ -5,7 +5,6 @@ use pacquet_npmrc::PackageImportMethod;
 use rayon::prelude::*;
 use std::{
     collections::HashMap,
-    ffi::OsString,
     path::{Path, PathBuf},
 };
 
@@ -22,7 +21,7 @@ pub enum CreateCasFilesError {
 pub fn create_cas_files(
     import_method: PackageImportMethod,
     dir_path: &Path,
-    cas_paths: &HashMap<OsString, PathBuf>,
+    cas_paths: &HashMap<String, PathBuf>,
 ) -> Result<(), CreateCasFilesError> {
     assert_eq!(
         import_method,

--- a/crates/package-manager/src/create_virtual_dir_by_snapshot.rs
+++ b/crates/package-manager/src/create_virtual_dir_by_snapshot.rs
@@ -5,7 +5,6 @@ use pacquet_lockfile::{DependencyPath, PackageSnapshot};
 use pacquet_npmrc::PackageImportMethod;
 use std::{
     collections::HashMap,
-    ffi::OsString,
     fs, io,
     path::{Path, PathBuf},
 };
@@ -14,7 +13,7 @@ use std::{
 #[must_use]
 pub struct CreateVirtualDirBySnapshot<'a> {
     pub virtual_store_dir: &'a Path,
-    pub cas_paths: &'a HashMap<OsString, PathBuf>,
+    pub cas_paths: &'a HashMap<String, PathBuf>,
     pub import_method: PackageImportMethod,
     pub dependency_path: &'a DependencyPath,
     pub package_snapshot: &'a PackageSnapshot,

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -237,9 +237,7 @@ impl<'a> DownloadTarballToStore<'a> {
                     .write_cas_file(&buffer, file_is_executable)
                     .map_err(TarballError::WriteCasFile)?;
 
-                let tarball_index_key = cleaned_entry_path.clone();
-
-                if let Some(previous) = cas_paths.insert(cleaned_entry_path, file_path) {
+                if let Some(previous) = cas_paths.insert(cleaned_entry_path.clone(), file_path) {
                     tracing::warn!(?previous, "Duplication detected. Old entry has been ejected");
                 }
 
@@ -253,7 +251,7 @@ impl<'a> DownloadTarballToStore<'a> {
                     size: file_size,
                 };
 
-                if let Some(previous) = pkg_files_idx.files.insert(tarball_index_key, file_attrs) {
+                if let Some(previous) = pkg_files_idx.files.insert(cleaned_entry_path, file_attrs) {
                     tracing::warn!(?previous, "Duplication detected. Old entry has been ejected");
                 }
             }

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::HashMap,
-    ffi::OsString,
     io::{Cursor, Read},
     path::PathBuf,
     sync::Arc,
@@ -82,7 +81,7 @@ pub enum CacheValue {
     /// The package is being processed.
     InProgress(Arc<Notify>),
     /// The package is saved.
-    Available(Arc<HashMap<OsString, PathBuf>>),
+    Available(Arc<HashMap<String, PathBuf>>),
 }
 
 /// Internal in-memory cache of tarballs.
@@ -120,7 +119,7 @@ impl<'a> DownloadTarballToStore<'a> {
     pub async fn run_with_mem_cache(
         self,
         mem_cache: &'a MemCache,
-    ) -> Result<Arc<HashMap<OsString, PathBuf>>, TarballError> {
+    ) -> Result<Arc<HashMap<String, PathBuf>>, TarballError> {
         let &DownloadTarballToStore { package_url, .. } = &self;
 
         // QUESTION: I see no copying from existing store_dir, is there such mechanism?
@@ -159,7 +158,7 @@ impl<'a> DownloadTarballToStore<'a> {
     }
 
     /// Execute the subroutine without an in-memory cache.
-    pub async fn run_without_mem_cache(&self) -> Result<HashMap<OsString, PathBuf>, TarballError> {
+    pub async fn run_without_mem_cache(&self) -> Result<HashMap<String, PathBuf>, TarballError> {
         let &DownloadTarballToStore {
             http_client,
             store_dir,
@@ -213,7 +212,7 @@ impl<'a> DownloadTarballToStore<'a> {
                 .filter(|entry| !entry.as_ref().unwrap().header().entry_type().is_dir());
 
             let ((_, Some(capacity)) | (capacity, None)) = entries.size_hint();
-            let mut cas_paths = HashMap::<OsString, PathBuf>::with_capacity(capacity);
+            let mut cas_paths = HashMap::<String, PathBuf>::with_capacity(capacity);
             let mut pkg_files_idx = PackageFilesIndex { files: HashMap::with_capacity(capacity) };
 
             for entry in entries {
@@ -227,16 +226,18 @@ impl<'a> DownloadTarballToStore<'a> {
                 entry.read_to_end(&mut buffer).unwrap();
 
                 let entry_path = entry.path().unwrap();
-                let cleaned_entry_path =
-                    entry_path.components().skip(1).collect::<PathBuf>().into_os_string();
+                let cleaned_entry_path = entry_path
+                    .components()
+                    .skip(1)
+                    .collect::<PathBuf>()
+                    .into_os_string()
+                    .into_string()
+                    .expect("entry path must be valid UTF-8");
                 let (file_path, file_hash) = store_dir
                     .write_cas_file(&buffer, file_is_executable)
                     .map_err(TarballError::WriteCasFile)?;
 
-                let tarball_index_key = cleaned_entry_path
-                    .to_str()
-                    .expect("entry path must be valid UTF-8") // TODO: propagate this error, provide more information
-                    .to_string(); // TODO: convert cleaned_entry_path to String too.
+                let tarball_index_key = cleaned_entry_path.clone();
 
                 if let Some(previous) = cas_paths.insert(cleaned_entry_path, file_path) {
                     tracing::warn!(?previous, "Duplication detected. Old entry has been ejected");


### PR DESCRIPTION
Initially, the use of `OsString` was to allow non-UTF8 paths. However, the index file feature requires `serde` which in turns require UTF-8 to serialize. So the need for `OsString` ceases to be necessary, and removing it open new opportunities for some micro-optimizations.