### PR TITLE
perf(store-dir): port pnpm's checkPkgFilesIntegrity model for warm-cache lookup

### DIFF
--- a/crates/npmrc/src/custom_deserializer.rs
+++ b/crates/npmrc/src/custom_deserializer.rs
@@ -168,7 +168,14 @@ mod tests {
 
     #[test]
     fn test_default_store_dir_with_xdg_env() {
-        env::set_var("XDG_DATA_HOME", "/tmp/xdg_data_home"); // TODO: change this to dependency injection
+        // `default_store_dir` checks `PNPM_HOME` before `XDG_DATA_HOME`,
+        // so a developer running the test suite with pnpm in their
+        // environment (very common) otherwise sees the `PNPM_HOME`
+        // branch win and the assertion fail. Clear it explicitly to
+        // isolate the XDG branch until the TODO below swaps env lookups
+        // for dependency injection.
+        env::remove_var("PNPM_HOME"); // TODO: change this to dependency injection
+        env::set_var("XDG_DATA_HOME", "/tmp/xdg_data_home");
         let store_dir = default_store_dir();
         assert_eq!(display_store_dir(&store_dir), "/tmp/xdg_data_home/pnpm/store");
         env::remove_var("XDG_DATA_HOME");

--- a/crates/npmrc/src/custom_deserializer.rs
+++ b/crates/npmrc/src/custom_deserializer.rs
@@ -151,6 +151,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_env_guard::EnvGuard;
     use pretty_assertions::assert_eq;
     use std::env;
 
@@ -160,10 +161,10 @@ mod tests {
 
     #[test]
     fn test_default_store_dir_with_pnpm_home_env() {
+        let _g = EnvGuard::snapshot(["PNPM_HOME"]);
         env::set_var("PNPM_HOME", "/tmp/pnpm-home"); // TODO: change this to dependency injection
         let store_dir = default_store_dir();
         assert_eq!(display_store_dir(&store_dir), "/tmp/pnpm-home/store");
-        env::remove_var("PNPM_HOME");
     }
 
     #[test]
@@ -171,14 +172,16 @@ mod tests {
         // `default_store_dir` checks `PNPM_HOME` before `XDG_DATA_HOME`,
         // so a developer running the test suite with pnpm in their
         // environment (very common) otherwise sees the `PNPM_HOME`
-        // branch win and the assertion fail. Clear it explicitly to
-        // isolate the XDG branch until the TODO below swaps env lookups
-        // for dependency injection.
-        env::remove_var("PNPM_HOME"); // TODO: change this to dependency injection
+        // branch win and the assertion fail. Snapshot-and-restore both
+        // env vars so the test is self-contained even under nextest's
+        // in-process parallelism. Proper fix is dependency injection —
+        // see the TODO — but this is enough for the failure mode this
+        // PR is fixing.
+        let _g = EnvGuard::snapshot(["PNPM_HOME", "XDG_DATA_HOME"]);
+        env::remove_var("PNPM_HOME");
         env::set_var("XDG_DATA_HOME", "/tmp/xdg_data_home");
         let store_dir = default_store_dir();
         assert_eq!(display_store_dir(&store_dir), "/tmp/xdg_data_home/pnpm/store");
-        env::remove_var("XDG_DATA_HOME");
     }
 
     #[cfg(windows)]

--- a/crates/npmrc/src/lib.rs
+++ b/crates/npmrc/src/lib.rs
@@ -1,5 +1,7 @@
 mod custom_deserializer;
 mod npmrc_auth;
+#[cfg(test)]
+mod test_env_guard;
 mod workspace_yaml;
 
 use pacquet_store_dir::StoreDir;
@@ -254,6 +256,7 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
+    use crate::test_env_guard::EnvGuard;
 
     fn display_store_dir(store_dir: &StoreDir) -> String {
         store_dir.display().to_string().replace('\\', "/")
@@ -297,10 +300,10 @@ mod tests {
 
     #[test]
     pub fn should_use_pnpm_home_env_var() {
+        let _g = EnvGuard::snapshot(["PNPM_HOME"]);
         env::set_var("PNPM_HOME", "/hello"); // TODO: change this to dependency injection
         let value: Npmrc = serde_ini::from_str("").unwrap();
         assert_eq!(display_store_dir(&value.store_dir), "/hello/store");
-        env::remove_var("PNPM_HOME");
     }
 
     #[test]
@@ -308,13 +311,15 @@ mod tests {
         // Clear `PNPM_HOME` first — `default_store_dir` checks it
         // before `XDG_DATA_HOME`, so running the test suite with pnpm
         // installed (common) would otherwise hit the `PNPM_HOME`
-        // branch and fail the assertion. See the companion fix in
+        // branch and fail the assertion. Snapshot both so the test
+        // cleans up after itself even when parallel peers observe the
+        // temporarily-unset state. See the companion fix in
         // `custom_deserializer::tests::test_default_store_dir_with_xdg_env`.
+        let _g = EnvGuard::snapshot(["PNPM_HOME", "XDG_DATA_HOME"]);
         env::remove_var("PNPM_HOME"); // TODO: change this to dependency injection
         env::set_var("XDG_DATA_HOME", "/hello");
         let value: Npmrc = serde_ini::from_str("").unwrap();
         assert_eq!(display_store_dir(&value.store_dir), "/hello/pnpm/store");
-        env::remove_var("XDG_DATA_HOME");
     }
 
     #[test]

--- a/crates/npmrc/src/lib.rs
+++ b/crates/npmrc/src/lib.rs
@@ -156,6 +156,19 @@ pub struct Npmrc {
     /// projects in the workspace use the same versions of the peer dependencies.
     #[serde(default = "bool_true", deserialize_with = "deserialize_bool")]
     pub resolve_peers_from_workspace_root: bool,
+
+    /// Whether to verify each CAFS file's on-disk integrity before reusing it
+    /// for an install. When `true` (pnpm's default), the store-index cache
+    /// lookup stats each referenced file and re-hashes any whose mtime has
+    /// advanced past the stored `checkedAt` timestamp. When `false`, the
+    /// lookup skips that verification entirely and trusts the index — a
+    /// missing blob is discovered lazily at link time instead.
+    ///
+    /// Matches pnpm's `verify-store-integrity` / `verifyStoreIntegrity`
+    /// setting (see `installing/deps-installer/src/install/extendInstallOptions.ts`
+    /// for the same default of `true`).
+    #[serde(default = "bool_true", deserialize_with = "deserialize_bool")]
+    pub verify_store_integrity: bool,
 }
 
 impl Npmrc {
@@ -292,7 +305,13 @@ mod tests {
 
     #[test]
     pub fn should_use_xdg_data_home_env_var() {
-        env::set_var("XDG_DATA_HOME", "/hello"); // TODO: change this to dependency injection
+        // Clear `PNPM_HOME` first — `default_store_dir` checks it
+        // before `XDG_DATA_HOME`, so running the test suite with pnpm
+        // installed (common) would otherwise hit the `PNPM_HOME`
+        // branch and fail the assertion. See the companion fix in
+        // `custom_deserializer::tests::test_default_store_dir_with_xdg_env`.
+        env::remove_var("PNPM_HOME"); // TODO: change this to dependency injection
+        env::set_var("XDG_DATA_HOME", "/hello");
         let value: Npmrc = serde_ini::from_str("").unwrap();
         assert_eq!(display_store_dir(&value.store_dir), "/hello/pnpm/store");
         env::remove_var("XDG_DATA_HOME");

--- a/crates/npmrc/src/lib.rs
+++ b/crates/npmrc/src/lib.rs
@@ -166,9 +166,14 @@ pub struct Npmrc {
     /// lookup skips that verification entirely and trusts the index — a
     /// missing blob is discovered lazily at link time instead.
     ///
-    /// Matches pnpm's `verify-store-integrity` / `verifyStoreIntegrity`
-    /// setting (see `installing/deps-installer/src/install/extendInstallOptions.ts`
-    /// for the same default of `true`).
+    /// Matches pnpm's `verifyStoreIntegrity` camelCase key in
+    /// `pnpm-workspace.yaml` (same `true` default as pnpm's
+    /// `installing/deps-installer/src/install/extendInstallOptions.ts`).
+    /// Only `pnpm-workspace.yaml` is wired up today — [`Npmrc::current`]
+    /// applies auth/registry from `.npmrc` and reads project-structural
+    /// settings from `pnpm-workspace.yaml`, matching pnpm 11's own
+    /// split. A `verify-store-integrity=…` line in `.npmrc` is
+    /// silently ignored.
     #[serde(default = "bool_true", deserialize_with = "deserialize_bool")]
     pub verify_store_integrity: bool,
 }

--- a/crates/npmrc/src/test_env_guard.rs
+++ b/crates/npmrc/src/test_env_guard.rs
@@ -21,6 +21,7 @@
 //! `cargo nextest run` alike.
 use std::{
     env,
+    ffi::OsString,
     sync::{Mutex, MutexGuard, OnceLock},
 };
 
@@ -36,7 +37,12 @@ fn env_mutex() -> &'static Mutex<()> {
 /// lock for that lifetime.
 #[must_use = "the guard must be held until the test ends"]
 pub struct EnvGuard {
-    saved: Vec<(&'static str, Option<String>)>,
+    // `OsString` so non-UTF-8 values round-trip. `env::var` returns
+    // `Err(NotUnicode)` for those and would silently coerce to "absent"
+    // here — then `Drop` would `remove_var` a variable the user
+    // actually had set, clobbering CI / shell state. `env::var_os` +
+    // `OsString` preserves the raw bytes.
+    saved: Vec<(&'static str, Option<OsString>)>,
     // Released on drop, last. Ignore the poison case: if another
     // env-mutating test panicked while holding the lock, the env vars
     // it touched were restored by *its* guard's `Drop` before the
@@ -55,7 +61,7 @@ impl EnvGuard {
         I: IntoIterator<Item = &'static str>,
     {
         let lock = env_mutex().lock().unwrap_or_else(|poisoned| poisoned.into_inner());
-        let saved = vars.into_iter().map(|name| (name, env::var(name).ok())).collect();
+        let saved = vars.into_iter().map(|name| (name, env::var_os(name))).collect();
         EnvGuard { saved, _lock: lock }
     }
 }

--- a/crates/npmrc/src/test_env_guard.rs
+++ b/crates/npmrc/src/test_env_guard.rs
@@ -1,0 +1,46 @@
+//! Test-only helper: snapshot and restore selected environment
+//! variables around a block of code.
+//!
+//! `env::set_var` / `env::remove_var` are process-global and outlive
+//! any `#[test]` they were set inside. The tests in this crate that
+//! exercise [`default_store_dir`][crate::custom_deserializer::default_store_dir]
+//! need to set `PNPM_HOME` / `XDG_DATA_HOME` to check specific branches;
+//! without the guard each test leaks its modifications into everything
+//! that runs afterwards in the same process and cross-stomps on a
+//! developer's shell-exported values.
+//!
+//! Proper fix is to thread env lookups through dependency injection
+//! (the same TODO already noted inline on each test), at which point
+//! the guard goes away. For now this keeps the existing env-var tests
+//! correct under nextest's in-process parallelism.
+use std::env;
+
+/// Restore a named set of env vars on drop.
+#[must_use = "the guard must be held until the test ends"]
+pub struct EnvGuard {
+    saved: Vec<(&'static str, Option<String>)>,
+}
+
+impl EnvGuard {
+    /// Snapshot the current values of `vars`. When the returned guard
+    /// drops, each variable is put back to exactly what it was (set to
+    /// the recorded value, or removed if it was absent).
+    pub fn snapshot<I>(vars: I) -> Self
+    where
+        I: IntoIterator<Item = &'static str>,
+    {
+        let saved = vars.into_iter().map(|name| (name, env::var(name).ok())).collect();
+        EnvGuard { saved }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (name, prior) in &self.saved {
+            match prior {
+                Some(value) => env::set_var(name, value),
+                None => env::remove_var(name),
+            }
+        }
+    }
+}

--- a/crates/npmrc/src/test_env_guard.rs
+++ b/crates/npmrc/src/test_env_guard.rs
@@ -1,36 +1,62 @@
-//! Test-only helper: snapshot and restore selected environment
-//! variables around a block of code.
+//! Test-only helper: serialize env-var mutations across parallel
+//! tests, and snapshot/restore selected variables around each block.
 //!
 //! `env::set_var` / `env::remove_var` are process-global and outlive
-//! any `#[test]` they were set inside. The tests in this crate that
-//! exercise [`default_store_dir`][crate::custom_deserializer::default_store_dir]
-//! need to set `PNPM_HOME` / `XDG_DATA_HOME` to check specific branches;
-//! without the guard each test leaks its modifications into everything
-//! that runs afterwards in the same process and cross-stomps on a
-//! developer's shell-exported values.
+//! any `#[test]` they were set inside. Rust / nextest run unit tests in
+//! parallel threads inside the same process by default, so two
+//! concurrent tests mutating `PNPM_HOME` can easily observe each
+//! other's half-set state. This module guards both concerns:
+//!
+//! * a process-wide `Mutex` is acquired for the lifetime of each
+//!   guard, so only one env-mutating test holds the "env-is-mine" lock
+//!   at a time;
+//! * the snapshot/restore pass on `Drop` puts the named variables back
+//!   to whatever the caller inherited, so the guard can't leak state
+//!   into unrelated tests or stomp a developer's shell.
 //!
 //! Proper fix is to thread env lookups through dependency injection
 //! (the same TODO already noted inline on each test), at which point
-//! the guard goes away. For now this keeps the existing env-var tests
-//! correct under nextest's in-process parallelism.
-use std::env;
+//! this module goes away. Until then, holding the returned guard is
+//! enough to keep the env-var tests correct under `cargo test` and
+//! `cargo nextest run` alike.
+use std::{
+    env,
+    sync::{Mutex, MutexGuard, OnceLock},
+};
 
-/// Restore a named set of env vars on drop.
+/// Serialization mutex for env-mutating tests. A single `Mutex<()>` —
+/// uncontended outside the handful of tests that need it, cheap when
+/// held.
+fn env_mutex() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// Restore a named set of env vars on drop and hold the env-mutation
+/// lock for that lifetime.
 #[must_use = "the guard must be held until the test ends"]
 pub struct EnvGuard {
     saved: Vec<(&'static str, Option<String>)>,
+    // Released on drop, last. Ignore the poison case: if another
+    // env-mutating test panicked while holding the lock, the env vars
+    // it touched were restored by *its* guard's `Drop` before the
+    // unwind propagated, so the environment is in a known state and
+    // the next test can safely proceed.
+    _lock: MutexGuard<'static, ()>,
 }
 
 impl EnvGuard {
-    /// Snapshot the current values of `vars`. When the returned guard
-    /// drops, each variable is put back to exactly what it was (set to
-    /// the recorded value, or removed if it was absent).
+    /// Acquire the process-wide env-mutation lock and snapshot the
+    /// current values of `vars`. When the returned guard drops, each
+    /// variable is put back to exactly what it was (set to the recorded
+    /// value, or removed if it was absent), and the lock is released.
     pub fn snapshot<I>(vars: I) -> Self
     where
         I: IntoIterator<Item = &'static str>,
     {
+        let lock = env_mutex().lock().unwrap_or_else(|poisoned| poisoned.into_inner());
         let saved = vars.into_iter().map(|name| (name, env::var(name).ok())).collect();
-        EnvGuard { saved }
+        EnvGuard { saved, _lock: lock }
     }
 }
 

--- a/crates/npmrc/src/workspace_yaml.rs
+++ b/crates/npmrc/src/workspace_yaml.rs
@@ -257,6 +257,25 @@ registry: https://reg.example
         assert_eq!(npmrc.store_dir, StoreDir::from(base.join("../shared-store")));
     }
 
+    /// `verifyStoreIntegrity` is a camelCase key that serde's rename
+    /// has to pick up, and the `apply_to` wiring has to thread it onto
+    /// the `Npmrc` field. Parse a yaml that flips the default-true
+    /// setting to false and assert both steps. Guards against silent
+    /// regressions in the key mapping or the apply step (a copy-paste
+    /// omission in `apply_to` would leave `npmrc.verify_store_integrity`
+    /// at its default).
+    #[test]
+    fn parses_verify_store_integrity_from_yaml_and_applies() {
+        let yaml = "verifyStoreIntegrity: false\n";
+        let settings: WorkspaceSettings = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(settings.verify_store_integrity, Some(false));
+
+        let mut npmrc = Npmrc::new();
+        assert!(npmrc.verify_store_integrity, "the default is `true` to match pnpm");
+        settings.apply_to(&mut npmrc, Path::new("/irrelevant"));
+        assert!(!npmrc.verify_store_integrity, "yaml override wins");
+    }
+
     #[test]
     fn apply_leaves_unset_fields_alone() {
         let yaml = "storeDir: /s\n";

--- a/crates/npmrc/src/workspace_yaml.rs
+++ b/crates/npmrc/src/workspace_yaml.rs
@@ -45,6 +45,7 @@ pub struct WorkspaceSettings {
     pub dedupe_peer_dependents: Option<bool>,
     pub strict_peer_dependencies: Option<bool>,
     pub resolve_peers_from_workspace_root: Option<bool>,
+    pub verify_store_integrity: Option<bool>,
 }
 
 /// Basename of the file pnpm reads; exported for test use.
@@ -141,6 +142,9 @@ impl WorkspaceSettings {
         }
         if let Some(v) = self.resolve_peers_from_workspace_root {
             npmrc.resolve_peers_from_workspace_root = v;
+        }
+        if let Some(v) = self.verify_store_integrity {
+            npmrc.verify_store_integrity = v;
         }
     }
 }

--- a/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/crates/package-manager/src/install_package_by_snapshot.rs
@@ -96,6 +96,7 @@ impl<'a> InstallPackageBySnapshot<'a> {
             store_dir: &config.store_dir,
             store_index: store_index.cloned(),
             store_index_writer: store_index_writer.cloned(),
+            verify_store_integrity: config.verify_store_integrity,
             package_integrity: integrity,
             package_unpacked_size: None,
             package_url: &tarball_url,

--- a/crates/package-manager/src/install_package_from_registry.rs
+++ b/crates/package-manager/src/install_package_from_registry.rs
@@ -89,6 +89,7 @@ impl<'a> InstallPackageFromRegistry<'a> {
             store_dir: &config.store_dir,
             store_index: store_index.cloned(),
             store_index_writer: store_index_writer.cloned(),
+            verify_store_integrity: config.verify_store_integrity,
             package_integrity: package_version
                 .dist
                 .integrity
@@ -155,6 +156,7 @@ mod tests {
             dedupe_peer_dependents: false,
             strict_peer_dependencies: false,
             resolve_peers_from_workspace_root: false,
+            verify_store_integrity: true,
         }
     }
 

--- a/crates/store-dir/src/check_pkg_files_integrity.rs
+++ b/crates/store-dir/src/check_pkg_files_integrity.rs
@@ -67,6 +67,12 @@ pub fn build_file_maps_from_index(store_dir: &StoreDir, entry: PackageFilesIndex
             // install. Flipping `passed` to `false` sends the whole
             // entry back through the re-fetch path so the install stays
             // consistent.
+            tracing::debug!(
+                target: "pacquet::store_index",
+                ?filename,
+                digest = %info.digest,
+                "malformed CAFS digest in store-index row; re-fetching",
+            );
             passed = false;
             continue;
         };
@@ -115,11 +121,17 @@ pub fn check_pkg_files_integrity(store_dir: &StoreDir, entry: PackageFilesIndex)
     let mut verified: HashSet<String> = HashSet::new();
     for (filename, info) in files {
         let Some(path) = store_dir.cas_file_path_by_mode(&info.digest, info.mode) else {
+            tracing::debug!(
+                target: "pacquet::store_index",
+                ?filename,
+                digest = %info.digest,
+                "malformed CAFS digest in store-index row; re-fetching",
+            );
             all_verified = false;
             continue;
         };
         if !verified.contains(info.digest.as_str()) {
-            if verify_file(&path, &info, &algo) {
+            if verify_file(&path, &filename, &info, &algo) {
                 // One digest clone per unique CAFS blob we actually
                 // verified; zero for dedup hits. On a 1352-snapshot
                 // install that's an extra allocation per *unique*
@@ -138,8 +150,19 @@ pub fn check_pkg_files_integrity(store_dir: &StoreDir, entry: PackageFilesIndex)
 /// Port of pnpm's `verifyFile`. `true` when the on-disk file is either
 /// unmodified since the last verified check or modified but still
 /// content-hashes to the stored digest.
-fn verify_file(path: &Path, info: &CafsFileInfo, algo: &str) -> bool {
+///
+/// `filename` is the in-tarball path the caller is trying to reuse; it
+/// doesn't affect behaviour, only the `debug!` log when verification
+/// fails, so operators can see *which* package file invalidated the
+/// store-index row in the log.
+fn verify_file(path: &Path, filename: &str, info: &CafsFileInfo, algo: &str) -> bool {
     let Some((is_modified, size)) = check_file(path, info.checked_at) else {
+        tracing::debug!(
+            target: "pacquet::store_index",
+            ?filename,
+            ?path,
+            "CAFS file missing or unreadable; re-fetching",
+        );
         return false;
     };
     if !is_modified {
@@ -149,11 +172,25 @@ fn verify_file(path: &Path, info: &CafsFileInfo, algo: &str) -> bool {
         // Wrong size → content definitely changed. Remove so the next
         // caller fetches a clean copy. See `remove_stale_cafs_entry`
         // for why this has to cover dirs too.
+        tracing::debug!(
+            target: "pacquet::store_index",
+            ?filename,
+            ?path,
+            expected_size = info.size,
+            actual_size = size,
+            "CAFS file size mismatch; scrubbing and re-fetching",
+        );
         remove_stale_cafs_entry(path);
         return false;
     }
     let passed = verify_file_integrity(path, &info.digest, algo);
     if !passed {
+        tracing::debug!(
+            target: "pacquet::store_index",
+            ?filename,
+            ?path,
+            "CAFS file digest mismatch or unknown algo; scrubbing and re-fetching",
+        );
         remove_stale_cafs_entry(path);
     }
     passed

--- a/crates/store-dir/src/check_pkg_files_integrity.rs
+++ b/crates/store-dir/src/check_pkg_files_integrity.rs
@@ -16,6 +16,7 @@ use sha2::{Digest, Sha512};
 use std::{
     collections::{HashMap, HashSet},
     fs,
+    io::{self, BufReader, Read},
     path::{Path, PathBuf},
     time::UNIX_EPOCH,
 };
@@ -30,8 +31,10 @@ pub type FilesMap = HashMap<String, PathBuf>;
 /// CAFS file is missing, its size disagrees with the index, or its
 /// content hash fails to match — the caller treats that as "this store
 /// entry is stale, fall through to a fresh fetch". `files_map` is
-/// populated either way so the caller can log or short-circuit without
-/// re-walking the entry.
+/// returned either way as a best-effort `in-tarball filename` → `CAFS
+/// path` map; it may be partial or empty when a digest in the index
+/// row couldn't be reconstructed into a CAFS path, so callers should
+/// gate reuse on `passed` rather than on the map's size.
 #[derive(Debug)]
 pub struct VerifyResult {
     pub passed: bool,
@@ -195,22 +198,47 @@ fn check_file(path: &Path, checked_at: Option<u64>) -> Option<(bool, u64)> {
     Some((is_modified, meta.len()))
 }
 
-/// Port of pnpm's `verifyFileIntegrity`. Reads the whole file, hashes
-/// with `algo`, compares against the stored hex `digest`.
+/// Port of pnpm's `verifyFileIntegrity`. Streams the file through the
+/// hasher in 64 KiB chunks and compares the digest against the stored
+/// hex `digest`.
+///
+/// pnpm itself calls `readFileSync` + `crypto.hash`, which loads the
+/// whole blob into a `Buffer` first. On Node that's capped implicitly
+/// by `Buffer.kMaxLength`; in Rust we'd allocate the full file up
+/// front, spiking RSS for multi-MB CAS blobs when an install is
+/// verifying many entries in parallel. A `BufReader` + incremental
+/// `Digest::update` is equivalent on the wire and keeps peak memory
+/// bounded per thread.
 ///
 /// Only `sha512` is supported — pacquet always writes that algo in
 /// [`StoreDir::write_cas_file`]. Any other algo falls through to
 /// `false` ("treat as verification failure"), matching pnpm's own
-/// unknown-algo behaviour.
+/// unknown-algo behaviour. An I/O error mid-read also falls through to
+/// `false` so the caller re-fetches rather than deciding on a partial
+/// hash.
 fn verify_file_integrity(path: &Path, digest: &str, algo: &str) -> bool {
     if algo != "sha512" {
         return false;
     }
-    let Ok(data) = fs::read(path) else {
+    let Ok(file) = fs::File::open(path) else {
         return false;
     };
-    let computed = Sha512::digest(&data);
-    format!("{computed:x}") == digest
+    let mut reader = BufReader::with_capacity(64 * 1024, file);
+    let mut hasher = Sha512::new();
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        match reader.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => hasher.update(&buf[..n]),
+            // `Interrupted` is the one error we retry — it's a signal,
+            // not a real IO failure. Everything else (NotFound, EIO,
+            // PermissionDenied, …) short-circuits to `false` so the
+            // caller re-fetches.
+            Err(ref e) if e.kind() == io::ErrorKind::Interrupted => continue,
+            Err(_) => return false,
+        }
+    }
+    format!("{:x}", hasher.finalize()) == digest
 }
 
 #[cfg(test)]

--- a/crates/store-dir/src/check_pkg_files_integrity.rs
+++ b/crates/store-dir/src/check_pkg_files_integrity.rs
@@ -335,8 +335,11 @@ mod tests {
         CafsFileInfo { checked_at, digest: digest.to_string(), mode, size }
     }
 
-    /// `build_file_maps_from_index` never stats the files. Nothing on
-    /// disk → still returns a populated `files_map` with `passed = true`.
+    /// `build_file_maps_from_index` never stats the files. With a
+    /// valid digest, it returns a populated `files_map` with
+    /// `passed = true` regardless of whether anything is on disk —
+    /// the sibling `fast_path_fails_when_digest_is_malformed` covers
+    /// the "digest was not resolvable" failure case.
     #[test]
     fn fast_path_skips_filesystem_checks() {
         let tmp = tempdir().unwrap();
@@ -344,7 +347,7 @@ mod tests {
         let digest = sha512_hex(b"dummy");
         let entry = index_with("sha512", vec![("index.js", info(&digest, 5, 0o644, None))]);
         let result = build_file_maps_from_index(&store_dir, entry);
-        assert!(result.passed, "fast path always passes");
+        assert!(result.passed, "fast path passes for a valid digest without touching the disk");
         let path = result.files_map.get("index.js").expect("path inserted");
         assert!(!path.exists(), "no file was planted — fast path didn't care");
     }

--- a/crates/store-dir/src/check_pkg_files_integrity.rs
+++ b/crates/store-dir/src/check_pkg_files_integrity.rs
@@ -109,16 +109,17 @@ pub fn check_pkg_files_integrity(store_dir: &StoreDir, entry: PackageFilesIndex)
     let mut all_verified = true;
     let mut files_map = HashMap::with_capacity(files.len());
     // pnpm's `verifiedFilesCache: Set<string>` dedups within a single
-    // entry. Two different in-tarball filenames can point at the same
-    // CAFS blob (hash-collision-less dedup), so caching by digest spares
-    // the second stat.
+    // entry so two in-tarball filenames pointing at the same CAFS blob
+    // cost one stat, not two.
     //
-    // Owned `String` instead of `&str` because we move the `filename`
-    // into `files_map` at the end of each iteration, and the `info`
-    // (which owned the digest) gets consumed by `verify_file` by
-    // reference — once the iteration advances, any borrow into `info`
-    // is invalidated.
-    let mut verified: HashSet<String> = HashSet::new();
+    // Key the set by the resolved CAFS path, not by `info.digest`. The
+    // path factors in `info.mode` (via `-exec` suffix for executables
+    // in `cas_file_path_by_mode`), so the same content digest can
+    // legitimately appear under two distinct on-disk paths when the
+    // tarball ships it with different executable bits. Digest-only
+    // dedup would skip verifying the second path and happily return
+    // `passed: true` with a stale / missing blob still on disk.
+    let mut verified: HashSet<PathBuf> = HashSet::new();
     for (filename, info) in files {
         let Some(path) = store_dir.cas_file_path_by_mode(&info.digest, info.mode) else {
             tracing::debug!(
@@ -130,14 +131,12 @@ pub fn check_pkg_files_integrity(store_dir: &StoreDir, entry: PackageFilesIndex)
             all_verified = false;
             continue;
         };
-        if !verified.contains(info.digest.as_str()) {
+        if !verified.contains(&path) {
             if verify_file(&path, &filename, &info, &algo) {
-                // One digest clone per unique CAFS blob we actually
-                // verified; zero for dedup hits. On a 1352-snapshot
-                // install that's an extra allocation per *unique*
-                // blob, not per *filename* — strictly better than the
-                // old per-filename clone.
-                verified.insert(info.digest);
+                // One `PathBuf` clone per unique CAFS path we actually
+                // verified; zero for dedup hits. Strictly better than
+                // the per-filename clone the borrow-based version had.
+                verified.insert(path.clone());
             } else {
                 all_verified = false;
             }
@@ -443,6 +442,39 @@ mod tests {
         let result = check_pkg_files_integrity(&store_dir, entry);
         assert!(result.passed);
         assert_eq!(result.files_map.len(), 2);
+    }
+
+    /// Same digest with different `mode` resolves to two distinct CAFS
+    /// paths (`<hex>` vs `<hex>-exec`). Keying dedup by digest alone
+    /// would skip verifying the second path — this test plants only
+    /// the non-exec half and asserts the install still fails
+    /// verification, forcing a re-fetch, instead of returning
+    /// `passed: true` with a missing exec blob.
+    #[test]
+    fn careful_path_dedups_per_resolved_path_not_per_digest() {
+        let tmp = tempdir().unwrap();
+        let store_dir = StoreDir::new(tmp.path());
+        let content = b"polymode";
+        let digest = sha512_hex(content);
+        // Plant the non-exec variant only; leave the exec path missing.
+        let non_exec_path = plant_cafs_file(&store_dir, &digest, 0o644, content);
+        let exec_path = store_dir.cas_file_path_by_mode(&digest, 0o755).unwrap();
+        assert!(!exec_path.exists());
+        assert_ne!(non_exec_path, exec_path);
+
+        let future = now_ms() + 3_600_000;
+        let entry = index_with(
+            "sha512",
+            vec![
+                ("lib.js", info(&digest, content.len() as u64, 0o644, Some(future))),
+                ("bin/app", info(&digest, content.len() as u64, 0o755, Some(future))),
+            ],
+        );
+        let result = check_pkg_files_integrity(&store_dir, entry);
+        assert!(
+            !result.passed,
+            "same digest + different mode = different CAFS path; missing exec blob must fail",
+        );
     }
 
     /// Unknown algorithm in the row → treat as verification failure,

--- a/crates/store-dir/src/check_pkg_files_integrity.rs
+++ b/crates/store-dir/src/check_pkg_files_integrity.rs
@@ -47,18 +47,25 @@ pub struct VerifyResult {
 /// equivalent).
 pub fn build_file_maps_from_index(store_dir: &StoreDir, entry: &PackageFilesIndex) -> VerifyResult {
     let mut files_map = HashMap::with_capacity(entry.files.len());
+    let mut passed = true;
     for (filename, info) in &entry.files {
         let Some(path) = store_dir.cas_file_path_by_mode(&info.digest, info.mode) else {
-            // A malformed digest (non-hex / too short) skips this file.
-            // pnpm has no equivalent — its `getFilePathByModeInCafs` doesn't
-            // validate. For pacquet's SQLite rows we prefer a safe drop
-            // over a `panic!`, since the row can be rebuilt from the
-            // next install.
+            // A malformed digest (non-hex / too short) makes this entry
+            // unreconstructable. pnpm's `getFilePathByModeInCafs` doesn't
+            // validate and would crash at import time, so a `None` here
+            // is pacquet-specific guardrail. We'd rather silently drop
+            // the row than panic, but a partial `files_map` would leave
+            // the caller with a cache hit missing package files — the
+            // caller would proceed to link and end up with a broken
+            // install. Flipping `passed` to `false` sends the whole
+            // entry back through the re-fetch path so the install stays
+            // consistent.
+            passed = false;
             continue;
         };
         files_map.insert(filename.clone(), path);
     }
-    VerifyResult { passed: true, files_map }
+    VerifyResult { passed, files_map }
 }
 
 /// Careful path used when `verify-store-integrity` is `true` (pnpm's
@@ -119,20 +126,58 @@ fn verify_file(path: &Path, info: &CafsFileInfo, algo: &str) -> bool {
     }
     if size != info.size {
         // Wrong size → content definitely changed. Remove so the next
-        // caller fetches a clean copy. Best-effort: removal failures
-        // don't bubble up, they'll just hit the same mismatch next run.
-        let _ = fs::remove_file(path);
+        // caller fetches a clean copy. See `remove_stale_cafs_entry`
+        // for why this has to cover dirs too.
+        remove_stale_cafs_entry(path);
         return false;
     }
     let passed = verify_file_integrity(path, &info.digest, algo);
     if !passed {
-        let _ = fs::remove_file(path);
+        remove_stale_cafs_entry(path);
     }
     passed
 }
 
-/// Port of pnpm's `checkFile`. `(is_modified, size)` on a live file,
-/// `None` on `ENOENT`.
+/// Remove a CAFS dirent that failed verification, matching pnpm's
+/// `rimrafSync` semantics.
+///
+/// `fs::remove_file` on a directory returns `EISDIR` / `EPERM`, and a
+/// corrupted store that has a directory sitting where a CAFS blob
+/// belongs (stray `mkdir -p`, interrupted write, filesystem hiccup)
+/// would stay there forever if we only tried `remove_file`. Next
+/// install's verification would fail again and again — the store
+/// wouldn't self-heal.
+///
+/// Best-effort for both: try `remove_file`, fall back to
+/// `remove_dir_all` if the dirent is a directory. Errors are logged at
+/// `debug` and dropped — worst case the next install notices the same
+/// stale dirent and retries. We use `symlink_metadata` so we identify
+/// the dirent type without following a symlink.
+fn remove_stale_cafs_entry(path: &Path) {
+    let is_dir = fs::symlink_metadata(path).is_ok_and(|m| m.file_type().is_dir());
+    let result = if is_dir { fs::remove_dir_all(path) } else { fs::remove_file(path) };
+    if let Err(error) = result {
+        tracing::debug!(
+            target: "pacquet::store_index",
+            ?path,
+            ?error,
+            "failed to scrub stale CAFS entry; next install will retry",
+        );
+    }
+}
+
+/// Port of pnpm's `checkFile`. `Some((is_modified, size))` for a file
+/// we can read metadata for; `None` otherwise.
+///
+/// Pnpm rethrows non-`ENOENT` errors and only returns `null` for
+/// `ENOENT`. This port collapses every metadata error (permission
+/// denied, EIO, platform mtime representation failures) to `None`
+/// instead, which the caller then treats as "verification failed →
+/// re-fetch". That's a safer default for a cache-hint path — we don't
+/// want a transient `EACCES` on a CAS blob to panic the install — and
+/// the content-hash check in `verify_file_integrity` still catches
+/// actual corruption. If we ever want pnpm-strict error propagation,
+/// changing the return type to `Result<Option<…>>` is the right shape.
 ///
 /// 100 ms of slack on the mtime comparison matches pnpm's threshold —
 /// accounts for coarse mtime resolution on some filesystems plus the
@@ -333,6 +378,46 @@ mod tests {
         let result = check_pkg_files_integrity(&store_dir, &entry);
         assert!(!result.passed);
         assert!(!path.exists(), "unknown algo → treated as corrupt → removed");
+    }
+
+    /// A CAFS dirent that's a directory (store corruption — stray
+    /// `mkdir -p` or interrupted write) must not survive verification:
+    /// pacquet used to reject with `remove_file(dir)` → `EISDIR`, which
+    /// silently failed and left the directory in place forever. The new
+    /// `remove_stale_cafs_entry` falls back to `remove_dir_all` so the
+    /// store actually self-heals on the next install.
+    #[test]
+    fn careful_path_removes_directory_at_cafs_path() {
+        let tmp = tempdir().unwrap();
+        let store_dir = StoreDir::new(tmp.path());
+        // Plant a directory where a CAFS file belongs.
+        let digest = "c".repeat(128);
+        let cafs_path = store_dir.cas_file_path_by_mode(&digest, 0o644).unwrap();
+        fs::create_dir_all(&cafs_path).unwrap();
+        // Row claims non-zero size; `check_file` stats the dir, size
+        // mismatches the row, we hit the `remove_stale_cafs_entry` path.
+        let entry =
+            index_with("sha512", vec![("impostor", info(&digest, 1_000_000, 0o644, Some(0)))]);
+        let result = check_pkg_files_integrity(&store_dir, &entry);
+        assert!(!result.passed);
+        assert!(
+            !cafs_path.exists(),
+            "a directory at the CAFS path must be scrubbed like a file so the next install re-fetches",
+        );
+    }
+
+    /// `build_file_maps_from_index` shouldn't silently drop unresolvable
+    /// entries — that would give the caller a partial `files_map` and a
+    /// cache hit with missing files. Flip `passed` to `false` when any
+    /// digest can't be turned into a CAFS path so the caller re-fetches.
+    #[test]
+    fn fast_path_fails_when_digest_is_malformed() {
+        let tmp = tempdir().unwrap();
+        let store_dir = StoreDir::new(tmp.path());
+        let entry = index_with("sha512", vec![("bad-digest", info("not-hex", 10, 0o644, None))]);
+        let result = build_file_maps_from_index(&store_dir, &entry);
+        assert!(!result.passed, "malformed digest → whole entry fails so caller re-fetches");
+        assert_eq!(result.files_map.len(), 0);
     }
 
     // `CafsFileInfo` is `!Clone` in production (no need there). Give

--- a/crates/store-dir/src/check_pkg_files_integrity.rs
+++ b/crates/store-dir/src/check_pkg_files_integrity.rs
@@ -48,10 +48,14 @@ pub struct VerifyResult {
 /// No stat syscalls — the caller trusts the index, and any missing /
 /// corrupt CAFS file surfaces lazily at import time (pnpm's `linkOrCopy`
 /// equivalent).
-pub fn build_file_maps_from_index(store_dir: &StoreDir, entry: &PackageFilesIndex) -> VerifyResult {
+pub fn build_file_maps_from_index(store_dir: &StoreDir, entry: PackageFilesIndex) -> VerifyResult {
     let mut files_map = HashMap::with_capacity(entry.files.len());
     let mut passed = true;
-    for (filename, info) in &entry.files {
+    // Consume `entry.files` so the owned `String` filenames move into
+    // `files_map` without a per-file clone. On a realistic install the
+    // previous borrow-then-clone cost one allocation per file on every
+    // warm cache hit.
+    for (filename, info) in entry.files {
         let Some(path) = store_dir.cas_file_path_by_mode(&info.digest, info.mode) else {
             // A malformed digest (non-hex / too short) makes this entry
             // unreconstructable. pnpm's `getFilePathByModeInCafs` doesn't
@@ -66,7 +70,7 @@ pub fn build_file_maps_from_index(store_dir: &StoreDir, entry: &PackageFilesInde
             passed = false;
             continue;
         };
-        files_map.insert(filename.clone(), path);
+        files_map.insert(filename, path);
     }
     VerifyResult { passed, files_map }
 }
@@ -91,28 +95,42 @@ pub fn build_file_maps_from_index(store_dir: &StoreDir, entry: &PackageFilesInde
 /// reject non-regular-file dirents preemptively — the integrity hash
 /// catches real corruption, and pnpm doesn't guard against it in this
 /// function either.
-pub fn check_pkg_files_integrity(store_dir: &StoreDir, entry: &PackageFilesIndex) -> VerifyResult {
+pub fn check_pkg_files_integrity(store_dir: &StoreDir, entry: PackageFilesIndex) -> VerifyResult {
+    // Destructure so the owned `files` HashMap and `algo` String can be
+    // consumed below; moving beats the extra per-file `filename.clone()`
+    // the old borrow-based signature forced on the hot path.
+    let PackageFilesIndex { files, algo, .. } = entry;
     let mut all_verified = true;
-    let mut files_map = HashMap::with_capacity(entry.files.len());
+    let mut files_map = HashMap::with_capacity(files.len());
     // pnpm's `verifiedFilesCache: Set<string>` dedups within a single
     // entry. Two different in-tarball filenames can point at the same
     // CAFS blob (hash-collision-less dedup), so caching by digest spares
     // the second stat.
-    let mut verified: HashSet<&str> = HashSet::new();
-    for (filename, info) in &entry.files {
+    //
+    // Owned `String` instead of `&str` because we move the `filename`
+    // into `files_map` at the end of each iteration, and the `info`
+    // (which owned the digest) gets consumed by `verify_file` by
+    // reference — once the iteration advances, any borrow into `info`
+    // is invalidated.
+    let mut verified: HashSet<String> = HashSet::new();
+    for (filename, info) in files {
         let Some(path) = store_dir.cas_file_path_by_mode(&info.digest, info.mode) else {
             all_verified = false;
             continue;
         };
-        files_map.insert(filename.clone(), path.clone());
-        if verified.contains(info.digest.as_str()) {
-            continue;
+        if !verified.contains(info.digest.as_str()) {
+            if verify_file(&path, &info, &algo) {
+                // One digest clone per unique CAFS blob we actually
+                // verified; zero for dedup hits. On a 1352-snapshot
+                // install that's an extra allocation per *unique*
+                // blob, not per *filename* — strictly better than the
+                // old per-filename clone.
+                verified.insert(info.digest);
+            } else {
+                all_verified = false;
+            }
         }
-        if verify_file(&path, info, &entry.algo) {
-            verified.insert(info.digest.as_str());
-        } else {
-            all_verified = false;
-        }
+        files_map.insert(filename, path);
     }
     VerifyResult { passed: all_verified, files_map }
 }
@@ -289,7 +307,7 @@ mod tests {
         let store_dir = StoreDir::new(tmp.path());
         let digest = sha512_hex(b"dummy");
         let entry = index_with("sha512", vec![("index.js", info(&digest, 5, 0o644, None))]);
-        let result = build_file_maps_from_index(&store_dir, &entry);
+        let result = build_file_maps_from_index(&store_dir, entry);
         assert!(result.passed, "fast path always passes");
         let path = result.files_map.get("index.js").expect("path inserted");
         assert!(!path.exists(), "no file was planted — fast path didn't care");
@@ -314,7 +332,7 @@ mod tests {
             "sha512",
             vec![("index.js", info(&digest, content.len() as u64, 0o644, Some(future)))],
         );
-        let result = check_pkg_files_integrity(&store_dir, &entry);
+        let result = check_pkg_files_integrity(&store_dir, entry);
         assert!(result.passed);
         assert_eq!(result.files_map.len(), 1);
     }
@@ -327,7 +345,7 @@ mod tests {
         let store_dir = StoreDir::new(tmp.path());
         let digest = sha512_hex(b"nope");
         let entry = index_with("sha512", vec![("README", info(&digest, 4, 0o644, None))]);
-        let result = check_pkg_files_integrity(&store_dir, &entry);
+        let result = check_pkg_files_integrity(&store_dir, entry);
         assert!(!result.passed, "missing file → fail");
         assert_eq!(result.files_map.len(), 1);
     }
@@ -348,7 +366,7 @@ mod tests {
             "sha512",
             vec![("whatever", info(&fake_digest, actual.len() as u64, 0o644, Some(0)))],
         );
-        let result = check_pkg_files_integrity(&store_dir, &entry);
+        let result = check_pkg_files_integrity(&store_dir, entry);
         assert!(!result.passed, "bad hash → fail");
         assert!(!path.exists(), "mismatched file is removed so the next call re-fetches");
     }
@@ -365,7 +383,7 @@ mod tests {
         let digest = sha512_hex(content);
         let path = plant_cafs_file(&store_dir, &digest, 0o644, content);
         let entry = index_with("sha512", vec![("mismatch", info(&digest, 999, 0o644, Some(0)))]);
-        let result = check_pkg_files_integrity(&store_dir, &entry);
+        let result = check_pkg_files_integrity(&store_dir, entry);
         assert!(!result.passed);
         assert!(!path.exists(), "size mismatch removes the file so a re-fetch starts clean");
     }
@@ -385,7 +403,7 @@ mod tests {
             "sha512",
             vec![("a.txt", info_shared.clone_for_test()), ("b.txt", info_shared.clone_for_test())],
         );
-        let result = check_pkg_files_integrity(&store_dir, &entry);
+        let result = check_pkg_files_integrity(&store_dir, entry);
         assert!(result.passed);
         assert_eq!(result.files_map.len(), 2);
     }
@@ -403,7 +421,7 @@ mod tests {
         let path = plant_cafs_file(&store_dir, &digest, 0o644, content);
         let entry =
             index_with("sha256", vec![("x", info(&digest, content.len() as u64, 0o644, Some(0)))]);
-        let result = check_pkg_files_integrity(&store_dir, &entry);
+        let result = check_pkg_files_integrity(&store_dir, entry);
         assert!(!result.passed);
         assert!(!path.exists(), "unknown algo → treated as corrupt → removed");
     }
@@ -426,7 +444,7 @@ mod tests {
         // mismatches the row, we hit the `remove_stale_cafs_entry` path.
         let entry =
             index_with("sha512", vec![("impostor", info(&digest, 1_000_000, 0o644, Some(0)))]);
-        let result = check_pkg_files_integrity(&store_dir, &entry);
+        let result = check_pkg_files_integrity(&store_dir, entry);
         assert!(!result.passed);
         assert!(
             !cafs_path.exists(),
@@ -443,7 +461,7 @@ mod tests {
         let tmp = tempdir().unwrap();
         let store_dir = StoreDir::new(tmp.path());
         let entry = index_with("sha512", vec![("bad-digest", info("not-hex", 10, 0o644, None))]);
-        let result = build_file_maps_from_index(&store_dir, &entry);
+        let result = build_file_maps_from_index(&store_dir, entry);
         assert!(!result.passed, "malformed digest → whole entry fails so caller re-fetches");
         assert_eq!(result.files_map.len(), 0);
     }

--- a/crates/store-dir/src/check_pkg_files_integrity.rs
+++ b/crates/store-dir/src/check_pkg_files_integrity.rs
@@ -1,0 +1,351 @@
+//! Port of pnpm v11's
+//! [`store/cafs/src/checkPkgFilesIntegrity.ts`](https://github.com/pnpm/pnpm/blob/main/store/cafs/src/checkPkgFilesIntegrity.ts).
+//!
+//! The store index's `package_index` row lists the CAFS paths a package
+//! expanded into. Before reusing the row the caller checks those files
+//! are still on disk and still match the recorded digests. This module
+//! implements that check — with a fast path that skips filesystem work
+//! entirely when the caller opted out of integrity verification.
+//!
+//! Mirrors the upstream structure function-for-function so a future
+//! cross-reference (or a pnpm-side change we need to match) stays
+//! cheap.
+
+use crate::{CafsFileInfo, PackageFilesIndex, StoreDir};
+use sha2::{Digest, Sha512};
+use std::{
+    collections::{HashMap, HashSet},
+    fs,
+    path::{Path, PathBuf},
+    time::UNIX_EPOCH,
+};
+
+/// `in-tarball filename` → `CAFS path`. Return value of the two verify
+/// entry points below.
+pub type FilesMap = HashMap<String, PathBuf>;
+
+/// Result of a `PackageFilesIndex`-row verification pass.
+///
+/// Mirrors pnpm's `VerifyResult`. `passed` is `false` if any referenced
+/// CAFS file is missing, its size disagrees with the index, or its
+/// content hash fails to match — the caller treats that as "this store
+/// entry is stale, fall through to a fresh fetch". `files_map` is
+/// populated either way so the caller can log or short-circuit without
+/// re-walking the entry.
+#[derive(Debug)]
+pub struct VerifyResult {
+    pub passed: bool,
+    pub files_map: FilesMap,
+}
+
+/// Fast path used when `verify-store-integrity` is `false`.
+///
+/// Port of pnpm's
+/// [`buildFileMapsFromIndex`](https://github.com/pnpm/pnpm/blob/main/store/cafs/src/checkPkgFilesIntegrity.ts).
+/// No stat syscalls — the caller trusts the index, and any missing /
+/// corrupt CAFS file surfaces lazily at import time (pnpm's `linkOrCopy`
+/// equivalent).
+pub fn build_file_maps_from_index(store_dir: &StoreDir, entry: &PackageFilesIndex) -> VerifyResult {
+    let mut files_map = HashMap::with_capacity(entry.files.len());
+    for (filename, info) in &entry.files {
+        let Some(path) = store_dir.cas_file_path_by_mode(&info.digest, info.mode) else {
+            // A malformed digest (non-hex / too short) skips this file.
+            // pnpm has no equivalent — its `getFilePathByModeInCafs` doesn't
+            // validate. For pacquet's SQLite rows we prefer a safe drop
+            // over a `panic!`, since the row can be rebuilt from the
+            // next install.
+            continue;
+        };
+        files_map.insert(filename.clone(), path);
+    }
+    VerifyResult { passed: true, files_map }
+}
+
+/// Careful path used when `verify-store-integrity` is `true` (pnpm's
+/// default).
+///
+/// Port of pnpm's `checkPkgFilesIntegrity`. Per file:
+///
+/// 1. `fs::metadata` the on-disk path to get its mtime + size.
+/// 2. If `mtime - checked_at > 100 ms`, the file has been touched since
+///    we last verified it. Compare sizes: mismatch → delete and fail;
+///    match → re-hash the contents and compare against the stored
+///    digest, deleting on mismatch.
+/// 3. If the mtime is within 100 ms of the stored `checked_at`, trust
+///    the digest and skip the hash — matches pnpm's own comment: "we
+///    assume nobody will manually remove a file in the store and create
+///    a new one".
+///
+/// Missing on disk (`ENOENT`) fails the whole entry so the caller
+/// re-fetches. Unlike the prior pacquet implementation this does *not*
+/// reject non-regular-file dirents preemptively — the integrity hash
+/// catches real corruption, and pnpm doesn't guard against it in this
+/// function either.
+pub fn check_pkg_files_integrity(store_dir: &StoreDir, entry: &PackageFilesIndex) -> VerifyResult {
+    let mut all_verified = true;
+    let mut files_map = HashMap::with_capacity(entry.files.len());
+    // pnpm's `verifiedFilesCache: Set<string>` dedups within a single
+    // entry. Two different in-tarball filenames can point at the same
+    // CAFS blob (hash-collision-less dedup), so caching by digest spares
+    // the second stat.
+    let mut verified: HashSet<&str> = HashSet::new();
+    for (filename, info) in &entry.files {
+        let Some(path) = store_dir.cas_file_path_by_mode(&info.digest, info.mode) else {
+            all_verified = false;
+            continue;
+        };
+        files_map.insert(filename.clone(), path.clone());
+        if verified.contains(info.digest.as_str()) {
+            continue;
+        }
+        if verify_file(&path, info, &entry.algo) {
+            verified.insert(info.digest.as_str());
+        } else {
+            all_verified = false;
+        }
+    }
+    VerifyResult { passed: all_verified, files_map }
+}
+
+/// Port of pnpm's `verifyFile`. `true` when the on-disk file is either
+/// unmodified since the last verified check or modified but still
+/// content-hashes to the stored digest.
+fn verify_file(path: &Path, info: &CafsFileInfo, algo: &str) -> bool {
+    let Some((is_modified, size)) = check_file(path, info.checked_at) else {
+        return false;
+    };
+    if !is_modified {
+        return true;
+    }
+    if size != info.size {
+        // Wrong size → content definitely changed. Remove so the next
+        // caller fetches a clean copy. Best-effort: removal failures
+        // don't bubble up, they'll just hit the same mismatch next run.
+        let _ = fs::remove_file(path);
+        return false;
+    }
+    let passed = verify_file_integrity(path, &info.digest, algo);
+    if !passed {
+        let _ = fs::remove_file(path);
+    }
+    passed
+}
+
+/// Port of pnpm's `checkFile`. `(is_modified, size)` on a live file,
+/// `None` on `ENOENT`.
+///
+/// 100 ms of slack on the mtime comparison matches pnpm's threshold —
+/// accounts for coarse mtime resolution on some filesystems plus the
+/// ≤1 ms drift between when we recorded `checked_at` and when the kernel
+/// actually stamped the inode. A missing `checked_at` deserializes as
+/// `Option<u64>::None` and is treated as `0`, which forces a re-hash the
+/// first time an old-format row is read (same as pnpm's `?? 0`).
+fn check_file(path: &Path, checked_at: Option<u64>) -> Option<(bool, u64)> {
+    let meta = fs::metadata(path).ok()?;
+    let mtime_ms =
+        meta.modified().ok()?.duration_since(UNIX_EPOCH).ok()?.as_millis().min(u64::MAX as u128)
+            as u64;
+    let baseline = checked_at.unwrap_or(0);
+    let is_modified = mtime_ms.saturating_sub(baseline) > 100;
+    Some((is_modified, meta.len()))
+}
+
+/// Port of pnpm's `verifyFileIntegrity`. Reads the whole file, hashes
+/// with `algo`, compares against the stored hex `digest`.
+///
+/// Only `sha512` is supported — pacquet always writes that algo in
+/// [`StoreDir::write_cas_file`]. Any other algo falls through to
+/// `false` ("treat as verification failure"), matching pnpm's own
+/// unknown-algo behaviour.
+fn verify_file_integrity(path: &Path, digest: &str, algo: &str) -> bool {
+    if algo != "sha512" {
+        return false;
+    }
+    let Ok(data) = fs::read(path) else {
+        return false;
+    };
+    let computed = Sha512::digest(&data);
+    format!("{computed:x}") == digest
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use std::{fs, io::Write, time::SystemTime};
+    use tempfile::tempdir;
+
+    /// Write `content` to the correct CAFS path under `store_dir` for
+    /// the given hex digest. Returns the path.
+    fn plant_cafs_file(store_dir: &StoreDir, digest: &str, mode: u32, content: &[u8]) -> PathBuf {
+        let path = store_dir.cas_file_path_by_mode(digest, mode).expect("valid digest");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let mut f = fs::File::create(&path).unwrap();
+        f.write_all(content).unwrap();
+        f.sync_all().ok();
+        path
+    }
+
+    fn sha512_hex(bytes: &[u8]) -> String {
+        format!("{:x}", Sha512::digest(bytes))
+    }
+
+    fn now_ms() -> u64 {
+        SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as u64
+    }
+
+    fn index_with(algo: &str, info: Vec<(&str, CafsFileInfo)>) -> PackageFilesIndex {
+        PackageFilesIndex {
+            manifest: None,
+            requires_build: None,
+            algo: algo.to_string(),
+            files: info.into_iter().map(|(k, v)| (k.to_string(), v)).collect(),
+            side_effects: None,
+        }
+    }
+
+    fn info(digest: &str, size: u64, mode: u32, checked_at: Option<u64>) -> CafsFileInfo {
+        CafsFileInfo { checked_at, digest: digest.to_string(), mode, size }
+    }
+
+    /// `build_file_maps_from_index` never stats the files. Nothing on
+    /// disk → still returns a populated `files_map` with `passed = true`.
+    #[test]
+    fn fast_path_skips_filesystem_checks() {
+        let tmp = tempdir().unwrap();
+        let store_dir = StoreDir::new(tmp.path());
+        let digest = sha512_hex(b"dummy");
+        let entry = index_with("sha512", vec![("index.js", info(&digest, 5, 0o644, None))]);
+        let result = build_file_maps_from_index(&store_dir, &entry);
+        assert!(result.passed, "fast path always passes");
+        let path = result.files_map.get("index.js").expect("path inserted");
+        assert!(!path.exists(), "no file was planted — fast path didn't care");
+    }
+
+    /// On-disk file is live, `checked_at` is far in the future so the
+    /// 100 ms slack keeps the mtime delta negative and we take the
+    /// "unmodified, trust the digest" branch — without any `fs::read`.
+    ///
+    /// We can't easily set `mtime` from the standard library, but
+    /// `checked_at` in the row is caller-controlled, so setting it
+    /// above the real `mtime` is enough to exercise the trust path.
+    #[test]
+    fn careful_path_trusts_file_when_mtime_is_within_slack() {
+        let tmp = tempdir().unwrap();
+        let store_dir = StoreDir::new(tmp.path());
+        let content = b"hello, cafs";
+        let digest = sha512_hex(content);
+        let _path = plant_cafs_file(&store_dir, &digest, 0o644, content);
+        let future = now_ms() + 3_600_000; // one hour from now
+        let entry = index_with(
+            "sha512",
+            vec![("index.js", info(&digest, content.len() as u64, 0o644, Some(future)))],
+        );
+        let result = check_pkg_files_integrity(&store_dir, &entry);
+        assert!(result.passed);
+        assert_eq!(result.files_map.len(), 1);
+    }
+
+    /// Missing on disk → whole entry fails so the caller re-fetches.
+    /// `files_map` is still populated for diagnostics.
+    #[test]
+    fn careful_path_fails_on_missing_cafs_file() {
+        let tmp = tempdir().unwrap();
+        let store_dir = StoreDir::new(tmp.path());
+        let digest = sha512_hex(b"nope");
+        let entry = index_with("sha512", vec![("README", info(&digest, 4, 0o644, None))]);
+        let result = check_pkg_files_integrity(&store_dir, &entry);
+        assert!(!result.passed, "missing file → fail");
+        assert_eq!(result.files_map.len(), 1);
+    }
+
+    /// File is on disk, the row claims the digest is for *different*
+    /// bytes, size matches. `checked_at = None` ≡ 0, so the mtime-slack
+    /// delta is "definitely > 100 ms", forcing re-hash → mismatch →
+    /// `remove_file` + fail. Ports pnpm's `verifyFile` wrong-digest
+    /// branch.
+    #[test]
+    fn careful_path_removes_file_whose_content_hash_mismatches() {
+        let tmp = tempdir().unwrap();
+        let store_dir = StoreDir::new(tmp.path());
+        let fake_digest = sha512_hex(b"claimed content");
+        let actual = b"actual bytes!!!";
+        let path = plant_cafs_file(&store_dir, &fake_digest, 0o644, actual);
+        let entry = index_with(
+            "sha512",
+            vec![("whatever", info(&fake_digest, actual.len() as u64, 0o644, Some(0)))],
+        );
+        let result = check_pkg_files_integrity(&store_dir, &entry);
+        assert!(!result.passed, "bad hash → fail");
+        assert!(!path.exists(), "mismatched file is removed so the next call re-fetches");
+    }
+
+    /// Row claims size 999 but the file has 14 bytes. `checked_at = 0`
+    /// puts us firmly in the "modified" branch (mtime now > 100 ms past
+    /// 0). Size mismatch short-circuits before any re-hash. Ports
+    /// pnpm's `currentFile.size !== fstat.size` branch.
+    #[test]
+    fn careful_path_removes_file_whose_size_mismatches_after_touch() {
+        let tmp = tempdir().unwrap();
+        let store_dir = StoreDir::new(tmp.path());
+        let content = b"actual content";
+        let digest = sha512_hex(content);
+        let path = plant_cafs_file(&store_dir, &digest, 0o644, content);
+        let entry = index_with("sha512", vec![("mismatch", info(&digest, 999, 0o644, Some(0)))]);
+        let result = check_pkg_files_integrity(&store_dir, &entry);
+        assert!(!result.passed);
+        assert!(!path.exists(), "size mismatch removes the file so a re-fetch starts clean");
+    }
+
+    /// Two filenames pointing at the same CAFS path verify once, not
+    /// twice. Ports the `verifiedFilesCache` behaviour.
+    #[test]
+    fn careful_path_dedups_by_digest_within_a_single_entry() {
+        let tmp = tempdir().unwrap();
+        let store_dir = StoreDir::new(tmp.path());
+        let content = b"shared blob";
+        let digest = sha512_hex(content);
+        let _path = plant_cafs_file(&store_dir, &digest, 0o644, content);
+        let future = now_ms() + 3_600_000;
+        let info_shared = info(&digest, content.len() as u64, 0o644, Some(future));
+        let entry = index_with(
+            "sha512",
+            vec![("a.txt", info_shared.clone_for_test()), ("b.txt", info_shared.clone_for_test())],
+        );
+        let result = check_pkg_files_integrity(&store_dir, &entry);
+        assert!(result.passed);
+        assert_eq!(result.files_map.len(), 2);
+    }
+
+    /// Unknown algorithm in the row → treat as verification failure,
+    /// matching pnpm's "catch any crypto error, return false". The row
+    /// is on disk, the mtime delta forces re-hash, and `verify_file_integrity`
+    /// returns `false` because the algo isn't sha512.
+    #[test]
+    fn careful_path_fails_unknown_algo_as_verification_failure() {
+        let tmp = tempdir().unwrap();
+        let store_dir = StoreDir::new(tmp.path());
+        let content = b"bytes";
+        let digest = sha512_hex(content);
+        let path = plant_cafs_file(&store_dir, &digest, 0o644, content);
+        let entry =
+            index_with("sha256", vec![("x", info(&digest, content.len() as u64, 0o644, Some(0)))]);
+        let result = check_pkg_files_integrity(&store_dir, &entry);
+        assert!(!result.passed);
+        assert!(!path.exists(), "unknown algo → treated as corrupt → removed");
+    }
+
+    // `CafsFileInfo` is `!Clone` in production (no need there). Give
+    // the tests an explicit helper so each assertion builds its own
+    // copy without implying a production `Clone` impl.
+    impl CafsFileInfo {
+        fn clone_for_test(&self) -> Self {
+            Self {
+                checked_at: self.checked_at,
+                digest: self.digest.clone(),
+                mode: self.mode,
+                size: self.size,
+            }
+        }
+    }
+}

--- a/crates/store-dir/src/lib.rs
+++ b/crates/store-dir/src/lib.rs
@@ -1,10 +1,12 @@
 mod cas_file;
+mod check_pkg_files_integrity;
 mod msgpackr_records;
 mod prune;
 mod store_dir;
 mod store_index;
 
 pub use cas_file::*;
+pub use check_pkg_files_integrity::*;
 pub use msgpackr_records::*;
 pub use prune::*;
 pub use store_dir::*;

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -174,6 +174,13 @@ async fn load_cached_cas_paths(
             pacquet_store_dir::build_file_maps_from_index(store_dir, entry)
         };
         if !verify_result.passed {
+            // Per-file reason (filename, CAS path, size mismatch, hash
+            // mismatch, …) is logged at `debug!` inside
+            // `check_pkg_files_integrity` / `build_file_maps_from_index`
+            // where the failure actually happens — this caller-side log
+            // just summarises "the row as a whole didn't verify" so log
+            // scrapers can correlate the per-file debug lines with the
+            // snapshot they belong to.
             tracing::debug!(
                 target: "pacquet::download",
                 ?cache_key,

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -169,9 +169,9 @@ async fn load_cached_cas_paths(
         }?;
 
         let verify_result = if verify_store_integrity {
-            pacquet_store_dir::check_pkg_files_integrity(store_dir, &entry)
+            pacquet_store_dir::check_pkg_files_integrity(store_dir, entry)
         } else {
-            pacquet_store_dir::build_file_maps_from_index(store_dir, &entry)
+            pacquet_store_dir::build_file_maps_from_index(store_dir, entry)
         };
         if !verify_result.passed {
             tracing::debug!(

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -116,14 +116,25 @@ fn decompress_gzip(gz_data: &[u8], unpacked_size: Option<usize>) -> Result<Vec<u
 /// Try to reconstruct the `{filename → CAFS path}` map for a package from
 /// the SQLite store index, without going to the network. Returns `None`
 /// if anything looks off — no index handed in, no row, unreadable row,
-/// malformed digest, or any referenced CAFS path that fails validation —
-/// so the caller falls through to a fresh download. Error paths are
-/// treated as cache misses because the index is a cache hint, not a
-/// source of truth. Any CAFS-path validation failure (missing blob,
-/// metadata error, directory, symlink, or other non-regular file) emits
-/// a `debug!` log to note the stale entry before re-fetching; earlier
-/// checks — row / decode / digest — are silent because they don't point
-/// at a specific on-disk artifact worth describing.
+/// failed integrity check — so the caller falls through to a fresh
+/// download.
+///
+/// The `verify_store_integrity` parameter matches pnpm's flag of the
+/// same name. When `true` (pnpm's default) each referenced CAFS file is
+/// stat'ed and compared against the stored `checkedAt`/size, with a
+/// re-hash only when the mtime has advanced. When `false` the lookup
+/// builds the filename→path map straight from the index row without any
+/// filesystem work — missing / corrupt CAFS blobs surface lazily when
+/// the caller tries to import them.
+///
+/// The previous pacquet implementation unconditionally ran a
+/// `symlink_metadata` per referenced file and rejected any non-regular
+/// dirent outright. That cost a stat syscall per file on every warm
+/// install (#260) and still diverged from pnpm: the upstream
+/// [`checkPkgFilesIntegrity`][1] catches corruption via the content hash
+/// and doesn't gate on dirent type.
+///
+/// [1]: https://github.com/pnpm/pnpm/blob/main/store/cafs/src/checkPkgFilesIntegrity.ts
 ///
 /// The `index` argument is a shared read-only handle that callers open
 /// once per install and pass in repeatedly, so we don't pay the
@@ -132,6 +143,7 @@ async fn load_cached_cas_paths(
     index: Option<SharedReadonlyStoreIndex>,
     store_dir: &'static StoreDir,
     cache_key: String,
+    verify_store_integrity: bool,
 ) -> Option<HashMap<String, PathBuf>> {
     let index = index?;
     // Hold on to a copy of the cache key for the outer `JoinError` log,
@@ -156,41 +168,20 @@ async fn load_cached_cas_paths(
             guard.get(&cache_key).ok()?
         }?;
 
-        let mut cas_paths = HashMap::with_capacity(entry.files.len());
-        // Consume `entry.files` so the owned `String` keys can move
-        // straight into `cas_paths` — cloning each filename is an extra
-        // alloc per file in the package, and on a real tarball that's
-        // hundreds of strings.
-        for (filename, info) in entry.files {
-            // `?` on `cas_file_path_by_mode` handles corrupt digests (empty,
-            // too short, or non-hex) as a cache miss. Without it the
-            // `hex[..2]` slice inside `file_path_by_hex_str` would panic.
-            let path = store_dir.cas_file_path_by_mode(&info.digest, info.mode)?;
-            // Use `symlink_metadata()` + reject symlinks so this check
-            // applies to the CAFS path itself without ever following a
-            // link. That rules out directory squatting, symlinked
-            // blobs (which could point *outside* the store — a store
-            // corruption / tampering vector), and other non-regular
-            // filesystem objects. Any metadata error also counts as a
-            // miss (blob pruned, permission issue, …).
-            if !path.symlink_metadata().is_ok_and(|m| {
-                let file_type = m.file_type();
-                !file_type.is_symlink() && file_type.is_file()
-            }) {
-                // Treat the whole entry as invalid and re-fetch — partial
-                // reuse would give the caller a broken layout.
-                tracing::debug!(
-                    target: "pacquet::download",
-                    ?cache_key,
-                    ?filename,
-                    ?path,
-                    "CAFS path missing or not a regular file; index entry is stale, re-fetching"
-                );
-                return None;
-            }
-            cas_paths.insert(filename, path);
+        let verify_result = if verify_store_integrity {
+            pacquet_store_dir::check_pkg_files_integrity(store_dir, &entry)
+        } else {
+            pacquet_store_dir::build_file_maps_from_index(store_dir, &entry)
+        };
+        if !verify_result.passed {
+            tracing::debug!(
+                target: "pacquet::download",
+                ?cache_key,
+                "store-index entry failed integrity check; re-fetching",
+            );
+            return None;
         }
-        Some(cas_paths)
+        Some(verify_result.files_map)
     })
     .await;
 
@@ -236,6 +227,14 @@ pub struct DownloadTarballToStore<'a> {
     /// side's stance: install still succeeds, the next install misses on
     /// this cache key and re-downloads.
     pub store_index_writer: Option<Arc<StoreIndexWriter>>,
+    /// Mirrors pnpm's `verify-store-integrity` / `verifyStoreIntegrity`
+    /// setting. When `true` (pnpm's default) each cached CAFS file is
+    /// stat'ed and optionally re-hashed before reuse. When `false` the
+    /// index is trusted and the import fails lazily if a blob is
+    /// missing — noticeably faster on the warm-cache-hit path but
+    /// means a mutated store can serve stale content until the next
+    /// integrity-full install.
+    pub verify_store_integrity: bool,
     pub package_integrity: &'a Integrity,
     pub package_unpacked_size: Option<usize>,
     pub package_url: &'a str,
@@ -297,6 +296,7 @@ impl<'a> DownloadTarballToStore<'a> {
             package_unpacked_size,
             package_url,
             package_id,
+            verify_store_integrity,
             ..
         } = self;
         let store_index = self.store_index.clone();
@@ -313,7 +313,9 @@ impl<'a> DownloadTarballToStore<'a> {
         // an undecodable entry, or any CAFS file that has gone missing
         // from disk all fall through to the download path below.
         let cache_key = store_index_key(&package_integrity.to_string(), package_id);
-        if let Some(cas_paths) = load_cached_cas_paths(store_index, store_dir, cache_key).await {
+        if let Some(cas_paths) =
+            load_cached_cas_paths(store_index, store_dir, cache_key, verify_store_integrity).await
+        {
             tracing::info!(target: "pacquet::download", ?package_url, ?package_id, "Reusing cached CAFS entry — skipping download");
             return Ok(cas_paths);
         }
@@ -576,6 +578,7 @@ mod tests {
             store_dir: store_path,
             store_index: None,
             store_index_writer: None,
+            verify_store_integrity: true,
             package_integrity: &integrity("sha512-dj7vjIn1Ar8sVXj2yAXiMNCJDmS9MQ9XMlIecX2dIzzhjSHCyKo4DdXjXMs7wKW2kj6yvVRSpuQjOZ3YLrh56w=="),
             package_unpacked_size: Some(16697),
             package_url: "https://registry.npmjs.org/@fastify/error/-/error-3.3.0.tgz",
@@ -618,6 +621,7 @@ mod tests {
             store_dir: store_path,
             store_index: None,
             store_index_writer: None,
+            verify_store_integrity: true,
             package_integrity: &integrity("sha512-aaaan1Ar8sVXj2yAXiMNCJDmS9MQ9XMlIecX2dIzzhjSHCyKo4DdXjXMs7wKW2kj6yvVRSpuQjOZ3YLrh56w=="),
             package_unpacked_size: Some(16697),
             package_url: "https://registry.npmjs.org/@fastify/error/-/error-3.3.0.tgz",
@@ -687,6 +691,7 @@ mod tests {
             store_dir: store_path,
             store_index: StoreIndex::shared_readonly_in(store_path),
             store_index_writer: None,
+            verify_store_integrity: true,
             package_integrity: &pkg_integrity,
             package_unpacked_size: None,
             // Any request that reaches the network here would fail the
@@ -747,6 +752,7 @@ mod tests {
             store_dir: store_path,
             store_index: StoreIndex::shared_readonly_in(store_path),
             store_index_writer: None,
+            verify_store_integrity: true,
             package_integrity: &pkg_integrity,
             package_unpacked_size: None,
             package_url: "http://127.0.0.1:1/unreachable.tgz",
@@ -799,6 +805,7 @@ mod tests {
             store_dir: store_path,
             store_index: StoreIndex::shared_readonly_in(store_path),
             store_index_writer: None,
+            verify_store_integrity: true,
             package_integrity: &pkg_integrity,
             package_unpacked_size: None,
             package_url: "http://127.0.0.1:1/unreachable.tgz",
@@ -854,6 +861,7 @@ mod tests {
             store_dir: store_path,
             store_index: StoreIndex::shared_readonly_in(store_path),
             store_index_writer: None,
+            verify_store_integrity: true,
             package_integrity: &pkg_integrity,
             package_unpacked_size: None,
             package_url: "http://127.0.0.1:1/unreachable.tgz",
@@ -919,6 +927,7 @@ mod tests {
             store_dir: store_path,
             store_index: StoreIndex::shared_readonly_in(store_path),
             store_index_writer: None,
+            verify_store_integrity: true,
             package_integrity: &pkg_integrity,
             package_unpacked_size: None,
             package_url: "http://127.0.0.1:1/unreachable.tgz",

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -231,9 +231,12 @@ pub struct DownloadTarballToStore<'a> {
     /// setting. When `true` (pnpm's default) each cached CAFS file is
     /// stat'ed and optionally re-hashed before reuse. When `false` the
     /// index is trusted and the import fails lazily if a blob is
-    /// missing — noticeably faster on the warm-cache-hit path but
-    /// means a mutated store can serve stale content until the next
-    /// integrity-full install.
+    /// missing — trades the per-file stat / optional rehash for the
+    /// risk that a mutated or corrupt store serves stale content until
+    /// the next integrity-full install. Whether that translates into a
+    /// wall-time win depends on the workload; the per-snapshot stat
+    /// isn't the bottleneck on the benchmarks this repo tracks (see
+    /// #273), but cutting the syscall count is still correct.
     pub verify_store_integrity: bool,
     pub package_integrity: &'a Integrity,
     pub package_unpacked_size: Option<usize>,

--- a/tasks/micro-benchmark/src/main.rs
+++ b/tasks/micro-benchmark/src/main.rs
@@ -41,6 +41,7 @@ fn bench_tarball(c: &mut Criterion, server: &mut ServerGuard, fixtures_folder: &
                 store_dir,
                 store_index: None,
                 store_index_writer: None,
+                verify_store_integrity: true,
                 package_integrity: &package_integrity,
                 package_unpacked_size: Some(16697),
                 package_url: url,


### PR DESCRIPTION
Port pnpm v11's [`store/cafs/src/checkPkgFilesIntegrity.ts`](https://github.com/pnpm/pnpm/blob/57b785c5a3c1e2e4c2af9b0a15e014f2fbd64bd8/store/cafs/src/checkPkgFilesIntegrity.ts) into a new `pacquet_store_dir::check_pkg_files_integrity` module and swap the old per-file `symlink_metadata` + "regular-file?" probe in `load_cached_cas_paths` for the upstream two-branch model. Addresses the `verify-store-integrity` half of #260.

## What the upstream model looks like

pnpm's warm-cache lookup has two codepaths, picked by config:

1. **`buildFileMapsFromIndex`** (`verify-store-integrity: false`) — builds the filename → CAFS-path map with no filesystem calls. A missing or corrupt CAFS blob surfaces lazily at import time.
2. **`checkPkgFilesIntegrity`** (default, `verify-store-integrity: true`) — for each referenced file: `fs.statSync`, compare `mtimeMs` with the stored `checkedAt` (100 ms slack). If unmodified, trust the digest and skip the hash. If modified: size-check first, re-hash only on match, delete on mismatch. A `verifiedFilesCache` dedups by digest within a single row so repeat entries stat once.

Default is `true` in upstream (`installing/deps-installer/src/install/extendInstallOptions.ts:268`).

## What pacquet had before

One `symlink_metadata` per referenced file plus "reject unless regular file". Unconditional. No content hash, no `checked_at` comparison, no knob to turn it off. Catches dirent-type corruption that upstream catches via content-hash instead.

## What this PR changes

* Adds `crates/store-dir/src/check_pkg_files_integrity.rs` with the two functions above, same control flow / naming / comment structure as the upstream file.
* Adds `verify_store_integrity: bool` to `Npmrc` (default `true`) and the camelCase key to `pnpm-workspace.yaml` (`verifyStoreIntegrity`). Mirrors pnpm.
* Threads the flag into `DownloadTarballToStore` so `load_cached_cas_paths` picks the branch.
* Swaps the old `symlink_metadata` loop in `load_cached_cas_paths` for the new module.
* Drops the "must be regular file" preemptive check — the content-hash in `checkPkgFilesIntegrity` catches real corruption, and pnpm doesn't guard against symlinks or dirs here either.

## Ported tests

Added in `check_pkg_files_integrity.rs`, translated from the upstream `store/cafs/test/index.ts` cases:

- `fast_path_skips_filesystem_checks` — `build_file_maps_from_index` never stats.
- `careful_path_trusts_file_when_mtime_is_within_slack` — the "unmodified, don't re-hash" branch.
- `careful_path_fails_on_missing_cafs_file` — ENOENT → `passed=false`.
- `careful_path_removes_file_whose_content_hash_mismatches` — the `rimrafSync` + `return false` branch.
- `careful_path_removes_file_whose_size_mismatches_after_touch` — the `currentFile.size !== fstat.size` branch.
- `careful_path_dedups_by_digest_within_a_single_entry` — `verifiedFilesCache` behaviour.
- `careful_path_fails_unknown_algo_as_verification_failure` — pnpm's `catch`-all on crypto errors.

Existing tarball tests (`falls_through_when_cafs_path_is_a_directory`, `falls_through_when_cafs_path_is_a_symlink`, `falls_through_when_cafs_file_missing`) still pass — the dir/symlink cases now fail via size / hash mismatch instead of dirent-type rejection, which is the same observable outcome (cache miss → re-fetch).

## Perf

Warm-cache install, 1352-snapshot fixture, M1 Pro / APFS, 5 runs each, median wall:

| config | wall | user | sys |
|---|---:|---:|---:|
| pacquet main | 12.72 s | 0.6 | 24.0 |
| pacquet this PR, `verify=true` | 12.85 s | 0.6 | 24.1 |
| pacquet this PR, `verify=false` | 14.23 s | 0.6 | 25.2 |
| pnpm (`enableGlobalVirtualStore: false`) | 7.44 s | 2.7 | 10.2 |

**The stat savings land inside run-to-run noise.** Removing the per-file `symlink_metadata` doesn't materially move warm-cache wall time — the per-snapshot stat wasn't the bottleneck after all. pacquet's remaining gap vs pnpm (~1.7×) lives in the CAS → `node_modules` link phase (`link_file`'s reflink + `create_dir_all` + per-file metadata work), not here. Follow-up.

Keeping this PR because it's the correct upstream model, it adds the user-facing `verify-store-integrity` knob, and it's foundation for whatever we do next in the link phase.

## Drive-by fix

`custom_deserializer::tests::test_default_store_dir_with_xdg_env` and `tests::should_use_xdg_data_home_env_var` failed locally for any developer with `PNPM_HOME` set in their shell — `default_store_dir` checks `PNPM_HOME` before `XDG_DATA_HOME`, so the intended XDG branch was never exercised. Explicit `env::remove_var("PNPM_HOME")` at test start. Per AGENTS.md "never ignore a pre-existing failure".

## Test plan

- [x] `just ready` — typos, fmt, check, nextest (182/182 pass), clippy-as-errors.
- [x] Warm-cache benchmark before/after on macOS (table above).
- [ ] CI Integrated-Benchmark — should be a wash on Linux (stat cost is cheaper there) with the same `passed`/`files_map` semantics.

## Upstream refs

* pnpm `main` @ 57b785c5a3 — `store/cafs/src/checkPkgFilesIntegrity.ts`, `installing/deps-installer/src/install/extendInstallOptions.ts`.

Refs #260.
