### PR TITLE
perf(tarball): skip download when SQLite index already has the entry

### DIFF
--- a/crates/fs/src/file_mode.rs
+++ b/crates/fs/src/file_mode.rs
@@ -6,9 +6,14 @@ pub const EXEC_MASK: u32 = 0b001_001_001;
 /// All can read and execute, but only owner can write (`rwxr-xr-x`).
 pub const EXEC_MODE: u32 = 0b111_101_101;
 
-/// Whether a file mode has all executable bits.
-pub fn is_all_exec(mode: u32) -> bool {
-    mode & EXEC_MASK == EXEC_MASK
+/// Whether a file mode has *any* executable bit set (`u+x`, `g+x`, or
+/// `o+x`). Matches pnpm's `modeIsExecutable` and is therefore the rule
+/// pacquet must follow when deciding whether a CAFS blob gets the
+/// `-exec` suffix or has its on-disk mode flipped executable. Tarballs
+/// from npm frequently ship scripts as `0o744` (user exec only) or
+/// `0o755` (all); both must be treated as executable for pnpm-interop.
+pub fn is_executable(mode: u32) -> bool {
+    mode & EXEC_MASK != 0
 }
 
 /// Set file mode to 777 on POSIX platforms such as Linux or macOS,

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -28,9 +28,17 @@ impl ThrottledClient {
     /// If the number of CPUs is greater than 16, the number of permits will be equal to the number of CPUs.
     /// Otherwise, the number of permits will be 16.
     pub fn new_from_cpu_count() -> Self {
+        ThrottledClient::from_client(Client::new())
+    }
+
+    /// Construct a throttled client wrapping a pre-built [`Client`].
+    /// Primarily useful for tests that need custom timeouts (a default
+    /// `Client` has no connect / request timeout, so a firewall that
+    /// silently drops packets instead of refusing them can stall the
+    /// test suite for TCP-retry worth of time).
+    pub fn from_client(client: Client) -> Self {
         const MIN_PERMITS: usize = 16;
         let semaphore = num_cpus::get().max(MIN_PERMITS).pipe(Semaphore::new);
-        let client = Client::new();
         ThrottledClient { semaphore, client }
     }
 }

--- a/crates/npmrc/src/workspace_yaml.rs
+++ b/crates/npmrc/src/workspace_yaml.rs
@@ -243,10 +243,14 @@ registry: https://reg.example
         let yaml = "storeDir: ../shared-store\n";
         let settings: WorkspaceSettings = serde_yaml::from_str(yaml).unwrap();
         let mut npmrc = Npmrc::new();
+        let base = Path::new("/workspace/root");
 
-        settings.apply_to(&mut npmrc, Path::new("/workspace/root"));
+        settings.apply_to(&mut npmrc, base);
 
-        assert_eq!(npmrc.store_dir.display().to_string(), "/workspace/root/../shared-store");
+        // Build the expected path via the same join machinery the code
+        // under test uses so the component separator matches on every
+        // platform (Windows uses `\` between joined components).
+        assert_eq!(npmrc.store_dir, StoreDir::from(base.join("../shared-store")));
     }
 
     #[test]

--- a/crates/store-dir/src/cas_file.rs
+++ b/crates/store-dir/src/cas_file.rs
@@ -12,6 +12,15 @@ impl StoreDir {
         let suffix = if executable { "-exec" } else { "" };
         self.file_path_by_hex_str(&hex, suffix)
     }
+
+    /// Path to a content-addressed file given its pre-computed hex digest
+    /// (from the SQLite store index) and its POSIX mode. Matches pnpm's
+    /// [`getFilePathByModeInCafs`](https://github.com/pnpm/pnpm/blob/main/store/cafs/src/getFilePathInCafs.ts)
+    /// so index entries written by either tool resolve to the same path.
+    pub fn cas_file_path_by_mode(&self, hex: &str, mode: u32) -> PathBuf {
+        let suffix = if (mode & 0o111) != 0 { "-exec" } else { "" };
+        self.file_path_by_hex_str(hex, suffix)
+    }
 }
 
 /// Error type of [`StoreDir::write_cas_file`].

--- a/crates/store-dir/src/cas_file.rs
+++ b/crates/store-dir/src/cas_file.rs
@@ -17,9 +17,18 @@ impl StoreDir {
     /// (from the SQLite store index) and its POSIX mode. Matches pnpm's
     /// [`getFilePathByModeInCafs`](https://github.com/pnpm/pnpm/blob/main/store/cafs/src/getFilePathInCafs.ts)
     /// so index entries written by either tool resolve to the same path.
-    pub fn cas_file_path_by_mode(&self, hex: &str, mode: u32) -> PathBuf {
+    ///
+    /// Returns `None` when `hex` is too short or not ASCII-hex — the
+    /// underlying split slices `hex[..2]` and would otherwise panic on a
+    /// corrupt / partially-interop row. Callers treat `None` as "cache
+    /// miss" so a bad index entry falls through to a fresh download
+    /// instead of aborting the install.
+    pub fn cas_file_path_by_mode(&self, hex: &str, mode: u32) -> Option<PathBuf> {
+        if hex.len() < 2 || !hex.bytes().all(|b| b.is_ascii_hexdigit()) {
+            return None;
+        }
         let suffix = if (mode & 0o111) != 0 { "-exec" } else { "" };
-        self.file_path_by_hex_str(hex, suffix)
+        Some(self.file_path_by_hex_str(hex, suffix))
     }
 }
 
@@ -71,5 +80,16 @@ mod tests {
             true,
             "STORE_DIR/v11/files/30/9ecc489c12d6eb4cc40f50c902f2b4d0ed77ee511a7c7a9bcd3ca86d4cd86f989dd35bc5ff499670da34255b45b0cfd830e81f605dcf7dc5542e93ae9cd76f-exec",
         );
+    }
+
+    #[test]
+    fn cas_file_path_by_mode_rejects_invalid_hex() {
+        let store_dir = StoreDir::new("STORE_DIR");
+        assert_eq!(store_dir.cas_file_path_by_mode("", 0o644), None);
+        assert_eq!(store_dir.cas_file_path_by_mode("a", 0o644), None);
+        assert_eq!(store_dir.cas_file_path_by_mode("zz", 0o644), None);
+        assert_eq!(store_dir.cas_file_path_by_mode("Ab\tcd", 0o644), None);
+        assert!(store_dir.cas_file_path_by_mode("ab", 0o644).is_some());
+        assert!(store_dir.cas_file_path_by_mode("abcdef", 0o755).is_some());
     }
 }

--- a/crates/store-dir/src/cas_file.rs
+++ b/crates/store-dir/src/cas_file.rs
@@ -1,7 +1,11 @@
 use crate::{FileHash, StoreDir};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
-use pacquet_fs::{ensure_file, file_mode::EXEC_MODE, EnsureFileError};
+use pacquet_fs::{
+    ensure_file,
+    file_mode::{is_executable, EXEC_MODE},
+    EnsureFileError,
+};
 use sha2::{Digest, Sha512};
 use std::path::PathBuf;
 
@@ -32,7 +36,13 @@ impl StoreDir {
         if hex.len() <= 2 || !hex.bytes().all(|b| b.is_ascii_hexdigit()) {
             return None;
         }
-        let suffix = if (mode & 0o111) != 0 { "-exec" } else { "" };
+        // Same executable-bit rule the write side uses
+        // (`pacquet_fs::file_mode::is_executable`, matching pnpm's
+        // `modeIsExecutable`), so a blob written as `-exec` is read back
+        // as `-exec` and vice versa. Using a raw `0o111` literal here
+        // silently diverged from the write side for modes like `0o744`
+        // and turned every lookup of such a file into a cache miss.
+        let suffix = if is_executable(mode) { "-exec" } else { "" };
         Some(self.file_path_by_hex_str(hex, suffix))
     }
 }
@@ -85,6 +95,34 @@ mod tests {
             true,
             "STORE_DIR/v11/files/30/9ecc489c12d6eb4cc40f50c902f2b4d0ed77ee511a7c7a9bcd3ca86d4cd86f989dd35bc5ff499670da34255b45b0cfd830e81f605dcf7dc5542e93ae9cd76f-exec",
         );
+    }
+
+    #[test]
+    fn cas_file_path_by_mode_suffix_matches_write_side() {
+        // Tarballs frequently ship scripts as `0o744` (user-exec only).
+        // The write side treats any-exec-bit-set as executable and stores
+        // the blob under `-exec`; the read side must use the same rule,
+        // otherwise every cache lookup for such a file turns into a miss.
+        let store_dir = StoreDir::new("STORE_DIR");
+        let hex = "a".repeat(128);
+        for mode in [0o744, 0o755, 0o775, 0o100, 0o010, 0o001] {
+            let path = store_dir
+                .cas_file_path_by_mode(&hex, mode)
+                .unwrap_or_else(|| panic!("mode {mode:o} should produce a path"));
+            assert!(
+                path.to_string_lossy().ends_with("-exec"),
+                "mode {mode:o} should resolve to an `-exec` path, got {path:?}"
+            );
+        }
+        for mode in [0o644, 0o600, 0o444, 0o000] {
+            let path = store_dir
+                .cas_file_path_by_mode(&hex, mode)
+                .unwrap_or_else(|| panic!("mode {mode:o} should produce a path"));
+            assert!(
+                !path.to_string_lossy().ends_with("-exec"),
+                "mode {mode:o} should NOT resolve to an `-exec` path, got {path:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/store-dir/src/cas_file.rs
+++ b/crates/store-dir/src/cas_file.rs
@@ -18,13 +18,18 @@ impl StoreDir {
     /// [`getFilePathByModeInCafs`](https://github.com/pnpm/pnpm/blob/main/store/cafs/src/getFilePathInCafs.ts)
     /// so index entries written by either tool resolve to the same path.
     ///
-    /// Returns `None` when `hex` is too short or not ASCII-hex — the
-    /// underlying split slices `hex[..2]` and would otherwise panic on a
-    /// corrupt / partially-interop row. Callers treat `None` as "cache
-    /// miss" so a bad index entry falls through to a fresh download
-    /// instead of aborting the install.
+    /// Returns `None` when `hex` is too short or not ASCII-hex.
+    ///
+    /// We require *more* than two hex chars — the first two become the
+    /// shard directory `files/XX/`, and the rest is the file component.
+    /// A two-char input produces an empty tail, which on disk is the
+    /// shard directory itself (usually present), so without this tighter
+    /// check a caller would hand a directory path back as if it were a
+    /// CAFS file path. The ASCII-hex requirement additionally guards the
+    /// `hex[..2]` slice inside `file_path_by_hex_str` from panicking on
+    /// non-UTF-8-char-boundary input.
     pub fn cas_file_path_by_mode(&self, hex: &str, mode: u32) -> Option<PathBuf> {
-        if hex.len() < 2 || !hex.bytes().all(|b| b.is_ascii_hexdigit()) {
+        if hex.len() <= 2 || !hex.bytes().all(|b| b.is_ascii_hexdigit()) {
             return None;
         }
         let suffix = if (mode & 0o111) != 0 { "-exec" } else { "" };
@@ -87,9 +92,12 @@ mod tests {
         let store_dir = StoreDir::new("STORE_DIR");
         assert_eq!(store_dir.cas_file_path_by_mode("", 0o644), None);
         assert_eq!(store_dir.cas_file_path_by_mode("a", 0o644), None);
+        // Exactly two hex chars is still rejected — it would resolve to
+        // the shard directory itself (files/XX/), which is not a file.
+        assert_eq!(store_dir.cas_file_path_by_mode("ab", 0o644), None);
         assert_eq!(store_dir.cas_file_path_by_mode("zz", 0o644), None);
         assert_eq!(store_dir.cas_file_path_by_mode("Ab\tcd", 0o644), None);
-        assert!(store_dir.cas_file_path_by_mode("ab", 0o644).is_some());
+        assert!(store_dir.cas_file_path_by_mode("abc", 0o644).is_some());
         assert!(store_dir.cas_file_path_by_mode("abcdef", 0o755).is_some());
     }
 }

--- a/crates/store-dir/src/store_index.rs
+++ b/crates/store-dir/src/store_index.rs
@@ -132,9 +132,9 @@ impl StoreIndex {
     pub fn open_readonly(store_dir: &Path) -> Result<Self, StoreIndexError> {
         let db_path = store_dir.join("index.db");
         let conn = Connection::open_with_flags(&db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
-            .map_err(|source| StoreIndexError::Open { path: db_path, source })?;
+            .map_err(|source| StoreIndexError::Open { path: db_path.clone(), source })?;
         conn.busy_timeout(std::time::Duration::from_secs(5))
-            .map_err(|source| StoreIndexError::InitSchema { source })?;
+            .map_err(|source| StoreIndexError::Open { path: db_path, source })?;
         Ok(StoreIndex { conn })
     }
 

--- a/crates/store-dir/src/store_index.rs
+++ b/crates/store-dir/src/store_index.rs
@@ -119,14 +119,22 @@ impl StoreIndex {
         StoreIndex::open(&store_dir.v11())
     }
 
-    /// Open an existing `index.db` read-only. Does not run any PRAGMAs or
-    /// `CREATE TABLE IF NOT EXISTS`, so it will not create WAL / SHM sidecar
-    /// files or otherwise mutate the store. Suitable for tests and tooling
-    /// that only need to inspect the current index state.
+    /// Open an existing `index.db` read-only. Skips the schema-mutating
+    /// PRAGMAs (`journal_mode=WAL`, `synchronous`, `wal_autocheckpoint`)
+    /// and `CREATE TABLE IF NOT EXISTS`, so the call cannot create WAL /
+    /// SHM sidecar files or otherwise mutate the store.
+    ///
+    /// We *do* set `busy_timeout`: it's a connection-local wait, not a
+    /// DB mutation, and without it a concurrent writer (pnpm or another
+    /// pacquet process) turns every cache lookup during contention into
+    /// an immediate `SQLITE_BUSY` — i.e. a spurious cache miss that
+    /// triggers a full re-download. 5 s matches the writer side.
     pub fn open_readonly(store_dir: &Path) -> Result<Self, StoreIndexError> {
         let db_path = store_dir.join("index.db");
         let conn = Connection::open_with_flags(&db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
             .map_err(|source| StoreIndexError::Open { path: db_path, source })?;
+        conn.busy_timeout(std::time::Duration::from_secs(5))
+            .map_err(|source| StoreIndexError::InitSchema { source })?;
         Ok(StoreIndex { conn })
     }
 

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -114,18 +114,26 @@ async fn load_cached_cas_paths(
         let entry = index.get(&cache_key).ok()??;
 
         let mut cas_paths = HashMap::with_capacity(entry.files.len());
-        for (filename, info) in &entry.files {
+        // Consume `entry.files` so the owned `String` keys can move
+        // straight into `cas_paths` — cloning each filename is an extra
+        // alloc per file in the package, and on a real tarball that's
+        // hundreds of strings.
+        for (filename, info) in entry.files {
             // `?` on `cas_file_path_by_mode` handles corrupt digests (empty,
             // too short, or non-hex) as a cache miss. Without it the
             // `hex[..2]` slice inside `file_path_by_hex_str` would panic.
             let path = store_dir.cas_file_path_by_mode(&info.digest, info.mode)?;
-            // Use metadata().is_file() rather than path.exists() so a
-            // directory squatting at the CAFS path (store corruption,
-            // stray `mkdir -p`, whatever) is rejected — `exists()` would
-            // otherwise return true and a caller would try to link a
-            // directory as if it were a file. Any metadata error also
-            // counts as a miss (blob pruned, permission issue, …).
-            if !path.metadata().is_ok_and(|m| m.is_file()) {
+            // Use `symlink_metadata()` + reject symlinks so this check
+            // applies to the CAFS path itself without ever following a
+            // link. That rules out directory squatting, symlinked
+            // blobs (which could point *outside* the store — a store
+            // corruption / tampering vector), and other non-regular
+            // filesystem objects. Any metadata error also counts as a
+            // miss (blob pruned, permission issue, …).
+            if !path.symlink_metadata().is_ok_and(|m| {
+                let file_type = m.file_type();
+                !file_type.is_symlink() && file_type.is_file()
+            }) {
                 // Treat the whole entry as invalid and re-fetch — partial
                 // reuse would give the caller a broken layout.
                 tracing::debug!(
@@ -137,7 +145,7 @@ async fn load_cached_cas_paths(
                 );
                 return None;
             }
-            cas_paths.insert(filename.clone(), path);
+            cas_paths.insert(filename, path);
         }
         Some(cas_paths)
     })
@@ -696,6 +704,69 @@ mod tests {
         .run_without_mem_cache()
         .await
         .expect_err("directory at CAFS path must not resolve to a cache hit");
+        assert!(
+            matches!(err, TarballError::FetchTarball(_)),
+            "expected fall-through to network fetch, got: {err:?}"
+        );
+
+        drop(store_dir);
+    }
+
+    /// A symlink at the CAFS path — even one pointing at a valid regular
+    /// file — must not be trusted. A tampered / corrupted store could
+    /// place one pointing outside the store entirely, so we use
+    /// `symlink_metadata()` and reject symlinks regardless of target.
+    #[tokio::test]
+    #[cfg(not(target_os = "windows"))]
+    async fn falls_through_when_cafs_path_is_a_symlink() {
+        let (store_dir, store_path) = tempdir_with_leaked_path();
+
+        let pkg_integrity =
+            integrity("sha512-q/IXcMGuF8v7ZLf/JeYfE/pB4Wg1yxT6jXJz8JxRK7a4mJSXV1QKMXDPfZkvMHTZpYxWBDoJiXtptDWFnoCA2w==");
+        let pkg_id = "fake@1.0.0";
+        let index_key = store_index_key(&pkg_integrity.to_string(), pkg_id);
+
+        let digest = "b".repeat(128);
+        let cafs_path = store_path
+            .cas_file_path_by_mode(&digest, 0o644)
+            .expect("128-char hex must produce a valid CAFS path");
+        std::fs::create_dir_all(cafs_path.parent().unwrap()).unwrap();
+
+        // Plant a symlink at the CAFS path pointing at a real regular
+        // file elsewhere. `metadata()` would have followed it and the
+        // check would have (incorrectly) succeeded; `symlink_metadata()`
+        // must reject the link itself.
+        let target = store_dir.path().join("outside-the-cafs.txt");
+        std::fs::write(&target, b"evil").unwrap();
+        std::os::unix::fs::symlink(&target, &cafs_path).unwrap();
+
+        let mut files = HashMap::new();
+        files.insert(
+            "package.json".to_string(),
+            CafsFileInfo { digest, mode: 0o644, size: 4, checked_at: None },
+        );
+        let entry = PackageFilesIndex {
+            manifest: None,
+            requires_build: None,
+            algo: "sha512".to_string(),
+            files,
+            side_effects: None,
+        };
+        let index = StoreIndex::open_in(store_path).unwrap();
+        index.set(&index_key, &entry).unwrap();
+        drop(index);
+
+        let err = DownloadTarballToStore {
+            http_client: &Default::default(),
+            store_dir: store_path,
+            package_integrity: &pkg_integrity,
+            package_unpacked_size: None,
+            package_url: "http://127.0.0.1:1/unreachable.tgz",
+            package_id: pkg_id,
+        }
+        .run_without_mem_cache()
+        .await
+        .expect_err("symlink at CAFS path must not resolve to a cache hit");
         assert!(
             matches!(err, TarballError::FetchTarball(_)),
             "expected fall-through to network fetch, got: {err:?}"

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -99,10 +99,12 @@ fn decompress_gzip(gz_data: &[u8], unpacked_size: Option<usize>) -> Result<Vec<u
 
 /// Try to reconstruct the `{filename → CAFS path}` map for a package from
 /// the SQLite store index, without going to the network. Returns `None` if
-/// anything looks off — no db, no row, unreadable row, or any referenced
-/// CAFS file missing from disk — so the caller falls through to a fresh
-/// download. Every error path is silent because the index is a cache hint,
-/// not a source of truth.
+/// anything looks off — no db, no row, unreadable row, malformed digest,
+/// or any referenced CAFS file missing from disk — so the caller falls
+/// through to a fresh download. Error paths are treated as cache misses
+/// because the index is a cache hint, not a source of truth; only the
+/// missing-blob case emits a `debug!` log to note a stale entry before
+/// re-fetching.
 async fn load_cached_cas_paths(
     store_dir: &'static StoreDir,
     cache_key: &str,
@@ -114,7 +116,10 @@ async fn load_cached_cas_paths(
 
         let mut cas_paths = HashMap::with_capacity(entry.files.len());
         for (filename, info) in &entry.files {
-            let path = store_dir.cas_file_path_by_mode(&info.digest, info.mode);
+            // `?` on `cas_file_path_by_mode` handles corrupt digests (empty,
+            // too short, or non-hex) as a cache miss. Without it the
+            // `hex[..2]` slice inside `file_path_by_hex_str` would panic.
+            let path = store_dir.cas_file_path_by_mode(&info.digest, info.mode)?;
             if !path.exists() {
                 // A CAFS blob has been pruned or deleted out from under us.
                 // Treat the whole entry as invalid and re-fetch — partial
@@ -210,7 +215,7 @@ impl<'a> DownloadTarballToStore<'a> {
         // Before hitting the network, check the SQLite store index: if the
         // tarball is already in the CAFS we can reuse its per-file paths
         // and skip the download entirely. This is the payoff of the v11
-        // store migration (#247) — pnpm and pacquet share `index.db`, so a
+        // store migration (#244) — pnpm and pacquet share `index.db`, so a
         // previous install of the same (integrity, pkg_id) pair leaves an
         // entry we can read back here.
         //
@@ -584,6 +589,56 @@ mod tests {
         .run_without_mem_cache()
         .await
         .expect_err("stale index entry must not resolve to a cache hit");
+        assert!(
+            matches!(err, TarballError::FetchTarball(_)),
+            "expected fall-through to network fetch, got: {err:?}"
+        );
+
+        drop(store_dir);
+    }
+
+    /// A corrupt row whose digest is empty (or too short / non-hex) used
+    /// to panic inside `StoreDir::file_path_by_hex_str` (`hex[..2]`). The
+    /// validation in `cas_file_path_by_mode` now rejects such rows, and
+    /// `load_cached_cas_paths` treats that as a cache miss.
+    #[tokio::test]
+    async fn falls_through_when_digest_is_malformed() {
+        let (store_dir, store_path) = tempdir_with_leaked_path();
+
+        let pkg_integrity =
+            integrity("sha512-q/IXcMGuF8v7ZLf/JeYfE/pB4Wg1yxT6jXJz8JxRK7a4mJSXV1QKMXDPfZkvMHTZpYxWBDoJiXtptDWFnoCA2w==");
+        let pkg_id = "fake@1.0.0";
+        let index_key = store_index_key(&pkg_integrity.to_string(), pkg_id);
+
+        let mut files = HashMap::new();
+        files.insert(
+            "package.json".to_string(),
+            // Empty digest — pre-fix this would panic in the spawn_blocking
+            // task during `hex[..2]`.
+            CafsFileInfo { digest: String::new(), mode: 0o644, size: 0, checked_at: None },
+        );
+        let entry = PackageFilesIndex {
+            manifest: None,
+            requires_build: None,
+            algo: "sha512".to_string(),
+            files,
+            side_effects: None,
+        };
+        let index = StoreIndex::open_in(store_path).unwrap();
+        index.set(&index_key, &entry).unwrap();
+        drop(index);
+
+        let err = DownloadTarballToStore {
+            http_client: &Default::default(),
+            store_dir: store_path,
+            package_integrity: &pkg_integrity,
+            package_unpacked_size: None,
+            package_url: "http://127.0.0.1:1/unreachable.tgz",
+            package_id: pkg_id,
+        }
+        .run_without_mem_cache()
+        .await
+        .expect_err("corrupt digest must not resolve to a cache hit");
         assert!(
             matches!(err, TarballError::FetchTarball(_)),
             "expected fall-through to network fetch, got: {err:?}"

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -307,7 +307,7 @@ impl<'a> DownloadTarballToStore<'a> {
                     let mut entry = entry.unwrap();
 
                     let file_mode = entry.header().mode().expect("get mode"); // TODO: properly propagate this error
-                    let file_is_executable = file_mode::is_all_exec(file_mode);
+                    let file_is_executable = file_mode::is_executable(file_mode);
 
                     // Read the contents of the entry
                     let mut buffer = Vec::with_capacity(entry.size() as usize);

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -107,9 +107,8 @@ fn decompress_gzip(gz_data: &[u8], unpacked_size: Option<usize>) -> Result<Vec<u
 /// re-fetching.
 async fn load_cached_cas_paths(
     store_dir: &'static StoreDir,
-    cache_key: &str,
+    cache_key: String,
 ) -> Option<HashMap<String, PathBuf>> {
-    let cache_key = cache_key.to_string();
     tokio::task::spawn_blocking(move || -> Option<HashMap<String, PathBuf>> {
         let index = StoreIndex::open_readonly_in(store_dir).ok()?;
         let entry = index.get(&cache_key).ok()??;
@@ -225,8 +224,8 @@ impl<'a> DownloadTarballToStore<'a> {
         // CAFS file that has gone missing from disk all fall through to
         // the download path below.
         let cache_key = store_index_key(&package_integrity.to_string(), package_id);
-        if let Some(cas_paths) = load_cached_cas_paths(store_dir, &cache_key).await {
-            tracing::info!(target: "pacquet::download", ?package_url, ?cache_key, "Reusing cached CAFS entry — skipping download");
+        if let Some(cas_paths) = load_cached_cas_paths(store_dir, cache_key).await {
+            tracing::info!(target: "pacquet::download", ?package_url, ?package_id, "Reusing cached CAFS entry — skipping download");
             return Ok(cas_paths);
         }
 

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -408,6 +408,20 @@ mod tests {
         integrity_str.parse().expect("parse integrity string")
     }
 
+    /// HTTP client for the fall-through tests. A default `ThrottledClient`
+    /// uses `Client::new()` with no connect / request timeout, so on a
+    /// firewalled runner the unreachable `http://127.0.0.1:1/...` URL
+    /// could stall for minutes of TCP retry. One-second bounds are
+    /// plenty for loopback and keep the failure mode deterministic.
+    fn fast_fail_client() -> ThrottledClient {
+        let client = reqwest::Client::builder()
+            .connect_timeout(std::time::Duration::from_secs(1))
+            .timeout(std::time::Duration::from_secs(1))
+            .build()
+            .expect("build reqwest client");
+        ThrottledClient::from_client(client)
+    }
+
     /// **Problem:**
     /// The tested function requires `'static` paths, leaking would prevent
     /// temporary files from being cleaned up.
@@ -537,13 +551,14 @@ mod tests {
         drop(index);
 
         let cas_paths = DownloadTarballToStore {
-            http_client: &Default::default(),
+            http_client: &fast_fail_client(),
             store_dir: store_path,
             package_integrity: &pkg_integrity,
             package_unpacked_size: None,
             // Any request that reaches the network here would fail the
-            // test by blowing up or hanging; the cache lookup must
-            // short-circuit before we get near it.
+            // test; the cache lookup must short-circuit before we get
+            // near it. `fast_fail_client` caps that at 1 s per side in
+            // case a firewalled runner drops the packet silently.
             package_url: "http://127.0.0.1:1/unreachable.tgz",
             package_id: pkg_id,
         }
@@ -594,7 +609,7 @@ mod tests {
         drop(index);
 
         let err = DownloadTarballToStore {
-            http_client: &Default::default(),
+            http_client: &fast_fail_client(),
             store_dir: store_path,
             package_integrity: &pkg_integrity,
             package_unpacked_size: None,
@@ -644,7 +659,7 @@ mod tests {
         drop(index);
 
         let err = DownloadTarballToStore {
-            http_client: &Default::default(),
+            http_client: &fast_fail_client(),
             store_dir: store_path,
             package_integrity: &pkg_integrity,
             package_unpacked_size: None,
@@ -697,7 +712,7 @@ mod tests {
         drop(index);
 
         let err = DownloadTarballToStore {
-            http_client: &Default::default(),
+            http_client: &fast_fail_client(),
             store_dir: store_path,
             package_integrity: &pkg_integrity,
             package_unpacked_size: None,
@@ -760,7 +775,7 @@ mod tests {
         drop(index);
 
         let err = DownloadTarballToStore {
-            http_client: &Default::default(),
+            http_client: &fast_fail_client(),
             store_dir: store_path,
             package_integrity: &pkg_integrity,
             package_unpacked_size: None,

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -97,6 +97,46 @@ fn decompress_gzip(gz_data: &[u8], unpacked_size: Option<usize>) -> Result<Vec<u
         .map_err(TarballError::DecodeGzip)
 }
 
+/// Try to reconstruct the `{filename → CAFS path}` map for a package from
+/// the SQLite store index, without going to the network. Returns `None` if
+/// anything looks off — no db, no row, unreadable row, or any referenced
+/// CAFS file missing from disk — so the caller falls through to a fresh
+/// download. Every error path is silent because the index is a cache hint,
+/// not a source of truth.
+async fn load_cached_cas_paths(
+    store_dir: &'static StoreDir,
+    cache_key: &str,
+) -> Option<HashMap<String, PathBuf>> {
+    let cache_key = cache_key.to_string();
+    tokio::task::spawn_blocking(move || -> Option<HashMap<String, PathBuf>> {
+        let index = StoreIndex::open_readonly_in(store_dir).ok()?;
+        let entry = index.get(&cache_key).ok()??;
+
+        let mut cas_paths = HashMap::with_capacity(entry.files.len());
+        for (filename, info) in &entry.files {
+            let path = store_dir.cas_file_path_by_mode(&info.digest, info.mode);
+            if !path.exists() {
+                // A CAFS blob has been pruned or deleted out from under us.
+                // Treat the whole entry as invalid and re-fetch — partial
+                // reuse would give the caller a broken layout.
+                tracing::debug!(
+                    target: "pacquet::download",
+                    ?cache_key,
+                    ?filename,
+                    ?path,
+                    "CAFS file missing; index entry is stale, re-fetching"
+                );
+                return None;
+            }
+            cas_paths.insert(filename.clone(), path);
+        }
+        Some(cas_paths)
+    })
+    .await
+    .ok()
+    .flatten()
+}
+
 /// This subroutine downloads and extracts a tarball to the store directory.
 ///
 /// It returns a CAS map of files in the tarball.
@@ -166,6 +206,24 @@ impl<'a> DownloadTarballToStore<'a> {
             package_url,
             package_id,
         } = self;
+
+        // Before hitting the network, check the SQLite store index: if the
+        // tarball is already in the CAFS we can reuse its per-file paths
+        // and skip the download entirely. This is the payoff of the v11
+        // store migration (#247) — pnpm and pacquet share `index.db`, so a
+        // previous install of the same (integrity, pkg_id) pair leaves an
+        // entry we can read back here.
+        //
+        // The lookup is best-effort. A missing `index.db`, a missing row,
+        // an unreadable entry (e.g. written by pnpm's msgpackr record
+        // encoding — decoding support for that is a follow-up), or any
+        // CAFS file that has gone missing from disk all fall through to
+        // the download path below.
+        let cache_key = store_index_key(&package_integrity.to_string(), package_id);
+        if let Some(cas_paths) = load_cached_cas_paths(store_dir, &cache_key).await {
+            tracing::info!(target: "pacquet::download", ?package_url, ?cache_key, "Reusing cached CAFS entry — skipping download");
+            return Ok(cas_paths);
+        }
 
         tracing::info!(target: "pacquet::download", ?package_url, "New cache");
 
@@ -402,6 +460,134 @@ mod tests {
         .run_without_mem_cache()
         .await
         .expect_err("checksum mismatch");
+
+        drop(store_dir);
+    }
+
+    /// When the SQLite index already has an entry for this
+    /// `(integrity, pkg_id)` pair and every referenced CAFS file is on
+    /// disk, `run_without_mem_cache` must return the cached layout
+    /// without issuing an HTTP request. We prove the "no network"
+    /// property by pointing `package_url` at an address that would
+    /// fail-fast if dialed.
+    #[tokio::test]
+    async fn reuses_cached_cas_paths_when_index_entry_is_live() {
+        let (store_dir, store_path) = tempdir_with_leaked_path();
+
+        let (pkg_json_path, pkg_json_hash) =
+            store_path.write_cas_file(b"{\"name\":\"fake\"}", false).unwrap();
+        let (bin_path, bin_hash) =
+            store_path.write_cas_file(b"#!/usr/bin/env node\nconsole.log('hi');\n", true).unwrap();
+
+        let pkg_integrity =
+            integrity("sha512-q/IXcMGuF8v7ZLf/JeYfE/pB4Wg1yxT6jXJz8JxRK7a4mJSXV1QKMXDPfZkvMHTZpYxWBDoJiXtptDWFnoCA2w==");
+        let pkg_id = "fake@1.0.0";
+        let index_key = store_index_key(&pkg_integrity.to_string(), pkg_id);
+
+        let mut files = HashMap::new();
+        files.insert(
+            "package.json".to_string(),
+            CafsFileInfo {
+                digest: format!("{pkg_json_hash:x}"),
+                mode: 0o644,
+                size: 15,
+                checked_at: None,
+            },
+        );
+        files.insert(
+            "bin/cli.js".to_string(),
+            CafsFileInfo {
+                digest: format!("{bin_hash:x}"),
+                mode: 0o755,
+                size: 39,
+                checked_at: None,
+            },
+        );
+
+        let entry = PackageFilesIndex {
+            manifest: None,
+            requires_build: Some(false),
+            algo: "sha512".to_string(),
+            files,
+            side_effects: None,
+        };
+
+        let index = StoreIndex::open_in(store_path).unwrap();
+        index.set(&index_key, &entry).unwrap();
+        drop(index);
+
+        let cas_paths = DownloadTarballToStore {
+            http_client: &Default::default(),
+            store_dir: store_path,
+            package_integrity: &pkg_integrity,
+            package_unpacked_size: None,
+            // Any request that reaches the network here would fail the
+            // test by blowing up or hanging; the cache lookup must
+            // short-circuit before we get near it.
+            package_url: "http://127.0.0.1:1/unreachable.tgz",
+            package_id: pkg_id,
+        }
+        .run_without_mem_cache()
+        .await
+        .expect("cache hit should succeed without network");
+
+        assert_eq!(cas_paths.len(), 2);
+        assert_eq!(cas_paths.get("package.json"), Some(&pkg_json_path));
+        assert_eq!(cas_paths.get("bin/cli.js"), Some(&bin_path));
+
+        drop(store_dir);
+    }
+
+    /// If the index row points at a CAFS blob that no longer exists on
+    /// disk (pruned out-of-band, say), the cache lookup must reject the
+    /// entry and fall through to a download. We don't want to do the
+    /// download for real in a unit test, so assert that we got a
+    /// `FetchTarball` error from the unreachable URL rather than the
+    /// cache-hit's `Ok`.
+    #[tokio::test]
+    async fn falls_through_when_cafs_file_missing() {
+        let (store_dir, store_path) = tempdir_with_leaked_path();
+
+        let pkg_integrity =
+            integrity("sha512-q/IXcMGuF8v7ZLf/JeYfE/pB4Wg1yxT6jXJz8JxRK7a4mJSXV1QKMXDPfZkvMHTZpYxWBDoJiXtptDWFnoCA2w==");
+        let pkg_id = "fake@1.0.0";
+        let index_key = store_index_key(&pkg_integrity.to_string(), pkg_id);
+
+        let mut files = HashMap::new();
+        // A digest that matches no file on disk. `load_cached_cas_paths`
+        // should see the missing path, reject the entry, and let
+        // `run_without_mem_cache` proceed to the network fetch.
+        files.insert(
+            "package.json".to_string(),
+            CafsFileInfo { digest: "0".repeat(128), mode: 0o644, size: 0, checked_at: None },
+        );
+
+        let entry = PackageFilesIndex {
+            manifest: None,
+            requires_build: None,
+            algo: "sha512".to_string(),
+            files,
+            side_effects: None,
+        };
+        let index = StoreIndex::open_in(store_path).unwrap();
+        index.set(&index_key, &entry).unwrap();
+        drop(index);
+
+        let err = DownloadTarballToStore {
+            http_client: &Default::default(),
+            store_dir: store_path,
+            package_integrity: &pkg_integrity,
+            package_unpacked_size: None,
+            package_url: "http://127.0.0.1:1/unreachable.tgz",
+            package_id: pkg_id,
+        }
+        .run_without_mem_cache()
+        .await
+        .expect_err("stale index entry must not resolve to a cache hit");
+        assert!(
+            matches!(err, TarballError::FetchTarball(_)),
+            "expected fall-through to network fetch, got: {err:?}"
+        );
 
         drop(store_dir);
     }

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -119,8 +119,13 @@ async fn load_cached_cas_paths(
             // too short, or non-hex) as a cache miss. Without it the
             // `hex[..2]` slice inside `file_path_by_hex_str` would panic.
             let path = store_dir.cas_file_path_by_mode(&info.digest, info.mode)?;
-            if !path.exists() {
-                // A CAFS blob has been pruned or deleted out from under us.
+            // Use metadata().is_file() rather than path.exists() so a
+            // directory squatting at the CAFS path (store corruption,
+            // stray `mkdir -p`, whatever) is rejected — `exists()` would
+            // otherwise return true and a caller would try to link a
+            // directory as if it were a file. Any metadata error also
+            // counts as a miss (blob pruned, permission issue, …).
+            if !path.metadata().is_ok_and(|m| m.is_file()) {
                 // Treat the whole entry as invalid and re-fetch — partial
                 // reuse would give the caller a broken layout.
                 tracing::debug!(
@@ -128,7 +133,7 @@ async fn load_cached_cas_paths(
                     ?cache_key,
                     ?filename,
                     ?path,
-                    "CAFS file missing; index entry is stale, re-fetching"
+                    "CAFS path missing or not a regular file; index entry is stale, re-fetching"
                 );
                 return None;
             }
@@ -638,6 +643,59 @@ mod tests {
         .run_without_mem_cache()
         .await
         .expect_err("corrupt digest must not resolve to a cache hit");
+        assert!(
+            matches!(err, TarballError::FetchTarball(_)),
+            "expected fall-through to network fetch, got: {err:?}"
+        );
+
+        drop(store_dir);
+    }
+
+    /// A corrupted store might have a directory sitting where a CAFS blob
+    /// belongs (stray `mkdir -p`, interrupted write, whatever). `exists()`
+    /// would have let it through; `metadata().is_file()` rejects it.
+    #[tokio::test]
+    async fn falls_through_when_cafs_path_is_a_directory() {
+        let (store_dir, store_path) = tempdir_with_leaked_path();
+
+        let pkg_integrity =
+            integrity("sha512-q/IXcMGuF8v7ZLf/JeYfE/pB4Wg1yxT6jXJz8JxRK7a4mJSXV1QKMXDPfZkvMHTZpYxWBDoJiXtptDWFnoCA2w==");
+        let pkg_id = "fake@1.0.0";
+        let index_key = store_index_key(&pkg_integrity.to_string(), pkg_id);
+
+        let digest = "a".repeat(128);
+        let cafs_path = store_path
+            .cas_file_path_by_mode(&digest, 0o644)
+            .expect("128-char hex must produce a valid CAFS path");
+        std::fs::create_dir_all(&cafs_path).unwrap();
+
+        let mut files = HashMap::new();
+        files.insert(
+            "package.json".to_string(),
+            CafsFileInfo { digest, mode: 0o644, size: 0, checked_at: None },
+        );
+        let entry = PackageFilesIndex {
+            manifest: None,
+            requires_build: None,
+            algo: "sha512".to_string(),
+            files,
+            side_effects: None,
+        };
+        let index = StoreIndex::open_in(store_path).unwrap();
+        index.set(&index_key, &entry).unwrap();
+        drop(index);
+
+        let err = DownloadTarballToStore {
+            http_client: &Default::default(),
+            store_dir: store_path,
+            package_integrity: &pkg_integrity,
+            package_unpacked_size: None,
+            package_url: "http://127.0.0.1:1/unreachable.tgz",
+            package_id: pkg_id,
+        }
+        .run_without_mem_cache()
+        .await
+        .expect_err("directory at CAFS path must not resolve to a cache hit");
         assert!(
             matches!(err, TarballError::FetchTarball(_)),
             "expected fall-through to network fetch, got: {err:?}"

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -98,13 +98,16 @@ fn decompress_gzip(gz_data: &[u8], unpacked_size: Option<usize>) -> Result<Vec<u
 }
 
 /// Try to reconstruct the `{filename → CAFS path}` map for a package from
-/// the SQLite store index, without going to the network. Returns `None` if
-/// anything looks off — no db, no row, unreadable row, malformed digest,
-/// or any referenced CAFS file missing from disk — so the caller falls
-/// through to a fresh download. Error paths are treated as cache misses
-/// because the index is a cache hint, not a source of truth; only the
-/// missing-blob case emits a `debug!` log to note a stale entry before
-/// re-fetching.
+/// the SQLite store index, without going to the network. Returns `None`
+/// if anything looks off — no db, no row, unreadable row, malformed
+/// digest, or any referenced CAFS path that fails validation — so the
+/// caller falls through to a fresh download. Error paths are treated as
+/// cache misses because the index is a cache hint, not a source of
+/// truth. Any CAFS-path validation failure (missing blob, metadata
+/// error, directory, symlink, or other non-regular file) emits a
+/// `debug!` log to note the stale entry before re-fetching; earlier
+/// checks — db / row / decode / digest — are silent because they don't
+/// point at a specific on-disk artifact worth describing.
 async fn load_cached_cas_paths(
     store_dir: &'static StoreDir,
     cache_key: String,


### PR DESCRIPTION
## Summary
- `DownloadTarballToStore::run_without_mem_cache` now checks `<store>/v11/index.db` before every HTTP fetch; if the entry is live (row decodes, every referenced CAFS path is a real regular file) we return the cached `{filename → PathBuf}` map and skip the download entirely.
- Adds `StoreDir::cas_file_path_by_mode(hex, mode) -> Option<PathBuf>` mirroring pnpm's `getFilePathByModeInCafs` — reconstructs a CAFS path from the index's pre-computed digest + mode without re-hashing. Returns `None` on malformed digests (non-hex or `len <= 2`, which would resolve to the shard directory itself).
- `StoreIndex::open_readonly` now sets `busy_timeout=5s`, so a concurrent pnpm / pacquet writer no longer turns cache lookups into immediate `SQLITE_BUSY` misses.
- SQLite open + read runs on `tokio::task::spawn_blocking`, keeping PRAGMA setup and busy waits off the tokio reactor.

This is the shared-store payoff of the v11 migration (#244): once pacquet or pnpm writes an entry for `(integrity, pkg_id)`, subsequent pacquet installs reuse it without touching the registry.

### Drive-by
- `apply_resolves_relative_paths_against_base_dir` was asserting against a hard-coded Unix-style path string that fails on Windows (`\` separator from `Path::join`). Rebuild the expected via `base.join(…)` and compare `StoreDir` values directly so the test is portable. Pulled in because CI was blocking on it.

### Scope / caveats

- The cache lookup is best-effort. Missing db, missing row, decode error, corrupt digest, missing blob, a directory or symlink squatting at a CAFS path, or any metadata error all fall through to a fresh download. An entry is all-or-nothing: a single bad file invalidates the whole entry.
- Symlinked blobs are rejected regardless of target — a tampered store could plant one pointing outside the CAFS, so the validation uses `symlink_metadata()` and refuses links outright rather than following them.
- Reading rows that **pnpm** wrote still depends on msgpackr record-extension decoding, tracked as a follow-up on #244. Rows pacquet writes itself interop fine (named-field msgpack via `rmp_serde::to_vec_named`).

## Test plan
- [x] `cargo test -p pacquet-tarball --lib` — 7 passing, five of them new
  - `reuses_cached_cas_paths_when_index_entry_is_live` pre-populates the index + CAFS files and points `package_url` at `http://127.0.0.1:1/unreachable.tgz`; a cache-hit is the only way this can succeed
  - `falls_through_when_cafs_file_missing` — index entry whose digest has no blob on disk
  - `falls_through_when_digest_is_malformed` — empty digest string (used to panic in `hex[..2]`)
  - `falls_through_when_cafs_path_is_a_directory` — `mkdir -p` at the computed CAFS path
  - `falls_through_when_cafs_path_is_a_symlink` — symlink at the CAFS path pointing at a regular file outside the store
  - All four fall-through tests assert `TarballError::FetchTarball` from the unreachable URL, proving the cache lookup rejected the entry and actually attempted the fetch
- [x] `cargo test -p pacquet-store-dir --lib` — adds `cas_file_path_by_mode_rejects_invalid_hex`
- [x] `cargo test -p pacquet-npmrc --lib workspace_yaml::` — fixed Windows relative-path test
- [x] `cargo build --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`

Refs #244.