### PR TITLE
fix(network): set explicit timeouts on default reqwest client; enable CI tracing

### DIFF
--- a/.github/workflows/integrated-benchmark.yml
+++ b/.github/workflows/integrated-benchmark.yml
@@ -116,6 +116,13 @@ jobs:
         # timeout (6 h). A normal run is ~2 min — 10 min is generous
         # headroom, and a failure surfaces fast enough to iterate on.
         timeout-minutes: 10
+        # Enable pacquet's tracing at `info` so the next hang shows
+        # which phase the stalled install was in (download,
+        # extraction, import, index write …) before it went silent.
+        # Without this, `--show-output` only captures pacquet's
+        # empty stream since the default filter is off.
+        env:
+          TRACE: pacquet=info
         # `--show-output` pipes each binary's stderr through hyperfine
         # so the step log captures traces / profile output / panics
         # inline with each run. Essential for diagnosing a hang on CI

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -50,9 +50,9 @@ impl ThrottledClient {
 
     /// Construct a throttled client wrapping a pre-built [`Client`].
     /// Useful for tests that want different timeout values than
-    /// [`new_from_cpu_count`] sets — e.g. sub-second connect timeouts
-    /// so firewalled / unreachable URLs fail within the test-suite
-    /// budget instead of waiting on TCP retry.
+    /// [`Self::new_from_cpu_count`] sets — e.g. sub-second connect
+    /// timeouts so firewalled / unreachable URLs fail within the
+    /// test-suite budget instead of waiting on TCP retry.
     pub fn from_client(client: Client) -> Self {
         const MIN_PERMITS: usize = 16;
         let semaphore = num_cpus::get().max(MIN_PERMITS).pipe(Semaphore::new);

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -28,20 +28,29 @@ impl ThrottledClient {
     /// If the number of CPUs is greater than 16, the number of permits will be equal to the number of CPUs.
     /// Otherwise, the number of permits will be 16.
     ///
-    /// The returned [`Client`] has explicit `connect` / `request` /
-    /// `pool_idle` timeouts set. A default `reqwest::Client` has none of
-    /// these, and on CI the bench's single-process verdaccio occasionally
-    /// stops responding (GC pause, uplink stall, TCP packet loss without
-    /// RST) — without a request deadline pacquet just sits on the
-    /// half-open socket forever, which is how `integrated-benchmark`
-    /// ends up hanging at "Benchmark 1: pacquet@HEAD" until the GHA step
-    /// timeout (see #263). 60 s per request is generous for localhost
-    /// tarballs (typical npm tarball is <5 MB) but short enough that a
-    /// real hang fails fast and hyperfine surfaces the error.
+    /// The returned [`Client`] carries explicit `connect` / `request` /
+    /// `pool_idle` deadlines. A default `reqwest::Client` has none of
+    /// these, and the CLI uses this constructor for real registry
+    /// traffic as well as the bench's local verdaccio — without a
+    /// request deadline pacquet just sits on a half-open socket
+    /// forever when an upstream stalls (GC pause, uplink stall, TCP
+    /// packet loss without RST). That's how `integrated-benchmark`
+    /// ends up hanging at "Benchmark 1: pacquet@HEAD" until the GHA
+    /// step timeout, see #263.
+    ///
+    /// The 5-minute `timeout` is deliberately generous: npm tarballs
+    /// are usually under 5 MB but can reach tens or even hundreds of
+    /// MB on slow connections, and there's no retry on transient
+    /// network errors yet (#259). 5 min keeps slow-but-progressing
+    /// downloads succeeding while still catching truly stuck sockets
+    /// inside the bench's step budget. Making these values
+    /// user-configurable (npmrc / env / CLI) is the natural next step
+    /// once the fetch-retry story is in place — left as follow-up so
+    /// this stays a minimal, PR-reviewable fix for the CI hang.
     pub fn new_from_cpu_count() -> Self {
         let client = Client::builder()
             .connect_timeout(Duration::from_secs(10))
-            .timeout(Duration::from_secs(60))
+            .timeout(Duration::from_secs(300))
             .pool_idle_timeout(Duration::from_secs(30))
             .build()
             .expect("build reqwest client with default timeouts");

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -1,6 +1,6 @@
 use pipe_trait::Pipe;
 use reqwest::Client;
-use std::future::IntoFuture;
+use std::{future::IntoFuture, time::Duration};
 use tokio::sync::Semaphore;
 
 /// Wrapper around [`Client`] with concurrent request limit enforced by the [`Semaphore`] mechanism.
@@ -27,15 +27,32 @@ impl ThrottledClient {
     /// Construct a new throttled client based on the number of CPUs.
     /// If the number of CPUs is greater than 16, the number of permits will be equal to the number of CPUs.
     /// Otherwise, the number of permits will be 16.
+    ///
+    /// The returned [`Client`] has explicit `connect` / `request` /
+    /// `pool_idle` timeouts set. A default `reqwest::Client` has none of
+    /// these, and on CI the bench's single-process verdaccio occasionally
+    /// stops responding (GC pause, uplink stall, TCP packet loss without
+    /// RST) — without a request deadline pacquet just sits on the
+    /// half-open socket forever, which is how `integrated-benchmark`
+    /// ends up hanging at "Benchmark 1: pacquet@HEAD" until the GHA step
+    /// timeout (see #263). 60 s per request is generous for localhost
+    /// tarballs (typical npm tarball is <5 MB) but short enough that a
+    /// real hang fails fast and hyperfine surfaces the error.
     pub fn new_from_cpu_count() -> Self {
-        ThrottledClient::from_client(Client::new())
+        let client = Client::builder()
+            .connect_timeout(Duration::from_secs(10))
+            .timeout(Duration::from_secs(60))
+            .pool_idle_timeout(Duration::from_secs(30))
+            .build()
+            .expect("build reqwest client with default timeouts");
+        ThrottledClient::from_client(client)
     }
 
     /// Construct a throttled client wrapping a pre-built [`Client`].
-    /// Primarily useful for tests that need custom timeouts (a default
-    /// `Client` has no connect / request timeout, so a firewall that
-    /// silently drops packets instead of refusing them can stall the
-    /// test suite for TCP-retry worth of time).
+    /// Useful for tests that want different timeout values than
+    /// [`new_from_cpu_count`] sets — e.g. sub-second connect timeouts
+    /// so firewalled / unreachable URLs fail within the test-suite
+    /// budget instead of waiting on TCP retry.
     pub fn from_client(client: Client) -> Self {
         const MIN_PERMITS: usize = 16;
         let semaphore = num_cpus::get().max(MIN_PERMITS).pipe(Semaphore::new);


### PR DESCRIPTION
## What this fixes

CI runs of `Integrated-Benchmark` frequently hang at:

```
Compiling pacquet-cli v0.0.1 ...
    Finished `release` profile [optimized] target(s) in 2m 50s
Benchmark 1: pacquet@HEAD
Error: The action 'Benchmark: Frozen Lockfile' has timed out after 10 minutes.
```

With `--show-output` already enabled, the absence of any pacquet stderr after `Benchmark 1:` means the install process genuinely went silent — no progress, no error, no panic. That rules out "bench is slow" and points at something blocking inside pacquet with no deadline on it.

## Root cause

`crates/network/src/lib.rs:31` hands back `Client::new()`, which has **no** connect/request/pool-idle timeouts. The sibling `from_client` docstring even called this out as a footgun:

> Primarily useful for tests that need custom timeouts (a default `Client` has no connect / request timeout, so a firewall that silently drops packets instead of refusing them can stall the test suite for TCP-retry worth of time).

Every `http_client.get(tarball_url).send()` in `crates/tarball/src/lib.rs:310` is therefore a potential forever-hang. The bench's verdaccio is a single Node process handling 16 concurrent requests from pacquet; on a GHA runner it's easy for the event loop to stall (GC, uplink hiccup, TCP packet loss without RST) for longer than our patience. Pacquet then sits on the half-open socket until the GHA job timeout, which is exactly the symptom.

Pacquet has no retry on transient network failures yet (tracked separately in #259), so even a transient stall becomes a permanent hang in the current code.

## Changes

1. `ThrottledClient::new_from_cpu_count` now builds its `Client` with explicit defaults:
   - `connect_timeout(10s)` — generous for localhost, snaps on resource-exhausted runners.
   - `timeout(60s)` — per-request deadline. Typical npm tarball < 5 MB, so 60s on localhost has huge margin; a real hang turns into `TarballError::FetchTarball` and hyperfine reports the non-zero exit instead of silent-hang-until-timeout.
   - `pool_idle_timeout(30s)` — evicts connections that verdaccio closed but we didn't notice.
2. `from_client` docstring updated — it's still the escape hatch for tests that want different (usually shorter) timeouts, not "the only way to get any timeouts at all".
3. CI bench step now runs with `TRACE=pacquet=info`. pacquet's tracing subscriber is gated on the `TRACE` env var; without it, `--show-output` only ever captured an empty stream. With it, the next stall will show which phase the stuck install was in ("Download completed", "New cache", "Reusing cached CAFS entry") before going silent.

## What this doesn't fix

This converts hangs into fast failures rather than preventing the stall itself. If verdaccio genuinely starts dropping requests, pacquet will now surface that as a `FetchTarball` error → hyperfine exits non-zero → the step fails visibly, but the underlying resource-exhaustion or verdaccio-instability problem still needs addressing. Options once we have the first post-fix log:

- Add retry-with-backoff on transient network errors (#259).
- Investigate why verdaccio stalls under 16-permit load on the GHA runner specifically.
- Reduce concurrency (cap on pacquet's request semaphore or `ThrottledClient` permit count).

## Test plan

- [x] `cargo check --workspace --all-targets`.
- [x] `cargo test -p pacquet-network -p pacquet-tarball -p pacquet-package-manager` — no test regressions (tests that use `fast_fail_client` with sub-second timeouts still work; they set their own `Client::builder`).
- [ ] Next CI Integrated-Benchmark run — expected outcome: either the bench runs green (hang was network-stall-related and 60s timeout now catches it), or it fails with `TarballError::FetchTarball` plus a tracing trail showing the last phase before the stall. Either way, actionable rather than silent.
