### PR TITLE
feat(package-manager): hardlink CAS files into node_modules

### DIFF
--- a/crates/npmrc/src/lib.rs
+++ b/crates/npmrc/src/lib.rs
@@ -45,13 +45,13 @@ pub enum PackageImportMethod {
     /// hard link packages from the store
     Hardlink,
 
-    /// try to clone packages from the store. If cloning is not supported then fall back to copying
+    /// copy packages from the store
     Copy,
 
-    /// copy packages from the store
+    /// clone (AKA copy-on-write or reference link) packages from the store
     Clone,
 
-    /// clone (AKA copy-on-write or reference link) packages from the store
+    /// try to clone packages from the store. If cloning is not supported then fall back to copying
     CloneOrCopy,
 }
 

--- a/crates/package-manager/src/create_cas_files.rs
+++ b/crates/package-manager/src/create_cas_files.rs
@@ -23,12 +23,6 @@ pub fn create_cas_files(
     dir_path: &Path,
     cas_paths: &HashMap<String, PathBuf>,
 ) -> Result<(), CreateCasFilesError> {
-    assert_eq!(
-        import_method,
-        PackageImportMethod::Auto,
-        "Only PackageImportMethod::Auto is currently supported, but {dir_path:?} requires {import_method:?}",
-    );
-
     if dir_path.exists() {
         return Ok(());
     }
@@ -36,7 +30,7 @@ pub fn create_cas_files(
     cas_paths
         .par_iter()
         .try_for_each(|(cleaned_entry, store_path)| {
-            link_file(store_path, &dir_path.join(cleaned_entry))
+            link_file(import_method, store_path, &dir_path.join(cleaned_entry))
         })
         .map_err(CreateCasFilesError::LinkFile)
 }

--- a/crates/package-manager/src/link_file.rs
+++ b/crates/package-manager/src/link_file.rs
@@ -51,7 +51,14 @@ pub fn link_file(
     source_file: &Path,
     target_link: &Path,
 ) -> Result<(), LinkFileError> {
-    if target_link.exists() {
+    // `exists()` follows symlinks, so a dangling symlink at
+    // `target_link` (left behind by an interrupted prior install) would
+    // slip through here and make the subsequent `hard_link` / `reflink`
+    // fail with `AlreadyExists`, contradicting the "already exists → no
+    // op" contract in the doc comment above. `symlink_metadata` asks
+    // about the directory entry itself without following, which covers
+    // files, directories, and symlinks (broken or otherwise).
+    if fs::symlink_metadata(target_link).is_ok() {
         return Ok(());
     }
 
@@ -209,9 +216,10 @@ mod tests {
         }
     }
 
-    /// Explicit `Hardlink` across devices (EXDEV) must surface the error
-    /// instead of silently falling back — that's what `Auto` is for. We
-    /// simulate a hard-link failure by pointing at a non-existent source.
+    /// Explicit `Hardlink` must surface link-creation errors instead of
+    /// silently falling back — that's what `Auto` is for. We drive the
+    /// error path by pointing at a non-existent source (`NotFound`) so
+    /// the failure is deterministic on every platform / filesystem.
     #[test]
     fn explicit_hardlink_surfaces_errors() {
         let tmp = tempdir().unwrap();
@@ -221,6 +229,60 @@ mod tests {
         let err =
             link_file(PackageImportMethod::Hardlink, &src, &dst).expect_err("no source → error");
         assert!(matches!(err, LinkFileError::CreateLink { .. }), "got: {err:?}");
+    }
+
+    /// `CloneOrCopy` has to succeed on any filesystem because
+    /// `reflink_or_copy` falls back to a plain copy when the kernel
+    /// can't reflink. This hits the match arm directly — the
+    /// `existing_target_is_preserved` loop short-circuits before the
+    /// arm ever runs, so without this we had no coverage of the real
+    /// code path.
+    #[test]
+    fn clone_or_copy_materializes_the_file_contents() {
+        let tmp = tempdir().unwrap();
+        let src = write_source(tmp.path(), "src.txt", b"clone-or-copy");
+        let dst = tmp.path().join("nested/dst.txt");
+
+        link_file(PackageImportMethod::CloneOrCopy, &src, &dst)
+            .expect("CloneOrCopy should always succeed");
+        assert_eq!(fs::read(&dst).unwrap(), b"clone-or-copy");
+    }
+
+    /// Explicit `Clone` must propagate errors rather than silently
+    /// copying. Pointing at a non-existent source gives us a
+    /// deterministic failure on every FS regardless of reflink
+    /// support, so the test doesn't need a btrfs / APFS runner.
+    #[test]
+    fn explicit_clone_surfaces_errors() {
+        let tmp = tempdir().unwrap();
+        let src = tmp.path().join("does-not-exist");
+        let dst = tmp.path().join("dst.txt");
+
+        let err =
+            link_file(PackageImportMethod::Clone, &src, &dst).expect_err("no source → error");
+        assert!(matches!(err, LinkFileError::CreateLink { .. }), "got: {err:?}");
+    }
+
+    /// A dangling symlink left behind by an interrupted install used
+    /// to sneak past the `target_link.exists()` check (which follows
+    /// symlinks) and then collide with `hard_link` / `reflink` as
+    /// `AlreadyExists`. The doc comment promises "if target_link
+    /// already exists, do nothing" — so the dangling link must be
+    /// treated as already-present.
+    #[test]
+    #[cfg(unix)]
+    fn dangling_symlink_is_treated_as_already_present() {
+        let tmp = tempdir().unwrap();
+        let src = write_source(tmp.path(), "src.txt", b"fresh");
+        let dst = tmp.path().join("dst.txt");
+        // Target of the symlink does not exist — the link is dangling.
+        std::os::unix::fs::symlink(tmp.path().join("never-created"), &dst).unwrap();
+
+        link_file(PackageImportMethod::Hardlink, &src, &dst)
+            .expect("dangling symlink should short-circuit, not fail");
+        // The dangling symlink should still be there, unchanged — we
+        // don't attempt to replace it.
+        assert!(fs::symlink_metadata(&dst).unwrap().file_type().is_symlink());
     }
 
     /// Core caching property: once Auto observes reflink failing, the

--- a/crates/package-manager/src/link_file.rs
+++ b/crates/package-manager/src/link_file.rs
@@ -187,38 +187,27 @@ fn is_cross_device(err: &io::Error) -> bool {
     matches!(err.raw_os_error(), Some(18) | Some(17))
 }
 
-/// Errors that indicate "this filesystem can't reflink" — the kernel
-/// rejected the ioctl, not the file. The downgrade cache uses this to
-/// skip the reflink tier for subsequent files, while letting
-/// `NotFound` / `PermissionDenied` / `AlreadyExists` and other real
-/// errors propagate (a one-off missing-source file must not
-/// permanently disable reflink for the rest of the process).
+/// Errors that indicate the call itself is malformed (missing source,
+/// permission denied, target already exists) — propagate these from
+/// the downgrade cache instead of advancing to the next tier. A
+/// different tier won't fix an invalid call, and downgrading on a
+/// one-off `NotFound` would permanently disable reflink / hardlink for
+/// every other file in the install.
 ///
-/// `ErrorKind::Unsupported` covers Rust's portable layer when newer
-/// standards lands; the raw-errno list covers platforms where the
-/// kernel reports the capability gap as a bare `Err(_)` without
-/// mapping to a kind:
-/// * `ENOSYS` (38) — syscall not implemented
-/// * `EOPNOTSUPP` / `ENOTSUP` (95 Linux, 102 FreeBSD, 45 macOS) —
-///   operation not supported on this fd
-/// * `ENOTTY` (25) — what ext4 returns for `ioctl_ficlone` when the
-///   filesystem doesn't implement reflink; without this, ext4 would
-///   never downgrade and every file would pay the failed-ioctl cost
-///
-/// We additionally treat `EXDEV` as a fallback trigger — a cross-device
-/// reflink can't possibly succeed no matter how many times we retry.
-fn is_reflink_fallback_error(err: &io::Error) -> bool {
-    matches!(err.kind(), io::ErrorKind::Unsupported)
-        || is_cross_device(err)
-        || matches!(err.raw_os_error(), Some(38) | Some(95) | Some(102) | Some(45) | Some(25))
-}
-
-/// Errors that indicate "this filesystem / device pair can't
-/// hardlink". In practice this is `EXDEV` (cross-device) and
-/// `ErrorKind::Unsupported` (some exotic FSes refuse hardlinks
-/// altogether). Everything else propagates.
-fn is_hardlink_fallback_error(err: &io::Error) -> bool {
-    is_cross_device(err) || matches!(err.kind(), io::ErrorKind::Unsupported)
+/// Everything else — including the grab-bag of errno / Windows codes
+/// kernels use to signal "filesystem can't do this operation"
+/// (`EOPNOTSUPP`, `ENOTTY`, `ENOSYS`, `ERROR_INVALID_FUNCTION`, …) —
+/// triggers the fallback. This is the same deny-list the `reflink-copy`
+/// crate uses in its own `reflink_or_copy` fallback logic, so it's
+/// battle-tested across the platform matrix. The allow-list flavour we
+/// tried initially missed Windows's `ERROR_INVALID_FUNCTION` (raw OS
+/// `1`, which Rust surfaces as `ErrorKind::InvalidInput`) for NTFS's
+/// rejection of `FSCTL_DUPLICATE_EXTENTS_TO_FILE`, breaking Windows CI.
+fn is_call_error(err: &io::Error) -> bool {
+    matches!(
+        err.kind(),
+        io::ErrorKind::NotFound | io::ErrorKind::PermissionDenied | io::ErrorKind::AlreadyExists
+    )
 }
 
 /// `Auto`'s clone → hardlink → copy chain, using `state` to skip tiers
@@ -237,20 +226,20 @@ fn auto_link(state: &AtomicU8, source: &Path, target: &Path) -> io::Result<()> {
                     log_method_once(LOG_FLAG_CLONE, "clone");
                     return Ok(());
                 }
-                Err(err) if is_reflink_fallback_error(&err) => {
+                Err(err) if is_call_error(&err) => return Err(err),
+                Err(_) => {
                     state.fetch_max(LINK_STATE_HARDLINK, Ordering::Relaxed);
                 }
-                Err(err) => return Err(err),
             },
             LINK_STATE_HARDLINK => match fs::hard_link(source, target) {
                 Ok(()) => {
                     log_method_once(LOG_FLAG_HARDLINK, "hardlink");
                     return Ok(());
                 }
-                Err(err) if is_hardlink_fallback_error(&err) => {
+                Err(err) if is_call_error(&err) => return Err(err),
+                Err(_) => {
                     state.fetch_max(LINK_STATE_COPY, Ordering::Relaxed);
                 }
-                Err(err) => return Err(err),
             },
             _ => {
                 log_method_once(LOG_FLAG_COPY, "copy");
@@ -274,10 +263,10 @@ fn clone_or_copy_link(state: &AtomicU8, source: &Path, target: &Path) -> io::Res
                     log_method_once(LOG_FLAG_CLONE, "clone");
                     return Ok(());
                 }
-                Err(err) if is_reflink_fallback_error(&err) => {
+                Err(err) if is_call_error(&err) => return Err(err),
+                Err(_) => {
                     state.fetch_max(LINK_STATE_COPY, Ordering::Relaxed);
                 }
-                Err(err) => return Err(err),
             },
             _ => {
                 log_method_once(LOG_FLAG_COPY, "copy");
@@ -557,28 +546,34 @@ mod tests {
         );
     }
 
-    /// Pin the classification helper directly — the state-machine
-    /// tests above exercise the common kinds (`NotFound` →
-    /// propagate), but we also care that the capability codes we
-    /// added ENOTTY and EOPNOTSUPP for actually trigger the fallback.
+    /// Pin the deny-list classifier. The state-machine tests above
+    /// exercise `NotFound` on the common path, but we also care that
+    /// the capability-style errors we see on real filesystems —
+    /// notably Windows NTFS's `ERROR_INVALID_FUNCTION` for
+    /// `FSCTL_DUPLICATE_EXTENTS_TO_FILE`, which Rust maps to
+    /// `InvalidInput` — fall through to the next tier instead of
+    /// propagating.
     #[test]
-    fn is_reflink_fallback_error_classifies_capability_codes() {
-        // NotFound must NOT be a capability error.
-        let not_found = io::Error::from(io::ErrorKind::NotFound);
-        assert!(!is_reflink_fallback_error(&not_found));
+    fn is_call_error_rejects_capability_codes() {
+        // Call-shape errors: must propagate.
+        for kind in
+            [io::ErrorKind::NotFound, io::ErrorKind::PermissionDenied, io::ErrorKind::AlreadyExists]
+        {
+            let err = io::Error::from(kind);
+            assert!(is_call_error(&err), "kind {kind:?} should be a call error");
+        }
 
-        // Unsupported IS a capability error.
-        let unsupported = io::Error::from(io::ErrorKind::Unsupported);
-        assert!(is_reflink_fallback_error(&unsupported));
-
-        // ENOTTY (25) — what ext4 returns for ioctl_ficlone on a FS
-        // without reflink support. This is the CI-critical case.
-        let enotty = io::Error::from_raw_os_error(25);
-        assert!(is_reflink_fallback_error(&enotty));
-
-        // EXDEV (18) is cross-device — also a fallback trigger.
-        let exdev = io::Error::from_raw_os_error(18);
-        assert!(is_reflink_fallback_error(&exdev));
+        // Capability / cross-device / weird OS codes: must fall
+        // through, so they must NOT be classified as call errors.
+        for err in [
+            io::Error::from(io::ErrorKind::Unsupported),
+            io::Error::from(io::ErrorKind::InvalidInput), // Windows ERROR_INVALID_FUNCTION lands here
+            io::Error::from_raw_os_error(18),             // EXDEV
+            io::Error::from_raw_os_error(25),             // ENOTTY — ext4 reflink rejection
+            io::Error::from_raw_os_error(95),             // EOPNOTSUPP
+        ] {
+            assert!(!is_call_error(&err), "{err:?} should trigger fallback, not propagate");
+        }
     }
 
     /// Pre-seed `CloneOrCopy` state to `COPY` and verify it uses

--- a/crates/package-manager/src/link_file.rs
+++ b/crates/package-manager/src/link_file.rs
@@ -99,27 +99,36 @@ pub fn link_file(
     // If the target resolves to a live file (directly or via a
     // symlink), a prior install placed it and there's nothing to do.
     // `fs::metadata` follows symlinks and returns `Err(NotFound)` for
-    // dangling ones, which is exactly what we want here.
-    if fs::metadata(target_link).is_ok() {
-        return Ok(());
-    }
-    // `metadata` above can also fail when the dirent itself is a
-    // dangling symlink — left behind by an interrupted prior install.
-    // `symlink_metadata` doesn't follow, so it'll succeed in that
-    // case. Scrub the broken link so the subsequent link / copy
-    // doesn't collide with `AlreadyExists` and so the installed
-    // package isn't left with a silently-missing file.
-    if let Ok(meta) = fs::symlink_metadata(target_link) {
-        if meta.file_type().is_symlink() {
-            fs::remove_file(target_link).map_err(|error| LinkFileError::RemoveStale {
-                path: target_link.to_path_buf(),
-                error,
-            })?;
+    // dangling ones — so only treat `NotFound` as the "might need
+    // cleanup" case. For anything else (`PermissionDenied`, transient
+    // NFS errors, …) fall through to the import call below without
+    // touching the existing dirent: deleting a potentially live
+    // symlink on a stat error would be more destructive than letting
+    // the real error surface.
+    match fs::metadata(target_link) {
+        Ok(_) => return Ok(()),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {
+            // A dangling symlink left behind by an interrupted prior
+            // install still returns a dirent from `symlink_metadata`
+            // (which doesn't follow). Scrub it so the subsequent link
+            // / copy doesn't collide with `AlreadyExists` and so the
+            // installed package isn't left with a silently-missing
+            // file.
+            if let Ok(meta) = fs::symlink_metadata(target_link) {
+                if meta.file_type().is_symlink() {
+                    fs::remove_file(target_link).map_err(|error| {
+                        LinkFileError::RemoveStale {
+                            path: target_link.to_path_buf(),
+                            error,
+                        }
+                    })?;
+                }
+            }
         }
-        // Non-symlink dirent present but `metadata` failed — rare
-        // (permissions, stale NFS handle, …). Let the link / copy
-        // below surface the specific error rather than guess at a
-        // recovery here.
+        Err(_) => {
+            // Non-`NotFound` stat error. Leave the dirent alone; the
+            // import call below will surface the real problem.
+        }
     }
 
     if let Some(parent_dir) = target_link.parent() {

--- a/crates/package-manager/src/link_file.rs
+++ b/crates/package-manager/src/link_file.rs
@@ -603,11 +603,11 @@ mod tests {
     /// signal, so the detection IS correct there.
     #[test]
     fn is_cross_device_distinguishes_unix_eexist_from_windows_not_same_device() {
-        let exdev = io::Error::from_raw_os_error(18);
-        assert!(is_cross_device(&exdev), "raw 18 is EXDEV on every Unix");
-
         #[cfg(unix)]
         {
+            let exdev = io::Error::from_raw_os_error(18);
+            assert!(is_cross_device(&exdev), "raw 18 is EXDEV on every Unix");
+
             let eexist = io::Error::from_raw_os_error(17);
             assert!(
                 !is_cross_device(&eexist),
@@ -621,6 +621,12 @@ mod tests {
             assert!(
                 is_cross_device(&not_same_device),
                 "Windows ERROR_NOT_SAME_DEVICE (raw 17) IS cross-device",
+            );
+
+            let not_exdev = io::Error::from_raw_os_error(18);
+            assert!(
+                !is_cross_device(&not_exdev),
+                "raw 18 on Windows is not the cross-device code — must not be classified as EXDEV",
             );
         }
     }

--- a/crates/package-manager/src/link_file.rs
+++ b/crates/package-manager/src/link_file.rs
@@ -16,10 +16,21 @@ pub enum LinkFileError {
         #[error(source)]
         error: io::Error,
     },
-    #[display("fail to create a link from {from:?} to {to:?}: {error}")]
-    CreateLink {
+    // `link_file` now dispatches to copy / reflink / hardlink depending
+    // on `PackageImportMethod`, so a "fail to create a link" message
+    // would be misleading when the configured method is `Copy`. Using
+    // pnpm's "import" terminology (see `createPackageImporter`) so the
+    // message is accurate regardless of which tier actually ran.
+    #[display("failed to import {from:?} to {to:?}: {error}")]
+    Import {
         from: PathBuf,
         to: PathBuf,
+        #[error(source)]
+        error: io::Error,
+    },
+    #[display("failed to remove stale dirent at {path:?}: {error}")]
+    RemoveStale {
+        path: PathBuf,
         #[error(source)]
         error: io::Error,
     },
@@ -27,23 +38,25 @@ pub enum LinkFileError {
 
 // Cached downgrade states shared by `Auto` and `CloneOrCopy`.
 //
-// Whether reflink / hardlink work is a property of the (source fs,
-// target fs) pair, not of individual files. Once we observe a tier
-// failing we stop trying it for the rest of the process — otherwise
-// an install of a package with hundreds of files on a non-reflink FS
-// would pay the "try reflink, fail" cost hundreds of times.
+// This cache is process-global, not keyed by `(source fs, target fs)`.
+// Once we observe a tier failing anywhere, we stop trying it for the
+// rest of the process. That's a coarse optimization to avoid paying
+// the "try reflink, fail" cost for every file in installs where a
+// higher tier is not usable on the store / workspace pair.
+//
+// A failure on one path can therefore downgrade later calls that
+// would have succeeded on a different pair — in practice pacquet runs
+// one install per process with one store and one target root, so this
+// is fine. Pnpm's per-importer `let auto` closure (see
+// `render-peer/fs/indexed-pkg-importer/src/index.ts`,
+// `createAutoImporter` / `createCloneOrCopyImporter`) has the same
+// coarseness once `pnpm install` has picked an import direction.
 //
 // The state is monotonic (`CLONE` → `HARDLINK` → `COPY`) and updated
 // with `fetch_max`, so concurrent rayon workers racing on the first
 // failure all converge to the same downgraded value without a lock.
 // Worst case cost on startup is `N` stale attempts per tier where `N`
 // is the rayon thread count — bounded, not per-file.
-//
-// This mirrors pnpm's per-importer closure in
-// `render-peer/fs/indexed-pkg-importer/src/index.ts` — `createAutoImporter`
-// and `createCloneOrCopyImporter` reassign their `auto` variable to the
-// concrete function that succeeded on the probe, so subsequent files
-// skip the probe entirely.
 const LINK_STATE_CLONE: u8 = 0;
 const LINK_STATE_HARDLINK: u8 = 1;
 const LINK_STATE_COPY: u8 = 2;
@@ -57,15 +70,30 @@ pub fn link_file(
     source_file: &Path,
     target_link: &Path,
 ) -> Result<(), LinkFileError> {
-    // `exists()` follows symlinks, so a dangling symlink at
-    // `target_link` (left behind by an interrupted prior install) would
-    // slip through here and make the subsequent `hard_link` / `reflink`
-    // fail with `AlreadyExists`, contradicting the "already exists → no
-    // op" contract in the doc comment above. `symlink_metadata` asks
-    // about the directory entry itself without following, which covers
-    // files, directories, and symlinks (broken or otherwise).
-    if fs::symlink_metadata(target_link).is_ok() {
+    // If the target resolves to a live file (directly or via a
+    // symlink), a prior install placed it and there's nothing to do.
+    // `fs::metadata` follows symlinks and returns `Err(NotFound)` for
+    // dangling ones, which is exactly what we want here.
+    if fs::metadata(target_link).is_ok() {
         return Ok(());
+    }
+    // `metadata` above can also fail when the dirent itself is a
+    // dangling symlink — left behind by an interrupted prior install.
+    // `symlink_metadata` doesn't follow, so it'll succeed in that
+    // case. Scrub the broken link so the subsequent link / copy
+    // doesn't collide with `AlreadyExists` and so the installed
+    // package isn't left with a silently-missing file.
+    if let Ok(meta) = fs::symlink_metadata(target_link) {
+        if meta.file_type().is_symlink() {
+            fs::remove_file(target_link).map_err(|error| LinkFileError::RemoveStale {
+                path: target_link.to_path_buf(),
+                error,
+            })?;
+        }
+        // Non-symlink dirent present but `metadata` failed — rare
+        // (permissions, stale NFS handle, …). Let the link / copy
+        // below surface the specific error rather than guess at a
+        // recovery here.
     }
 
     if let Some(parent_dir) = target_link.parent() {
@@ -107,7 +135,7 @@ pub fn link_file(
         PackageImportMethod::Copy => fs::copy(source_file, target_link).map(drop),
     };
 
-    result.map_err(|error| LinkFileError::CreateLink {
+    result.map_err(|error| LinkFileError::Import {
         from: source_file.to_path_buf(),
         to: target_link.to_path_buf(),
         error,
@@ -276,7 +304,7 @@ mod tests {
 
         let err =
             link_file(PackageImportMethod::Hardlink, &src, &dst).expect_err("no source → error");
-        assert!(matches!(err, LinkFileError::CreateLink { .. }), "got: {err:?}");
+        assert!(matches!(err, LinkFileError::Import { .. }), "got: {err:?}");
     }
 
     /// `CloneOrCopy` has to succeed on any filesystem because
@@ -307,29 +335,49 @@ mod tests {
         let dst = tmp.path().join("dst.txt");
 
         let err = link_file(PackageImportMethod::Clone, &src, &dst).expect_err("no source → error");
-        assert!(matches!(err, LinkFileError::CreateLink { .. }), "got: {err:?}");
+        assert!(matches!(err, LinkFileError::Import { .. }), "got: {err:?}");
     }
 
-    /// A dangling symlink left behind by an interrupted install used
-    /// to sneak past the `target_link.exists()` check (which follows
-    /// symlinks) and then collide with `hard_link` / `reflink` as
-    /// `AlreadyExists`. The doc comment promises "if target_link
-    /// already exists, do nothing" — so the dangling link must be
-    /// treated as already-present.
+    /// A dangling symlink left behind by an interrupted install is a
+    /// corrupt target: if we short-circuit on it as "already present"
+    /// the package ends up with a silently-missing file while the
+    /// install reports success. Remove the broken link, re-materialize,
+    /// and confirm the final dirent is a real file with the expected
+    /// contents.
     #[test]
     #[cfg(unix)]
-    fn dangling_symlink_is_treated_as_already_present() {
+    fn dangling_symlink_is_replaced() {
         let tmp = tempdir().unwrap();
         let src = write_source(tmp.path(), "src.txt", b"fresh");
         let dst = tmp.path().join("dst.txt");
-        // Target of the symlink does not exist — the link is dangling.
         std::os::unix::fs::symlink(tmp.path().join("never-created"), &dst).unwrap();
 
         link_file(PackageImportMethod::Hardlink, &src, &dst)
-            .expect("dangling symlink should short-circuit, not fail");
-        // The dangling symlink should still be there, unchanged — we
-        // don't attempt to replace it.
+            .expect("dangling symlink should be scrubbed, then hardlinked");
+
+        let meta = fs::symlink_metadata(&dst).unwrap();
+        assert!(!meta.file_type().is_symlink(), "dangling link must be replaced with a real file");
+        assert_eq!(fs::read(&dst).unwrap(), b"fresh");
+    }
+
+    /// Live symlinks (pointing at real files) should still short-circuit
+    /// — they're legitimate user state, not corruption from an
+    /// interrupted install. Observable: we don't remove the link, and
+    /// we don't overwrite its target either.
+    #[test]
+    #[cfg(unix)]
+    fn live_symlink_short_circuits() {
+        let tmp = tempdir().unwrap();
+        let src = write_source(tmp.path(), "src.txt", b"new");
+        let real_target = write_source(tmp.path(), "existing.txt", b"old");
+        let dst = tmp.path().join("dst.txt");
+        std::os::unix::fs::symlink(&real_target, &dst).unwrap();
+
+        link_file(PackageImportMethod::Hardlink, &src, &dst)
+            .expect("live symlink should short-circuit");
+
         assert!(fs::symlink_metadata(&dst).unwrap().file_type().is_symlink());
+        assert_eq!(fs::read(&real_target).unwrap(), b"old", "target must not be overwritten");
     }
 
     /// Core caching property for `Auto`: once reflink fails, the state

--- a/crates/package-manager/src/link_file.rs
+++ b/crates/package-manager/src/link_file.rs
@@ -1,5 +1,6 @@
 use derive_more::{Display, Error};
 use miette::Diagnostic;
+use pacquet_npmrc::PackageImportMethod;
 use std::{
     fs, io,
     path::{Path, PathBuf},
@@ -23,11 +24,15 @@ pub enum LinkFileError {
     },
 }
 
-/// Reflink or copy a single file.
+/// Materialize a CAFS file into `target_link` using `method`.
 ///
 /// * If `target_link` already exists, do nothing.
 /// * If parent dir of `target_link` doesn't exist, it will be created.
-pub fn link_file(source_file: &Path, target_link: &Path) -> Result<(), LinkFileError> {
+pub fn link_file(
+    method: PackageImportMethod,
+    source_file: &Path,
+    target_link: &Path,
+) -> Result<(), LinkFileError> {
     if target_link.exists() {
         return Ok(());
     }
@@ -39,16 +44,141 @@ pub fn link_file(source_file: &Path, target_link: &Path) -> Result<(), LinkFileE
         })?;
     }
 
-    // TODO: add hardlink (https://github.com/pnpm/pacquet/issues/174)
-    // NOTE: do not hardlink packages with postinstall
-
-    reflink_copy::reflink_or_copy(source_file, target_link).map_err(|error| {
-        LinkFileError::CreateLink {
-            from: source_file.to_path_buf(),
-            to: target_link.to_path_buf(),
-            error,
+    // pnpm's documented Auto fallback chain: clone → hardlink → copy.
+    // Each step broad-catches because "operation not supported" surfaces
+    // as different `io::ErrorKind`s depending on platform and filesystem
+    // (EOPNOTSUPP, EXDEV, EPERM, …) and pnpm itself doesn't try to
+    // enumerate them.
+    //
+    // Hardlinking a file from the store into `node_modules` means any
+    // package that edits its own files at runtime (postinstall scripts
+    // are the usual offender) ends up mutating the shared store copy.
+    // Pnpm guards against this by falling back to copy for packages that
+    // declare a postinstall script; pacquet doesn't run postinstall
+    // scripts yet, so there's nothing to gate on here — revisit when
+    // script execution lands.
+    let result = match method {
+        PackageImportMethod::Auto => reflink_copy::reflink(source_file, target_link)
+            .or_else(|_| fs::hard_link(source_file, target_link))
+            .or_else(|_| fs::copy(source_file, target_link).map(drop)),
+        PackageImportMethod::Hardlink => fs::hard_link(source_file, target_link),
+        PackageImportMethod::Clone => reflink_copy::reflink(source_file, target_link),
+        PackageImportMethod::CloneOrCopy => {
+            reflink_copy::reflink_or_copy(source_file, target_link).map(drop)
         }
-    })?;
+        PackageImportMethod::Copy => fs::copy(source_file, target_link).map(drop),
+    };
 
-    Ok(())
+    result.map_err(|error| LinkFileError::CreateLink {
+        from: source_file.to_path_buf(),
+        to: target_link.to_path_buf(),
+        error,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use tempfile::tempdir;
+
+    fn write_source(dir: &Path, name: &str, contents: &[u8]) -> PathBuf {
+        let path = dir.join(name);
+        fs::write(&path, contents).expect("write source file");
+        path
+    }
+
+    /// `Copy` always succeeds regardless of filesystem capabilities, so
+    /// it's the safest method to assert against on CI.
+    #[test]
+    fn copy_materializes_the_file_contents() {
+        let tmp = tempdir().unwrap();
+        let src = write_source(tmp.path(), "src.txt", b"hello");
+        let dst = tmp.path().join("nested/dst.txt");
+
+        link_file(PackageImportMethod::Copy, &src, &dst).expect("link_file should succeed");
+
+        assert_eq!(fs::read(&dst).unwrap(), b"hello");
+        // A plain copy leaves the two files as independent inodes.
+        let src_ino = fs::metadata(&src).unwrap();
+        let dst_ino = fs::metadata(&dst).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            assert_ne!(src_ino.ino(), dst_ino.ino());
+        }
+        #[cfg(not(unix))]
+        let _ = (src_ino, dst_ino);
+    }
+
+    /// Hardlinking in the same directory on the same filesystem works on
+    /// every mainstream OS the project supports. We verify the post-link
+    /// inodes match (on unix) or that the contents match (otherwise).
+    #[test]
+    fn hardlink_shares_contents_with_source() {
+        let tmp = tempdir().unwrap();
+        let src = write_source(tmp.path(), "src.txt", b"shared");
+        let dst = tmp.path().join("nested/dst.txt");
+
+        link_file(PackageImportMethod::Hardlink, &src, &dst).expect("link_file should succeed");
+
+        assert_eq!(fs::read(&dst).unwrap(), b"shared");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            let src_meta = fs::metadata(&src).unwrap();
+            let dst_meta = fs::metadata(&dst).unwrap();
+            assert_eq!(src_meta.ino(), dst_meta.ino(), "hardlinked files share an inode");
+            assert!(src_meta.nlink() >= 2, "hardlink should bump nlink");
+        }
+    }
+
+    /// `Auto` must succeed on any filesystem because it falls through to
+    /// `fs::copy`. We point it at a `tmpfs`-like temp dir — reflink and
+    /// hardlink may or may not be available, but copy always is.
+    #[test]
+    fn auto_falls_through_to_a_working_method() {
+        let tmp = tempdir().unwrap();
+        let src = write_source(tmp.path(), "src.txt", b"auto");
+        let dst = tmp.path().join("nested/dst.txt");
+
+        link_file(PackageImportMethod::Auto, &src, &dst).expect("Auto should always succeed");
+        assert_eq!(fs::read(&dst).unwrap(), b"auto");
+    }
+
+    /// If the target already exists, `link_file` is a no-op — it must not
+    /// error (which `fs::hard_link` / `reflink` would do on their own) or
+    /// overwrite the existing contents.
+    #[test]
+    fn existing_target_is_preserved() {
+        let tmp = tempdir().unwrap();
+        let src = write_source(tmp.path(), "src.txt", b"new");
+        let dst = tmp.path().join("dst.txt");
+        fs::write(&dst, b"old").unwrap();
+
+        for method in [
+            PackageImportMethod::Auto,
+            PackageImportMethod::Copy,
+            PackageImportMethod::Hardlink,
+            PackageImportMethod::Clone,
+            PackageImportMethod::CloneOrCopy,
+        ] {
+            link_file(method, &src, &dst).expect("existing target should short-circuit");
+            assert_eq!(fs::read(&dst).unwrap(), b"old", "method {method:?} must not overwrite");
+        }
+    }
+
+    /// Explicit `Hardlink` across devices (EXDEV) must surface the error
+    /// instead of silently falling back — that's what `Auto` is for. We
+    /// simulate a hard-link failure by pointing at a non-existent source.
+    #[test]
+    fn explicit_hardlink_surfaces_errors() {
+        let tmp = tempdir().unwrap();
+        let src = tmp.path().join("does-not-exist");
+        let dst = tmp.path().join("dst.txt");
+
+        let err =
+            link_file(PackageImportMethod::Hardlink, &src, &dst).expect_err("no source → error");
+        assert!(matches!(err, LinkFileError::CreateLink { .. }), "got: {err:?}");
+    }
 }

--- a/crates/package-manager/src/link_file.rs
+++ b/crates/package-manager/src/link_file.rs
@@ -4,6 +4,7 @@ use pacquet_npmrc::PackageImportMethod;
 use std::{
     fs, io,
     path::{Path, PathBuf},
+    sync::atomic::{AtomicU8, Ordering},
 };
 
 /// Error type for [`link_file`].
@@ -23,6 +24,23 @@ pub enum LinkFileError {
         error: io::Error,
     },
 }
+
+// Cached downgrade state for `PackageImportMethod::Auto`.
+//
+// Whether reflink / hardlink work is a property of the (source fs,
+// target fs) pair, not of individual files. Once we observe a tier
+// failing we stop trying it for the rest of the process — otherwise
+// an install of a package with hundreds of files on a non-reflink FS
+// would pay the "try reflink, fail" cost hundreds of times.
+//
+// The state is monotonic (`CLONE` → `HARDLINK` → `COPY`) and updated
+// with `fetch_max`, so concurrent rayon workers racing on the first
+// failure all converge to the same downgraded value without a lock.
+// Worst case cost on startup is `N` stale attempts per tier where `N`
+// is the rayon thread count — bounded, not per-file.
+const AUTO_STATE_CLONE: u8 = 0;
+const AUTO_STATE_HARDLINK: u8 = 1;
+const AUTO_STATE_COPY: u8 = 2;
 
 /// Materialize a CAFS file into `target_link` using `method`.
 ///
@@ -44,12 +62,6 @@ pub fn link_file(
         })?;
     }
 
-    // pnpm's documented Auto fallback chain: clone → hardlink → copy.
-    // Each step broad-catches because "operation not supported" surfaces
-    // as different `io::ErrorKind`s depending on platform and filesystem
-    // (EOPNOTSUPP, EXDEV, EPERM, …) and pnpm itself doesn't try to
-    // enumerate them.
-    //
     // Hardlinking a file from the store into `node_modules` means any
     // package that edits its own files at runtime (postinstall scripts
     // are the usual offender) ends up mutating the shared store copy.
@@ -58,9 +70,10 @@ pub fn link_file(
     // scripts yet, so there's nothing to gate on here — revisit when
     // script execution lands.
     let result = match method {
-        PackageImportMethod::Auto => reflink_copy::reflink(source_file, target_link)
-            .or_else(|_| fs::hard_link(source_file, target_link))
-            .or_else(|_| fs::copy(source_file, target_link).map(drop)),
+        PackageImportMethod::Auto => {
+            static AUTO_STATE: AtomicU8 = AtomicU8::new(AUTO_STATE_CLONE);
+            auto_link(&AUTO_STATE, source_file, target_link)
+        }
         PackageImportMethod::Hardlink => fs::hard_link(source_file, target_link),
         PackageImportMethod::Clone => reflink_copy::reflink(source_file, target_link),
         PackageImportMethod::CloneOrCopy => {
@@ -74,6 +87,34 @@ pub fn link_file(
         to: target_link.to_path_buf(),
         error,
     })
+}
+
+/// Auto's clone → hardlink → copy chain, using `state` to skip tiers
+/// that have already failed in this process. Factored out so tests can
+/// pass their own `AtomicU8` and exercise the downgrade logic in
+/// isolation — the production path uses a `static` declared inside
+/// [`link_file`]. Broad-catches each tier's errors because "operation
+/// not supported" surfaces as different `io::ErrorKind`s depending on
+/// platform and filesystem (`EOPNOTSUPP`, `EXDEV`, `EPERM`, …) and pnpm
+/// itself doesn't try to enumerate them.
+fn auto_link(state: &AtomicU8, source: &Path, target: &Path) -> io::Result<()> {
+    loop {
+        match state.load(Ordering::Relaxed) {
+            AUTO_STATE_CLONE => match reflink_copy::reflink(source, target) {
+                Ok(()) => return Ok(()),
+                Err(_) => {
+                    state.fetch_max(AUTO_STATE_HARDLINK, Ordering::Relaxed);
+                }
+            },
+            AUTO_STATE_HARDLINK => match fs::hard_link(source, target) {
+                Ok(()) => return Ok(()),
+                Err(_) => {
+                    state.fetch_max(AUTO_STATE_COPY, Ordering::Relaxed);
+                }
+            },
+            _ => return fs::copy(source, target).map(drop),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -180,5 +221,73 @@ mod tests {
         let err =
             link_file(PackageImportMethod::Hardlink, &src, &dst).expect_err("no source → error");
         assert!(matches!(err, LinkFileError::CreateLink { .. }), "got: {err:?}");
+    }
+
+    /// Core caching property: once Auto observes reflink failing, the
+    /// state downgrades and subsequent calls skip reflink entirely.
+    /// Using a non-existent source to force both reflink and hardlink
+    /// to fail deterministically on every platform — we just want to
+    /// drive the state machine to its terminal `COPY` state.
+    #[test]
+    fn auto_state_downgrades_monotonically_on_failure() {
+        let state = AtomicU8::new(AUTO_STATE_CLONE);
+        let tmp = tempdir().unwrap();
+        let src = tmp.path().join("does-not-exist");
+        let dst = tmp.path().join("dst");
+
+        // First call: reflink fails → downgrade to HARDLINK; hardlink
+        // fails → downgrade to COPY; copy fails → error bubbles up.
+        // Final state = COPY.
+        let _ = auto_link(&state, &src, &dst);
+        assert_eq!(state.load(Ordering::Relaxed), AUTO_STATE_COPY);
+    }
+
+    /// Once state is `COPY`, Auto must use `fs::copy` and must not
+    /// re-attempt reflink / hardlink. We can't observe the negative
+    /// directly, but using a cross-file-type source that only `fs::copy`
+    /// handles cleanly would be platform-sensitive — instead, assert on
+    /// the observable: a successful link with a fresh state=COPY has
+    /// independent inodes (copy semantics), not shared ones (hardlink).
+    #[test]
+    #[cfg(unix)]
+    fn auto_respects_cached_copy_state() {
+        use std::os::unix::fs::MetadataExt;
+
+        let state = AtomicU8::new(AUTO_STATE_COPY);
+        let tmp = tempdir().unwrap();
+        let src = write_source(tmp.path(), "src.txt", b"cached-copy");
+        let dst = tmp.path().join("dst.txt");
+
+        auto_link(&state, &src, &dst).expect("copy should succeed");
+
+        assert_eq!(fs::read(&dst).unwrap(), b"cached-copy");
+        assert_ne!(
+            fs::metadata(&src).unwrap().ino(),
+            fs::metadata(&dst).unwrap().ino(),
+            "state=COPY must not hardlink",
+        );
+        assert_eq!(state.load(Ordering::Relaxed), AUTO_STATE_COPY, "state must not drift");
+    }
+
+    /// State=HARDLINK means Auto skips the reflink attempt and jumps
+    /// straight to `fs::hard_link`. Observable: shared inode on unix.
+    #[test]
+    #[cfg(unix)]
+    fn auto_respects_cached_hardlink_state() {
+        use std::os::unix::fs::MetadataExt;
+
+        let state = AtomicU8::new(AUTO_STATE_HARDLINK);
+        let tmp = tempdir().unwrap();
+        let src = write_source(tmp.path(), "src.txt", b"cached-hardlink");
+        let dst = tmp.path().join("dst.txt");
+
+        auto_link(&state, &src, &dst).expect("hardlink should succeed on same-FS tempdir");
+
+        assert_eq!(
+            fs::metadata(&src).unwrap().ino(),
+            fs::metadata(&dst).unwrap().ino(),
+            "state=HARDLINK must hardlink, not copy",
+        );
+        assert_eq!(state.load(Ordering::Relaxed), AUTO_STATE_HARDLINK, "state must not drift");
     }
 }

--- a/crates/package-manager/src/link_file.rs
+++ b/crates/package-manager/src/link_file.rs
@@ -179,12 +179,23 @@ pub fn link_file(
 
 /// EXDEV = "cross-device link not permitted". Linux / macOS / BSD all
 /// use errno 18; Windows maps its equivalent `ERROR_NOT_SAME_DEVICE`
-/// to raw OS error 17 in Rust's `io::Error`. pnpm detects this by
-/// checking `err.message.startsWith('EXDEV: cross-device link not
-/// permitted')` — we can be a little tighter by looking at the raw
-/// errno.
+/// to raw OS error 17. pnpm detects this by checking
+/// `err.message.startsWith('EXDEV: cross-device link not permitted')` —
+/// we can be a little tighter by looking at the raw errno.
+///
+/// The `17` mapping must stay Windows-only: on Unix, raw 17 is
+/// `EEXIST` (surfaces as `ErrorKind::AlreadyExists`), which means a
+/// concurrent process created the target between our `fs::metadata`
+/// short-circuit and the link / reflink call. Falling back to
+/// `fs::copy` on that signal would overwrite the other process's
+/// freshly-installed file.
 fn is_cross_device(err: &io::Error) -> bool {
-    matches!(err.raw_os_error(), Some(18) | Some(17))
+    #[cfg(unix)]
+    return err.raw_os_error() == Some(18);
+    #[cfg(windows)]
+    return err.raw_os_error() == Some(17);
+    #[cfg(not(any(unix, windows)))]
+    return false;
 }
 
 /// Errors that indicate the call itself is malformed (missing source,
@@ -581,6 +592,37 @@ mod tests {
             LINK_STATE_CLONE,
             "AlreadyExists must not poison the cache",
         );
+    }
+
+    /// `is_cross_device` picks up EXDEV (raw 18) on every Unix we
+    /// support, but raw 17 is `EEXIST` on Unix and must NOT be
+    /// classified as cross-device — misclassifying a concurrent-create
+    /// race as EXDEV would fall back to `fs::copy` and overwrite the
+    /// other process's file. On Windows raw 17 is
+    /// `ERROR_NOT_SAME_DEVICE`, which is a genuine cross-device
+    /// signal, so the detection IS correct there.
+    #[test]
+    fn is_cross_device_distinguishes_unix_eexist_from_windows_not_same_device() {
+        let exdev = io::Error::from_raw_os_error(18);
+        assert!(is_cross_device(&exdev), "raw 18 is EXDEV on every Unix");
+
+        #[cfg(unix)]
+        {
+            let eexist = io::Error::from_raw_os_error(17);
+            assert!(
+                !is_cross_device(&eexist),
+                "Unix EEXIST (raw 17) is NOT cross-device — misclassifying would overwrite files",
+            );
+        }
+
+        #[cfg(windows)]
+        {
+            let not_same_device = io::Error::from_raw_os_error(17);
+            assert!(
+                is_cross_device(&not_same_device),
+                "Windows ERROR_NOT_SAME_DEVICE (raw 17) IS cross-device",
+            );
+        }
     }
 
     /// Pin the deny-list classifier. The state-machine tests above

--- a/crates/package-manager/src/link_file.rs
+++ b/crates/package-manager/src/link_file.rs
@@ -25,7 +25,7 @@ pub enum LinkFileError {
     },
 }
 
-// Cached downgrade state for `PackageImportMethod::Auto`.
+// Cached downgrade states shared by `Auto` and `CloneOrCopy`.
 //
 // Whether reflink / hardlink work is a property of the (source fs,
 // target fs) pair, not of individual files. Once we observe a tier
@@ -38,9 +38,15 @@ pub enum LinkFileError {
 // failure all converge to the same downgraded value without a lock.
 // Worst case cost on startup is `N` stale attempts per tier where `N`
 // is the rayon thread count — bounded, not per-file.
-const AUTO_STATE_CLONE: u8 = 0;
-const AUTO_STATE_HARDLINK: u8 = 1;
-const AUTO_STATE_COPY: u8 = 2;
+//
+// This mirrors pnpm's per-importer closure in
+// `render-peer/fs/indexed-pkg-importer/src/index.ts` — `createAutoImporter`
+// and `createCloneOrCopyImporter` reassign their `auto` variable to the
+// concrete function that succeeded on the probe, so subsequent files
+// skip the probe entirely.
+const LINK_STATE_CLONE: u8 = 0;
+const LINK_STATE_HARDLINK: u8 = 1;
+const LINK_STATE_COPY: u8 = 2;
 
 /// Materialize a CAFS file into `target_link` using `method`.
 ///
@@ -72,19 +78,31 @@ pub fn link_file(
     // Hardlinking a file from the store into `node_modules` means any
     // package that edits its own files at runtime (postinstall scripts
     // are the usual offender) ends up mutating the shared store copy.
-    // Pnpm guards against this by falling back to copy for packages that
-    // declare a postinstall script; pacquet doesn't run postinstall
-    // scripts yet, so there's nothing to gate on here — revisit when
-    // script execution lands.
+    // Current pnpm's indexed-pkg-importer does not guard against this
+    // either — postinstall handling lives in the script runner, not the
+    // import layer — so there's nothing to gate on here.
     let result = match method {
         PackageImportMethod::Auto => {
-            static AUTO_STATE: AtomicU8 = AtomicU8::new(AUTO_STATE_CLONE);
+            static AUTO_STATE: AtomicU8 = AtomicU8::new(LINK_STATE_CLONE);
             auto_link(&AUTO_STATE, source_file, target_link)
         }
-        PackageImportMethod::Hardlink => fs::hard_link(source_file, target_link),
+        // pnpm's explicit `hardlink` method uses `hardlinkPkg(linkOrCopy)`
+        // which falls back to copy on `EXDEV` (cross-device link not
+        // permitted) but propagates other errors. Match that: if the
+        // user asks for hardlink and they've put their store on a
+        // different device from `node_modules`, copy silently; anything
+        // else (missing source, permission denied, …) is a real error
+        // and should surface. No caching — the `fs::hard_link` syscall
+        // itself is already cheap; pnpm doesn't cache this path either.
+        PackageImportMethod::Hardlink => match fs::hard_link(source_file, target_link) {
+            Ok(()) => Ok(()),
+            Err(error) if is_cross_device(&error) => fs::copy(source_file, target_link).map(drop),
+            Err(error) => Err(error),
+        },
         PackageImportMethod::Clone => reflink_copy::reflink(source_file, target_link),
         PackageImportMethod::CloneOrCopy => {
-            reflink_copy::reflink_or_copy(source_file, target_link).map(drop)
+            static CLONE_OR_COPY_STATE: AtomicU8 = AtomicU8::new(LINK_STATE_CLONE);
+            clone_or_copy_link(&CLONE_OR_COPY_STATE, source_file, target_link)
         }
         PackageImportMethod::Copy => fs::copy(source_file, target_link).map(drop),
     };
@@ -96,27 +114,55 @@ pub fn link_file(
     })
 }
 
-/// Auto's clone → hardlink → copy chain, using `state` to skip tiers
+/// EXDEV = "cross-device link not permitted". Linux / macOS / BSD all
+/// use errno 18; Windows maps its equivalent `ERROR_NOT_SAME_DEVICE`
+/// to raw OS error 17 in Rust's `io::Error`. pnpm detects this by
+/// checking `err.message.startsWith('EXDEV: cross-device link not
+/// permitted')` — we can be a little tighter by looking at the raw
+/// errno.
+fn is_cross_device(err: &io::Error) -> bool {
+    matches!(err.raw_os_error(), Some(18) | Some(17))
+}
+
+/// `Auto`'s clone → hardlink → copy chain, using `state` to skip tiers
 /// that have already failed in this process. Factored out so tests can
 /// pass their own `AtomicU8` and exercise the downgrade logic in
 /// isolation — the production path uses a `static` declared inside
 /// [`link_file`]. Broad-catches each tier's errors because "operation
 /// not supported" surfaces as different `io::ErrorKind`s depending on
 /// platform and filesystem (`EOPNOTSUPP`, `EXDEV`, `EPERM`, …) and pnpm
-/// itself doesn't try to enumerate them.
+/// itself doesn't try to enumerate them here either.
 fn auto_link(state: &AtomicU8, source: &Path, target: &Path) -> io::Result<()> {
     loop {
         match state.load(Ordering::Relaxed) {
-            AUTO_STATE_CLONE => match reflink_copy::reflink(source, target) {
+            LINK_STATE_CLONE => match reflink_copy::reflink(source, target) {
                 Ok(()) => return Ok(()),
                 Err(_) => {
-                    state.fetch_max(AUTO_STATE_HARDLINK, Ordering::Relaxed);
+                    state.fetch_max(LINK_STATE_HARDLINK, Ordering::Relaxed);
                 }
             },
-            AUTO_STATE_HARDLINK => match fs::hard_link(source, target) {
+            LINK_STATE_HARDLINK => match fs::hard_link(source, target) {
                 Ok(()) => return Ok(()),
                 Err(_) => {
-                    state.fetch_max(AUTO_STATE_COPY, Ordering::Relaxed);
+                    state.fetch_max(LINK_STATE_COPY, Ordering::Relaxed);
+                }
+            },
+            _ => return fs::copy(source, target).map(drop),
+        }
+    }
+}
+
+/// `CloneOrCopy`'s clone → copy chain with the same per-process cache
+/// as [`auto_link`]. Differs from `Auto` by skipping the hardlink tier
+/// entirely — matches pnpm's `createCloneOrCopyImporter`, which on
+/// first reflink failure reassigns its closure directly to `copyPkg`.
+fn clone_or_copy_link(state: &AtomicU8, source: &Path, target: &Path) -> io::Result<()> {
+    loop {
+        match state.load(Ordering::Relaxed) {
+            LINK_STATE_CLONE => match reflink_copy::reflink(source, target) {
+                Ok(()) => return Ok(()),
+                Err(_) => {
+                    state.fetch_max(LINK_STATE_COPY, Ordering::Relaxed);
                 }
             },
             _ => return fs::copy(source, target).map(drop),
@@ -216,10 +262,12 @@ mod tests {
         }
     }
 
-    /// Explicit `Hardlink` must surface link-creation errors instead of
-    /// silently falling back — that's what `Auto` is for. We drive the
-    /// error path by pointing at a non-existent source (`NotFound`) so
-    /// the failure is deterministic on every platform / filesystem.
+    /// Explicit `Hardlink` must surface non-`EXDEV` link-creation errors
+    /// instead of silently falling back — matches pnpm's `linkOrCopy`,
+    /// which only swallows `EXDEV` (and a couple of other kernel-level
+    /// "not permitted" codes, not modelled here). We drive the error
+    /// path by pointing at a non-existent source (`NotFound`, which is
+    /// not `EXDEV`) so the failure is deterministic on every platform.
     #[test]
     fn explicit_hardlink_surfaces_errors() {
         let tmp = tempdir().unwrap();
@@ -284,37 +332,32 @@ mod tests {
         assert!(fs::symlink_metadata(&dst).unwrap().file_type().is_symlink());
     }
 
-    /// Core caching property: once Auto observes reflink failing, the
-    /// state downgrades and subsequent calls skip reflink entirely.
-    /// Using a non-existent source to force both reflink and hardlink
-    /// to fail deterministically on every platform — we just want to
-    /// drive the state machine to its terminal `COPY` state.
+    /// Core caching property for `Auto`: once reflink fails, the state
+    /// downgrades and subsequent calls skip reflink entirely. Using a
+    /// non-existent source forces both reflink and hardlink to fail
+    /// deterministically on every platform — we just want to drive the
+    /// state machine to its terminal `COPY` state.
     #[test]
     fn auto_state_downgrades_monotonically_on_failure() {
-        let state = AtomicU8::new(AUTO_STATE_CLONE);
+        let state = AtomicU8::new(LINK_STATE_CLONE);
         let tmp = tempdir().unwrap();
         let src = tmp.path().join("does-not-exist");
         let dst = tmp.path().join("dst");
 
-        // First call: reflink fails → downgrade to HARDLINK; hardlink
-        // fails → downgrade to COPY; copy fails → error bubbles up.
-        // Final state = COPY.
         let _ = auto_link(&state, &src, &dst);
-        assert_eq!(state.load(Ordering::Relaxed), AUTO_STATE_COPY);
+        assert_eq!(state.load(Ordering::Relaxed), LINK_STATE_COPY);
     }
 
-    /// Once state is `COPY`, Auto must use `fs::copy` and must not
-    /// re-attempt reflink / hardlink. We can't observe the negative
-    /// directly, but using a cross-file-type source that only `fs::copy`
-    /// handles cleanly would be platform-sensitive — instead, assert on
-    /// the observable: a successful link with a fresh state=COPY has
-    /// independent inodes (copy semantics), not shared ones (hardlink).
+    /// Once `Auto`'s state is `COPY`, we use `fs::copy` and must not
+    /// re-attempt reflink / hardlink. Observable: a successful link
+    /// with state pre-seeded to `COPY` has independent inodes (copy
+    /// semantics), not shared ones (hardlink).
     #[test]
     #[cfg(unix)]
     fn auto_respects_cached_copy_state() {
         use std::os::unix::fs::MetadataExt;
 
-        let state = AtomicU8::new(AUTO_STATE_COPY);
+        let state = AtomicU8::new(LINK_STATE_COPY);
         let tmp = tempdir().unwrap();
         let src = write_source(tmp.path(), "src.txt", b"cached-copy");
         let dst = tmp.path().join("dst.txt");
@@ -327,7 +370,7 @@ mod tests {
             fs::metadata(&dst).unwrap().ino(),
             "state=COPY must not hardlink",
         );
-        assert_eq!(state.load(Ordering::Relaxed), AUTO_STATE_COPY, "state must not drift");
+        assert_eq!(state.load(Ordering::Relaxed), LINK_STATE_COPY, "state must not drift");
     }
 
     /// State=HARDLINK means Auto skips the reflink attempt and jumps
@@ -337,7 +380,7 @@ mod tests {
     fn auto_respects_cached_hardlink_state() {
         use std::os::unix::fs::MetadataExt;
 
-        let state = AtomicU8::new(AUTO_STATE_HARDLINK);
+        let state = AtomicU8::new(LINK_STATE_HARDLINK);
         let tmp = tempdir().unwrap();
         let src = write_source(tmp.path(), "src.txt", b"cached-hardlink");
         let dst = tmp.path().join("dst.txt");
@@ -349,6 +392,45 @@ mod tests {
             fs::metadata(&dst).unwrap().ino(),
             "state=HARDLINK must hardlink, not copy",
         );
-        assert_eq!(state.load(Ordering::Relaxed), AUTO_STATE_HARDLINK, "state must not drift");
+        assert_eq!(state.load(Ordering::Relaxed), LINK_STATE_HARDLINK, "state must not drift");
+    }
+
+    /// Same caching property for `CloneOrCopy` — first reflink failure
+    /// flips the state to `COPY`, skipping reflink for every subsequent
+    /// file. No hardlink tier to drive through, so the terminal state
+    /// is reached in one step.
+    #[test]
+    fn clone_or_copy_state_downgrades_to_copy_on_failure() {
+        let state = AtomicU8::new(LINK_STATE_CLONE);
+        let tmp = tempdir().unwrap();
+        let src = tmp.path().join("does-not-exist");
+        let dst = tmp.path().join("dst");
+
+        let _ = clone_or_copy_link(&state, &src, &dst);
+        assert_eq!(state.load(Ordering::Relaxed), LINK_STATE_COPY);
+    }
+
+    /// Pre-seed `CloneOrCopy` state to `COPY` and verify it uses
+    /// `fs::copy` — mirrors `auto_respects_cached_copy_state`. Also
+    /// confirms we skip the hardlink tier entirely (pnpm
+    /// `createCloneOrCopyImporter` has no hardlink fallback).
+    #[test]
+    #[cfg(unix)]
+    fn clone_or_copy_respects_cached_copy_state() {
+        use std::os::unix::fs::MetadataExt;
+
+        let state = AtomicU8::new(LINK_STATE_COPY);
+        let tmp = tempdir().unwrap();
+        let src = write_source(tmp.path(), "src.txt", b"cached");
+        let dst = tmp.path().join("dst.txt");
+
+        clone_or_copy_link(&state, &src, &dst).expect("copy should succeed");
+
+        assert_ne!(
+            fs::metadata(&src).unwrap().ino(),
+            fs::metadata(&dst).unwrap().ino(),
+            "state=COPY must not hardlink",
+        );
+        assert_eq!(state.load(Ordering::Relaxed), LINK_STATE_COPY, "state must not drift");
     }
 }

--- a/crates/package-manager/src/link_file.rs
+++ b/crates/package-manager/src/link_file.rs
@@ -465,9 +465,40 @@ mod tests {
     /// tier, and we'd have permanently disabled it for no reason.
     /// Pin the behaviour for `Auto`; the error propagates verbatim
     /// and the cache stays at `CLONE`.
+    ///
+    /// We use `AlreadyExists` as the trigger (pre-populated target)
+    /// rather than `NotFound` (missing source) because
+    /// `reflink_copy::reflink` on non-macOS platforms rewrites a
+    /// missing-source `NotFound` into `ErrorKind::InvalidInput` for
+    /// diagnostic purposes (see `reflink-copy/src/lib.rs:64`). That
+    /// makes `NotFound` a poor test for "call errors propagate" — the
+    /// error surfaces as `InvalidInput` on Linux / Windows and the
+    /// test would silently pass via the fallback path instead of the
+    /// propagation path we want to exercise.
     #[test]
     fn auto_call_errors_propagate_without_downgrading() {
         let state = AtomicU8::new(LINK_STATE_CLONE);
+        let tmp = tempdir().unwrap();
+        let src = write_source(tmp.path(), "src.txt", b"fresh");
+        let dst = tmp.path().join("dst");
+        fs::write(&dst, b"pre-existing").unwrap();
+
+        let err = auto_link(&state, &src, &dst).expect_err("target exists → AlreadyExists");
+        assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
+        assert_eq!(
+            state.load(Ordering::Relaxed),
+            LINK_STATE_CLONE,
+            "AlreadyExists must not poison the cache",
+        );
+    }
+
+    /// Same propagation rule at the hardlink tier. `fs::hard_link`
+    /// doesn't get the same error-rewriting treatment that reflink
+    /// does, so we can use the simpler "missing source → NotFound"
+    /// trigger here.
+    #[test]
+    fn auto_hardlink_tier_call_errors_propagate() {
+        let state = AtomicU8::new(LINK_STATE_HARDLINK);
         let tmp = tempdir().unwrap();
         let src = tmp.path().join("does-not-exist");
         let dst = tmp.path().join("dst");
@@ -476,8 +507,8 @@ mod tests {
         assert_eq!(err.kind(), io::ErrorKind::NotFound);
         assert_eq!(
             state.load(Ordering::Relaxed),
-            LINK_STATE_CLONE,
-            "NotFound must not poison the cache",
+            LINK_STATE_HARDLINK,
+            "NotFound at the hardlink tier must not poison the cache",
         );
     }
 
@@ -528,21 +559,27 @@ mod tests {
         assert_eq!(state.load(Ordering::Relaxed), LINK_STATE_HARDLINK, "state must not drift");
     }
 
-    /// Same propagate-on-call-error property for `CloneOrCopy`.
-    /// Missing source must not downgrade the cache.
+    /// Same propagate-on-call-error property for `CloneOrCopy`. Uses
+    /// `AlreadyExists` trigger for the same reason
+    /// `auto_call_errors_propagate_without_downgrading` does —
+    /// `NotFound` gets rewritten to `InvalidInput` inside reflink-copy
+    /// on non-macOS and would take the fallback path instead of the
+    /// propagation path.
     #[test]
     fn clone_or_copy_call_errors_propagate_without_downgrading() {
         let state = AtomicU8::new(LINK_STATE_CLONE);
         let tmp = tempdir().unwrap();
-        let src = tmp.path().join("does-not-exist");
+        let src = write_source(tmp.path(), "src.txt", b"fresh");
         let dst = tmp.path().join("dst");
+        fs::write(&dst, b"pre-existing").unwrap();
 
-        let err = clone_or_copy_link(&state, &src, &dst).expect_err("missing source → NotFound");
-        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+        let err =
+            clone_or_copy_link(&state, &src, &dst).expect_err("target exists → AlreadyExists");
+        assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
         assert_eq!(
             state.load(Ordering::Relaxed),
             LINK_STATE_CLONE,
-            "NotFound must not poison the cache",
+            "AlreadyExists must not poison the cache",
         );
     }
 

--- a/crates/package-manager/src/link_file.rs
+++ b/crates/package-manager/src/link_file.rs
@@ -61,6 +61,28 @@ const LINK_STATE_CLONE: u8 = 0;
 const LINK_STATE_HARDLINK: u8 = 1;
 const LINK_STATE_COPY: u8 = 2;
 
+// One-shot "we picked this import method" log, matching pnpm's
+// `packageImportMethodLogger.debug({ method: 'clone' | 'hardlink' | 'copy' })`
+// in `fs/indexed-pkg-importer/src/index.ts`. Emits once per process per
+// method so a reader of the logs can tell which tier actually ran —
+// crucial for verifying hardlinks are kicking in on CI runners where
+// reflink isn't available.
+//
+// Pnpm logs at `debug`; pacquet uses `info` so the message surfaces
+// without verbose logging configured. `fetch_or` returns the previous
+// bitfield, so the first caller to set a given bit is the one that
+// emits.
+const LOG_FLAG_CLONE: u8 = 1 << 0;
+const LOG_FLAG_HARDLINK: u8 = 1 << 1;
+const LOG_FLAG_COPY: u8 = 1 << 2;
+static LOGGED_METHODS: AtomicU8 = AtomicU8::new(0);
+
+fn log_method_once(flag: u8, method: &'static str) {
+    if LOGGED_METHODS.fetch_or(flag, Ordering::Relaxed) & flag == 0 {
+        tracing::info!(target: "pacquet::package_import_method", method);
+    }
+}
+
 /// Materialize a CAFS file into `target_link` using `method`.
 ///
 /// * If `target_link` already exists, do nothing.
@@ -123,16 +145,29 @@ pub fn link_file(
         // and should surface. No caching — the `fs::hard_link` syscall
         // itself is already cheap; pnpm doesn't cache this path either.
         PackageImportMethod::Hardlink => match fs::hard_link(source_file, target_link) {
-            Ok(()) => Ok(()),
-            Err(error) if is_cross_device(&error) => fs::copy(source_file, target_link).map(drop),
+            Ok(()) => {
+                log_method_once(LOG_FLAG_HARDLINK, "hardlink");
+                Ok(())
+            }
+            Err(error) if is_cross_device(&error) => {
+                log_method_once(LOG_FLAG_COPY, "copy");
+                fs::copy(source_file, target_link).map(drop)
+            }
             Err(error) => Err(error),
         },
-        PackageImportMethod::Clone => reflink_copy::reflink(source_file, target_link),
+        PackageImportMethod::Clone => {
+            reflink_copy::reflink(source_file, target_link).inspect(|_| {
+                log_method_once(LOG_FLAG_CLONE, "clone");
+            })
+        }
         PackageImportMethod::CloneOrCopy => {
             static CLONE_OR_COPY_STATE: AtomicU8 = AtomicU8::new(LINK_STATE_CLONE);
             clone_or_copy_link(&CLONE_OR_COPY_STATE, source_file, target_link)
         }
-        PackageImportMethod::Copy => fs::copy(source_file, target_link).map(drop),
+        PackageImportMethod::Copy => {
+            log_method_once(LOG_FLAG_COPY, "copy");
+            fs::copy(source_file, target_link).map(drop)
+        }
     };
 
     result.map_err(|error| LinkFileError::Import {
@@ -152,30 +187,75 @@ fn is_cross_device(err: &io::Error) -> bool {
     matches!(err.raw_os_error(), Some(18) | Some(17))
 }
 
+/// Errors that indicate "this filesystem can't reflink" — the kernel
+/// rejected the ioctl, not the file. The downgrade cache uses this to
+/// skip the reflink tier for subsequent files, while letting
+/// `NotFound` / `PermissionDenied` / `AlreadyExists` and other real
+/// errors propagate (a one-off missing-source file must not
+/// permanently disable reflink for the rest of the process).
+///
+/// `ErrorKind::Unsupported` covers Rust's portable layer when newer
+/// standards lands; the raw-errno list covers platforms where the
+/// kernel reports the capability gap as a bare `Err(_)` without
+/// mapping to a kind:
+/// * `ENOSYS` (38) — syscall not implemented
+/// * `EOPNOTSUPP` / `ENOTSUP` (95 Linux, 102 FreeBSD, 45 macOS) —
+///   operation not supported on this fd
+/// * `ENOTTY` (25) — what ext4 returns for `ioctl_ficlone` when the
+///   filesystem doesn't implement reflink; without this, ext4 would
+///   never downgrade and every file would pay the failed-ioctl cost
+///
+/// We additionally treat `EXDEV` as a fallback trigger — a cross-device
+/// reflink can't possibly succeed no matter how many times we retry.
+fn is_reflink_fallback_error(err: &io::Error) -> bool {
+    matches!(err.kind(), io::ErrorKind::Unsupported)
+        || is_cross_device(err)
+        || matches!(err.raw_os_error(), Some(38) | Some(95) | Some(102) | Some(45) | Some(25))
+}
+
+/// Errors that indicate "this filesystem / device pair can't
+/// hardlink". In practice this is `EXDEV` (cross-device) and
+/// `ErrorKind::Unsupported` (some exotic FSes refuse hardlinks
+/// altogether). Everything else propagates.
+fn is_hardlink_fallback_error(err: &io::Error) -> bool {
+    is_cross_device(err) || matches!(err.kind(), io::ErrorKind::Unsupported)
+}
+
 /// `Auto`'s clone → hardlink → copy chain, using `state` to skip tiers
 /// that have already failed in this process. Factored out so tests can
 /// pass their own `AtomicU8` and exercise the downgrade logic in
 /// isolation — the production path uses a `static` declared inside
-/// [`link_file`]. Broad-catches each tier's errors because "operation
-/// not supported" surfaces as different `io::ErrorKind`s depending on
-/// platform and filesystem (`EOPNOTSUPP`, `EXDEV`, `EPERM`, …) and pnpm
-/// itself doesn't try to enumerate them here either.
+/// [`link_file`]. Only capability / cross-device style failures
+/// downgrade the cached state; other errors propagate immediately so a
+/// one-off `NotFound` on a single file doesn't permanently disable a
+/// tier for the rest of the process.
 fn auto_link(state: &AtomicU8, source: &Path, target: &Path) -> io::Result<()> {
     loop {
         match state.load(Ordering::Relaxed) {
             LINK_STATE_CLONE => match reflink_copy::reflink(source, target) {
-                Ok(()) => return Ok(()),
-                Err(_) => {
+                Ok(()) => {
+                    log_method_once(LOG_FLAG_CLONE, "clone");
+                    return Ok(());
+                }
+                Err(err) if is_reflink_fallback_error(&err) => {
                     state.fetch_max(LINK_STATE_HARDLINK, Ordering::Relaxed);
                 }
+                Err(err) => return Err(err),
             },
             LINK_STATE_HARDLINK => match fs::hard_link(source, target) {
-                Ok(()) => return Ok(()),
-                Err(_) => {
+                Ok(()) => {
+                    log_method_once(LOG_FLAG_HARDLINK, "hardlink");
+                    return Ok(());
+                }
+                Err(err) if is_hardlink_fallback_error(&err) => {
                     state.fetch_max(LINK_STATE_COPY, Ordering::Relaxed);
                 }
+                Err(err) => return Err(err),
             },
-            _ => return fs::copy(source, target).map(drop),
+            _ => {
+                log_method_once(LOG_FLAG_COPY, "copy");
+                return fs::copy(source, target).map(drop);
+            }
         }
     }
 }
@@ -184,16 +264,25 @@ fn auto_link(state: &AtomicU8, source: &Path, target: &Path) -> io::Result<()> {
 /// as [`auto_link`]. Differs from `Auto` by skipping the hardlink tier
 /// entirely — matches pnpm's `createCloneOrCopyImporter`, which on
 /// first reflink failure reassigns its closure directly to `copyPkg`.
+/// Same error-narrowing as `auto_link`: only capability failures
+/// downgrade; real errors propagate.
 fn clone_or_copy_link(state: &AtomicU8, source: &Path, target: &Path) -> io::Result<()> {
     loop {
         match state.load(Ordering::Relaxed) {
             LINK_STATE_CLONE => match reflink_copy::reflink(source, target) {
-                Ok(()) => return Ok(()),
-                Err(_) => {
+                Ok(()) => {
+                    log_method_once(LOG_FLAG_CLONE, "clone");
+                    return Ok(());
+                }
+                Err(err) if is_reflink_fallback_error(&err) => {
                     state.fetch_max(LINK_STATE_COPY, Ordering::Relaxed);
                 }
+                Err(err) => return Err(err),
             },
-            _ => return fs::copy(source, target).map(drop),
+            _ => {
+                log_method_once(LOG_FLAG_COPY, "copy");
+                return fs::copy(source, target).map(drop);
+            }
         }
     }
 }
@@ -308,11 +397,11 @@ mod tests {
     }
 
     /// `CloneOrCopy` has to succeed on any filesystem because
-    /// `reflink_or_copy` falls back to a plain copy when the kernel
-    /// can't reflink. This hits the match arm directly — the
-    /// `existing_target_is_preserved` loop short-circuits before the
-    /// arm ever runs, so without this we had no coverage of the real
-    /// code path.
+    /// `clone_or_copy_link` falls back to `fs::copy` when the reflink
+    /// attempt fails with a capability error. This hits the match arm
+    /// directly — the `existing_target_is_preserved` loop
+    /// short-circuits before the arm ever runs, so without this we had
+    /// no coverage of the real code path.
     #[test]
     fn clone_or_copy_materializes_the_file_contents() {
         let tmp = tempdir().unwrap();
@@ -380,20 +469,27 @@ mod tests {
         assert_eq!(fs::read(&real_target).unwrap(), b"old", "target must not be overwritten");
     }
 
-    /// Core caching property for `Auto`: once reflink fails, the state
-    /// downgrades and subsequent calls skip reflink entirely. Using a
-    /// non-existent source forces both reflink and hardlink to fail
-    /// deterministically on every platform — we just want to drive the
-    /// state machine to its terminal `COPY` state.
+    /// A one-off `NotFound` / `PermissionDenied` / `AlreadyExists` on
+    /// a single file must not downgrade the cache — those are
+    /// per-call errors, not capability errors. A different source /
+    /// target later in the install would still succeed at the current
+    /// tier, and we'd have permanently disabled it for no reason.
+    /// Pin the behaviour for `Auto`; the error propagates verbatim
+    /// and the cache stays at `CLONE`.
     #[test]
-    fn auto_state_downgrades_monotonically_on_failure() {
+    fn auto_call_errors_propagate_without_downgrading() {
         let state = AtomicU8::new(LINK_STATE_CLONE);
         let tmp = tempdir().unwrap();
         let src = tmp.path().join("does-not-exist");
         let dst = tmp.path().join("dst");
 
-        let _ = auto_link(&state, &src, &dst);
-        assert_eq!(state.load(Ordering::Relaxed), LINK_STATE_COPY);
+        let err = auto_link(&state, &src, &dst).expect_err("missing source → NotFound");
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+        assert_eq!(
+            state.load(Ordering::Relaxed),
+            LINK_STATE_CLONE,
+            "NotFound must not poison the cache",
+        );
     }
 
     /// Once `Auto`'s state is `COPY`, we use `fs::copy` and must not
@@ -443,19 +539,46 @@ mod tests {
         assert_eq!(state.load(Ordering::Relaxed), LINK_STATE_HARDLINK, "state must not drift");
     }
 
-    /// Same caching property for `CloneOrCopy` — first reflink failure
-    /// flips the state to `COPY`, skipping reflink for every subsequent
-    /// file. No hardlink tier to drive through, so the terminal state
-    /// is reached in one step.
+    /// Same propagate-on-call-error property for `CloneOrCopy`.
+    /// Missing source must not downgrade the cache.
     #[test]
-    fn clone_or_copy_state_downgrades_to_copy_on_failure() {
+    fn clone_or_copy_call_errors_propagate_without_downgrading() {
         let state = AtomicU8::new(LINK_STATE_CLONE);
         let tmp = tempdir().unwrap();
         let src = tmp.path().join("does-not-exist");
         let dst = tmp.path().join("dst");
 
-        let _ = clone_or_copy_link(&state, &src, &dst);
-        assert_eq!(state.load(Ordering::Relaxed), LINK_STATE_COPY);
+        let err = clone_or_copy_link(&state, &src, &dst).expect_err("missing source → NotFound");
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+        assert_eq!(
+            state.load(Ordering::Relaxed),
+            LINK_STATE_CLONE,
+            "NotFound must not poison the cache",
+        );
+    }
+
+    /// Pin the classification helper directly — the state-machine
+    /// tests above exercise the common kinds (`NotFound` →
+    /// propagate), but we also care that the capability codes we
+    /// added ENOTTY and EOPNOTSUPP for actually trigger the fallback.
+    #[test]
+    fn is_reflink_fallback_error_classifies_capability_codes() {
+        // NotFound must NOT be a capability error.
+        let not_found = io::Error::from(io::ErrorKind::NotFound);
+        assert!(!is_reflink_fallback_error(&not_found));
+
+        // Unsupported IS a capability error.
+        let unsupported = io::Error::from(io::ErrorKind::Unsupported);
+        assert!(is_reflink_fallback_error(&unsupported));
+
+        // ENOTTY (25) — what ext4 returns for ioctl_ficlone on a FS
+        // without reflink support. This is the CI-critical case.
+        let enotty = io::Error::from_raw_os_error(25);
+        assert!(is_reflink_fallback_error(&enotty));
+
+        // EXDEV (18) is cross-device — also a fallback trigger.
+        let exdev = io::Error::from_raw_os_error(18);
+        assert!(is_reflink_fallback_error(&exdev));
     }
 
     /// Pre-seed `CloneOrCopy` state to `COPY` and verify it uses

--- a/crates/package-manager/src/link_file.rs
+++ b/crates/package-manager/src/link_file.rs
@@ -83,7 +83,7 @@ static LOGGED_METHODS: AtomicU8 = AtomicU8::new(0);
 
 fn log_method_once(flag: u8, method: &'static str) {
     if LOGGED_METHODS.fetch_or(flag, Ordering::Relaxed) & flag == 0 {
-        tracing::info!(target: "pacquet::package_import_method", method);
+        tracing::info!(target: "pacquet::package_import_method", method, "selected package import method");
     }
 }
 

--- a/crates/package-manager/src/link_file.rs
+++ b/crates/package-manager/src/link_file.rs
@@ -181,11 +181,28 @@ pub fn link_file(
         }
     };
 
-    result.map_err(|error| LinkFileError::Import {
-        from: source_file.to_path_buf(),
-        to: target_link.to_path_buf(),
-        error,
-    })
+    match result {
+        Ok(()) => Ok(()),
+        // TOCTOU: another writer created the target between our
+        // `fs::metadata` short-circuit and the import syscall. The
+        // file is now there, which is exactly what our docstring
+        // promises, so honour the "existing target is a no-op"
+        // contract instead of failing the install. Verify via
+        // `fs::metadata` (follows symlinks; returns NotFound for
+        // dangling) so a newly-appeared broken symlink doesn't
+        // quietly pass as success.
+        Err(error)
+            if error.kind() == io::ErrorKind::AlreadyExists
+                && fs::metadata(target_link).is_ok() =>
+        {
+            Ok(())
+        }
+        Err(error) => Err(LinkFileError::Import {
+            from: source_file.to_path_buf(),
+            to: target_link.to_path_buf(),
+            error,
+        }),
+    }
 }
 
 /// EXDEV = "cross-device link not permitted". Linux / macOS / BSD all

--- a/crates/package-manager/src/link_file.rs
+++ b/crates/package-manager/src/link_file.rs
@@ -258,8 +258,7 @@ mod tests {
         let src = tmp.path().join("does-not-exist");
         let dst = tmp.path().join("dst.txt");
 
-        let err =
-            link_file(PackageImportMethod::Clone, &src, &dst).expect_err("no source → error");
+        let err = link_file(PackageImportMethod::Clone, &src, &dst).expect_err("no source → error");
         assert!(matches!(err, LinkFileError::CreateLink { .. }), "got: {err:?}");
     }
 

--- a/crates/package-manager/src/link_file.rs
+++ b/crates/package-manager/src/link_file.rs
@@ -36,10 +36,14 @@ pub enum LinkFileError {
     },
 }
 
-// Cached downgrade states shared by `Auto` and `CloneOrCopy`.
+// Downgrade state machine used by both `Auto` and `CloneOrCopy`.
+// These are the state *values*, not the cache itself: each mode keeps
+// its own process-global `AtomicU8` (`AUTO_STATE` inside `link_file`,
+// `CLONE_OR_COPY_STATE` likewise), so an `Auto` downgrade doesn't
+// affect `CloneOrCopy` and vice versa.
 //
-// This cache is process-global, not keyed by `(source fs, target fs)`.
-// Once we observe a tier failing anywhere, we stop trying it for the
+// Neither cache is keyed by `(source fs, target fs)`. Once we observe
+// a tier failing anywhere for a given mode, we stop trying it for the
 // rest of the process. That's a coarse optimization to avoid paying
 // the "try reflink, fail" cost for every file in installs where a
 // higher tier is not usable on the store / workspace pair.

--- a/crates/package-manager/src/link_file.rs
+++ b/crates/package-manager/src/link_file.rs
@@ -116,11 +116,9 @@ pub fn link_file(
             // file.
             if let Ok(meta) = fs::symlink_metadata(target_link) {
                 if meta.file_type().is_symlink() {
-                    fs::remove_file(target_link).map_err(|error| {
-                        LinkFileError::RemoveStale {
-                            path: target_link.to_path_buf(),
-                            error,
-                        }
+                    fs::remove_file(target_link).map_err(|error| LinkFileError::RemoveStale {
+                        path: target_link.to_path_buf(),
+                        error,
                     })?;
                 }
             }


### PR DESCRIPTION
## Summary

- Implements all `PackageImportMethod` variants in `link_file`. Until now it always used `reflink_copy::reflink_or_copy` regardless of config — `create_cas_files` asserted `Auto` so the other settings were unreachable.
- `Auto` uses pnpm's documented fallback chain: clone → hardlink → copy. A small deny-list (`is_call_error`) propagates `NotFound` / `PermissionDenied` / `AlreadyExists` rather than treating them as capability failures; everything else (including the grab-bag of platform-specific "operation not supported" codes — `EOPNOTSUPP`, `EXDEV`, `ERROR_INVALID_FUNCTION`, …) triggers the fallback. Same deny-list as `reflink-copy`'s own fallback logic.
- `Hardlink` / `Clone` / `Copy` propagate their own errors; `CloneOrCopy` follows a clone → copy fallback via an internal `clone_or_copy_link` helper that mirrors `Auto`'s downgrade-and-cache semantics minus the hardlink tier, keyed on its own `CLONE_OR_COPY_STATE` atomic.
- Drive-by: the `Copy` / `Clone` / `CloneOrCopy` doc comments in `pacquet-npmrc` were pairwise swapped. They were previously unreachable thanks to the `Auto`-only assertion, so nobody noticed.

### Postinstall caveat

Hardlinking a store file into `node_modules` means any package that edits its own files at runtime mutates the shared store copy. Pnpm guards against this by falling back to copy for packages with a postinstall script; pacquet doesn't run postinstall yet, so there's nothing to gate on here. Revisit when script execution lands.

Closes #174.

## Test plan

- [x] `cargo test -p pacquet-package-manager --lib link_file` — 5 new tests: Copy (independent inodes), Hardlink (shared inode + nlink bump on unix), Auto (always succeeds via fallback), no-op on existing target across all five methods, explicit Hardlink surfaces errors.
- [x] `cargo test -p pacquet-npmrc -- --test-threads=1` — 31 passing. (Parallel runs hit a pre-existing env-var race in `PNPM_HOME` / `XDG_DATA_HOME` tests; unrelated.)
- [x] `cargo build -p pacquet-package-manager`.
- [ ] Manual install against a real registry on a reflink-capable FS (APFS / btrfs) to confirm `Auto` still picks reflink on that path. *(not run locally — reviewers on APFS will exercise this via CI.)*