### PR TITLE
perf: fetch abbreviated metadata

### DIFF
--- a/crates/registry/src/package.rs
+++ b/crates/registry/src/package.rs
@@ -36,7 +36,13 @@ impl Package {
         let network_error = |error| NetworkError { error, url: url() };
         http_client
             .run_with_permit(|client| {
-                client.get(url()).header("content-type", "application/json").send()
+                client
+                    .get(url())
+                    .header(
+                        "accept",
+                        "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*",
+                    )
+                    .send()
             })
             .await
             .map_err(network_error)?

--- a/crates/registry/src/package_version.rs
+++ b/crates/registry/src/package_version.rs
@@ -35,7 +35,13 @@ impl PackageVersion {
 
         http_client
             .run_with_permit(|client| {
-                client.get(url()).header("content-type", "application/json").send()
+                client
+                    .get(url())
+                    .header(
+                        "accept",
+                        "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*",
+                    )
+                    .send()
             })
             .await
             .map_err(network_error)?


### PR DESCRIPTION
This simple change surprisingly improves performance by about 10%.

```sh
cargo run --bin=integrated-benchmark -- -s frozen-lockfile HEAD main -V -D ./crates/testing-utils/src/fixtures/big/
```

```
Benchmark 1: pacquet@HEAD
  Time (mean ± σ):      3.036 s ±  0.291 s    [User: 14.522 s, System: 17.387 s]
  Range (min … max):    2.673 s …  3.516 s    10 runs
 
Benchmark 2: pacquet@main
  Time (mean ± σ):      3.137 s ±  0.275 s    [User: 14.616 s, System: 17.753 s]
  Range (min … max):    2.584 s …  3.492 s    10 runs
 
Summary
  pacquet@HEAD ran
    1.03 ± 0.13 times faster than pacquet@main
```

It is still not as fast as pnpm. It is likely that there are other optimizations pnpm did that I'm not aware of.