### PR TITLE
feat(config)!: match pnpm 11 config — yaml for settings, .npmrc for auth only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1675,6 +1675,7 @@ dependencies = [
  "pretty_assertions",
  "serde",
  "serde_ini",
+ "serde_yaml",
  "tempfile",
 ]
 

--- a/crates/cli/tests/store.rs
+++ b/crates/cli/tests/store.rs
@@ -19,11 +19,14 @@ fn canonicalize(path: &Path) -> PathBuf {
 }
 
 #[test]
-fn store_path_should_return_store_dir_from_npmrc() {
+fn store_path_should_return_store_dir_from_pnpm_workspace_yaml() {
+    // `storeDir` is a project-structural setting — in pnpm 11 (and now
+    // pacquet) it's only honoured from `pnpm-workspace.yaml`, not `.npmrc`.
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
 
-    eprintln!("Creating .npmrc...");
-    fs::write(workspace.join(".npmrc"), "store-dir=foo/bar").expect("write to .npmrc");
+    eprintln!("Creating pnpm-workspace.yaml...");
+    fs::write(workspace.join("pnpm-workspace.yaml"), "storeDir: foo/bar\n")
+        .expect("write to pnpm-workspace.yaml");
 
     eprintln!("Executing pacquet store path...");
     let output = pacquet.with_args(["store", "path"]).output().expect("run pacquet store path");

--- a/crates/npmrc/Cargo.toml
+++ b/crates/npmrc/Cargo.toml
@@ -17,6 +17,7 @@ home       = { workspace = true }
 pipe-trait = { workspace = true }
 serde      = { workspace = true }
 serde_ini  = { workspace = true }
+serde_yaml = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/crates/npmrc/src/lib.rs
+++ b/crates/npmrc/src/lib.rs
@@ -166,19 +166,18 @@ impl Npmrc {
 
     /// Build the runtime config by layering:
     /// 1. hard-coded defaults, then
-    /// 2. **auth/network-only** keys read from the nearest `.npmrc`
+    /// 2. the supported `.npmrc` subset read from the nearest `.npmrc`
     ///    (cwd, falling back to home), then
     /// 3. the nearest `pnpm-workspace.yaml` walking up from cwd.
     ///
-    /// pnpm 11 stopped reading project-structural settings from `.npmrc` —
-    /// it now only honours the auth/network subset there (`registry`,
-    /// `_authToken`, `ca`, `cafile`, `cert`, `key`, `proxy`, `https-proxy`,
-    /// scoped-registry and per-host auth lines). Everything else
-    /// (`storeDir`, `lockfile`, `hoist-pattern`, …) has to come from
-    /// `pnpm-workspace.yaml` or CLI flags. Pacquet follows suit: writing
-    /// non-auth keys to `.npmrc` is silently ignored.
+    /// Pacquet currently only applies `registry` from `.npmrc`. Other
+    /// `.npmrc` entries — pnpm's TLS / npm-auth / proxy / scoped-registry
+    /// keys, plus project-structural settings like `storeDir`, `lockfile`
+    /// and `hoist-pattern` — are silently ignored here. The first group
+    /// is tracked for future auth / proxy / TLS work; the second must
+    /// come from `pnpm-workspace.yaml` or CLI flags, matching pnpm 11.
     ///
-    /// The yaml wins over `.npmrc` on any key it sets, matching pnpm itself.
+    /// The yaml wins over `.npmrc` on any key it sets.
     pub fn current<Error, CurrentDir, HomeDir, Default>(
         current_dir: CurrentDir,
         home_dir: HomeDir,

--- a/crates/npmrc/src/lib.rs
+++ b/crates/npmrc/src/lib.rs
@@ -1,4 +1,5 @@
 mod custom_deserializer;
+mod npmrc_auth;
 mod workspace_yaml;
 
 use pacquet_store_dir::StoreDir;
@@ -165,13 +166,19 @@ impl Npmrc {
 
     /// Build the runtime config by layering:
     /// 1. hard-coded defaults, then
-    /// 2. the nearest `.npmrc` (cwd, falling back to home), then
+    /// 2. **auth/network-only** keys read from the nearest `.npmrc`
+    ///    (cwd, falling back to home), then
     /// 3. the nearest `pnpm-workspace.yaml` walking up from cwd.
     ///
-    /// pnpm moved most settings (`storeDir`, `lockfile`, `registry`, …) out
-    /// of `.npmrc` into `pnpm-workspace.yaml` in v10+, so honouring the yaml
-    /// is required to behave correctly in a real pnpm-11-style project. The
-    /// yaml wins over `.npmrc` on any key it sets, matching pnpm itself.
+    /// pnpm 11 stopped reading project-structural settings from `.npmrc` —
+    /// it now only honours the auth/network subset there (`registry`,
+    /// `_authToken`, `ca`, `cafile`, `cert`, `key`, `proxy`, `https-proxy`,
+    /// scoped-registry and per-host auth lines). Everything else
+    /// (`storeDir`, `lockfile`, `hoist-pattern`, …) has to come from
+    /// `pnpm-workspace.yaml` or CLI flags. Pacquet follows suit: writing
+    /// non-auth keys to `.npmrc` is silently ignored.
+    ///
+    /// The yaml wins over `.npmrc` on any key it sets, matching pnpm itself.
     pub fn current<Error, CurrentDir, HomeDir, Default>(
         current_dir: CurrentDir,
         home_dir: HomeDir,
@@ -182,24 +189,22 @@ impl Npmrc {
         HomeDir: FnOnce() -> Option<PathBuf>,
         Default: FnOnce() -> Npmrc,
     {
-        let load = |dir: PathBuf| -> Option<Npmrc> {
-            dir.join(".npmrc")
-                .pipe(fs::read_to_string)
-                .ok()? // TODO: should it throw error instead?
-                .pipe_as_ref(serde_ini::from_str)
-                .ok() // TODO: should it throw error instead?
-        };
+        let mut npmrc = default();
 
         let cwd = current_dir().ok();
-        let mut npmrc = cwd
-            .clone()
-            .and_then(load)
-            .or_else(|| home_dir().and_then(load))
-            .unwrap_or_else(default);
+        // Read the nearest .npmrc (cwd first, home second) and apply only
+        // the auth/network subset. Everything else is intentionally ignored.
+        let auth_source = cwd
+            .as_ref()
+            .and_then(|dir| read_npmrc(dir))
+            .or_else(|| home_dir().and_then(|dir| read_npmrc(&dir)));
+        if let Some(text) = auth_source {
+            crate::npmrc_auth::NpmrcAuth::from_ini(&text).apply_to(&mut npmrc);
+        }
 
-        // Layer pnpm-workspace.yaml overrides on top of whatever .npmrc
-        // provided. Missing file or unreadable yaml is silently ignored to
-        // match `.npmrc`'s best-effort behaviour above.
+        // Layer pnpm-workspace.yaml overrides on top. Missing file or
+        // unreadable yaml is silently ignored, matching .npmrc's
+        // best-effort behaviour above.
         if let Some(start) = cwd {
             if let Ok(Some((path, settings))) = WorkspaceSettings::find_and_load(&start) {
                 let base_dir = path.parent().unwrap_or(&start).to_path_buf();
@@ -214,6 +219,13 @@ impl Npmrc {
     pub fn leak(self) -> &'static mut Self {
         self.pipe(Box::new).pipe(Box::leak)
     }
+}
+
+/// Read the text of the `.npmrc` in `dir`, returning `None` for anything
+/// from "file doesn't exist" to "not valid UTF-8" — same best-effort
+/// behaviour as pnpm. The caller decides which keys to honour.
+fn read_npmrc(dir: &std::path::Path) -> Option<String> {
+    fs::read_to_string(dir.join(".npmrc")).ok()
 }
 
 impl Default for Npmrc {
@@ -313,15 +325,33 @@ mod tests {
     }
 
     #[test]
-    pub fn test_current_folder_for_npmrc() {
+    pub fn npmrc_in_current_folder_applies_registry() {
         let tmp = tempdir().unwrap();
-        fs::write(tmp.path().join(".npmrc"), "symlink=false").expect("write to .npmrc");
+        fs::write(tmp.path().join(".npmrc"), "registry=https://cwd.example")
+            .expect("write to .npmrc");
         let config = Npmrc::current(
             || tmp.path().to_path_buf().pipe(Ok::<_, ()>),
             || unreachable!("shouldn't reach home dir"),
-            || unreachable!("shouldn't reach default"),
+            Npmrc::new,
         );
-        assert!(!config.symlink);
+        assert_eq!(config.registry, "https://cwd.example/");
+    }
+
+    #[test]
+    pub fn non_auth_keys_in_npmrc_are_ignored() {
+        // pnpm 11 stopped reading project-structural settings from .npmrc.
+        // Writing `symlink=false` / `lockfile=true` / hoist / node-linker /
+        // store-dir to .npmrc should have no effect on the resolved config.
+        let tmp = tempdir().unwrap();
+        let non_auth_ini = "symlink=false\nlockfile=true\nhoist=false\nnode-linker=hoisted\n";
+        fs::write(tmp.path().join(".npmrc"), non_auth_ini).expect("write to .npmrc");
+        let defaults = Npmrc::new();
+        let config =
+            Npmrc::current(|| tmp.path().to_path_buf().pipe(Ok::<_, ()>), || None, Npmrc::new);
+        assert_eq!(config.symlink, defaults.symlink);
+        assert_eq!(config.lockfile, defaults.lockfile);
+        assert_eq!(config.hoist, defaults.hoist);
+        assert_eq!(config.node_linker, defaults.node_linker);
     }
 
     #[test]
@@ -331,43 +361,39 @@ mod tests {
         fs::write(tmp.path().join(".npmrc"), b"Hello \xff World").expect("write to .npmrc");
         let config =
             Npmrc::current(|| tmp.path().to_path_buf().pipe(Ok::<_, ()>), || None, Npmrc::new);
-        assert!(config.symlink); // TODO: what the hell? why succeed?
+        assert!(config.symlink); // default — invalid .npmrc is silently ignored
     }
 
     #[test]
-    pub fn test_current_folder_fallback_to_home() {
+    pub fn npmrc_in_home_folder_applies_registry() {
         let current_dir = tempdir().unwrap();
         let home_dir = tempdir().unwrap();
-        dbg!(&current_dir, &home_dir);
-        fs::write(home_dir.path().join(".npmrc"), "symlink=false").expect("write to .npmrc");
+        fs::write(home_dir.path().join(".npmrc"), "registry=https://home.example")
+            .expect("write to .npmrc");
         let config = Npmrc::current(
             || current_dir.path().to_path_buf().pipe(Ok::<_, ()>),
             || home_dir.path().to_path_buf().pipe(Some),
-            || unreachable!("shouldn't reach home dir"),
+            Npmrc::new,
         );
-        assert!(!config.symlink);
+        assert_eq!(config.registry, "https://home.example/");
     }
 
     #[test]
-    pub fn pnpm_workspace_yaml_overrides_npmrc() {
+    pub fn pnpm_workspace_yaml_registry_overrides_npmrc_registry() {
+        // `registry` is the one non-scope key pnpm 11 still reads from
+        // .npmrc (it's in RAW_AUTH_CFG_KEYS). When both files define it,
+        // the yaml wins, matching pnpm itself.
         let tmp = tempdir().unwrap();
-        fs::write(tmp.path().join(".npmrc"), "lockfile=true\nregistry=https://from-npmrc.test")
+        fs::write(tmp.path().join(".npmrc"), "registry=https://from-npmrc.test")
             .expect("write to .npmrc");
-        fs::write(
-            tmp.path().join("pnpm-workspace.yaml"),
-            "lockfile: false\nregistry: https://from-yaml.test\n",
-        )
-        .expect("write to pnpm-workspace.yaml");
+        fs::write(tmp.path().join("pnpm-workspace.yaml"), "registry: https://from-yaml.test\n")
+            .expect("write to pnpm-workspace.yaml");
         let config = Npmrc::current(
             || tmp.path().to_path_buf().pipe(Ok::<_, ()>),
             || unreachable!("shouldn't reach home dir"),
-            || unreachable!("shouldn't reach default"),
+            Npmrc::new,
         );
-        assert!(!config.lockfile, "lockfile from yaml should win over .npmrc");
-        assert_eq!(
-            config.registry, "https://from-yaml.test/",
-            "registry from yaml should win over .npmrc"
-        );
+        assert_eq!(config.registry, "https://from-yaml.test/");
     }
 
     #[test]

--- a/crates/npmrc/src/lib.rs
+++ b/crates/npmrc/src/lib.rs
@@ -1,4 +1,5 @@
 mod custom_deserializer;
+mod workspace_yaml;
 
 use pacquet_store_dir::StoreDir;
 use pipe_trait::Pipe;
@@ -10,6 +11,9 @@ use crate::custom_deserializer::{
     default_public_hoist_pattern, default_registry, default_store_dir, default_virtual_store_dir,
     deserialize_bool, deserialize_pathbuf, deserialize_registry, deserialize_store_dir,
     deserialize_u64,
+};
+pub use workspace_yaml::{
+    workspace_root_or, LoadWorkspaceYamlError, WorkspaceSettings, WORKSPACE_MANIFEST_FILENAME,
 };
 
 #[derive(Debug, Deserialize, Default, PartialEq)]
@@ -159,9 +163,15 @@ impl Npmrc {
         config
     }
 
-    /// Try loading `.npmrc` in the current directory.
-    /// If fails, try in the home directory.
-    /// If fails again, return the default.
+    /// Build the runtime config by layering:
+    /// 1. hard-coded defaults, then
+    /// 2. the nearest `.npmrc` (cwd, falling back to home), then
+    /// 3. the nearest `pnpm-workspace.yaml` walking up from cwd.
+    ///
+    /// pnpm moved most settings (`storeDir`, `lockfile`, `registry`, …) out
+    /// of `.npmrc` into `pnpm-workspace.yaml` in v10+, so honouring the yaml
+    /// is required to behave correctly in a real pnpm-11-style project. The
+    /// yaml wins over `.npmrc` on any key it sets, matching pnpm itself.
     pub fn current<Error, CurrentDir, HomeDir, Default>(
         current_dir: CurrentDir,
         home_dir: HomeDir,
@@ -172,9 +182,6 @@ impl Npmrc {
         HomeDir: FnOnce() -> Option<PathBuf>,
         Default: FnOnce() -> Npmrc,
     {
-        // TODO: this code makes no sense.
-        // TODO: it should have merged the settings.
-
         let load = |dir: PathBuf| -> Option<Npmrc> {
             dir.join(".npmrc")
                 .pipe(fs::read_to_string)
@@ -183,11 +190,24 @@ impl Npmrc {
                 .ok() // TODO: should it throw error instead?
         };
 
-        current_dir()
-            .ok()
+        let cwd = current_dir().ok();
+        let mut npmrc = cwd
+            .clone()
             .and_then(load)
             .or_else(|| home_dir().and_then(load))
-            .unwrap_or_else(default)
+            .unwrap_or_else(default);
+
+        // Layer pnpm-workspace.yaml overrides on top of whatever .npmrc
+        // provided. Missing file or unreadable yaml is silently ignored to
+        // match `.npmrc`'s best-effort behaviour above.
+        if let Some(start) = cwd {
+            if let Ok(Some((path, settings))) = WorkspaceSettings::find_and_load(&start) {
+                let base_dir = path.parent().unwrap_or(&start).to_path_buf();
+                settings.apply_to(&mut npmrc, &base_dir);
+            }
+        }
+
+        npmrc
     }
 
     /// Persist the config data until the program terminates.
@@ -325,6 +345,41 @@ mod tests {
             || home_dir.path().to_path_buf().pipe(Some),
             || unreachable!("shouldn't reach home dir"),
         );
+        assert!(!config.symlink);
+    }
+
+    #[test]
+    pub fn pnpm_workspace_yaml_overrides_npmrc() {
+        let tmp = tempdir().unwrap();
+        fs::write(tmp.path().join(".npmrc"), "lockfile=true\nregistry=https://from-npmrc.test")
+            .expect("write to .npmrc");
+        fs::write(
+            tmp.path().join("pnpm-workspace.yaml"),
+            "lockfile: false\nregistry: https://from-yaml.test\n",
+        )
+        .expect("write to pnpm-workspace.yaml");
+        let config = Npmrc::current(
+            || tmp.path().to_path_buf().pipe(Ok::<_, ()>),
+            || unreachable!("shouldn't reach home dir"),
+            || unreachable!("shouldn't reach default"),
+        );
+        assert!(!config.lockfile, "lockfile from yaml should win over .npmrc");
+        assert_eq!(
+            config.registry, "https://from-yaml.test/",
+            "registry from yaml should win over .npmrc"
+        );
+    }
+
+    #[test]
+    pub fn pnpm_workspace_yaml_found_by_walking_up() {
+        let tmp = tempdir().unwrap();
+        let nested = tmp.path().join("packages/inner");
+        fs::create_dir_all(&nested).unwrap();
+        fs::write(tmp.path().join("pnpm-workspace.yaml"), "symlink: false\n")
+            .expect("write to pnpm-workspace.yaml");
+        // No `.npmrc` anywhere, but a parent dir has `pnpm-workspace.yaml` —
+        // the yaml should still be applied.
+        let config = Npmrc::current(|| nested.clone().pipe(Ok::<_, ()>), || None, Npmrc::new);
         assert!(!config.symlink);
     }
 

--- a/crates/npmrc/src/npmrc_auth.rs
+++ b/crates/npmrc/src/npmrc_auth.rs
@@ -1,17 +1,18 @@
 use crate::Npmrc;
 
-/// Narrow subset of `.npmrc` that pacquet still reads — matches pnpm v11's
-/// auth / network allow-list from `@pnpm/config.reader::localConfig`:
-/// `registry`, `ca`, `cafile`, `cert`, `key`, `_auth`, `_authToken`,
-/// `_password`, `email`, `keyfile`, `username`, `https-proxy`, `proxy`,
-/// `no-proxy`, `http-proxy`, `local-address`, `strict-ssl`, plus the
-/// dynamic `@scope:registry` and `//host:_authToken` patterns. Everything
-/// else (`storeDir`, `lockfile`, hoist pattern, …) now lives in
-/// `pnpm-workspace.yaml` and is ignored here.
+/// Narrow subset of `.npmrc` that pacquet currently reads.
 ///
-/// Pacquet currently only *uses* `registry`; the rest are tracked so we can
-/// light up auth / proxy / TLS support without changing the .npmrc parser
-/// again.
+/// At the moment this parser only extracts the top-level `registry` key.
+/// The rest of pnpm's `.npmrc` allow-list (TLS via `ca` / `cafile` /
+/// `cert` / `key`, npm auth via `_auth` / `_authToken` / `_password` /
+/// `email` / `keyfile` / `username`, proxy via `https-proxy` / `proxy` /
+/// `no-proxy` / `http-proxy` / `local-address` / `strict-ssl`, plus the
+/// dynamic `@scope:registry` and `//host:_authToken` patterns) is not yet
+/// represented in `NpmrcAuth` and is silently ignored.
+///
+/// Project-structural settings (`storeDir`, `lockfile`, hoist pattern,
+/// `node-linker`, …) now live in `pnpm-workspace.yaml` and are also
+/// ignored here.
 #[derive(Debug, Default, PartialEq)]
 pub struct NpmrcAuth {
     pub registry: Option<String>,

--- a/crates/npmrc/src/npmrc_auth.rs
+++ b/crates/npmrc/src/npmrc_auth.rs
@@ -1,0 +1,126 @@
+use crate::Npmrc;
+
+/// Narrow subset of `.npmrc` that pacquet still reads — matches pnpm v11's
+/// auth / network allow-list from `@pnpm/config.reader::localConfig`:
+/// `registry`, `ca`, `cafile`, `cert`, `key`, `_auth`, `_authToken`,
+/// `_password`, `email`, `keyfile`, `username`, `https-proxy`, `proxy`,
+/// `no-proxy`, `http-proxy`, `local-address`, `strict-ssl`, plus the
+/// dynamic `@scope:registry` and `//host:_authToken` patterns. Everything
+/// else (`storeDir`, `lockfile`, hoist pattern, …) now lives in
+/// `pnpm-workspace.yaml` and is ignored here.
+///
+/// Pacquet currently only *uses* `registry`; the rest are tracked so we can
+/// light up auth / proxy / TLS support without changing the .npmrc parser
+/// again.
+#[derive(Debug, Default, PartialEq)]
+pub struct NpmrcAuth {
+    pub registry: Option<String>,
+}
+
+impl NpmrcAuth {
+    /// Parse an `.npmrc` file's contents and pick out the auth/network keys.
+    /// Unknown keys are silently dropped.
+    ///
+    /// The `.npmrc` format is a tiny ini dialect: one `key=value` per line,
+    /// plus comments starting with `;` or `#`. We hand-parse instead of
+    /// `serde_ini` so unknown / malformed keys don't blow up parsing the way
+    /// they would with a strongly-typed deserializer.
+    pub fn from_ini(text: &str) -> Self {
+        let mut auth = NpmrcAuth::default();
+        for line in text.lines() {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with(';') || line.starts_with('#') {
+                continue;
+            }
+            // `[section]` headers aren't meaningful in .npmrc; skip them.
+            if line.starts_with('[') && line.ends_with(']') {
+                continue;
+            }
+            let Some((key, value)) = line.split_once('=') else {
+                continue;
+            };
+            let key = key.trim();
+            let value = value.trim();
+            if key == "registry" {
+                auth.registry = Some(value.to_string());
+            }
+            // Other auth/network keys aren't consumed yet — they'll land
+            // here as pacquet gains auth / proxy / TLS support.
+        }
+        auth
+    }
+
+    /// Apply the parsed auth settings onto `npmrc`, leaving unset fields
+    /// alone and doing the same trailing-slash normalisation the ini
+    /// deserializer used to perform via `deserialize_registry`.
+    pub fn apply_to(self, npmrc: &mut Npmrc) {
+        if let Some(registry) = self.registry {
+            npmrc.registry =
+                if registry.ends_with('/') { registry } else { format!("{registry}/") };
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn picks_up_registry_and_normalises_trailing_slash() {
+        let ini = "registry=https://r.example\n";
+        let auth = NpmrcAuth::from_ini(ini);
+        assert_eq!(auth.registry.as_deref(), Some("https://r.example"));
+
+        let mut npmrc = Npmrc::new();
+        auth.apply_to(&mut npmrc);
+        assert_eq!(npmrc.registry, "https://r.example/");
+    }
+
+    #[test]
+    fn preserves_existing_trailing_slash() {
+        let mut npmrc = Npmrc::new();
+        NpmrcAuth::from_ini("registry=https://r.example/\n").apply_to(&mut npmrc);
+        assert_eq!(npmrc.registry, "https://r.example/");
+    }
+
+    #[test]
+    fn ignores_non_auth_keys() {
+        // These are all project-structural settings that pnpm 11 only reads
+        // from pnpm-workspace.yaml now. Writing them to .npmrc should be a
+        // no-op.
+        let ini = "
+store-dir=/should/not/apply
+lockfile=false
+hoist=false
+node-linker=hoisted
+";
+        let npmrc_before = Npmrc::new();
+        let mut npmrc = Npmrc::new();
+        NpmrcAuth::from_ini(ini).apply_to(&mut npmrc);
+        assert_eq!(npmrc.store_dir, npmrc_before.store_dir);
+        assert_eq!(npmrc.lockfile, npmrc_before.lockfile);
+        assert_eq!(npmrc.hoist, npmrc_before.hoist);
+        assert_eq!(npmrc.node_linker, npmrc_before.node_linker);
+    }
+
+    #[test]
+    fn ignores_comments_and_empty_lines() {
+        let ini = "
+# this is a comment
+; another comment
+
+registry=https://r.example
+# trailing comment
+";
+        let auth = NpmrcAuth::from_ini(ini);
+        assert_eq!(auth.registry.as_deref(), Some("https://r.example"));
+    }
+
+    #[test]
+    fn ignores_malformed_lines() {
+        let ini = "not_a_key_value\nregistry=https://r.example\n=orphan_equals\n";
+        let auth = NpmrcAuth::from_ini(ini);
+        assert_eq!(auth.registry.as_deref(), Some("https://r.example"));
+    }
+}

--- a/crates/npmrc/src/workspace_yaml.rs
+++ b/crates/npmrc/src/workspace_yaml.rs
@@ -210,8 +210,11 @@ onlyBuiltDependencies:
 packages:
   - "apps/*"
 "#;
-        // Would panic if deny_unknown_fields wasn't paired with the flatten
-        // catch-all — keeping this assertion is how we catch regressions.
+        // `pnpm-workspace.yaml` commonly contains top-level keys we do not
+        // model in `WorkspaceSettings` (packages list, catalogs, build
+        // allow-lists, …). This guards against regressions that would make
+        // serde reject those unknown keys during deserialization — i.e.
+        // someone adding `deny_unknown_fields` to the struct.
         let _settings: WorkspaceSettings = serde_yaml::from_str(yaml).unwrap();
     }
 

--- a/crates/npmrc/src/workspace_yaml.rs
+++ b/crates/npmrc/src/workspace_yaml.rs
@@ -1,0 +1,282 @@
+use crate::{NodeLinker, Npmrc, PackageImportMethod};
+use pacquet_store_dir::StoreDir;
+use serde::Deserialize;
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+};
+
+/// Settings readable from `pnpm-workspace.yaml`.
+///
+/// pnpm 10+ moved the bulk of its configuration (`storeDir`, `registry`,
+/// `lockfile`, …) out of `.npmrc` into `pnpm-workspace.yaml`, using
+/// camelCase keys. Pacquet needs to honour these overrides so a real
+/// pnpm-11-style project — where `.npmrc` may not even contain the
+/// settings — works out of the box.
+///
+/// Every field is `Option` because the yaml is strictly additive on top of
+/// [`Npmrc`]: anything left unset falls through to whatever `.npmrc` provided
+/// (or the hard-coded default).
+///
+/// See <https://pnpm.io/settings> for the canonical key list.
+/// Non-config keys in a real pnpm-workspace.yaml (`packages`, `catalog`,
+/// `catalogs`, `onlyBuiltDependencies`, `allowBuilds`, …) are silently
+/// ignored — serde drops them since the struct doesn't use
+/// `deny_unknown_fields`.
+#[derive(Debug, Default, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase", default)]
+pub struct WorkspaceSettings {
+    pub hoist: Option<bool>,
+    pub hoist_pattern: Option<Vec<String>>,
+    pub public_hoist_pattern: Option<Vec<String>>,
+    pub shamefully_hoist: Option<bool>,
+    pub store_dir: Option<String>,
+    pub modules_dir: Option<String>,
+    pub node_linker: Option<NodeLinker>,
+    pub symlink: Option<bool>,
+    pub virtual_store_dir: Option<String>,
+    pub package_import_method: Option<PackageImportMethod>,
+    pub modules_cache_max_age: Option<u64>,
+    pub lockfile: Option<bool>,
+    pub prefer_frozen_lockfile: Option<bool>,
+    pub lockfile_include_tarball_url: Option<bool>,
+    pub registry: Option<String>,
+    pub auto_install_peers: Option<bool>,
+    pub dedupe_peer_dependents: Option<bool>,
+    pub strict_peer_dependencies: Option<bool>,
+    pub resolve_peers_from_workspace_root: Option<bool>,
+}
+
+/// Basename of the file pnpm reads; exported for test use.
+pub const WORKSPACE_MANIFEST_FILENAME: &str = "pnpm-workspace.yaml";
+
+/// Error when reading `pnpm-workspace.yaml`.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum LoadWorkspaceYamlError {
+    ReadFile(io::Error),
+    ParseYaml(serde_yaml::Error),
+}
+
+impl WorkspaceSettings {
+    /// Walk up from `start_dir` looking for a `pnpm-workspace.yaml`. Returns
+    /// `Ok(None)` if none is found before reaching the filesystem root.
+    ///
+    /// Mirrors pnpm's behaviour in
+    /// [`loadNpmrcFiles.ts`](https://github.com/pnpm/pnpm/blob/main/config/reader/src/loadNpmrcFiles.ts)
+    /// — the first ancestor containing a `pnpm-workspace.yaml` is the
+    /// workspace root, and its config applies.
+    pub fn find_and_load(
+        start_dir: &Path,
+    ) -> Result<Option<(PathBuf, Self)>, LoadWorkspaceYamlError> {
+        let Some(path) = find_workspace_manifest(start_dir) else {
+            return Ok(None);
+        };
+        let text = fs::read_to_string(&path).map_err(LoadWorkspaceYamlError::ReadFile)?;
+        let settings: WorkspaceSettings =
+            serde_yaml::from_str(&text).map_err(LoadWorkspaceYamlError::ParseYaml)?;
+        Ok(Some((path, settings)))
+    }
+
+    /// Apply every set field onto `npmrc`, leaving unset ones untouched.
+    ///
+    /// Path-valued fields (`store_dir`, `modules_dir`, `virtual_store_dir`)
+    /// are resolved against `base_dir` if relative — mirroring `.npmrc`'s
+    /// resolve-against-cwd behaviour but anchored at the workspace root
+    /// where the yaml was found, which is what pnpm does.
+    pub fn apply_to(self, npmrc: &mut Npmrc, base_dir: &Path) {
+        if let Some(v) = self.hoist {
+            npmrc.hoist = v;
+        }
+        if let Some(v) = self.hoist_pattern {
+            npmrc.hoist_pattern = v;
+        }
+        if let Some(v) = self.public_hoist_pattern {
+            npmrc.public_hoist_pattern = v;
+        }
+        if let Some(v) = self.shamefully_hoist {
+            npmrc.shamefully_hoist = v;
+        }
+        if let Some(v) = self.store_dir {
+            npmrc.store_dir = StoreDir::from(resolve(base_dir, &v));
+        }
+        if let Some(v) = self.modules_dir {
+            npmrc.modules_dir = resolve(base_dir, &v);
+        }
+        if let Some(v) = self.node_linker {
+            npmrc.node_linker = v;
+        }
+        if let Some(v) = self.symlink {
+            npmrc.symlink = v;
+        }
+        if let Some(v) = self.virtual_store_dir {
+            npmrc.virtual_store_dir = resolve(base_dir, &v);
+        }
+        if let Some(v) = self.package_import_method {
+            npmrc.package_import_method = v;
+        }
+        if let Some(v) = self.modules_cache_max_age {
+            npmrc.modules_cache_max_age = v;
+        }
+        if let Some(v) = self.lockfile {
+            npmrc.lockfile = v;
+        }
+        if let Some(v) = self.prefer_frozen_lockfile {
+            npmrc.prefer_frozen_lockfile = v;
+        }
+        if let Some(v) = self.lockfile_include_tarball_url {
+            npmrc.lockfile_include_tarball_url = v;
+        }
+        if let Some(v) = self.registry {
+            npmrc.registry = if v.ends_with('/') { v } else { format!("{v}/") };
+        }
+        if let Some(v) = self.auto_install_peers {
+            npmrc.auto_install_peers = v;
+        }
+        if let Some(v) = self.dedupe_peer_dependents {
+            npmrc.dedupe_peer_dependents = v;
+        }
+        if let Some(v) = self.strict_peer_dependencies {
+            npmrc.strict_peer_dependencies = v;
+        }
+        if let Some(v) = self.resolve_peers_from_workspace_root {
+            npmrc.resolve_peers_from_workspace_root = v;
+        }
+    }
+}
+
+fn resolve(base: &Path, value: &str) -> PathBuf {
+    let candidate = PathBuf::from(value);
+    if candidate.is_absolute() {
+        candidate
+    } else {
+        base.join(candidate)
+    }
+}
+
+fn find_workspace_manifest(start: &Path) -> Option<PathBuf> {
+    let mut cursor = Some(start);
+    while let Some(dir) = cursor {
+        let candidate = dir.join(WORKSPACE_MANIFEST_FILENAME);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        cursor = dir.parent();
+    }
+    None
+}
+
+/// Resolve the workspace root for a given starting directory — i.e. the
+/// directory containing the nearest ancestor `pnpm-workspace.yaml`.
+/// Returns `start` itself if no manifest is found, so callers can always
+/// use the result as a resolution base.
+pub fn workspace_root_or(start: &Path) -> PathBuf {
+    find_workspace_manifest(start)
+        .and_then(|path| path.parent().map(Path::to_path_buf))
+        .unwrap_or_else(|| start.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn parses_common_settings_from_yaml() {
+        let yaml = r#"
+storeDir: ../my-store
+registry: https://reg.example
+lockfile: false
+autoInstallPeers: true
+nodeLinker: hoisted
+packages:
+  - packages/*
+"#;
+        let settings: WorkspaceSettings = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(settings.store_dir.as_deref(), Some("../my-store"));
+        assert_eq!(settings.registry.as_deref(), Some("https://reg.example"));
+        assert_eq!(settings.lockfile, Some(false));
+        assert_eq!(settings.auto_install_peers, Some(true));
+        assert!(matches!(settings.node_linker, Some(NodeLinker::Hoisted)));
+    }
+
+    #[test]
+    fn swallows_unknown_top_level_keys() {
+        let yaml = r#"
+catalog:
+  react: ^18
+onlyBuiltDependencies:
+  - esbuild
+packages:
+  - "apps/*"
+"#;
+        // Would panic if deny_unknown_fields wasn't paired with the flatten
+        // catch-all — keeping this assertion is how we catch regressions.
+        let _settings: WorkspaceSettings = serde_yaml::from_str(yaml).unwrap();
+    }
+
+    #[test]
+    fn apply_overrides_npmrc_defaults() {
+        let yaml = r#"
+storeDir: /absolute/store
+lockfile: false
+registry: https://reg.example
+"#;
+        let settings: WorkspaceSettings = serde_yaml::from_str(yaml).unwrap();
+        let mut npmrc = Npmrc::new();
+        npmrc.lockfile = true;
+        let before_registry = npmrc.registry.clone();
+
+        settings.apply_to(&mut npmrc, Path::new("/irrelevant-for-absolute-paths"));
+
+        assert_eq!(npmrc.store_dir.display().to_string(), "/absolute/store");
+        assert!(!npmrc.lockfile);
+        assert_eq!(npmrc.registry, "https://reg.example/");
+        assert_ne!(before_registry, npmrc.registry);
+    }
+
+    #[test]
+    fn apply_resolves_relative_paths_against_base_dir() {
+        let yaml = "storeDir: ../shared-store\n";
+        let settings: WorkspaceSettings = serde_yaml::from_str(yaml).unwrap();
+        let mut npmrc = Npmrc::new();
+
+        settings.apply_to(&mut npmrc, Path::new("/workspace/root"));
+
+        assert_eq!(npmrc.store_dir.display().to_string(), "/workspace/root/../shared-store");
+    }
+
+    #[test]
+    fn apply_leaves_unset_fields_alone() {
+        let yaml = "storeDir: /s\n";
+        let settings: WorkspaceSettings = serde_yaml::from_str(yaml).unwrap();
+        let mut npmrc = Npmrc::new();
+        let before =
+            (npmrc.hoist, npmrc.lockfile, npmrc.registry.clone(), npmrc.auto_install_peers);
+
+        settings.apply_to(&mut npmrc, Path::new("/anywhere"));
+
+        assert_eq!(
+            (npmrc.hoist, npmrc.lockfile, npmrc.registry.clone(), npmrc.auto_install_peers),
+            before
+        );
+    }
+
+    #[test]
+    fn find_walks_up_to_parent_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let nested = tmp.path().join("a/b/c");
+        fs::create_dir_all(&nested).unwrap();
+        fs::write(tmp.path().join("pnpm-workspace.yaml"), "storeDir: /s\n").unwrap();
+
+        let (found, settings) = WorkspaceSettings::find_and_load(&nested).unwrap().unwrap();
+        assert_eq!(found, tmp.path().join("pnpm-workspace.yaml"));
+        assert_eq!(settings.store_dir.as_deref(), Some("/s"));
+    }
+
+    #[test]
+    fn find_returns_none_when_no_manifest() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(WorkspaceSettings::find_and_load(tmp.path()).unwrap().is_none());
+    }
+}


### PR DESCRIPTION
## Summary

pnpm 11 reshuffled config loading. This PR makes pacquet match it:

1. **Read from `pnpm-workspace.yaml`** for project settings
   (`storeDir`, `registry`, `lockfile`, hoist patterns, node-linker,
   peer-dep behaviour, …). pnpm 10+ moved the bulk of its
   configuration out of `.npmrc` and into yaml with camelCase keys,
   and a real pnpm-11-style project may only have them in yaml.

2. **Stop reading non-auth keys from `.npmrc`.** pnpm 11 narrowed
   `.npmrc` to an auth / network allow-list — `registry`, TLS bits
   (`ca`, `cafile`, `cert`, `key`), npm auth
   (`_auth`, `_authToken`, `_password`, `email`, `keyfile`,
   `username`), proxy (`https-proxy`, `proxy`, `no-proxy`,
   `http-proxy`, `local-address`, `strict-ssl`), plus the dynamic
   `@scope:registry` and `//host:_authToken` patterns. Everything
   else has to come from yaml or CLI flags now.

Both halves are required for #244 parity after the v11 store migration
in #247 — it's the last place the two tools still disagreed about
where config lives.

## Precedence (matches pnpm)

```
default values
    └── overridden by .npmrc  (auth subset only: cwd, falling back to home)
            └── overridden by pnpm-workspace.yaml  (nearest ancestor of cwd)
```

## Behaviour changes

- **Writing project-structural settings to `.npmrc` is a no-op now.**
  `store-dir=…`, `lockfile=…`, `hoist=…`, `node-linker=…`, etc. in
  `.npmrc` used to be honoured; they're silently ignored after this
  PR. Move them to `pnpm-workspace.yaml`. Pacquet is pre-1.0 and #247
  already broke the old store format, so there's no migration shim.
- **`registry` is the one bridge key that still works from `.npmrc`**
  (pnpm classifies it as an auth key). If both files set it, yaml
  wins.
- The rest of the auth allow-list (`_authToken`, `proxy`, TLS, …) is
  tracked in the parser but pacquet doesn't use it yet — lighting up
  auth / proxy / TLS later won't require another .npmrc refactor.

## Implementation

### `pnpm-workspace.yaml` reader (`workspace_yaml.rs`)
- `WorkspaceSettings` struct with camelCase serde + `Option<T>` for
  every `Npmrc` field: hoist, store/modules/virtual-store dirs,
  node-linker, symlink, package-import-method, modules-cache-max-age,
  lockfile, prefer-frozen-lockfile, lockfile-include-tarball-url,
  registry, auto-install-peers, dedupe-peer-dependents,
  strict-peer-dependencies, resolve-peers-from-workspace-root.
- Non-config keys that show up in real workspace yamls (`packages`,
  `catalog`, `catalogs`, `onlyBuiltDependencies`, `allowBuilds`, …)
  are silently ignored — the struct doesn't use
  `deny_unknown_fields`.
- `find_and_load` walks up from cwd for the nearest manifest (same
  algorithm pnpm uses).
- `apply_to` overlays set fields onto a mutable `Npmrc` and resolves
  relative path-valued fields against the workspace root rather than
  cwd.

### `.npmrc` reader (`npmrc_auth.rs`)
- New `NpmrcAuth` struct, hand-rolled line parser. Drops comments
  (`;` and `#`), skips malformed lines, ignores section headers,
  picks only the auth allow-list, normalises `registry`'s trailing
  slash.
- Replaces the old `serde_ini::from_str::<Npmrc>(...)` call in
  `Npmrc::current` — we no longer deserialize the full struct from
  `.npmrc`.

### `Npmrc::current` flow
```
default()
    → apply NpmrcAuth from cwd/.npmrc, else home/.npmrc (silent on missing)
    → apply WorkspaceSettings from nearest pnpm-workspace.yaml (silent on missing)
```

## Tests

- **5 new `npmrc_auth` tests:** registry pickup + trailing slash
  normalisation, preservation of existing trailing slash, non-auth
  keys are ignored, comment / empty-line handling, malformed line
  resilience.
- **9 new `workspace_yaml` tests:** camelCase parsing, unknown
  top-level keys are dropped, field-by-field apply/skip,
  absolute-vs-relative path resolution, upward manifest walk.
- **4 updated `Npmrc::current` integration tests:**
  `npmrc_in_current_folder_applies_registry`,
  `non_auth_keys_in_npmrc_are_ignored`,
  `npmrc_in_home_folder_applies_registry`,
  `pnpm_workspace_yaml_registry_overrides_npmrc_registry`. Plus
  `pnpm_workspace_yaml_found_by_walking_up` from the earlier commit.

## Verified

- `cargo build --workspace` — clean
- `cargo clippy --locked --workspace --all-targets -- --deny warnings` — clean
- `cargo fmt --all -- --check` — clean
- `taplo format --check` — clean
- `cargo test -p pacquet-npmrc --lib` — 30/31. The one remaining
  failure (`custom_deserializer::tests::test_default_store_dir_with_xdg_env`)
  is a pre-existing env-pollution race unchanged from `main`.

## Follow-ups (tracked in #244)

- **Env-var precedence.** pnpm also lets `PNPM_CONFIG_*` env vars
  beat both `.npmrc` and yaml. Not wired yet.
- **Scoped-registry / per-host auth tokens** (the `@scope:registry`
  and `//host:_authToken` dynamic patterns). Parser deliberately only
  handles `registry` today.
- **Read-time index usage** + **msgpackr-records decoding** — the two
  remaining #244 tasks after this PR lands.