### PR TITLE
refactor(store-dir): batch store-index writes via a single writer task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1778,6 +1778,8 @@ dependencies = [
  "sha2",
  "ssri",
  "tempfile",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/package-manager/src/create_virtual_store.rs
+++ b/crates/package-manager/src/create_virtual_store.rs
@@ -5,7 +5,7 @@ use miette::Diagnostic;
 use pacquet_lockfile::{PackageKey, PackageMetadata, SnapshotEntry};
 use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
-use pacquet_store_dir::StoreIndex;
+use pacquet_store_dir::{StoreIndex, StoreIndexWriter};
 use pipe_trait::Pipe;
 use std::collections::HashMap;
 
@@ -86,6 +86,25 @@ impl<'a> CreateVirtualStore<'a> {
             };
         let store_index_ref = store_index.as_ref();
 
+        // Spawn the batched store-index writer. A single `spawn_blocking`
+        // task owns the writable SQLite connection for the whole install;
+        // every successfully extracted tarball just sends a row to it and
+        // the task flushes them in batched transactions. The old per-
+        // tarball `StoreIndex::open` + solo-INSERT pattern dominated
+        // install wall time on slow-metadata filesystems (#263) because
+        // each open is ~15 ms of metadata work on APFS and tokio's
+        // blocking pool grew to 500+ threads to service them.
+        //
+        // We drop our own copy of the `Arc<StoreIndexWriter>` after the
+        // `try_join_all` below so the channel can close once every tarball
+        // task has dropped its clone; then `.await` on the join handle
+        // waits for the final batch to flush before returning. A writer-
+        // side `JoinError` or open failure is surfaced at `warn!` and
+        // degraded to "no writer" — the install still succeeds, missing
+        // rows just force a re-download on the next install.
+        let (store_index_writer, writer_task) = StoreIndexWriter::spawn(store_dir);
+        let store_index_writer_ref = Some(&store_index_writer);
+
         snapshots
             .iter()
             .map(|(snapshot_key, snapshot)| async move {
@@ -100,6 +119,7 @@ impl<'a> CreateVirtualStore<'a> {
                     http_client,
                     config,
                     store_index: store_index_ref,
+                    store_index_writer: store_index_writer_ref,
                     package_key: snapshot_key,
                     metadata,
                     snapshot,
@@ -110,6 +130,25 @@ impl<'a> CreateVirtualStore<'a> {
             })
             .pipe(future::try_join_all)
             .await?;
+
+        // Drop the orchestration's sender so the channel closes once every
+        // per-tarball clone has also dropped; then wait for the writer task
+        // to flush its final batch. Swallow any error with `warn!` — we've
+        // already done the install and cache-miss degradation is fine.
+        drop(store_index_writer);
+        match writer_task.await {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => tracing::warn!(
+                target: "pacquet::install",
+                ?error,
+                "store-index writer task returned an error; some rows may not be persisted",
+            ),
+            Err(error) => tracing::warn!(
+                target: "pacquet::install",
+                ?error,
+                "store-index writer task panicked; some rows may not be persisted",
+            ),
+        }
 
         Ok(())
     }

--- a/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/crates/package-manager/src/install_package_by_snapshot.rs
@@ -4,10 +4,10 @@ use miette::Diagnostic;
 use pacquet_lockfile::{LockfileResolution, PackageKey, PackageMetadata, SnapshotEntry};
 use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
-use pacquet_store_dir::SharedReadonlyStoreIndex;
+use pacquet_store_dir::{SharedReadonlyStoreIndex, StoreIndexWriter};
 use pacquet_tarball::{DownloadTarballToStore, TarballError};
 use pipe_trait::Pipe;
-use std::borrow::Cow;
+use std::{borrow::Cow, sync::Arc};
 
 /// This subroutine downloads a package tarball, extracts it, installs it to a virtual dir,
 /// then creates the symlink layout for the package.
@@ -16,6 +16,7 @@ pub struct InstallPackageBySnapshot<'a> {
     pub http_client: &'a ThrottledClient,
     pub config: &'static Npmrc,
     pub store_index: Option<&'a SharedReadonlyStoreIndex>,
+    pub store_index_writer: Option<&'a Arc<StoreIndexWriter>>,
     pub package_key: &'a PackageKey,
     pub metadata: &'a PackageMetadata,
     pub snapshot: &'a SnapshotEntry,
@@ -50,6 +51,7 @@ impl<'a> InstallPackageBySnapshot<'a> {
             http_client,
             config,
             store_index,
+            store_index_writer,
             package_key,
             metadata,
             snapshot,
@@ -93,6 +95,7 @@ impl<'a> InstallPackageBySnapshot<'a> {
             http_client,
             store_dir: &config.store_dir,
             store_index: store_index.cloned(),
+            store_index_writer: store_index_writer.cloned(),
             package_integrity: integrity,
             package_unpacked_size: None,
             package_url: &tarball_url,

--- a/crates/package-manager/src/install_package_from_registry.rs
+++ b/crates/package-manager/src/install_package_from_registry.rs
@@ -4,9 +4,9 @@ use miette::Diagnostic;
 use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
 use pacquet_registry::{Package, PackageTag, PackageVersion, RegistryError};
-use pacquet_store_dir::SharedReadonlyStoreIndex;
+use pacquet_store_dir::{SharedReadonlyStoreIndex, StoreIndexWriter};
 use pacquet_tarball::{DownloadTarballToStore, MemCache, TarballError};
-use std::{path::Path, str::FromStr};
+use std::{path::Path, str::FromStr, sync::Arc};
 
 /// This subroutine executes the following and returns the package
 /// * Retrieves the package from the registry
@@ -22,6 +22,7 @@ pub struct InstallPackageFromRegistry<'a> {
     pub http_client: &'a ThrottledClient,
     pub config: &'static Npmrc,
     pub store_index: Option<&'a SharedReadonlyStoreIndex>,
+    pub store_index_writer: Option<&'a Arc<StoreIndexWriter>>,
     pub node_modules_dir: &'a Path,
     pub name: &'a str,
     pub version_range: &'a str,
@@ -74,6 +75,7 @@ impl<'a> InstallPackageFromRegistry<'a> {
             http_client,
             config,
             store_index,
+            store_index_writer,
             node_modules_dir,
             ..
         } = self;
@@ -86,6 +88,7 @@ impl<'a> InstallPackageFromRegistry<'a> {
             http_client,
             store_dir: &config.store_dir,
             store_index: store_index.cloned(),
+            store_index_writer: store_index_writer.cloned(),
             package_integrity: package_version
                 .dist
                 .integrity
@@ -170,6 +173,7 @@ mod tests {
             config,
             http_client: &http_client,
             store_index: None,
+            store_index_writer: None,
             name: "fast-querystring",
             version_range: "1.0.0",
             node_modules_dir: modules_dir.path(),

--- a/crates/package-manager/src/install_without_lockfile.rs
+++ b/crates/package-manager/src/install_without_lockfile.rs
@@ -9,7 +9,7 @@ use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_registry::PackageVersion;
-use pacquet_store_dir::StoreIndex;
+use pacquet_store_dir::{StoreIndex, StoreIndexWriter};
 use pacquet_tarball::MemCache;
 use pipe_trait::Pipe;
 
@@ -82,6 +82,12 @@ impl<'a, DependencyGroupList> InstallWithoutLockfile<'a, DependencyGroupList> {
             };
         let store_index_ref = store_index.as_ref();
 
+        // Batched store-index writer. See `create_virtual_store.rs` for
+        // the full rationale — we spawn once, every tarball just queues a
+        // row, and one writer task flushes them in batched transactions.
+        let (store_index_writer, writer_task) = StoreIndexWriter::spawn(store_dir);
+        let store_index_writer_ref = Some(&store_index_writer);
+
         manifest
             .dependencies(dependency_groups)
             .map(|(name, version_range)| async move {
@@ -90,6 +96,7 @@ impl<'a, DependencyGroupList> InstallWithoutLockfile<'a, DependencyGroupList> {
                     http_client,
                     config,
                     store_index: store_index_ref,
+                    store_index_writer: store_index_writer_ref,
                     node_modules_dir: &config.modules_dir,
                     name,
                     version_range,
@@ -106,13 +113,35 @@ impl<'a, DependencyGroupList> InstallWithoutLockfile<'a, DependencyGroupList> {
                     dependency_groups: (),
                     resolved_packages,
                 }
-                .install_dependencies_from_registry(&dependency, store_index_ref)
+                .install_dependencies_from_registry(
+                    &dependency,
+                    store_index_ref,
+                    store_index_writer_ref,
+                )
                 .await?;
 
                 Ok::<_, InstallWithoutLockfileError>(())
             })
             .pipe(future::try_join_all)
             .await?;
+
+        // Drop the orchestration's writer handle so the channel closes,
+        // then wait for the final batch flush. See `create_virtual_store.rs`
+        // for why errors here are downgraded to `warn!`.
+        drop(store_index_writer);
+        match writer_task.await {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => tracing::warn!(
+                target: "pacquet::install",
+                ?error,
+                "store-index writer task returned an error; some rows may not be persisted",
+            ),
+            Err(error) => tracing::warn!(
+                target: "pacquet::install",
+                ?error,
+                "store-index writer task panicked; some rows may not be persisted",
+            ),
+        }
 
         Ok(())
     }
@@ -125,6 +154,9 @@ impl<'a> InstallWithoutLockfile<'a, ()> {
         &self,
         package: &PackageVersion,
         store_index: Option<&'async_recursion pacquet_store_dir::SharedReadonlyStoreIndex>,
+        store_index_writer: Option<
+            &'async_recursion std::sync::Arc<pacquet_store_dir::StoreIndexWriter>,
+        >,
     ) -> Result<(), InstallWithoutLockfileError> {
         let InstallWithoutLockfile {
             tarball_mem_cache,
@@ -157,6 +189,7 @@ impl<'a> InstallWithoutLockfile<'a, ()> {
                     http_client,
                     config,
                     store_index,
+                    store_index_writer,
                     node_modules_dir: node_modules_path_ref,
                     name,
                     version_range,
@@ -164,7 +197,12 @@ impl<'a> InstallWithoutLockfile<'a, ()> {
                 .run::<Version>()
                 .await
                 .map_err(InstallWithoutLockfileError::InstallPackageFromRegistry)?;
-                self.install_dependencies_from_registry(&dependency, store_index).await?;
+                self.install_dependencies_from_registry(
+                    &dependency,
+                    store_index,
+                    store_index_writer,
+                )
+                .await?;
                 Ok::<_, InstallWithoutLockfileError>(())
             })
             .pipe(future::try_join_all)

--- a/crates/store-dir/Cargo.toml
+++ b/crates/store-dir/Cargo.toml
@@ -21,6 +21,8 @@ serde       = { workspace = true }
 serde_json  = { workspace = true }
 sha2        = { workspace = true }
 ssri        = { workspace = true }
+tokio       = { workspace = true, features = ["sync"] }
+tracing     = { workspace = true }
 
 [dev-dependencies]
 pipe-trait        = { workspace = true }

--- a/crates/store-dir/src/store_index.rs
+++ b/crates/store-dir/src/store_index.rs
@@ -31,6 +31,103 @@ pub struct StoreIndex {
 /// then hands off to per-file work without holding the lock.
 pub type SharedReadonlyStoreIndex = Arc<Mutex<StoreIndex>>;
 
+/// Handle producers use to hand rows off to the batched writer task. Clone
+/// cheaply via [`Arc`] to share across tokio tasks.
+///
+/// The design mirrors pnpm's `queueWrites` / `flush` / `setRawMany` pattern
+/// (see `store/index/src/index.ts`): producers don't touch SQLite, they
+/// just push `(key, value)` onto an unbounded channel. A single
+/// [`spawn_blocking`][tokio::task::spawn_blocking] task drains the channel,
+/// collects each non-blocking burst into a batch (capped at
+/// [`MAX_BATCH_SIZE`]), and flushes it with one `BEGIN IMMEDIATE` …
+/// `COMMIT`. That turns the per-snapshot `Connection::open` + 7-PRAGMA +
+/// solo-INSERT pattern into one open + N transactions, amortizes the WAL
+/// commit fsync across the batch, and leaves tokio's blocking pool alone
+/// (one writer thread, not one per tarball).
+pub struct StoreIndexWriter {
+    tx: tokio::sync::mpsc::UnboundedSender<(String, PackageFilesIndex)>,
+}
+
+/// Batch cap for [`StoreIndexWriter`]. Big enough that a 1352-snapshot
+/// install flushes in a handful of transactions (so the fsync cost is
+/// amortized), small enough that a single failing row doesn't cost
+/// thousands of predecessors' worth of redo work on rollback. pnpm's
+/// `setRawMany` has no explicit cap (it drains whatever `nextTick`
+/// scheduled) but in practice its batches stay in the low hundreds.
+const MAX_BATCH_SIZE: usize = 256;
+
+impl StoreIndexWriter {
+    /// Spawn the batched writer task. Returns the handle producers push
+    /// rows to, and a [`JoinHandle`][tokio::task::JoinHandle] the caller
+    /// must `await` after dropping the last `Arc` to the handle so the
+    /// final batch flushes before the install returns.
+    ///
+    /// The writer task owns the [`StoreIndex`] connection for its entire
+    /// lifetime; on DB open failure the task returns the error and the
+    /// channel closes on the first producer send.
+    pub fn spawn(
+        store_dir: &StoreDir,
+    ) -> (Arc<StoreIndexWriter>, tokio::task::JoinHandle<Result<(), StoreIndexError>>) {
+        let v11_dir = store_dir.v11();
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<(String, PackageFilesIndex)>();
+        let handle = tokio::task::spawn_blocking(move || -> Result<(), StoreIndexError> {
+            let mut index = StoreIndex::open(&v11_dir)?;
+            let mut batch: Vec<(String, PackageFilesIndex)> = Vec::with_capacity(MAX_BATCH_SIZE);
+            while let Some(first) = rx.blocking_recv() {
+                batch.push(first);
+                // Drain whatever else is already queued to maximize batch
+                // size without ever blocking on the channel — a single
+                // `recv` above is the only blocking wait per transaction.
+                // Cap at `MAX_BATCH_SIZE` so a producer storm doesn't grow
+                // an unbounded buffer on the writer side.
+                while batch.len() < MAX_BATCH_SIZE {
+                    match rx.try_recv() {
+                        Ok(item) => batch.push(item),
+                        // `Empty` / `Disconnected` both mean "nothing more
+                        // to drain right now" — we flush the current batch
+                        // and loop back; if the channel is disconnected
+                        // the outer `blocking_recv` returns `None` next
+                        // and the task exits cleanly.
+                        Err(_) => break,
+                    }
+                }
+                if let Err(error) = index.set_many(batch.drain(..)) {
+                    // Drop the batch and keep going. One failed flush
+                    // (e.g. a disk-full hiccup) shouldn't silently drop
+                    // the rest of the install's entries; the next install
+                    // will cache-miss those rows and re-populate them,
+                    // matching the "best-effort index" stance the read
+                    // path already takes.
+                    tracing::warn!(
+                        target: "pacquet::store_index",
+                        ?error,
+                        "batched store-index write failed; dropping this batch and continuing",
+                    );
+                    batch.clear();
+                }
+            }
+            Ok(())
+        });
+        (Arc::new(StoreIndexWriter { tx }), handle)
+    }
+
+    /// Queue one `(key, value)` to be flushed in the next transaction.
+    ///
+    /// Silently drops the entry if the writer task has exited (closed
+    /// channel). Matches pnpm's graceful-degradation on failed writes:
+    /// the install in flight still completes, the next install misses on
+    /// this cache-key and re-downloads.
+    pub fn queue(&self, key: String, value: PackageFilesIndex) {
+        if let Err(error) = self.tx.send((key, value)) {
+            tracing::warn!(
+                target: "pacquet::store_index",
+                ?error,
+                "store-index writer channel closed; dropping queued row",
+            );
+        }
+    }
+}
+
 /// Error type of [`StoreIndex`].
 #[derive(Debug, Display, Error, Diagnostic)]
 #[non_exhaustive]
@@ -235,6 +332,53 @@ impl StoreIndex {
             )
             .map(|_| ())
             .map_err(|source| StoreIndexError::Write { source })
+    }
+
+    /// Insert-or-replace a batch of rows in a single transaction.
+    ///
+    /// Matches pnpm's `setRawMany` (see `store/index/src/index.ts`): one
+    /// `BEGIN IMMEDIATE` … `COMMIT` around the inserts, which amortizes the
+    /// WAL commit fsync across the whole batch. At 1352 snapshots that
+    /// turns 1352 per-row fsyncs into ⌈1352/batch_size⌉ — on APFS this is
+    /// the single biggest lever for `pacquet install` wall time (#263).
+    ///
+    /// Errors during the batch roll the transaction back before returning,
+    /// so a partial apply never leaves the index in a half-written state.
+    /// Encoding is done up front into a `Vec<(String, Vec<u8>)>` so the
+    /// transaction body is pure SQLite — the caller's producer thread pays
+    /// the msgpack cost, not the single writer thread.
+    pub fn set_many(
+        &mut self,
+        entries: impl IntoIterator<Item = (String, PackageFilesIndex)>,
+    ) -> Result<(), StoreIndexError> {
+        // Encode outside the transaction so a single malformed row can't
+        // hold `BEGIN IMMEDIATE`'s write lock while we serialize msgpack.
+        let encoded: Vec<(String, Vec<u8>)> = entries
+            .into_iter()
+            .map(|(key, value)| {
+                crate::msgpackr_records::encode_package_files_index(&value)
+                    .map(|buf| (key, buf))
+                    .map_err(|source| StoreIndexError::Encode { source })
+            })
+            .collect::<Result<_, _>>()?;
+        if encoded.is_empty() {
+            return Ok(());
+        }
+
+        let tx = self
+            .conn
+            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+            .map_err(|source| StoreIndexError::Write { source })?;
+        {
+            let mut stmt = tx
+                .prepare_cached("INSERT OR REPLACE INTO package_index (key, data) VALUES (?1, ?2)")
+                .map_err(|source| StoreIndexError::Write { source })?;
+            for (key, buf) in &encoded {
+                stmt.execute(rusqlite::params![key, buf])
+                    .map_err(|source| StoreIndexError::Write { source })?;
+            }
+        }
+        tx.commit().map_err(|source| StoreIndexError::Write { source })
     }
 
     /// `true` iff a row with this key exists.

--- a/crates/store-dir/src/store_index.rs
+++ b/crates/store-dir/src/store_index.rs
@@ -6,7 +6,10 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
-    sync::{Arc, Mutex},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
 };
 
 /// SQLite-backed per-package index that pnpm v11 stores alongside the CAFS
@@ -38,14 +41,22 @@ pub type SharedReadonlyStoreIndex = Arc<Mutex<StoreIndex>>;
 /// (see `store/index/src/index.ts`): producers don't touch SQLite, they
 /// just push `(key, value)` onto an unbounded channel. A single
 /// [`spawn_blocking`][tokio::task::spawn_blocking] task drains the channel,
-/// collects each non-blocking burst into a batch (capped at
-/// [`MAX_BATCH_SIZE`]), and flushes it with one `BEGIN IMMEDIATE` …
+/// collects each non-blocking burst into a batch (capped at 256 entries —
+/// see `MAX_BATCH_SIZE`), and flushes it with one `BEGIN IMMEDIATE` …
 /// `COMMIT`. That turns the per-snapshot `Connection::open` + 7-PRAGMA +
 /// solo-INSERT pattern into one open + N transactions, amortizes the WAL
 /// commit fsync across the batch, and leaves tokio's blocking pool alone
 /// (one writer thread, not one per tarball).
 pub struct StoreIndexWriter {
     tx: tokio::sync::mpsc::UnboundedSender<(String, PackageFilesIndex)>,
+    /// One-shot log guard for the "channel closed" case in [`Self::queue`].
+    /// A dead writer (task panicked, [`StoreIndex::open`] failed) means
+    /// every subsequent `queue` call fails — without this guard that
+    /// spams 1352+ identical warnings into the install log. Once the
+    /// first failure has been logged, further failures go silent;
+    /// subsequent installs will still observe the missing index rows
+    /// and re-download, which is the only actionable signal anyway.
+    warn_on_send_failure: AtomicBool,
 }
 
 /// Batch cap for [`StoreIndexWriter`]. Big enough that a 1352-snapshot
@@ -108,7 +119,7 @@ impl StoreIndexWriter {
             }
             Ok(())
         });
-        (Arc::new(StoreIndexWriter { tx }), handle)
+        (Arc::new(StoreIndexWriter { tx, warn_on_send_failure: AtomicBool::new(true) }), handle)
     }
 
     /// Queue one `(key, value)` to be flushed in the next transaction.
@@ -116,14 +127,20 @@ impl StoreIndexWriter {
     /// Silently drops the entry if the writer task has exited (closed
     /// channel). Matches pnpm's graceful-degradation on failed writes:
     /// the install in flight still completes, the next install misses on
-    /// this cache-key and re-downloads.
+    /// this cache-key and re-downloads. The "channel closed" warning is
+    /// logged only on the first failure per writer instance — every
+    /// subsequent call would emit the same message, and on a 1352-
+    /// snapshot install that's a thousand identical warnings drowning
+    /// out real diagnostics.
     pub fn queue(&self, key: String, value: PackageFilesIndex) {
         if let Err(error) = self.tx.send((key, value)) {
-            tracing::warn!(
-                target: "pacquet::store_index",
-                ?error,
-                "store-index writer channel closed; dropping queued row",
-            );
+            if self.warn_on_send_failure.swap(false, Ordering::Relaxed) {
+                tracing::warn!(
+                    target: "pacquet::store_index",
+                    ?error,
+                    "store-index writer channel closed; dropping queued row (further failures silenced)",
+                );
+            }
         }
     }
 }

--- a/crates/store-dir/src/store_index.rs
+++ b/crates/store-dir/src/store_index.rs
@@ -342,8 +342,12 @@ impl StoreIndex {
     /// turns 1352 per-row fsyncs into ⌈1352/batch_size⌉ — on APFS this is
     /// the single biggest lever for `pacquet install` wall time (#263).
     ///
-    /// Errors during the batch roll the transaction back before returning,
+    /// SQLite errors during the transaction roll it back before returning,
     /// so a partial apply never leaves the index in a half-written state.
+    /// A per-row msgpack encoding error is logged at `warn!` and skipped
+    /// — one malformed `PackageFilesIndex` shouldn't cost every other row
+    /// in the batch the chance to commit, matching the "best-effort
+    /// index" stance the writer task and the read path already take.
     /// Encoding is done up front into a `Vec<(String, Vec<u8>)>` so the
     /// transaction body is pure SQLite — the caller's producer thread pays
     /// the msgpack cost, not the single writer thread.
@@ -352,15 +356,21 @@ impl StoreIndex {
         entries: impl IntoIterator<Item = (String, PackageFilesIndex)>,
     ) -> Result<(), StoreIndexError> {
         // Encode outside the transaction so a single malformed row can't
-        // hold `BEGIN IMMEDIATE`'s write lock while we serialize msgpack.
-        let encoded: Vec<(String, Vec<u8>)> = entries
-            .into_iter()
-            .map(|(key, value)| {
-                crate::msgpackr_records::encode_package_files_index(&value)
-                    .map(|buf| (key, buf))
-                    .map_err(|source| StoreIndexError::Encode { source })
-            })
-            .collect::<Result<_, _>>()?;
+        // hold `BEGIN IMMEDIATE`'s write lock while we serialize msgpack,
+        // and skip individual encoding failures with a log so one bad
+        // entry doesn't drop the rest of the batch on the floor.
+        let mut encoded: Vec<(String, Vec<u8>)> = Vec::new();
+        for (key, value) in entries {
+            match crate::msgpackr_records::encode_package_files_index(&value) {
+                Ok(buf) => encoded.push((key, buf)),
+                Err(source) => tracing::warn!(
+                    target: "pacquet::store_index",
+                    ?key,
+                    error = ?source,
+                    "failed to encode package_index row; skipping",
+                ),
+            }
+        }
         if encoded.is_empty() {
             return Ok(());
         }

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -428,14 +428,14 @@ impl<'a> DownloadTarballToStore<'a> {
 
             // Hand the per-tarball files index off to the shared writer
             // task. `queue` is a non-blocking `UnboundedSender::send` — no
-            // more `spawn_blocking` per tarball (the big thread-pool
-            // blowup we saw before #263 was fixed), no more reopening
-            // SQLite per row; the writer task owns one connection and
-            // batches whatever it drains in one `BEGIN IMMEDIATE; … ;
-            // COMMIT`. `None` here means we opened the writer but it
-            // failed, or the caller explicitly handed us no writer —
-            // either way the row is dropped with a `warn!` and the next
-            // install will miss on this cache key, same as the read path.
+            // more `spawn_blocking` per tarball (the per-write blocking
+            // thread churn described in #263), no more reopening SQLite
+            // per row; the writer task owns one connection and batches
+            // whatever it drains in one `BEGIN IMMEDIATE; … ; COMMIT`.
+            // `None` here means we opened the writer but it failed, or
+            // the caller explicitly handed us no writer — either way the
+            // row is dropped with a `warn!` and the next install will
+            // miss on this cache key, same as the read path.
             let index_key = store_index_key(&package_integrity.to_string(), &package_id);
             if let Some(writer) = store_index_writer {
                 writer.queue(index_key, pkg_files_idx);

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -13,7 +13,7 @@ use pacquet_fs::file_mode;
 use pacquet_network::ThrottledClient;
 use pacquet_store_dir::{
     store_index_key, CafsFileInfo, PackageFilesIndex, SharedReadonlyStoreIndex, StoreDir,
-    StoreIndex, StoreIndexError, WriteCasFileError,
+    StoreIndexError, StoreIndexWriter, WriteCasFileError,
 };
 use pipe_trait::Pipe;
 use ssri::Integrity;
@@ -209,6 +209,17 @@ pub struct DownloadTarballToStore<'a> {
     /// install and pass the same handle to every `DownloadTarballToStore`
     /// so we don't reopen the DB per package.
     pub store_index: Option<SharedReadonlyStoreIndex>,
+    /// Handle to the batched store-index writer. Each successful tarball
+    /// extraction queues one `(key, PackageFilesIndex)` row; a single
+    /// writer task drains the channel and flushes batches of up to 256 in
+    /// one transaction each, so the whole install goes through one
+    /// `Connection::open` and a handful of WAL commits instead of the old
+    /// "open + PRAGMA + insert + drop" per tarball (which ballooned
+    /// tokio's blocking pool to 500+ threads on a 1352-snapshot install —
+    /// see #263). `None` degrades to "skip index row", matching the read
+    /// side's stance: install still succeeds, the next install misses on
+    /// this cache key and re-downloads.
+    pub store_index_writer: Option<Arc<StoreIndexWriter>>,
     pub package_integrity: &'a Integrity,
     pub package_unpacked_size: Option<usize>,
     pub package_url: &'a str,
@@ -273,6 +284,7 @@ impl<'a> DownloadTarballToStore<'a> {
             ..
         } = self;
         let store_index = self.store_index.clone();
+        let store_index_writer = self.store_index_writer.clone();
 
         // Before hitting the network, check the SQLite store index: if the
         // tarball is already in the CAFS we can reuse its per-file paths
@@ -414,25 +426,26 @@ impl<'a> DownloadTarballToStore<'a> {
                 (cas_paths, pkg_files_idx)
             };
 
-            // Record the per-tarball file index in the shared SQLite index so
-            // other pacquet / pnpm processes can find these files on disk.
-            // SQLite open + PRAGMA + INSERT are blocking (and can stall for up
-            // to `busy_timeout=5000` ms when contending with a concurrent
-            // writer), so run them on the blocking pool rather than the
-            // tokio reactor. One StoreIndex per spawned task keeps the code
-            // lock-free; SQLite serializes concurrent writers via its
-            // busy_timeout.
+            // Hand the per-tarball files index off to the shared writer
+            // task. `queue` is a non-blocking `UnboundedSender::send` — no
+            // more `spawn_blocking` per tarball (the big thread-pool
+            // blowup we saw before #263 was fixed), no more reopening
+            // SQLite per row; the writer task owns one connection and
+            // batches whatever it drains in one `BEGIN IMMEDIATE; … ;
+            // COMMIT`. `None` here means we opened the writer but it
+            // failed, or the caller explicitly handed us no writer —
+            // either way the row is dropped with a `warn!` and the next
+            // install will miss on this cache key, same as the read path.
             let index_key = store_index_key(&package_integrity.to_string(), &package_id);
-            let v11_dir = store_dir.v11();
-            tokio::task::spawn_blocking(move || -> Result<(), StoreIndexError> {
-                let store_index = StoreIndex::open(&v11_dir)?;
-                store_index.set(&index_key, &pkg_files_idx)?;
-                Ok(())
-            })
-            .await
-            .expect("store-index writer task panicked")
-            .map_err(TarballError::WriteStoreIndex)
-            .map_err(TaskError::Other)?;
+            if let Some(writer) = store_index_writer {
+                writer.queue(index_key, pkg_files_idx);
+            } else {
+                tracing::warn!(
+                    target: "pacquet::download",
+                    ?index_key,
+                    "no shared store-index writer; skipping index row for this tarball",
+                );
+            }
 
             Ok(cas_paths)
         })
@@ -453,6 +466,7 @@ impl<'a> DownloadTarballToStore<'a> {
 
 #[cfg(test)]
 mod tests {
+    use pacquet_store_dir::StoreIndex;
     use pipe_trait::Pipe;
     use pretty_assertions::assert_eq;
     use tempfile::{tempdir, TempDir};
@@ -502,6 +516,7 @@ mod tests {
             http_client: &Default::default(),
             store_dir: store_path,
             store_index: None,
+            store_index_writer: None,
             package_integrity: &integrity("sha512-dj7vjIn1Ar8sVXj2yAXiMNCJDmS9MQ9XMlIecX2dIzzhjSHCyKo4DdXjXMs7wKW2kj6yvVRSpuQjOZ3YLrh56w=="),
             package_unpacked_size: Some(16697),
             package_url: "https://registry.npmjs.org/@fastify/error/-/error-3.3.0.tgz",
@@ -543,6 +558,7 @@ mod tests {
             http_client: &Default::default(),
             store_dir: store_path,
             store_index: None,
+            store_index_writer: None,
             package_integrity: &integrity("sha512-aaaan1Ar8sVXj2yAXiMNCJDmS9MQ9XMlIecX2dIzzhjSHCyKo4DdXjXMs7wKW2kj6yvVRSpuQjOZ3YLrh56w=="),
             package_unpacked_size: Some(16697),
             package_url: "https://registry.npmjs.org/@fastify/error/-/error-3.3.0.tgz",
@@ -611,6 +627,7 @@ mod tests {
             http_client: &fast_fail_client(),
             store_dir: store_path,
             store_index: StoreIndex::shared_readonly_in(store_path),
+            store_index_writer: None,
             package_integrity: &pkg_integrity,
             package_unpacked_size: None,
             // Any request that reaches the network here would fail the
@@ -670,6 +687,7 @@ mod tests {
             http_client: &fast_fail_client(),
             store_dir: store_path,
             store_index: StoreIndex::shared_readonly_in(store_path),
+            store_index_writer: None,
             package_integrity: &pkg_integrity,
             package_unpacked_size: None,
             package_url: "http://127.0.0.1:1/unreachable.tgz",
@@ -721,6 +739,7 @@ mod tests {
             http_client: &fast_fail_client(),
             store_dir: store_path,
             store_index: StoreIndex::shared_readonly_in(store_path),
+            store_index_writer: None,
             package_integrity: &pkg_integrity,
             package_unpacked_size: None,
             package_url: "http://127.0.0.1:1/unreachable.tgz",
@@ -775,6 +794,7 @@ mod tests {
             http_client: &fast_fail_client(),
             store_dir: store_path,
             store_index: StoreIndex::shared_readonly_in(store_path),
+            store_index_writer: None,
             package_integrity: &pkg_integrity,
             package_unpacked_size: None,
             package_url: "http://127.0.0.1:1/unreachable.tgz",
@@ -839,6 +859,7 @@ mod tests {
             http_client: &fast_fail_client(),
             store_dir: store_path,
             store_index: StoreIndex::shared_readonly_in(store_path),
+            store_index_writer: None,
             package_integrity: &pkg_integrity,
             package_unpacked_size: None,
             package_url: "http://127.0.0.1:1/unreachable.tgz",

--- a/tasks/micro-benchmark/src/main.rs
+++ b/tasks/micro-benchmark/src/main.rs
@@ -40,6 +40,7 @@ fn bench_tarball(c: &mut Criterion, server: &mut ServerGuard, fixtures_folder: &
                 http_client: &http_client,
                 store_dir,
                 store_index: None,
+                store_index_writer: None,
                 package_integrity: &package_integrity,
                 package_unpacked_size: Some(16697),
                 package_url: url,


### PR DESCRIPTION
Port pnpm v11's `queueWrites` / `flush` / `setRawMany` pattern from `store/index/src/index.ts`. The write path used to do `StoreIndex::open` + 7-PRAGMA + solo-INSERT per extracted tarball, each one under its own `tokio::task::spawn_blocking` — so a 1352-snapshot install opened SQLite 1352 times and ballooned tokio's blocking pool on every install. This PR collapses that to one open + one writer thread + N batched transactions.

## Design

* **`StoreIndex::set_many`** — wraps a batch in `BEGIN IMMEDIATE; INSERT OR REPLACE xN; COMMIT;`. One WAL fsync amortizes across the batch, with a rollback on per-batch error so a partial apply never leaves the index in a half-written state. Encoding happens on the caller's thread before the transaction begins, so the writer only pays SQLite work.
* **`StoreIndexWriter`** — `Arc`-cloneable handle around a tokio unbounded channel. Producers call `queue(key, value)` — no SQLite, no `spawn_blocking`, no per-row lock. A single blocking task drains the channel, collects each non-blocking burst into a batch (cap 256), and flushes via `set_many`.
* **Orchestration** — `CreateVirtualStore` and `InstallWithoutLockfile` spawn the writer at the top of the run, thread `Arc<StoreIndexWriter>` through `InstallPackageBySnapshot` / `InstallPackageFromRegistry` / `DownloadTarballToStore`, drop the orchestration's clone after `try_join_all`, then `await` the writer task so the final batch flushes before the install returns.
* **Tarball path** — `DownloadTarballToStore::run_without_mem_cache` drops its per-tarball `spawn_blocking` for the index write entirely.

Batch errors, `JoinError`s, and writer-open failures are all downgraded to `warn!` and \"skip the row\", matching the read side's graceful-degradation stance from #261.

## Honest framing — opened as `refactor`, not `perf`

Context: this came out of investigating #263. On macOS I have not been able to demonstrate a wall-time win from this change — fix vs main cold-install runs are in the same 12–24 s variance band with identical sys time. The measurable bottleneck in pacquet's cold-install sys time sits elsewhere, most likely in tarball extraction / `write_cas_file` and sha512-per-file, see the comment thread on #263 for the investigation notes and sample profiles.

The change still stands as structural cleanup:

* Matches pnpm v11's model one-for-one, so pacquet and pnpm use the same write strategy against a shared `index.db`.
* Collapses the per-tarball `StoreIndex::open` (+ 7 PRAGMAs) churn.
* Removes the per-tarball `spawn_blocking` for index writes from the hot path.
* Compounds with whatever fix the real bottleneck eventually gets.

If reviewers would rather hold this until the actual hot path is fixed so the two can land together (the batching framework makes things like #260's per-file stat-storm fix cleaner to wire in), happy to park the branch.

Depends on #264 for anyone wanting to bench this locally on macOS — without that PR the bench silently measures the wrong path.

## Test plan

- [x] `cargo check --workspace --all-targets`.
- [x] `cargo test -p pacquet-tarball -p pacquet-store-dir -p pacquet-package-manager` green (against the prepared `pacquet-registry-mock` instance).
- [x] Manual cold install against a real verdaccio exercises both branches (writer `Some` and writer-task `JoinError` downgrade) without panicking.
- [ ] CI Integrated-Benchmark — expected to be a wash on Linux (the open cost is small on ext4 and the 1352 threads were cheap there), primary goal is correctness, not wall-time.