### PR TITLE
perf(store-dir): share one read-only StoreIndex across cache lookups

### DIFF
--- a/crates/package-manager/Cargo.toml
+++ b/crates/package-manager/Cargo.toml
@@ -28,6 +28,7 @@ node-semver     = { workspace = true }
 pipe-trait      = { workspace = true }
 rayon           = { workspace = true }
 reflink-copy    = { workspace = true }
+tokio           = { workspace = true }
 tracing         = { workspace = true }
 miette          = { workspace = true }
 
@@ -41,5 +42,4 @@ pretty_assertions = { workspace = true }
 serde_yaml        = { workspace = true }
 ssri              = { workspace = true }
 tempfile          = { workspace = true }
-tokio             = { workspace = true }
 walkdir           = { workspace = true }

--- a/crates/package-manager/Cargo.toml
+++ b/crates/package-manager/Cargo.toml
@@ -17,6 +17,7 @@ pacquet-network          = { workspace = true }
 pacquet-npmrc            = { workspace = true }
 pacquet-package-manifest = { workspace = true }
 pacquet-registry         = { workspace = true }
+pacquet-store-dir        = { workspace = true }
 pacquet-tarball          = { workspace = true }
 
 async-recursion = { workspace = true }
@@ -31,7 +32,6 @@ tracing         = { workspace = true }
 miette          = { workspace = true }
 
 [dev-dependencies]
-pacquet-store-dir     = { workspace = true }
 pacquet-registry-mock = { workspace = true }
 pacquet-testing-utils = { workspace = true }
 

--- a/crates/package-manager/src/create_virtual_store.rs
+++ b/crates/package-manager/src/create_virtual_store.rs
@@ -61,11 +61,18 @@ impl<'a> CreateVirtualStore<'a> {
         // + a `PRAGMA busy_timeout`), so park it on the blocking pool instead
         // of stalling the reactor thread, even for the sub-millisecond it
         // usually takes.
+        //
+        // A `JoinError` here (blocking-task panic, or cancellation during
+        // runtime shutdown) is degraded into `None` so the install still
+        // makes progress — cache lookups just miss. `shared_readonly_in`
+        // already yields `None` for a first-time install against an empty
+        // store, and downstream callers handle that shape correctly.
         let store_dir: &'static _ = &config.store_dir;
         let store_index =
             tokio::task::spawn_blocking(move || StoreIndex::shared_readonly_in(store_dir))
                 .await
-                .expect("store-index open task panicked");
+                .ok()
+                .flatten();
         let store_index_ref = store_index.as_ref();
 
         snapshots

--- a/crates/package-manager/src/create_virtual_store.rs
+++ b/crates/package-manager/src/create_virtual_store.rs
@@ -5,6 +5,7 @@ use miette::Diagnostic;
 use pacquet_lockfile::{PackageKey, PackageMetadata, SnapshotEntry};
 use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
+use pacquet_store_dir::StoreIndex;
 use pipe_trait::Pipe;
 use std::collections::HashMap;
 
@@ -47,9 +48,19 @@ impl<'a> CreateVirtualStore<'a> {
         };
         let packages = packages.ok_or(CreateVirtualStoreError::MissingPackagesSection)?;
 
+        // Open the read-only SQLite index once for the whole run instead of
+        // per snapshot. Every `InstallPackageBySnapshot` performs a cache
+        // lookup against this index before falling through to the network;
+        // on a 1352-package lockfile the per-snapshot reopen accounted for
+        // ~1.3 s of wall time even with a fully populated store (see #260).
+        // A `None` here means the store has no `index.db` yet (first install
+        // against an empty store), in which case every lookup would miss —
+        // so we keep the handle `Option`al and short-circuit.
+        let store_index = StoreIndex::shared_readonly_in(&config.store_dir);
+
         snapshots
             .iter()
-            .map(|(snapshot_key, snapshot)| async move {
+            .map(|(snapshot_key, snapshot)| async {
                 let metadata_key = snapshot_key.without_peer();
                 let metadata = packages.get(&metadata_key).ok_or_else(|| {
                     CreateVirtualStoreError::MissingPackageMetadata {
@@ -60,6 +71,7 @@ impl<'a> CreateVirtualStore<'a> {
                 InstallPackageBySnapshot {
                     http_client,
                     config,
+                    store_index: store_index.as_ref(),
                     package_key: snapshot_key,
                     metadata,
                     snapshot,

--- a/crates/package-manager/src/create_virtual_store.rs
+++ b/crates/package-manager/src/create_virtual_store.rs
@@ -70,21 +70,20 @@ impl<'a> CreateVirtualStore<'a> {
         // surface the error at `warn!` so a silent task panic or
         // cancellation is still diagnosable in the log.
         let store_dir: &'static _ = &config.store_dir;
-        let store_index = match tokio::task::spawn_blocking(move || {
-            StoreIndex::shared_readonly_in(store_dir)
-        })
-        .await
-        {
-            Ok(store_index) => store_index,
-            Err(error) => {
-                tracing::warn!(
-                    target: "pacquet::install",
-                    ?error,
-                    "store-index open task failed; continuing without a shared cache index",
-                );
-                None
-            }
-        };
+        let store_index =
+            match tokio::task::spawn_blocking(move || StoreIndex::shared_readonly_in(store_dir))
+                .await
+            {
+                Ok(store_index) => store_index,
+                Err(error) => {
+                    tracing::warn!(
+                        target: "pacquet::install",
+                        ?error,
+                        "store-index open task failed; continuing without a shared cache index",
+                    );
+                    None
+                }
+            };
         let store_index_ref = store_index.as_ref();
 
         snapshots

--- a/crates/package-manager/src/create_virtual_store.rs
+++ b/crates/package-manager/src/create_virtual_store.rs
@@ -56,7 +56,16 @@ impl<'a> CreateVirtualStore<'a> {
         // A `None` here means the store has no `index.db` yet (first install
         // against an empty store), in which case every lookup would miss —
         // so we keep the handle `Option`al and short-circuit.
-        let store_index = StoreIndex::shared_readonly_in(&config.store_dir);
+        //
+        // The open itself is synchronous SQLite I/O (`Connection::open_with_flags`
+        // + a `PRAGMA busy_timeout`), so park it on the blocking pool instead
+        // of stalling the reactor thread, even for the sub-millisecond it
+        // usually takes.
+        let store_dir: &'static _ = &config.store_dir;
+        let store_index =
+            tokio::task::spawn_blocking(move || StoreIndex::shared_readonly_in(store_dir))
+                .await
+                .expect("store-index open task panicked");
         let store_index_ref = store_index.as_ref();
 
         snapshots

--- a/crates/package-manager/src/create_virtual_store.rs
+++ b/crates/package-manager/src/create_virtual_store.rs
@@ -57,10 +57,11 @@ impl<'a> CreateVirtualStore<'a> {
         // against an empty store), in which case every lookup would miss —
         // so we keep the handle `Option`al and short-circuit.
         let store_index = StoreIndex::shared_readonly_in(&config.store_dir);
+        let store_index_ref = store_index.as_ref();
 
         snapshots
             .iter()
-            .map(|(snapshot_key, snapshot)| async {
+            .map(|(snapshot_key, snapshot)| async move {
                 let metadata_key = snapshot_key.without_peer();
                 let metadata = packages.get(&metadata_key).ok_or_else(|| {
                     CreateVirtualStoreError::MissingPackageMetadata {
@@ -71,7 +72,7 @@ impl<'a> CreateVirtualStore<'a> {
                 InstallPackageBySnapshot {
                     http_client,
                     config,
-                    store_index: store_index.as_ref(),
+                    store_index: store_index_ref,
                     package_key: snapshot_key,
                     metadata,
                     snapshot,

--- a/crates/package-manager/src/create_virtual_store.rs
+++ b/crates/package-manager/src/create_virtual_store.rs
@@ -66,13 +66,25 @@ impl<'a> CreateVirtualStore<'a> {
         // runtime shutdown) is degraded into `None` so the install still
         // makes progress — cache lookups just miss. `shared_readonly_in`
         // already yields `None` for a first-time install against an empty
-        // store, and downstream callers handle that shape correctly.
+        // store, and downstream callers handle that shape correctly. We
+        // surface the error at `warn!` so a silent task panic or
+        // cancellation is still diagnosable in the log.
         let store_dir: &'static _ = &config.store_dir;
-        let store_index =
-            tokio::task::spawn_blocking(move || StoreIndex::shared_readonly_in(store_dir))
-                .await
-                .ok()
-                .flatten();
+        let store_index = match tokio::task::spawn_blocking(move || {
+            StoreIndex::shared_readonly_in(store_dir)
+        })
+        .await
+        {
+            Ok(store_index) => store_index,
+            Err(error) => {
+                tracing::warn!(
+                    target: "pacquet::install",
+                    ?error,
+                    "store-index open task failed; continuing without a shared cache index",
+                );
+                None
+            }
+        };
         let store_index_ref = store_index.as_ref();
 
         snapshots

--- a/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/crates/package-manager/src/install_package_by_snapshot.rs
@@ -4,6 +4,7 @@ use miette::Diagnostic;
 use pacquet_lockfile::{LockfileResolution, PackageKey, PackageMetadata, SnapshotEntry};
 use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
+use pacquet_store_dir::SharedReadonlyStoreIndex;
 use pacquet_tarball::{DownloadTarballToStore, TarballError};
 use pipe_trait::Pipe;
 use std::borrow::Cow;
@@ -14,6 +15,7 @@ use std::borrow::Cow;
 pub struct InstallPackageBySnapshot<'a> {
     pub http_client: &'a ThrottledClient,
     pub config: &'static Npmrc,
+    pub store_index: Option<&'a SharedReadonlyStoreIndex>,
     pub package_key: &'a PackageKey,
     pub metadata: &'a PackageMetadata,
     pub snapshot: &'a SnapshotEntry,
@@ -44,8 +46,14 @@ pub enum InstallPackageBySnapshotError {
 impl<'a> InstallPackageBySnapshot<'a> {
     /// Execute the subroutine.
     pub async fn run(self) -> Result<(), InstallPackageBySnapshotError> {
-        let InstallPackageBySnapshot { http_client, config, package_key, metadata, snapshot } =
-            self;
+        let InstallPackageBySnapshot {
+            http_client,
+            config,
+            store_index,
+            package_key,
+            metadata,
+            snapshot,
+        } = self;
 
         let (tarball_url, integrity) = match &metadata.resolution {
             LockfileResolution::Tarball(tarball_resolution) => {
@@ -84,6 +92,7 @@ impl<'a> InstallPackageBySnapshot<'a> {
         let cas_paths = DownloadTarballToStore {
             http_client,
             store_dir: &config.store_dir,
+            store_index: store_index.cloned(),
             package_integrity: integrity,
             package_unpacked_size: None,
             package_url: &tarball_url,

--- a/crates/package-manager/src/install_package_from_registry.rs
+++ b/crates/package-manager/src/install_package_from_registry.rs
@@ -4,6 +4,7 @@ use miette::Diagnostic;
 use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
 use pacquet_registry::{Package, PackageTag, PackageVersion, RegistryError};
+use pacquet_store_dir::SharedReadonlyStoreIndex;
 use pacquet_tarball::{DownloadTarballToStore, MemCache, TarballError};
 use std::{path::Path, str::FromStr};
 
@@ -20,6 +21,7 @@ pub struct InstallPackageFromRegistry<'a> {
     pub tarball_mem_cache: &'a MemCache,
     pub http_client: &'a ThrottledClient,
     pub config: &'static Npmrc,
+    pub store_index: Option<&'a SharedReadonlyStoreIndex>,
     pub node_modules_dir: &'a Path,
     pub name: &'a str,
     pub version_range: &'a str,
@@ -71,6 +73,7 @@ impl<'a> InstallPackageFromRegistry<'a> {
             tarball_mem_cache,
             http_client,
             config,
+            store_index,
             node_modules_dir,
             ..
         } = self;
@@ -82,6 +85,7 @@ impl<'a> InstallPackageFromRegistry<'a> {
         let cas_paths = DownloadTarballToStore {
             http_client,
             store_dir: &config.store_dir,
+            store_index: store_index.cloned(),
             package_integrity: package_version
                 .dist
                 .integrity
@@ -165,6 +169,7 @@ mod tests {
             tarball_mem_cache: &Default::default(),
             config,
             http_client: &http_client,
+            store_index: None,
             name: "fast-querystring",
             version_range: "1.0.0",
             node_modules_dir: modules_dir.path(),

--- a/crates/package-manager/src/install_without_lockfile.rs
+++ b/crates/package-manager/src/install_without_lockfile.rs
@@ -62,8 +62,13 @@ impl<'a, DependencyGroupList> InstallWithoutLockfile<'a, DependencyGroupList> {
 
         // Open the read-only SQLite index once per install, shared across
         // every `DownloadTarballToStore`. See the matching comment in
-        // `create_virtual_store.rs` for the why.
-        let store_index = StoreIndex::shared_readonly_in(&config.store_dir);
+        // `create_virtual_store.rs` for why — including why the synchronous
+        // SQLite open is parked on the blocking pool.
+        let store_dir: &'static _ = &config.store_dir;
+        let store_index =
+            tokio::task::spawn_blocking(move || StoreIndex::shared_readonly_in(store_dir))
+                .await
+                .expect("store-index open task panicked");
         let store_index_ref = store_index.as_ref();
 
         manifest

--- a/crates/package-manager/src/install_without_lockfile.rs
+++ b/crates/package-manager/src/install_without_lockfile.rs
@@ -66,21 +66,20 @@ impl<'a, DependencyGroupList> InstallWithoutLockfile<'a, DependencyGroupList> {
         // `JoinError`-to-cache-miss degradation (with a `warn!` so it
         // stays diagnosable).
         let store_dir: &'static _ = &config.store_dir;
-        let store_index = match tokio::task::spawn_blocking(move || {
-            StoreIndex::shared_readonly_in(store_dir)
-        })
-        .await
-        {
-            Ok(store_index) => store_index,
-            Err(error) => {
-                tracing::warn!(
-                    target: "pacquet::install",
-                    ?error,
-                    "store-index open task failed; continuing without a shared cache index",
-                );
-                None
-            }
-        };
+        let store_index =
+            match tokio::task::spawn_blocking(move || StoreIndex::shared_readonly_in(store_dir))
+                .await
+            {
+                Ok(store_index) => store_index,
+                Err(error) => {
+                    tracing::warn!(
+                        target: "pacquet::install",
+                        ?error,
+                        "store-index open task failed; continuing without a shared cache index",
+                    );
+                    None
+                }
+            };
         let store_index_ref = store_index.as_ref();
 
         manifest

--- a/crates/package-manager/src/install_without_lockfile.rs
+++ b/crates/package-manager/src/install_without_lockfile.rs
@@ -63,13 +63,24 @@ impl<'a, DependencyGroupList> InstallWithoutLockfile<'a, DependencyGroupList> {
         // Open the read-only SQLite index once per install, shared across
         // every `DownloadTarballToStore`. See the matching comment in
         // `create_virtual_store.rs` for the full rationale, including the
-        // `JoinError`-to-cache-miss degradation.
+        // `JoinError`-to-cache-miss degradation (with a `warn!` so it
+        // stays diagnosable).
         let store_dir: &'static _ = &config.store_dir;
-        let store_index =
-            tokio::task::spawn_blocking(move || StoreIndex::shared_readonly_in(store_dir))
-                .await
-                .ok()
-                .flatten();
+        let store_index = match tokio::task::spawn_blocking(move || {
+            StoreIndex::shared_readonly_in(store_dir)
+        })
+        .await
+        {
+            Ok(store_index) => store_index,
+            Err(error) => {
+                tracing::warn!(
+                    target: "pacquet::install",
+                    ?error,
+                    "store-index open task failed; continuing without a shared cache index",
+                );
+                None
+            }
+        };
         let store_index_ref = store_index.as_ref();
 
         manifest

--- a/crates/package-manager/src/install_without_lockfile.rs
+++ b/crates/package-manager/src/install_without_lockfile.rs
@@ -62,13 +62,14 @@ impl<'a, DependencyGroupList> InstallWithoutLockfile<'a, DependencyGroupList> {
 
         // Open the read-only SQLite index once per install, shared across
         // every `DownloadTarballToStore`. See the matching comment in
-        // `create_virtual_store.rs` for why — including why the synchronous
-        // SQLite open is parked on the blocking pool.
+        // `create_virtual_store.rs` for the full rationale, including the
+        // `JoinError`-to-cache-miss degradation.
         let store_dir: &'static _ = &config.store_dir;
         let store_index =
             tokio::task::spawn_blocking(move || StoreIndex::shared_readonly_in(store_dir))
                 .await
-                .expect("store-index open task panicked");
+                .ok()
+                .flatten();
         let store_index_ref = store_index.as_ref();
 
         manifest

--- a/crates/package-manager/src/install_without_lockfile.rs
+++ b/crates/package-manager/src/install_without_lockfile.rs
@@ -138,15 +138,16 @@ impl<'a> InstallWithoutLockfile<'a, ()> {
 
         tracing::info!(target: "pacquet::install", node_modules = ?node_modules_path, "Start subset");
 
+        let node_modules_path_ref = &node_modules_path;
         package
             .dependencies(self.config.auto_install_peers)
-            .map(|(name, version_range)| async {
+            .map(|(name, version_range)| async move {
                 let dependency = InstallPackageFromRegistry {
                     tarball_mem_cache,
                     http_client,
                     config,
                     store_index,
-                    node_modules_dir: &node_modules_path,
+                    node_modules_dir: node_modules_path_ref,
                     name,
                     version_range,
                 }

--- a/crates/package-manager/src/install_without_lockfile.rs
+++ b/crates/package-manager/src/install_without_lockfile.rs
@@ -9,6 +9,7 @@ use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_registry::PackageVersion;
+use pacquet_store_dir::StoreIndex;
 use pacquet_tarball::MemCache;
 use pipe_trait::Pipe;
 
@@ -59,6 +60,12 @@ impl<'a, DependencyGroupList> InstallWithoutLockfile<'a, DependencyGroupList> {
             resolved_packages,
         } = self;
 
+        // Open the read-only SQLite index once per install, shared across
+        // every `DownloadTarballToStore`. See the matching comment in
+        // `create_virtual_store.rs` for the why.
+        let store_index = StoreIndex::shared_readonly_in(&config.store_dir);
+        let store_index_ref = store_index.as_ref();
+
         manifest
             .dependencies(dependency_groups)
             .map(|(name, version_range)| async move {
@@ -66,6 +73,7 @@ impl<'a, DependencyGroupList> InstallWithoutLockfile<'a, DependencyGroupList> {
                     tarball_mem_cache,
                     http_client,
                     config,
+                    store_index: store_index_ref,
                     node_modules_dir: &config.modules_dir,
                     name,
                     version_range,
@@ -82,7 +90,7 @@ impl<'a, DependencyGroupList> InstallWithoutLockfile<'a, DependencyGroupList> {
                     dependency_groups: (),
                     resolved_packages,
                 }
-                .install_dependencies_from_registry(&dependency)
+                .install_dependencies_from_registry(&dependency, store_index_ref)
                 .await?;
 
                 Ok::<_, InstallWithoutLockfileError>(())
@@ -100,6 +108,7 @@ impl<'a> InstallWithoutLockfile<'a, ()> {
     async fn install_dependencies_from_registry(
         &self,
         package: &PackageVersion,
+        store_index: Option<&'async_recursion pacquet_store_dir::SharedReadonlyStoreIndex>,
     ) -> Result<(), InstallWithoutLockfileError> {
         let InstallWithoutLockfile {
             tarball_mem_cache,
@@ -130,6 +139,7 @@ impl<'a> InstallWithoutLockfile<'a, ()> {
                     tarball_mem_cache,
                     http_client,
                     config,
+                    store_index,
                     node_modules_dir: &node_modules_path,
                     name,
                     version_range,
@@ -137,7 +147,7 @@ impl<'a> InstallWithoutLockfile<'a, ()> {
                 .run::<Version>()
                 .await
                 .map_err(InstallWithoutLockfileError::InstallPackageFromRegistry)?;
-                self.install_dependencies_from_registry(&dependency).await?;
+                self.install_dependencies_from_registry(&dependency, store_index).await?;
                 Ok::<_, InstallWithoutLockfileError>(())
             })
             .pipe(future::try_join_all)

--- a/crates/store-dir/src/store_index.rs
+++ b/crates/store-dir/src/store_index.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
+    sync::{Arc, Mutex},
 };
 
 /// SQLite-backed per-package index that pnpm v11 stores alongside the CAFS
@@ -22,6 +23,13 @@ use std::{
 pub struct StoreIndex {
     conn: Connection,
 }
+
+/// Shared handle to a read-only [`StoreIndex`] that can be cheaply cloned and
+/// sent across blocking tasks. SQLite's `Connection` is `Send` but not
+/// `Sync`, so the `Mutex` gates concurrent reads to a single query at a time
+/// — fine for our workload where every caller serializes one short query and
+/// then hands off to per-file work without holding the lock.
+pub type SharedReadonlyStoreIndex = Arc<Mutex<StoreIndex>>;
 
 /// Error type of [`StoreIndex`].
 #[derive(Debug, Display, Error, Diagnostic)]
@@ -148,6 +156,23 @@ impl StoreIndex {
     /// Read-only counterpart to [`StoreIndex::open_in`].
     pub fn open_readonly_in(store_dir: &StoreDir) -> Result<Self, StoreIndexError> {
         StoreIndex::open_readonly(&store_dir.v11())
+    }
+
+    /// Open a read-only index wrapped in `Arc<Mutex<…>>` so it can be shared
+    /// across the many cache lookups an install performs. Returns `None` if
+    /// `index.db` does not yet exist under the store — a first-time install
+    /// against an empty store — since there is nothing to read back and every
+    /// lookup would be a miss anyway.
+    ///
+    /// Reusing one connection avoids reopening the SQLite database (and
+    /// redoing its PRAGMAs) on every package, which otherwise scales
+    /// linearly with the snapshot count.
+    pub fn shared_readonly_in(store_dir: &StoreDir) -> Option<SharedReadonlyStoreIndex> {
+        let v11_dir = store_dir.v11();
+        if !v11_dir.join("index.db").exists() {
+            return None;
+        }
+        StoreIndex::open_readonly(&v11_dir).ok().map(|index| Arc::new(Mutex::new(index)))
     }
 
     /// Look up a package-files index by key. Returns `Ok(None)` if no row exists.

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -119,8 +119,21 @@ async fn load_cached_cas_paths(
 ) -> Option<HashMap<String, PathBuf>> {
     let index = index?;
     tokio::task::spawn_blocking(move || -> Option<HashMap<String, PathBuf>> {
+        // Treat a poisoned mutex as a cache miss rather than propagating the
+        // panic: the `SELECT` is stateless, so the prior panic couldn't have
+        // left the index in an inconsistent shape, and cache lookups are a
+        // best-effort hint anyway — failing over to a fresh download is the
+        // more resilient default than turning every subsequent snapshot into
+        // a crash.
         let entry = {
-            let guard = index.lock().expect("store-index mutex poisoned");
+            let Ok(guard) = index.lock() else {
+                tracing::debug!(
+                    target: "pacquet::download",
+                    ?cache_key,
+                    "store-index mutex poisoned; treating cache lookup as a miss",
+                );
+                return None;
+            };
             guard.get(&cache_key).ok()?
         }?;
 

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -12,8 +12,8 @@ use miette::Diagnostic;
 use pacquet_fs::file_mode;
 use pacquet_network::ThrottledClient;
 use pacquet_store_dir::{
-    store_index_key, CafsFileInfo, PackageFilesIndex, StoreDir, StoreIndex, StoreIndexError,
-    WriteCasFileError,
+    store_index_key, CafsFileInfo, PackageFilesIndex, SharedReadonlyStoreIndex, StoreDir,
+    StoreIndex, StoreIndexError, WriteCasFileError,
 };
 use pipe_trait::Pipe;
 use ssri::Integrity;
@@ -99,22 +99,30 @@ fn decompress_gzip(gz_data: &[u8], unpacked_size: Option<usize>) -> Result<Vec<u
 
 /// Try to reconstruct the `{filename → CAFS path}` map for a package from
 /// the SQLite store index, without going to the network. Returns `None`
-/// if anything looks off — no db, no row, unreadable row, malformed
-/// digest, or any referenced CAFS path that fails validation — so the
-/// caller falls through to a fresh download. Error paths are treated as
-/// cache misses because the index is a cache hint, not a source of
-/// truth. Any CAFS-path validation failure (missing blob, metadata
-/// error, directory, symlink, or other non-regular file) emits a
-/// `debug!` log to note the stale entry before re-fetching; earlier
-/// checks — db / row / decode / digest — are silent because they don't
-/// point at a specific on-disk artifact worth describing.
+/// if anything looks off — no index handed in, no row, unreadable row,
+/// malformed digest, or any referenced CAFS path that fails validation —
+/// so the caller falls through to a fresh download. Error paths are
+/// treated as cache misses because the index is a cache hint, not a
+/// source of truth. Any CAFS-path validation failure (missing blob,
+/// metadata error, directory, symlink, or other non-regular file) emits
+/// a `debug!` log to note the stale entry before re-fetching; earlier
+/// checks — row / decode / digest — are silent because they don't point
+/// at a specific on-disk artifact worth describing.
+///
+/// The `index` argument is a shared read-only handle that callers open
+/// once per install and pass in repeatedly, so we don't pay the
+/// `Connection::open` + PRAGMA cost per package.
 async fn load_cached_cas_paths(
+    index: Option<SharedReadonlyStoreIndex>,
     store_dir: &'static StoreDir,
     cache_key: String,
 ) -> Option<HashMap<String, PathBuf>> {
+    let index = index?;
     tokio::task::spawn_blocking(move || -> Option<HashMap<String, PathBuf>> {
-        let index = StoreIndex::open_readonly_in(store_dir).ok()?;
-        let entry = index.get(&cache_key).ok()??;
+        let entry = {
+            let guard = index.lock().expect("store-index mutex poisoned");
+            guard.get(&cache_key).ok()?
+        }?;
 
         let mut cas_paths = HashMap::with_capacity(entry.files.len());
         // Consume `entry.files` so the owned `String` keys can move
@@ -164,6 +172,12 @@ async fn load_cached_cas_paths(
 pub struct DownloadTarballToStore<'a> {
     pub http_client: &'a ThrottledClient,
     pub store_dir: &'static StoreDir,
+    /// Shared read-only handle to the SQLite store index. `None` when the
+    /// store does not (yet) have an `index.db`, in which case every cache
+    /// lookup short-circuits to a network fetch. Callers open this once per
+    /// install and pass the same handle to every `DownloadTarballToStore`
+    /// so we don't reopen the DB per package.
+    pub store_index: Option<SharedReadonlyStoreIndex>,
     pub package_integrity: &'a Integrity,
     pub package_unpacked_size: Option<usize>,
     pub package_url: &'a str,
@@ -225,7 +239,9 @@ impl<'a> DownloadTarballToStore<'a> {
             package_unpacked_size,
             package_url,
             package_id,
+            ..
         } = self;
+        let store_index = self.store_index.clone();
 
         // Before hitting the network, check the SQLite store index: if the
         // tarball is already in the CAFS we can reuse its per-file paths
@@ -240,7 +256,7 @@ impl<'a> DownloadTarballToStore<'a> {
         // CAFS file that has gone missing from disk all fall through to
         // the download path below.
         let cache_key = store_index_key(&package_integrity.to_string(), package_id);
-        if let Some(cas_paths) = load_cached_cas_paths(store_dir, cache_key).await {
+        if let Some(cas_paths) = load_cached_cas_paths(store_index, store_dir, cache_key).await {
             tracing::info!(target: "pacquet::download", ?package_url, ?package_id, "Reusing cached CAFS entry — skipping download");
             return Ok(cas_paths);
         }
@@ -456,6 +472,7 @@ mod tests {
         let cas_files = DownloadTarballToStore {
             http_client: &Default::default(),
             store_dir: store_path,
+            store_index: None,
             package_integrity: &integrity("sha512-dj7vjIn1Ar8sVXj2yAXiMNCJDmS9MQ9XMlIecX2dIzzhjSHCyKo4DdXjXMs7wKW2kj6yvVRSpuQjOZ3YLrh56w=="),
             package_unpacked_size: Some(16697),
             package_url: "https://registry.npmjs.org/@fastify/error/-/error-3.3.0.tgz",
@@ -496,6 +513,7 @@ mod tests {
         DownloadTarballToStore {
             http_client: &Default::default(),
             store_dir: store_path,
+            store_index: None,
             package_integrity: &integrity("sha512-aaaan1Ar8sVXj2yAXiMNCJDmS9MQ9XMlIecX2dIzzhjSHCyKo4DdXjXMs7wKW2kj6yvVRSpuQjOZ3YLrh56w=="),
             package_unpacked_size: Some(16697),
             package_url: "https://registry.npmjs.org/@fastify/error/-/error-3.3.0.tgz",
@@ -563,6 +581,7 @@ mod tests {
         let cas_paths = DownloadTarballToStore {
             http_client: &fast_fail_client(),
             store_dir: store_path,
+            store_index: StoreIndex::shared_readonly_in(store_path),
             package_integrity: &pkg_integrity,
             package_unpacked_size: None,
             // Any request that reaches the network here would fail the
@@ -621,6 +640,7 @@ mod tests {
         let err = DownloadTarballToStore {
             http_client: &fast_fail_client(),
             store_dir: store_path,
+            store_index: StoreIndex::shared_readonly_in(store_path),
             package_integrity: &pkg_integrity,
             package_unpacked_size: None,
             package_url: "http://127.0.0.1:1/unreachable.tgz",
@@ -671,6 +691,7 @@ mod tests {
         let err = DownloadTarballToStore {
             http_client: &fast_fail_client(),
             store_dir: store_path,
+            store_index: StoreIndex::shared_readonly_in(store_path),
             package_integrity: &pkg_integrity,
             package_unpacked_size: None,
             package_url: "http://127.0.0.1:1/unreachable.tgz",
@@ -724,6 +745,7 @@ mod tests {
         let err = DownloadTarballToStore {
             http_client: &fast_fail_client(),
             store_dir: store_path,
+            store_index: StoreIndex::shared_readonly_in(store_path),
             package_integrity: &pkg_integrity,
             package_unpacked_size: None,
             package_url: "http://127.0.0.1:1/unreachable.tgz",
@@ -787,6 +809,7 @@ mod tests {
         let err = DownloadTarballToStore {
             http_client: &fast_fail_client(),
             store_dir: store_path,
+            store_index: StoreIndex::shared_readonly_in(store_path),
             package_integrity: &pkg_integrity,
             package_unpacked_size: None,
             package_url: "http://127.0.0.1:1/unreachable.tgz",

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -118,7 +118,10 @@ async fn load_cached_cas_paths(
     cache_key: String,
 ) -> Option<HashMap<String, PathBuf>> {
     let index = index?;
-    tokio::task::spawn_blocking(move || -> Option<HashMap<String, PathBuf>> {
+    // Hold on to a copy of the cache key for the outer `JoinError` log,
+    // since the task body moves the original in.
+    let outer_cache_key = cache_key.clone();
+    let result = tokio::task::spawn_blocking(move || -> Option<HashMap<String, PathBuf>> {
         // Treat a poisoned mutex as a cache miss rather than propagating the
         // panic: the `SELECT` is stateless, so the prior panic couldn't have
         // left the index in an inconsistent shape, and cache lookups are a
@@ -173,9 +176,24 @@ async fn load_cached_cas_paths(
         }
         Some(cas_paths)
     })
-    .await
-    .ok()
-    .flatten()
+    .await;
+
+    match result {
+        Ok(cas_paths) => cas_paths,
+        Err(error) => {
+            // `JoinError` — the blocking task panicked, or the runtime was
+            // cancelled mid-install. Degrade to a cache miss so the caller
+            // falls through to a fresh download, but surface the error so
+            // the panic / cancellation stays diagnosable.
+            tracing::warn!(
+                target: "pacquet::download",
+                ?error,
+                cache_key = ?outer_cache_key,
+                "store-index lookup task failed; treating cache lookup as a miss",
+            );
+            None
+        }
+    }
 }
 
 /// This subroutine downloads and extracts a tarball to the store directory.
@@ -264,10 +282,8 @@ impl<'a> DownloadTarballToStore<'a> {
         // entry we can read back here.
         //
         // The lookup is best-effort. A missing `index.db`, a missing row,
-        // an unreadable entry (e.g. written by pnpm's msgpackr record
-        // encoding — decoding support for that is a follow-up), or any
-        // CAFS file that has gone missing from disk all fall through to
-        // the download path below.
+        // an undecodable entry, or any CAFS file that has gone missing
+        // from disk all fall through to the download path below.
         let cache_key = store_index_key(&package_integrity.to_string(), package_id);
         if let Some(cas_paths) = load_cached_cas_paths(store_index, store_dir, cache_key).await {
             tracing::info!(target: "pacquet::download", ?package_url, ?package_id, "Reusing cached CAFS entry — skipping download");

--- a/tasks/micro-benchmark/src/main.rs
+++ b/tasks/micro-benchmark/src/main.rs
@@ -39,6 +39,7 @@ fn bench_tarball(c: &mut Criterion, server: &mut ServerGuard, fixtures_folder: &
             let cas_map = DownloadTarballToStore {
                 http_client: &http_client,
                 store_dir,
+                store_index: None,
                 package_integrity: &package_integrity,
                 package_unpacked_size: Some(16697),
                 package_url: url,


### PR DESCRIPTION
## Summary

Fixes part 1 of #260. `DownloadTarballToStore::load_cached_cas_paths` opened a fresh `Connection::open_with_flags` + `PRAGMA busy_timeout` per snapshot — a 1352-package frozen-lockfile install paid 1352 connection-opens just to read cache hints, all serialized on the tokio blocking pool.

Open a \`StoreIndex\` once per install, wrap in \`Arc<Mutex<…>>\` (rusqlite \`Connection\` is \`Send\` but not \`Sync\`), and thread the handle through \`CreateVirtualStore\`, \`InstallWithoutLockfile\`, and \`DownloadTarballToStore\`. The mutex is taken only for the sub-millisecond \`SELECT\` and released before the per-file validation pass.

Follow-up #260 item — replace the per-file \`symlink_metadata\` storm with pnpm's \`checkedAt\`-based fast path — is left for a separate PR.

## Test plan

- [x] \`cargo test -p pacquet-tarball\` — all 7 cache-hit / fall-through cases pass (\`reuses_cached_cas_paths_when_index_entry_is_live\`, \`falls_through_when_cafs_file_missing\`, \`…_digest_is_malformed\`, \`…_cafs_path_is_a_directory\`, \`…_cafs_path_is_a_symlink\`, plus the two download-path tests updated to \`store_index: None\`).
- [x] Bench on #260 repro (1352 packages, release, macOS APFS, warm CAS store): \`rm -rf node_modules && pacquet install --frozen-lockfile\` 17.4 s → 13.9 s. CPU utilization 135 % → 160 % as the serialized-open bottleneck clears.
- [x] \`cargo fmt --all -- --check\` clean.