### PR TITLE
ci: split cargo doc into its own job with --no-deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,6 @@ jobs:
       - name: Install Rust Toolchain
         uses: ./.github/actions/rustup
         with:
-          docs: true
           clippy: true
           save-cache: ${{ github.ref_name == 'main' }}
 
@@ -59,11 +58,6 @@ jobs:
       - name: Clippy
         run: cargo clippy --locked -- -D warnings
 
-      - name: Doc
-        env:
-          RUSTDOCFLAGS: '-D warnings'
-        run: cargo doc
-
       - name: Install just
         uses: taiki-e/install-action@just
 
@@ -86,6 +80,25 @@ jobs:
           just test
 
           just registry-mock end
+
+  doc:
+    name: Doc
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust Toolchain
+        uses: ./.github/actions/rustup
+        with:
+          docs: true
+
+      - name: Doc
+        env:
+          RUSTDOCFLAGS: '-D warnings'
+        # --no-deps skips rendering HTML for every transitive crate. Only
+        # workspace crates are documented; broken intra-doc links and bad
+        # rustdoc markup in pacquet's own code are still caught.
+        run: cargo doc --no-deps --workspace
 
   typos:
     name: Spell Check


### PR DESCRIPTION
## Summary

The \`Doc\` step was the longest step in the \`Lint and Test\` matrix on
every platform in the previous CI run:

| OS | Clippy | **Doc** | Test |
|---|---|---|---|
| ubuntu-latest  | 1:54 | **4:34** | 0:55 |
| windows-latest | 1:33 | **6:13** | 2:26 |
| macos-latest   | 0:38 | **5:00** | 0:44 |

It ran per-OS even though rustdoc warnings in pure-Rust code don't
depend on the OS, and it also blocked the test-feedback pipeline behind
several minutes of HTML generation.

This PR moves it out of the matrix:

- New top-level \`doc\` job, \`ubuntu-latest\` only, runs in parallel with
  \`Lint and Test\`.
- Uses \`cargo doc --no-deps --workspace\`. Only the 16 pacquet crates get
  HTML rendered; transitive deps are skipped. The signal we care about
  — broken intra-doc links and malformed rustdoc in our own code — is
  still caught under \`RUSTDOCFLAGS='-D warnings'\`.
- Drops the \`docs: true\` flag from the \`Lint and Test\` matrix's rustup
  step so the matrix doesn't install \`rust-docs\` it no longer needs.

## Expected savings

- ~6m (windows) + ~5m (macos) of wall-clock per CI run gone.
- Test feedback from the matrix lands ~5 min sooner.
- The new \`doc\` job runs \`--no-deps\` which should come in under the
  previous 4:34 ubuntu Doc step.

## Verified locally

\`\`\`
$ RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --workspace
 ...
    Finished \`dev\` profile [unoptimized + debuginfo] target(s) in 15.50s
   Generated /Volumes/src/pnpm/pacquet/target/doc/pacquet_cli/index.html and 16 other files
\`\`\`

No doc warnings on any workspace crate.