### PR TITLE
fix(tarball): run post-download pipeline on blocking pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1789,6 +1789,7 @@ dependencies = [
  "dashmap",
  "derive_more",
  "miette 7.6.0",
+ "num_cpus",
  "pacquet-diagnostics",
  "pacquet-fs",
  "pacquet-network",

--- a/crates/tarball/Cargo.toml
+++ b/crates/tarball/Cargo.toml
@@ -19,6 +19,7 @@ pacquet-store-dir   = { workspace = true }
 dashmap      = { workspace = true }
 derive_more  = { workspace = true }
 miette       = { workspace = true }
+num_cpus     = { workspace = true }
 pipe-trait   = { workspace = true }
 reqwest      = { workspace = true }
 serde        = { workspace = true }

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -2,7 +2,7 @@ use std::{
     collections::HashMap,
     io::{Cursor, Read},
     path::PathBuf,
-    sync::Arc,
+    sync::{Arc, OnceLock},
     time::UNIX_EPOCH,
 };
 
@@ -18,9 +18,25 @@ use pacquet_store_dir::{
 use pipe_trait::Pipe;
 use ssri::Integrity;
 use tar::Archive;
-use tokio::sync::{Notify, RwLock};
+use tokio::sync::{Notify, RwLock, Semaphore};
 use tracing::instrument;
 use zune_inflate::{errors::InflateDecodeErrors, DeflateDecoder, DeflateOptions};
+
+/// Cap on concurrent post-download tarball work (SHA-512 of the whole
+/// tarball + gzip inflate + per-file SHA-512 + CAFS writes). The body is
+/// CPU-bound with some blocking FS I/O, and putting it on
+/// `tokio::task::spawn_blocking` makes the default 512-thread blocking
+/// pool available — but async fan-out across `try_join_all` routinely
+/// fires hundreds of these at once on a 1352-snapshot install, which
+/// thrashes small CI runners. Past "Download completed" a 2-CPU GitHub
+/// Actions runner wedged between decompress-close and `Checksum verified`
+/// on #269 until the step timeout. `num_cpus * 2` (floor 4) keeps enough
+/// work in flight to overlap per-file FS writes with SHA on another task
+/// without oversubscribing the cores.
+fn post_download_semaphore() -> &'static Semaphore {
+    static SEM: OnceLock<Semaphore> = OnceLock::new();
+    SEM.get_or_init(|| Semaphore::new(num_cpus::get().saturating_mul(2).max(4)))
+}
 
 #[derive(Debug, Display, Error, Diagnostic)]
 #[display("Failed to fetch {url}: {error}")]
@@ -341,6 +357,17 @@ impl<'a> DownloadTarballToStore<'a> {
         // The store-index row handoff at the end stays non-blocking
         // (`StoreIndexWriter::queue`, #265), so the closure itself does
         // no SQLite work.
+        //
+        // Gate the in-flight count with `post_download_semaphore` — the
+        // blocking pool is 512-wide by default, which is right for I/O
+        // wait but disastrous for CPU work that can only really run
+        // `num_cpus` at a time. The permit is held across the
+        // `spawn_blocking.await` below (it drops naturally at end of
+        // scope) so no task enters the body until one is free.
+        let _post_download_permit = post_download_semaphore()
+            .acquire()
+            .await
+            .expect("post-download semaphore shouldn't be closed this soon");
         let cas_paths =
             tokio::task::spawn_blocking(move || -> Result<HashMap<String, PathBuf>, TaskError> {
                 package_integrity.check(&response).map_err(TaskError::Checksum)?;
@@ -468,7 +495,7 @@ impl<'a> DownloadTarballToStore<'a> {
                 Ok(cas_paths)
             })
             .await
-            .expect("tarball-processing blocking task panicked")
+            .map_err(TarballError::TaskJoin)?
             .map_err(|error| match error {
                 TaskError::Checksum(error) => TarballError::Checksum(VerifyChecksumError {
                     url: package_url.to_string(),

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -329,8 +329,8 @@ impl<'a> DownloadTarballToStore<'a> {
         // "Checksum verified"). `spawn_blocking` uses tokio's dedicated
         // blocking-thread pool (default 512) instead, so the tail drains
         // in parallel.
-        let cas_paths = tokio::task::spawn_blocking(
-            move || -> Result<HashMap<String, PathBuf>, TaskError> {
+        let cas_paths =
+            tokio::task::spawn_blocking(move || -> Result<HashMap<String, PathBuf>, TaskError> {
                 package_integrity.check(&response).map_err(TaskError::Checksum)?;
 
                 // TODO: move tarball extraction to its own function
@@ -447,16 +447,16 @@ impl<'a> DownloadTarballToStore<'a> {
                     .map_err(TarballError::WriteStoreIndex)?;
 
                 Ok(cas_paths)
-            },
-        )
-        .await
-        .expect("tarball-processing blocking task panicked")
-        .map_err(|error| match error {
-            TaskError::Checksum(error) => {
-                TarballError::Checksum(VerifyChecksumError { url: package_url.to_string(), error })
-            }
-            TaskError::Other(error) => error,
-        })?;
+            })
+            .await
+            .expect("tarball-processing blocking task panicked")
+            .map_err(|error| match error {
+                TaskError::Checksum(error) => TarballError::Checksum(VerifyChecksumError {
+                    url: package_url.to_string(),
+                    error,
+                }),
+                TaskError::Other(error) => error,
+            })?;
 
         tracing::info!(target: "pacquet::download", ?package_url, "Checksum verified");
 

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -323,13 +323,36 @@ impl<'a> DownloadTarballToStore<'a> {
         let network_error = |error| {
             TarballError::FetchTarball(NetworkError { url: package_url.to_string(), error })
         };
-        let response = http_client
+        let response_head = http_client
             .run_with_permit(|client| client.get(package_url).send())
             .await
-            .map_err(network_error)?
-            .bytes()
-            .await
             .map_err(network_error)?;
+
+        // Gate the memory-heavy + CPU-heavy part of the pipeline with
+        // `post_download_semaphore`:
+        //
+        // - The blocking pool is 512-wide by default, which is right
+        //   for I/O wait but disastrous for CPU work that can only
+        //   really run `num_cpus` at a time, so we cap concurrent
+        //   `spawn_blocking` bodies.
+        // - We also acquire the permit *before* `.bytes().await`
+        //   rather than right before `spawn_blocking`. Buffering is
+        //   where the per-tarball memory spike lives (a full
+        //   decompressed package can be many MB), so holding the
+        //   permit across buffering bounds the number of fully-buffered
+        //   response bodies in RAM to the post-download cap. Without
+        //   this, a fast registry + `try_join_all` fan-out could pile
+        //   up hundreds of buffered tarballs waiting for a permit to
+        //   process (Copilot review on #269).
+        //
+        // The permit is held across both `.bytes().await` and the
+        // `spawn_blocking.await` below, dropping at end of scope.
+        let _post_download_permit = post_download_semaphore()
+            .acquire()
+            .await
+            .expect("post-download semaphore shouldn't be closed this soon");
+
+        let response = response_head.bytes().await.map_err(network_error)?;
 
         tracing::info!(target: "pacquet::download", ?package_url, "Download completed");
 
@@ -356,18 +379,8 @@ impl<'a> DownloadTarballToStore<'a> {
         // blocking-thread pool instead, so the tail drains in parallel.
         // The store-index row handoff at the end stays non-blocking
         // (`StoreIndexWriter::queue`, #265), so the closure itself does
-        // no SQLite work.
-        //
-        // Gate the in-flight count with `post_download_semaphore` — the
-        // blocking pool is 512-wide by default, which is right for I/O
-        // wait but disastrous for CPU work that can only really run
-        // `num_cpus` at a time. The permit is held across the
-        // `spawn_blocking.await` below (it drops naturally at end of
-        // scope) so no task enters the body until one is free.
-        let _post_download_permit = post_download_semaphore()
-            .acquire()
-            .await
-            .expect("post-download semaphore shouldn't be closed this soon");
+        // no SQLite work. Concurrency is already capped by the
+        // `_post_download_permit` acquired above.
         let cas_paths =
             tokio::task::spawn_blocking(move || -> Result<HashMap<String, PathBuf>, TaskError> {
                 package_integrity.check(&response).map_err(TaskError::Checksum)?;

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -316,128 +316,141 @@ impl<'a> DownloadTarballToStore<'a> {
             Checksum(ssri::Error),
             Other(TarballError),
         }
-        let cas_paths = tokio::task::spawn(async move {
-            package_integrity.check(&response).map_err(TaskError::Checksum)?;
+        // Run the whole post-download pipeline on the blocking pool. The
+        // body is a dense mix of CPU-bound work (SHA-512 over the full
+        // tarball, gzip inflate, per-file SHA-512) and blocking I/O
+        // (`write_cas_file`, SQLite open + INSERT). Running it as a plain
+        // `tokio::task::spawn` pinned a tokio reactor worker for the
+        // entirety of each tarball — on a 2-core runner that meant at
+        // most two tarballs could make progress at a time, and the tail
+        // of large packages missed the CI step budget even though the
+        // network side was long done (#268 — all downloads complete,
+        // ~1115 tarballs stuck between "Download completed" and
+        // "Checksum verified"). `spawn_blocking` uses tokio's dedicated
+        // blocking-thread pool (default 512) instead, so the tail drains
+        // in parallel.
+        let cas_paths = tokio::task::spawn_blocking(
+            move || -> Result<HashMap<String, PathBuf>, TaskError> {
+                package_integrity.check(&response).map_err(TaskError::Checksum)?;
 
-            // TODO: move tarball extraction to its own function
-            // TODO: test it
-            // TODO: test the duplication of entries
+                // TODO: move tarball extraction to its own function
+                // TODO: test it
+                // TODO: test the duplication of entries
 
-            // Extract the tarball in a scope so the `!Send` `tar::Archive`
-            // (it holds `RefCell<_>` / `Cell<_>`) is dropped before the
-            // `spawn_blocking` await below.
-            let (cas_paths, pkg_files_idx) = {
-                let mut archive = decompress_gzip(&response, package_unpacked_size)
-                    .map_err(TaskError::Other)?
-                    .pipe(Cursor::new)
-                    .pipe(Archive::new);
+                // Extract the tarball in a scope so the decompressed
+                // buffer + `tar::Archive` are released before the SQLite
+                // write — on large packages the inflated bytes can be
+                // multiple MB, and with hundreds of concurrent blocking
+                // tasks that memory adds up fast.
+                let (cas_paths, pkg_files_idx) = {
+                    let mut archive = decompress_gzip(&response, package_unpacked_size)
+                        .map_err(TaskError::Other)?
+                        .pipe(Cursor::new)
+                        .pipe(Archive::new);
 
-                let entries = archive
-                    .entries()
-                    .map_err(TarballError::ReadTarballEntries)
-                    .map_err(TaskError::Other)?
-                    .filter(|entry| !entry.as_ref().unwrap().header().entry_type().is_dir());
-
-                let ((_, Some(capacity)) | (capacity, None)) = entries.size_hint();
-                let mut cas_paths = HashMap::<String, PathBuf>::with_capacity(capacity);
-                let mut pkg_files_idx = PackageFilesIndex {
-                    manifest: None,
-                    requires_build: None,
-                    algo: "sha512".to_string(),
-                    files: HashMap::with_capacity(capacity),
-                    side_effects: None,
-                };
-
-                for entry in entries {
-                    let mut entry = entry.unwrap();
-
-                    let file_mode = entry.header().mode().expect("get mode"); // TODO: properly propagate this error
-                    let file_is_executable = file_mode::is_executable(file_mode);
-
-                    // Read the contents of the entry
-                    let mut buffer = Vec::with_capacity(entry.size() as usize);
-                    entry.read_to_end(&mut buffer).unwrap();
-
-                    let entry_path = entry.path().unwrap();
-                    let cleaned_entry_path = entry_path
-                        .components()
-                        .skip(1)
-                        .collect::<PathBuf>()
-                        .into_os_string()
-                        .into_string()
-                        .expect("entry path must be valid UTF-8");
-                    let (file_path, file_hash) = store_dir
-                        .write_cas_file(&buffer, file_is_executable)
-                        .map_err(TarballError::WriteCasFile)?;
-
-                    if let Some(previous) = cas_paths.insert(cleaned_entry_path.clone(), file_path)
-                    {
-                        tracing::warn!(
-                            ?previous,
-                            "Duplication detected. Old entry has been ejected"
-                        );
-                    }
-
-                    // `as_millis()` returns `u128`; narrow to `u64` to match
-                    // the store index schema — see `CafsFileInfo::checked_at`
-                    // for why `u64` is used. Using `u64::try_from` rather
-                    // than `as u64` avoids a silent wrap: even though
-                    // millisecond epochs don't overflow `u64` for ~584M
-                    // years, the intent should be explicit. If the clock
-                    // ever reports something unrepresentable, drop the
-                    // timestamp — the `checkedAt` field is optional and
-                    // pnpm tolerates `None`.
-                    let checked_at =
-                        UNIX_EPOCH.elapsed().ok().and_then(|x| u64::try_from(x.as_millis()).ok());
-                    let file_size = entry
-                        .header()
-                        .size()
+                    let entries = archive
+                        .entries()
                         .map_err(TarballError::ReadTarballEntries)
-                        .map_err(TaskError::Other)?;
-                    let file_attrs = CafsFileInfo {
-                        digest: format!("{file_hash:x}"),
-                        mode: file_mode,
-                        size: file_size,
-                        checked_at,
+                        .map_err(TaskError::Other)?
+                        .filter(|entry| !entry.as_ref().unwrap().header().entry_type().is_dir());
+
+                    let ((_, Some(capacity)) | (capacity, None)) = entries.size_hint();
+                    let mut cas_paths = HashMap::<String, PathBuf>::with_capacity(capacity);
+                    let mut pkg_files_idx = PackageFilesIndex {
+                        manifest: None,
+                        requires_build: None,
+                        algo: "sha512".to_string(),
+                        files: HashMap::with_capacity(capacity),
+                        side_effects: None,
                     };
 
-                    if let Some(previous) =
-                        pkg_files_idx.files.insert(cleaned_entry_path, file_attrs)
-                    {
-                        tracing::warn!(
-                            ?previous,
-                            "Duplication detected. Old entry has been ejected"
-                        );
+                    for entry in entries {
+                        let mut entry = entry.unwrap();
+
+                        let file_mode = entry.header().mode().expect("get mode"); // TODO: properly propagate this error
+                        let file_is_executable = file_mode::is_executable(file_mode);
+
+                        // Read the contents of the entry
+                        let mut buffer = Vec::with_capacity(entry.size() as usize);
+                        entry.read_to_end(&mut buffer).unwrap();
+
+                        let entry_path = entry.path().unwrap();
+                        let cleaned_entry_path = entry_path
+                            .components()
+                            .skip(1)
+                            .collect::<PathBuf>()
+                            .into_os_string()
+                            .into_string()
+                            .expect("entry path must be valid UTF-8");
+                        let (file_path, file_hash) = store_dir
+                            .write_cas_file(&buffer, file_is_executable)
+                            .map_err(TarballError::WriteCasFile)?;
+
+                        if let Some(previous) =
+                            cas_paths.insert(cleaned_entry_path.clone(), file_path)
+                        {
+                            tracing::warn!(
+                                ?previous,
+                                "Duplication detected. Old entry has been ejected"
+                            );
+                        }
+
+                        // `as_millis()` returns `u128`; narrow to `u64` to match
+                        // the store index schema — see `CafsFileInfo::checked_at`
+                        // for why `u64` is used. Using `u64::try_from` rather
+                        // than `as u64` avoids a silent wrap: even though
+                        // millisecond epochs don't overflow `u64` for ~584M
+                        // years, the intent should be explicit. If the clock
+                        // ever reports something unrepresentable, drop the
+                        // timestamp — the `checkedAt` field is optional and
+                        // pnpm tolerates `None`.
+                        let checked_at = UNIX_EPOCH
+                            .elapsed()
+                            .ok()
+                            .and_then(|x| u64::try_from(x.as_millis()).ok());
+                        let file_size = entry
+                            .header()
+                            .size()
+                            .map_err(TarballError::ReadTarballEntries)
+                            .map_err(TaskError::Other)?;
+                        let file_attrs = CafsFileInfo {
+                            digest: format!("{file_hash:x}"),
+                            mode: file_mode,
+                            size: file_size,
+                            checked_at,
+                        };
+
+                        if let Some(previous) =
+                            pkg_files_idx.files.insert(cleaned_entry_path, file_attrs)
+                        {
+                            tracing::warn!(
+                                ?previous,
+                                "Duplication detected. Old entry has been ejected"
+                            );
+                        }
                     }
-                }
 
-                (cas_paths, pkg_files_idx)
-            };
+                    (cas_paths, pkg_files_idx)
+                };
 
-            // Record the per-tarball file index in the shared SQLite index so
-            // other pacquet / pnpm processes can find these files on disk.
-            // SQLite open + PRAGMA + INSERT are blocking (and can stall for up
-            // to `busy_timeout=5000` ms when contending with a concurrent
-            // writer), so run them on the blocking pool rather than the
-            // tokio reactor. One StoreIndex per spawned task keeps the code
-            // lock-free; SQLite serializes concurrent writers via its
-            // busy_timeout.
-            let index_key = store_index_key(&package_integrity.to_string(), &package_id);
-            let v11_dir = store_dir.v11();
-            tokio::task::spawn_blocking(move || -> Result<(), StoreIndexError> {
-                let store_index = StoreIndex::open(&v11_dir)?;
-                store_index.set(&index_key, &pkg_files_idx)?;
-                Ok(())
-            })
-            .await
-            .expect("store-index writer task panicked")
-            .map_err(TarballError::WriteStoreIndex)
-            .map_err(TaskError::Other)?;
+                // Record the per-tarball file index in the shared SQLite
+                // index so other pacquet / pnpm processes can find these
+                // files on disk. We're already on the blocking pool, so
+                // the synchronous `Connection::open` + PRAGMA + INSERT
+                // run inline — no nested `spawn_blocking` needed.
+                // SQLite serializes concurrent writers via its
+                // `busy_timeout=5000 ms`.
+                let index_key = store_index_key(&package_integrity.to_string(), &package_id);
+                let v11_dir = store_dir.v11();
+                StoreIndex::open(&v11_dir)
+                    .and_then(|index| index.set(&index_key, &pkg_files_idx))
+                    .map_err(TarballError::WriteStoreIndex)?;
 
-            Ok(cas_paths)
-        })
+                Ok(cas_paths)
+            },
+        )
         .await
-        .expect("no join error")
+        .expect("tarball-processing blocking task panicked")
         .map_err(|error| match error {
             TaskError::Checksum(error) => {
                 TarballError::Checksum(VerifyChecksumError { url: package_url.to_string(), error })


### PR DESCRIPTION
## Summary

The `frozen-lockfile` benchmark job has been flaky, with the 10-minute step timeout firing during `Benchmark 1: pacquet@HEAD` (e.g. [this run's log](https://productionresultssa13.blob.core.windows.net/actions-results/6fbca4c2-5214-44f0-8a12-080d78988e64/workflow-job-run-9afc2c9e-1f21-57f6-ac11-f1e63aa5cb9f/logs/job/job-logs.txt)). Diagnosis:

- All 8112 tarballs reached `Download completed` — network side was fine (the reqwest timeouts from #267 did their job).
- Only 6997 reached `Checksum verified` — ~1115 stuck in the post-download stage.
- Last tracing event at `12:07:55`, then **3m46s of total silence** before the runner SIGKILLed the job. `pacquet` was still alive in the orphan-process list.

The stuck stage was this block in `crates/tarball/src/lib.rs`:

```rust
let cas_paths = tokio::task::spawn(async move {
    package_integrity.check(&response)...;            // SHA-512 over full tarball
    let mut archive = decompress_gzip(&response...);  // gzip inflate
    for entry in entries {                            // per-file SHA-512 + blocking write
        ...
        store_dir.write_cas_file(&buffer, ...)...;
    }
    tokio::task::spawn_blocking(...).await ...;       // SQLite INSERT
})
```

The body is entirely synchronous CPU + blocking I/O with **no `.await` until the final nested `spawn_blocking`**. Every tarball pins a tokio reactor worker for its full duration. On a 2-core GHA runner that caps concurrency at ~2 tarballs, and the tail of large packages (100-200 KB compressed, MB+ inflated, dozens of files each) overruns the 10-minute step budget. The per-second throughput trace makes it obvious:

| time | downloaded | verified |
|---|---|---|
| 12:07:27-51 | ~350/s | ~350/s |
| 12:07:53 | **750** | 237 (consumer falling behind) |
| 12:07:54 | 526 | **0** |
| 12:07:55 → 12:11:41 | 0 | 0 |

## Change

- Outer `tokio::task::spawn(async move { ... })` → `tokio::task::spawn_blocking(move || { ... })`. The work now runs on tokio's blocking pool (default 512 threads) instead of the 2 reactor workers.
- The inner `spawn_blocking` around the SQLite write is no longer useful — we're already on the blocking pool — so it's inlined as a direct synchronous call.
- Comments updated, including the scope comment (the `!Send` `tar::Archive` drop-ordering reasoning no longer applies; the scope is kept for memory efficiency since the inflated buffer can be multi-MB).

## What this does NOT address

`CreateVirtualDirBySnapshot.run()` in `crates/package-manager/src/install_package_by_snapshot.rs` is still called synchronously from async context, and internally uses `rayon::par_iter` (`create_cas_files`, `create_symlink_layout`), which also blocks a tokio worker. That's a smaller window than the tarball pipeline (dozens of files vs. the full SHA + gunzip + per-file loop), but if CI still flakes after this, that's the next thing to wrap in `spawn_blocking`.

## Test plan

- [x] `cargo check --workspace` — clean.
- [x] `cargo test -p pacquet-tarball` — 7/7 pass (including `packages_under_orgs_should_work`, which actually downloads from npmjs.org).
- [x] `cargo test -p pacquet-package-manager` — 28/28 pass (including `should_install_dependencies`, the end-to-end install flow).
- [ ] CI run of the `Benchmark: Frozen Lockfile` job — this is the real verification; the hang is timing-dependent and only triggers under the 1352-snapshot fixture's load profile.