### PR TITLE
ci(benchmark): compare against pnpm in Integrated-Benchmark

### DIFF
--- a/.github/workflows/integrated-benchmark.yml
+++ b/.github/workflows/integrated-benchmark.yml
@@ -121,7 +121,7 @@ jobs:
       #   run: |
       #     just integrated-benchmark --scenario=clean-install --verdaccio --with-pnpm HEAD main
       #     cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_CLEAN_INSTALL.md
-      #     cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_FROZEN_LOCKFILE.json
+      #     cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_CLEAN_INSTALL.json
 
       - name: Generate summary
         shell: bash

--- a/.github/workflows/integrated-benchmark.yml
+++ b/.github/workflows/integrated-benchmark.yml
@@ -112,14 +112,14 @@ jobs:
       - name: 'Benchmark: Frozen Lockfile'
         shell: bash
         run: |
-          just integrated-benchmark --scenario=frozen-lockfile --verdaccio HEAD main
+          just integrated-benchmark --scenario=frozen-lockfile --verdaccio --with-pnpm HEAD main
           cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_FROZEN_LOCKFILE.md
           cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_FROZEN_LOCKFILE.json
 
       # - name: 'Benchmark: Clean Install'
       #   shell: bash
       #   run: |
-      #     just integrated-benchmark --scenario=clean-install --verdaccio HEAD main
+      #     just integrated-benchmark --scenario=clean-install --verdaccio --with-pnpm HEAD main
       #     cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_CLEAN_INSTALL.md
       #     cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_FROZEN_LOCKFILE.json
 

--- a/tasks/integrated-benchmark/src/work_env.rs
+++ b/tasks/integrated-benchmark/src/work_env.rs
@@ -172,10 +172,17 @@ impl WorkEnv {
     }
 
     fn benchmark(&self) {
+        // hyperfine runs `--prepare` before *each* timed invocation, so
+        // cleanup must cover every bench dir we're about to measure.
+        // Previously this only wiped the pacquet revisions — if
+        // `--with-pnpm` was set, pnpm's `node_modules` survived between
+        // iterations, and after the warmup pnpm just hit a no-op
+        // "already installed" code path instead of doing real work.
         let cleanup_targets = self
             .revision_ids()
-            .map(|revision| self.bench_dir(revision))
-            .flat_map(|revision| [revision.join("node_modules"), revision.join("store-dir")])
+            .chain(self.with_pnpm.then_some(WorkEnv::PNPM))
+            .map(|id| self.bench_dir(id))
+            .flat_map(|dir| [dir.join("node_modules"), dir.join("store-dir")])
             .map(|path| path.maybe_quote().to_string())
             .join(" ");
         let cleanup_command = format!("rm -rf {cleanup_targets}");


### PR DESCRIPTION
## Summary

Add a `pnpm` row to the PR-comment benchmark tables. Closes #177 by reviving just the core change — the 2023 branch had bit-rotted beyond trivial rebasing (the store-dir schema, benchmark-task layout, `just` harness, and the pnpm RC version have all moved under it), so this is a fresh, minimal implementation.

## Changes

- `.github/workflows/integrated-benchmark.yml`: pass `--with-pnpm` to the `just integrated-benchmark` invocation. The flag and the required plumbing have been wired through the benchmark crate for a while (see `CliArgs::with_pnpm`, `WorkEnv::with_pnpm`); nothing was using them in CI.
- `tasks/integrated-benchmark/src/work_env.rs`: bugfix — `WorkEnv::benchmark` built the hyperfine `--prepare "rm -rf …"` command from `revision_ids()` only, which covers the `pacquet@HEAD` / `pacquet@main` bench dirs but skips the `pnpm` one when `--with-pnpm` is set. Result: pnpm's `node_modules` survives between iterations, and every run after the warmup hits an "already installed" fast-path instead of doing real work. Fix: include the `pnpm` bench dir in the cleanup iterator when `with_pnpm` is on, so pnpm and pacquet are both measured under cold-`node_modules` conditions. pnpm's global store (`$PNPM_HOME/store/v11`) stays warm across iterations, same as pacquet's — both tools get a fair repeat-install timing.

## Test plan

- [x] `cargo build -p pacquet-integrated-benchmark`
- [x] `cargo clippy -p pacquet-integrated-benchmark --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] **Real verification is the CI run on this PR**: the Integrated-Benchmark job should post a comment whose Markdown table now has three rows (`pacquet@HEAD`, `pacquet@main`, `pnpm`). The `pnpm` row must show a realistic install time (multiple seconds on the benchmark fixture), *not* a warmup-then-noop number.