### PR TITLE
bench(integrated-benchmark): level cold-install comparison on macOS and across platforms

### DIFF
--- a/tasks/integrated-benchmark/src/fixtures/pnpm-workspace.yaml
+++ b/tasks/integrated-benchmark/src/fixtures/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+storeDir: ./store-dir
+
 allowBuilds:
   core-js: false
   es5-ext: false

--- a/tasks/integrated-benchmark/src/fixtures/pnpm-workspace.yaml
+++ b/tasks/integrated-benchmark/src/fixtures/pnpm-workspace.yaml
@@ -3,3 +3,8 @@ storeDir: ./store-dir
 allowBuilds:
   core-js: false
   es5-ext: false
+  # macOS-only optional dep. Absent on Linux (where CI runs), present
+  # on developer macOS machines — without this entry pnpm exits 1 with
+  # `ERR_PNPM_IGNORED_BUILDS` on the first warmup run, taking the
+  # whole benchmark down. Harmless no-op on Linux.
+  fsevents: false

--- a/tasks/integrated-benchmark/src/fixtures/pnpm-workspace.yaml
+++ b/tasks/integrated-benchmark/src/fixtures/pnpm-workspace.yaml
@@ -1,10 +1,36 @@
 storeDir: ./store-dir
 
+# Force pnpm to install every optional dependency in the lockfile
+# regardless of the runner's own os/cpu/libc, so its install payload
+# matches pacquet's (which currently installs every snapshot in the
+# lockfile unconditionally — it doesn't filter optionals by platform).
+#
+# Without this, pnpm on Linux CI skips darwin-only optionals like
+# `fsevents` via its normal platform filter and ends up doing less
+# work than pacquet, which quietly tilts the benchmark in pnpm's
+# favour. Listing every OS / CPU / libc combo we realistically care
+# about removes that asymmetry; the exact set mirrors pnpm's own
+# release matrix.
+supportedArchitectures:
+  os:
+    - darwin
+    - linux
+    - win32
+  cpu:
+    - x64
+    - arm64
+  libc:
+    - glibc
+    - musl
+
 allowBuilds:
   core-js: false
   es5-ext: false
-  # macOS-only optional dep. Absent on Linux (where CI runs), present
-  # on developer macOS machines — without this entry pnpm exits 1 with
-  # `ERR_PNPM_IGNORED_BUILDS` on the first warmup run, taking the
-  # whole benchmark down. Harmless no-op on Linux.
+  # `fsevents` ships a native postinstall that would fire on macOS.
+  # The fixture's `.npmrc` sets `ignore-scripts=true`, so pnpm emits
+  # `ERR_PNPM_IGNORED_BUILDS` and exits 1 on the first warmup run,
+  # taking the whole benchmark down. Explicitly declining its build
+  # silences the error. Now reachable on Linux too because
+  # `supportedArchitectures` above pulls fsevents in on every
+  # platform — the entry is no longer a macOS-only concern.
   fsevents: false


### PR DESCRIPTION
Three related bench-harness fixes discovered while digging into #263. No production code changes — only fixture files the harness embeds.

## 1. `storeDir` in `pnpm-workspace.yaml` (commit `7887d9e`)

`create_npmrc` in the harness writes `store-dir=<bench-dir>/store-dir` into the fixture's `.npmrc`, and `hyperfine --prepare` wipes that path between iterations — the intent being a cold install per timed run.

Pacquet's `.npmrc` parser only reads the auth/registry subset though (see `crates/npmrc/src/lib.rs:173-178`, matching pnpm 11 which moved project-structural settings to `pnpm-workspace.yaml`). With no `storeDir` in the workspace yaml the bench silently fell through to pacquet's default — `~/Library/pnpm/store` on macOS, `~/.local/share/pnpm/store` on Linux.

On a developer machine whose default store already holds the fixture's 1352 snapshots (any prior `pnpm install` of a similar project), every bench iteration then hit the warm-store cache-lookup path instead of the cold-install path, so the benchmark was measuring the per-file `symlink_metadata` pass from #260 rather than the fetch+extract+write pipeline it was designed to stress. Observed locally: `hyperfine --prepare` would happily wipe `<bench-dir>/store-dir`, pacquet would finish its install, and no `store-dir` ever appeared in the bench dir — the CAFS writes and hardlinks were all going through `~/Library/pnpm/store` instead.

Adding `storeDir: ./store-dir` in `pnpm-workspace.yaml` makes pacquet honour the prepared per-revision store. No-op on a fresh CI runner where the default store is empty anyway — the fix prevents developer-local runs from producing meaningless numbers.

## 2. `allowBuilds: fsevents: false` (commit `9481f35`)

`fsevents` is a macOS-native optional dep of `chokidar` (several fixture entries pull it in). On a macOS developer machine it installs and pnpm emits `ERR_PNPM_IGNORED_BUILDS: fsevents@1.2.13` because the fixture's `.npmrc` has `ignore-scripts=true`.

That error exits pnpm with status 1, hyperfine flags it via the harness's exit-code check, and `just integrated-benchmark` dies on the first warmup run. Adding `fsevents: false` to `allowBuilds` silences that specific package (matching what pnpm writes when you run `pnpm approve-builds` and decline fsevents) without re-enabling scripts anywhere else. Also reached on Linux after the next commit pulls fsevents into the Linux install set.

## 3. `supportedArchitectures` (commit `d47e192`)

Pacquet doesn't filter optional dependencies by `os` / `cpu` / `libc` — `create_virtual_store` iterates every snapshot in the lockfile unconditionally, so platform-specific optionals end up in its install payload regardless of runner.

pnpm does filter, so on Linux CI it skips `fsevents` (and every other darwin-only optional) entirely. That's a real payload difference: pnpm's install does strictly less tarball fetching / extraction / CAS writing than pacquet's on the same lockfile. Small in absolute terms for this fixture, but a hidden handicap in a benchmark whose whole point is to measure the fetch+extract+write pipeline.

Setting `supportedArchitectures` to cover every OS / CPU / libc combo we care about makes pnpm pull cross-platform optionals on every runner, matching pacquet's payload. The fix belongs on the pnpm side of the fixture because pacquet's filter-by-platform is a future code change with larger blast radius — bringing the two tools to the same install set in one-line config here is the lower-risk intermediate.

Verified locally: with the setting pulled into place, `pnpm install --frozen-lockfile` creates `store-dir/v11/.../fsevents/1.2.13/…` and `node_modules/.pnpm/node_modules/fsevents` on macOS, and will do the equivalent on Linux.

## Test plan

- [x] `cargo build -p pacquet-integrated-benchmark`.
- [x] Local `just integrated-benchmark --verdaccio --with-pnpm HEAD main` now completes on macOS and creates a populated `<bench-dir>/store-dir/v11/index.db` per iteration.
- [x] `pnpm install --frozen-lockfile` with the yaml in place downloads fsevents on macOS (visible in `store-dir`) — same behaviour expected on Linux.
- [ ] CI Integrated-Benchmark — numbers will shift a bit for pnpm on Linux (now has to download & extract the extra cross-platform optionals). That's the point.
