### PR TITLE
fix(cli): honour --frozen-lockfile over config.lockfile

### DIFF
--- a/.github/workflows/integrated-benchmark.yml
+++ b/.github/workflows/integrated-benchmark.yml
@@ -111,8 +111,17 @@ jobs:
 
       - name: 'Benchmark: Frozen Lockfile'
         shell: bash
+        # Hyperfine has no per-command timeout, so a single hanging
+        # install takes the whole step down with the GHA default job
+        # timeout (6 h). A normal run is ~2 min — 10 min is generous
+        # headroom, and a failure surfaces fast enough to iterate on.
+        timeout-minutes: 10
+        # `--show-output` pipes each binary's stderr through hyperfine
+        # so the step log captures traces / profile output / panics
+        # inline with each run. Essential for diagnosing a hang on CI
+        # where we can't attach a debugger.
         run: |
-          just integrated-benchmark --scenario=frozen-lockfile --verdaccio --with-pnpm HEAD main
+          just integrated-benchmark --show-output --scenario=frozen-lockfile --verdaccio --with-pnpm HEAD main
           cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_FROZEN_LOCKFILE.md
           cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_FROZEN_LOCKFILE.json
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1704,6 +1704,7 @@ dependencies = [
  "pretty_assertions",
  "rayon",
  "reflink-copy",
+ "serde_yaml",
  "ssri",
  "tempfile",
  "tokio",

--- a/crates/cli/src/cli_args.rs
+++ b/crates/cli/src/cli_args.rs
@@ -55,14 +55,26 @@ impl CliArgs {
         let CliArgs { command, dir } = self;
         let manifest_path = || dir.join("package.json");
         let npmrc = || Npmrc::current(env::current_dir, home::home_dir, Default::default).leak();
-        let state = || State::init(manifest_path(), npmrc()).wrap_err("initialize the state");
+        // `require_lockfile` is the "this subcommand cannot run without a
+        // lockfile loaded" signal, used by `State::init` to override
+        // `config.lockfile=false`. Only `install --frozen-lockfile` needs
+        // it today; other subcommands follow `config.lockfile`. Matches
+        // pnpm's CLI: `--frozen-lockfile` is the strongest signal and
+        // must not be silently dropped because `lockfile=false` was set
+        // (or defaulted) in config.
+        let state = |require_lockfile: bool| {
+            State::init(manifest_path(), npmrc(), require_lockfile).wrap_err("initialize the state")
+        };
 
         match command {
             CliCommand::Init => {
                 PackageManifest::init(&manifest_path()).wrap_err("initialize package.json")?;
             }
-            CliCommand::Add(args) => args.run(state()?).await?,
-            CliCommand::Install(args) => args.run(state()?).await?,
+            CliCommand::Add(args) => args.run(state(false)?).await?,
+            CliCommand::Install(args) => {
+                let require_lockfile = args.frozen_lockfile;
+                args.run(state(require_lockfile)?).await?
+            }
             CliCommand::Test => {
                 let manifest = PackageManifest::from_path(manifest_path())
                     .wrap_err("getting the package.json in current directory")?;

--- a/crates/cli/src/state.rs
+++ b/crates/cli/src/state.rs
@@ -38,13 +38,25 @@ pub enum InitStateError {
 
 impl State {
     /// Initialize the application state.
-    pub fn init(manifest_path: PathBuf, config: &'static Npmrc) -> Result<Self, InitStateError> {
+    ///
+    /// `require_lockfile` is `true` when the caller has committed to the
+    /// frozen-lockfile install path (via `--frozen-lockfile`) and needs
+    /// the lockfile loaded even when `config.lockfile` is `false`.
+    /// Matches pnpm's CLI: `--frozen-lockfile` is the strongest signal,
+    /// it must not be silently dropped because `lockfile` is disabled
+    /// (or unset) in config.
+    pub fn init(
+        manifest_path: PathBuf,
+        config: &'static Npmrc,
+        require_lockfile: bool,
+    ) -> Result<Self, InitStateError> {
+        let should_load = config.lockfile || require_lockfile;
         Ok(State {
             config,
             manifest: manifest_path
                 .pipe(PackageManifest::create_if_needed)
                 .map_err(InitStateError::LoadManifest)?,
-            lockfile: call_load_lockfile(config.lockfile, Lockfile::load_from_current_dir)
+            lockfile: call_load_lockfile(should_load, Lockfile::load_from_current_dir)
                 .map_err(InitStateError::LoadLockfile)?,
             http_client: ThrottledClient::new_from_cpu_count(),
             tarball_mem_cache: MemCache::new(),
@@ -53,17 +65,19 @@ impl State {
     }
 }
 
-/// Private function to load lockfile from current directory should `config.lockfile` is `true`.
+/// Load the lockfile from the current directory when `should_load` is
+/// `true`. Callers compose `should_load` from `config.lockfile ||
+/// --frozen-lockfile` so the CLI flag is always honoured.
 ///
 /// This function was extracted to be tested independently.
 fn call_load_lockfile<LoadLockfile, Lockfile, Error>(
-    config_lockfile: bool,
+    should_load: bool,
     load_lockfile: LoadLockfile,
 ) -> Result<Option<Lockfile>, Error>
 where
     LoadLockfile: FnOnce() -> Result<Option<Lockfile>, Error>,
 {
-    config_lockfile.then(load_lockfile).transpose().map(Option::flatten)
+    should_load.then(load_lockfile).transpose().map(Option::flatten)
 }
 
 #[cfg(test)]
@@ -74,15 +88,15 @@ mod tests {
     #[test]
     fn test_call_load_lockfile() {
         macro_rules! case {
-            ($config_lockfile:expr, $load_lockfile:expr => $output:expr) => {{
-                let config_lockfile = $config_lockfile;
+            ($should_load:expr, $load_lockfile:expr => $output:expr) => {{
+                let should_load = $should_load;
                 let load_lockfile = $load_lockfile;
                 let output: Result<Option<&str>, &str> = $output;
                 eprintln!(
-                    "CASE: {config_lockfile:?}, {load_lockfile} => {output:?}",
+                    "CASE: {should_load:?}, {load_lockfile} => {output:?}",
                     load_lockfile = stringify!($load_lockfile),
                 );
-                assert_eq!(call_load_lockfile(config_lockfile, load_lockfile), output);
+                assert_eq!(call_load_lockfile(should_load, load_lockfile), output);
             }};
         }
 

--- a/crates/package-manager/Cargo.toml
+++ b/crates/package-manager/Cargo.toml
@@ -38,6 +38,7 @@ pacquet-testing-utils = { workspace = true }
 node-semver       = { workspace = true }
 insta             = { workspace = true }
 pretty_assertions = { workspace = true }
+serde_yaml        = { workspace = true }
 ssri              = { workspace = true }
 tempfile          = { workspace = true }
 tokio             = { workspace = true }

--- a/crates/package-manager/src/install.rs
+++ b/crates/package-manager/src/install.rs
@@ -67,40 +67,54 @@ where
 
         tracing::info!(target: "pacquet::install", "Start all");
 
-        match (config.lockfile, frozen_lockfile, lockfile) {
-            (false, _, _) => {
-                InstallWithoutLockfile {
-                    tarball_mem_cache,
-                    resolved_packages,
-                    http_client,
-                    config,
-                    manifest,
-                    dependency_groups,
-                }
-                .run()
-                .await
-                .map_err(InstallError::WithoutLockfile)?;
-            }
-            (true, true, None) => return Err(InstallError::NoLockfile),
-            (true, false, Some(_)) | (true, false, None) => {
-                return Err(InstallError::UnsupportedLockfileMode);
-            }
-            (true, true, Some(lockfile)) => {
-                let Lockfile { lockfile_version, importers, packages, snapshots, .. } = lockfile;
-                assert_eq!(lockfile_version.major, 9); // compatibility check already happens at serde, but this still helps preventing programmer mistakes.
+        // Dispatch priority, matching pnpm's CLI semantics:
+        //
+        // 1. `--frozen-lockfile` is the strongest signal. If the user
+        //    passed the flag, use the frozen-lockfile path regardless of
+        //    `config.lockfile`. The prior `match` treated
+        //    `config.lockfile=false` as "skip the lockfile entirely" and
+        //    silently dropped the CLI flag — so pacquet's new-config
+        //    default (lockfile unset → `false`) turned every
+        //    `--frozen-lockfile` install into a registry-resolving
+        //    no-lockfile install, which is also what the integrated
+        //    benchmark has been measuring.
+        //
+        // 2. Otherwise follow `config.lockfile`. `true` means we'd
+        //    normally generate / update a lockfile, which pacquet
+        //    doesn't support yet → `UnsupportedLockfileMode`. `false`
+        //    means "lockfile disabled, resolve from registry".
+        if frozen_lockfile {
+            let Some(lockfile) = lockfile else {
+                return Err(InstallError::NoLockfile);
+            };
+            let Lockfile { lockfile_version, importers, packages, snapshots, .. } = lockfile;
+            assert_eq!(lockfile_version.major, 9); // compatibility check already happens at serde, but this still helps preventing programmer mistakes.
 
-                InstallFrozenLockfile {
-                    http_client,
-                    config,
-                    importers,
-                    packages: packages.as_ref(),
-                    snapshots: snapshots.as_ref(),
-                    dependency_groups,
-                }
-                .run()
-                .await
-                .map_err(InstallError::FrozenLockfile)?;
+            InstallFrozenLockfile {
+                http_client,
+                config,
+                importers,
+                packages: packages.as_ref(),
+                snapshots: snapshots.as_ref(),
+                dependency_groups,
             }
+            .run()
+            .await
+            .map_err(InstallError::FrozenLockfile)?;
+        } else if config.lockfile {
+            return Err(InstallError::UnsupportedLockfileMode);
+        } else {
+            InstallWithoutLockfile {
+                tarball_mem_cache,
+                resolved_packages,
+                http_client,
+                config,
+                manifest,
+                dependency_groups,
+            }
+            .run()
+            .await
+            .map_err(InstallError::WithoutLockfile)?;
         }
 
         tracing::info!(target: "pacquet::install", "Complete all");
@@ -245,6 +259,111 @@ mod tests {
         .await;
 
         assert!(matches!(result, Err(InstallError::UnsupportedLockfileMode)));
+        drop(dir);
+    }
+
+    /// `--frozen-lockfile` passed on the CLI must take precedence over
+    /// `config.lockfile=false`. Before this fix the dispatch matched on
+    /// `(config.lockfile, frozen_lockfile, lockfile)` in an order that
+    /// treated `config.lockfile=false` as "skip lockfile entirely",
+    /// silently dropping the CLI flag and resolving from the registry
+    /// instead — the very regression the integrated benchmark was
+    /// measuring. Pin the new priority: frozen flag + lockfile present
+    /// → `InstallFrozenLockfile`, regardless of `config.lockfile`.
+    ///
+    /// We don't need the full install to succeed here — any error that
+    /// *isn't* `NoLockfile` / `UnsupportedLockfileMode` proves the
+    /// dispatch picked the frozen path. Passing a malformed lockfile
+    /// integrity surfaces as `FrozenLockfile(...)`.
+    #[tokio::test]
+    async fn frozen_lockfile_flag_overrides_config_lockfile_false() {
+        use pacquet_lockfile::Lockfile;
+
+        let dir = tempdir().unwrap();
+        let store_dir = dir.path().join("pacquet-store");
+        let project_root = dir.path().join("project");
+        let modules_dir = project_root.join("node_modules");
+        let virtual_store_dir = modules_dir.join(".pacquet");
+
+        let manifest_path = dir.path().join("package.json");
+        let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
+
+        let mut config = Npmrc::new();
+        // Explicitly disabled — this is the pacquet default today. The
+        // CLI flag must still take over.
+        config.lockfile = false;
+        config.store_dir = store_dir.into();
+        config.modules_dir = modules_dir.to_path_buf();
+        config.virtual_store_dir = virtual_store_dir;
+        let config = config.leak();
+
+        // Minimal v9 lockfile with no snapshots — the frozen path will
+        // run through `CreateVirtualStore` with an empty snapshot set,
+        // which is a successful no-op. That's enough to prove we took
+        // the frozen branch.
+        let lockfile: Lockfile = serde_yaml::from_str(concat!(
+            "lockfileVersion: '9.0'\n",
+            "importers:\n",
+            "  .:\n",
+            "    dependencies: {}\n",
+            "packages: {}\n",
+            "snapshots: {}\n",
+        ))
+        .expect("parse minimal v9 lockfile");
+
+        Install {
+            tarball_mem_cache: &Default::default(),
+            http_client: &Default::default(),
+            config,
+            manifest: &manifest,
+            lockfile: Some(&lockfile),
+            dependency_groups: [DependencyGroup::Prod],
+            frozen_lockfile: true,
+            resolved_packages: &Default::default(),
+        }
+        .run()
+        .await
+        .expect("--frozen-lockfile + empty lockfile should succeed via InstallFrozenLockfile");
+
+        drop(dir);
+    }
+
+    /// Symmetric negative: `--frozen-lockfile` with no lockfile
+    /// loadable must surface `NoLockfile`, even when `config.lockfile`
+    /// is `false` (which used to fall through to the no-lockfile path
+    /// and silently succeed).
+    #[tokio::test]
+    async fn frozen_lockfile_flag_with_no_lockfile_errors() {
+        let dir = tempdir().unwrap();
+        let store_dir = dir.path().join("pacquet-store");
+        let project_root = dir.path().join("project");
+        let modules_dir = project_root.join("node_modules");
+        let virtual_store_dir = modules_dir.join(".pacquet");
+
+        let manifest_path = dir.path().join("package.json");
+        let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
+
+        let mut config = Npmrc::new();
+        config.lockfile = false;
+        config.store_dir = store_dir.into();
+        config.modules_dir = modules_dir.to_path_buf();
+        config.virtual_store_dir = virtual_store_dir;
+        let config = config.leak();
+
+        let result = Install {
+            tarball_mem_cache: &Default::default(),
+            http_client: &Default::default(),
+            config,
+            manifest: &manifest,
+            lockfile: None,
+            dependency_groups: [DependencyGroup::Prod],
+            frozen_lockfile: true,
+            resolved_packages: &Default::default(),
+        }
+        .run()
+        .await;
+
+        assert!(matches!(result, Err(InstallError::NoLockfile)));
         drop(dir);
     }
 }


### PR DESCRIPTION
## Summary

`pacquet install --frozen-lockfile` silently downgraded to the no-lockfile registry-resolving install path whenever `config.lockfile` was `false` — which is the default since the new yaml-first config model (#248 / `9c00046`). `.npmrc`'s `lockfile=true` is no longer read, and the struct default is Rust's `bool::default()`. The CI benchmark's `.npmrc lockfile=true` has been a no-op, and every `--frozen-lockfile` install has been measuring the wrong path.

### Impact

On the integrated-benchmark fixture locally:
| | main | with this fix |
|---|---|---|
| `pacquet install --frozen-lockfile` | 6.8–9.0 s (hits npmjs.org) | **0.15 s** |

The CI Integrated-Benchmark gap of pacquet 3.33 s vs pnpm 0.75 s is almost entirely this — pacquet was running `InstallWithoutLockfile` (verdaccio-resolved fetches) while pnpm was running its frozen-lockfile path. The hardlink work in #256 didn't move the benchmark needle because the slow phase was never even the link phase.

### What changed

- `State::init` gains a `require_lockfile: bool` parameter. Lockfile is loaded when `config.lockfile || require_lockfile`. CLI passes `args.frozen_lockfile` as `require_lockfile`, so the flag guarantees the file is read even when lockfiles are disabled in config.
- `Install::run` dispatch rewritten with explicit priority:
  1. `--frozen-lockfile` → `InstallFrozenLockfile` (or `NoLockfile` if missing), regardless of `config.lockfile`.
  2. `config.lockfile=true` without the flag → `UnsupportedLockfileMode`.
  3. Otherwise → `InstallWithoutLockfile`.

  Matches pnpm's CLI: the flag is the strongest signal. The prior `match (config.lockfile, frozen_lockfile, lockfile)` had `(false, _, _) => InstallWithoutLockfile` as its first arm, which silently consumed the flag.

### Notes

- The pre-existing `should_install_dependencies` test keeps failing with the unrelated `runtime from within runtime` tokio panic in `registry_anchor.rs:81` — same state as main.
- This may surface a latent issue in `InstallFrozenLockfile` that was hidden while the CLI silently avoided that path. If anything breaks in CI it's likely that.

## Test plan

- [x] `frozen_lockfile_flag_overrides_config_lockfile_false` — pins the new priority (`config.lockfile=false` + `--frozen-lockfile` + minimal lockfile → `InstallFrozenLockfile` runs; previously would have silently used `InstallWithoutLockfile`).
- [x] `frozen_lockfile_flag_with_no_lockfile_errors` — symmetric negative (flag without a lockfile file → `NoLockfile` error; previously fell through and succeeded).
- [x] Pre-existing `test_call_load_lockfile` updated for the renamed parameter.
- [x] End-to-end against the integrated-benchmark fixture — 50× speedup locally, `.pnpm/` virtual store is created (wasn't before).