### PR TITLE
perf(package-manager): parallelise symlink layout with tarball fetch

### DIFF
--- a/crates/package-manager/src/create_symlink_layout.rs
+++ b/crates/package-manager/src/create_symlink_layout.rs
@@ -8,15 +8,22 @@ use std::{collections::HashMap, path::Path};
 /// the symlink filename under `node_modules/` uses the entry key (the alias),
 /// while the virtual-store lookup uses the aliased target.
 ///
-/// **NOTE:** `virtual_node_modules_dir` is assumed to already exist.
+/// `virtual_node_modules_dir` does not have to exist — `symlink_package` calls
+/// `fs::create_dir_all` on the symlink path's parent before each link. Callers
+/// that already know the directory exists (e.g. `CreateVirtualStore::run`,
+/// which `mkdir`s it just before calling this function) just pay redundant
+/// stat syscalls, which is cheap and matches pnpm's own redundant-mkdir shape.
 pub fn create_symlink_layout(
     dependencies: &HashMap<PkgName, SnapshotDepRef>,
     virtual_root: &Path,
     virtual_node_modules_dir: &Path,
 ) -> Result<(), SymlinkPackageError> {
-    // Serial iteration here: the caller is expected to parallelise across
-    // snapshots, so nesting a rayon `par_iter` inside would only add task-
-    // scheduling overhead without giving rayon a wider work queue.
+    // Serial iteration: the symlink work per snapshot is small (a handful of
+    // entries), so fanning out to rayon here would just add task-scheduling
+    // overhead without a wider work queue to amortise it against. The
+    // single-caller policy upstream is to run this stage single-threaded on a
+    // `spawn_blocking` worker (see `CreateVirtualStore::run`), mirroring
+    // pnpm's `symlinkAllModules` in `worker/src/start.ts`.
     dependencies.iter().try_for_each(|(alias_name, dep_ref)| {
         let target = dep_ref.resolve(alias_name);
         let virtual_store_name = target.to_virtual_store_name();

--- a/crates/package-manager/src/create_symlink_layout.rs
+++ b/crates/package-manager/src/create_symlink_layout.rs
@@ -1,6 +1,5 @@
-use crate::symlink_package;
+use crate::{symlink_package, SymlinkPackageError};
 use pacquet_lockfile::{PkgName, SnapshotDepRef};
-use rayon::prelude::*;
 use std::{collections::HashMap, path::Path};
 
 /// Create symlink layout of dependencies for a package in a virtual dir.
@@ -14,8 +13,11 @@ pub fn create_symlink_layout(
     dependencies: &HashMap<PkgName, SnapshotDepRef>,
     virtual_root: &Path,
     virtual_node_modules_dir: &Path,
-) {
-    dependencies.par_iter().for_each(|(alias_name, dep_ref)| {
+) -> Result<(), SymlinkPackageError> {
+    // Serial iteration here: the caller is expected to parallelise across
+    // snapshots, so nesting a rayon `par_iter` inside would only add task-
+    // scheduling overhead without giving rayon a wider work queue.
+    dependencies.iter().try_for_each(|(alias_name, dep_ref)| {
         let target = dep_ref.resolve(alias_name);
         let virtual_store_name = target.to_virtual_store_name();
         let target_name_str = target.name.to_string();
@@ -24,6 +26,5 @@ pub fn create_symlink_layout(
             &virtual_root.join(virtual_store_name).join("node_modules").join(&target_name_str),
             &virtual_node_modules_dir.join(&alias_name_str),
         )
-        .expect("symlink pkg successful"); // TODO: properly propagate this error
-    });
+    })
 }

--- a/crates/package-manager/src/create_virtual_dir_by_snapshot.rs
+++ b/crates/package-manager/src/create_virtual_dir_by_snapshot.rs
@@ -10,12 +10,14 @@ use std::{
 
 /// Install extracted CAS files into the package's slot in the virtual store.
 ///
-/// The virtual-store package directory
-/// (`node_modules/.pacquet/{name}@{version}/node_modules/`) is expected to
-/// already exist — it's created up-front in
-/// [`CreateVirtualStore::run`](crate::CreateVirtualStore::run) so intra-package
-/// symlinking can run concurrently with tarball fetching. This subroutine only
-/// populates the package's own files.
+/// Runs concurrently with the symlink branch in
+/// [`CreateVirtualStore::run`](crate::CreateVirtualStore::run), so the virtual-
+/// store package directory (`node_modules/.pacquet/{name}@{version}/node_modules/`)
+/// may or may not exist when this subroutine is called — either the symlink
+/// branch has already `create_dir_all`'d it, or it doesn't yet. Populating the
+/// package's own files is safe in both cases: `link_file` calls
+/// `fs::create_dir_all` on every target's parent before importing, so any
+/// missing ancestor is materialised on demand.
 #[must_use]
 pub struct CreateVirtualDirBySnapshot<'a> {
     pub virtual_store_dir: &'a Path,

--- a/crates/package-manager/src/create_virtual_dir_by_snapshot.rs
+++ b/crates/package-manager/src/create_virtual_dir_by_snapshot.rs
@@ -1,35 +1,32 @@
-use crate::{create_cas_files, create_symlink_layout, CreateCasFilesError};
+use crate::{create_cas_files, CreateCasFilesError};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
-use pacquet_lockfile::{PackageKey, SnapshotEntry};
+use pacquet_lockfile::PackageKey;
 use pacquet_npmrc::PackageImportMethod;
 use std::{
     collections::HashMap,
-    fs, io,
     path::{Path, PathBuf},
 };
 
-/// This subroutine installs the files from [`cas_paths`](Self::cas_paths) then creates the symlink layout.
+/// Install extracted CAS files into the package's slot in the virtual store.
+///
+/// The virtual-store package directory
+/// (`node_modules/.pacquet/{name}@{version}/node_modules/`) is expected to
+/// already exist — it's created up-front in
+/// [`CreateVirtualStore::run`](crate::CreateVirtualStore::run) so intra-package
+/// symlinking can run concurrently with tarball fetching. This subroutine only
+/// populates the package's own files.
 #[must_use]
 pub struct CreateVirtualDirBySnapshot<'a> {
     pub virtual_store_dir: &'a Path,
     pub cas_paths: &'a HashMap<String, PathBuf>,
     pub import_method: PackageImportMethod,
     pub package_key: &'a PackageKey,
-    pub snapshot: &'a SnapshotEntry,
 }
 
 /// Error type of [`CreateVirtualDirBySnapshot`].
 #[derive(Debug, Display, Error, Diagnostic)]
 pub enum CreateVirtualDirError {
-    #[display("Failed to recursively create node_modules directory at {dir:?}: {error}")]
-    #[diagnostic(code(pacquet_package_manager::create_node_modules_dir))]
-    CreateNodeModulesDir {
-        dir: PathBuf,
-        #[error(source)]
-        error: io::Error,
-    },
-
     #[diagnostic(transparent)]
     CreateCasFiles(#[error(source)] CreateCasFilesError),
 }
@@ -37,34 +34,14 @@ pub enum CreateVirtualDirError {
 impl<'a> CreateVirtualDirBySnapshot<'a> {
     /// Execute the subroutine.
     pub fn run(self) -> Result<(), CreateVirtualDirError> {
-        let CreateVirtualDirBySnapshot {
-            virtual_store_dir,
-            cas_paths,
-            import_method,
-            package_key,
-            snapshot,
-        } = self;
+        let CreateVirtualDirBySnapshot { virtual_store_dir, cas_paths, import_method, package_key } =
+            self;
 
-        // node_modules/.pacquet/pkg-name@x.y.z/node_modules
-        let virtual_node_modules_dir =
-            virtual_store_dir.join(package_key.to_virtual_store_name()).join("node_modules");
-        fs::create_dir_all(&virtual_node_modules_dir).map_err(|error| {
-            CreateVirtualDirError::CreateNodeModulesDir {
-                dir: virtual_node_modules_dir.to_path_buf(),
-                error,
-            }
-        })?;
-
-        // 1. Install the files from `cas_paths`
-        let save_path = virtual_node_modules_dir.join(package_key.name.to_string());
+        let save_path = virtual_store_dir
+            .join(package_key.to_virtual_store_name())
+            .join("node_modules")
+            .join(package_key.name.to_string());
         create_cas_files(import_method, &save_path, cas_paths)
-            .map_err(CreateVirtualDirError::CreateCasFiles)?;
-
-        // 2. Create the symlink layout
-        if let Some(dependencies) = &snapshot.dependencies {
-            create_symlink_layout(dependencies, virtual_store_dir, &virtual_node_modules_dir)
-        }
-
-        Ok(())
+            .map_err(CreateVirtualDirError::CreateCasFiles)
     }
 }

--- a/crates/package-manager/src/create_virtual_dir_by_snapshot.rs
+++ b/crates/package-manager/src/create_virtual_dir_by_snapshot.rs
@@ -1,49 +1,95 @@
-use crate::{create_cas_files, CreateCasFilesError};
+use crate::{create_cas_files, create_symlink_layout, CreateCasFilesError, SymlinkPackageError};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
-use pacquet_lockfile::PackageKey;
+use pacquet_lockfile::{PackageKey, SnapshotEntry};
 use pacquet_npmrc::PackageImportMethod;
 use std::{
     collections::HashMap,
+    fs, io,
     path::{Path, PathBuf},
 };
 
-/// Install extracted CAS files into the package's slot in the virtual store.
+/// This subroutine creates the virtual-store slot for one package and then
+/// runs the two post-extraction tasks — CAS file import and intra-package
+/// symlink creation — in parallel via `rayon::join`.
 ///
-/// Runs concurrently with the symlink branch in
-/// [`CreateVirtualStore::run`](crate::CreateVirtualStore::run), so the virtual-
-/// store package directory (`node_modules/.pacquet/{name}@{version}/node_modules/`)
-/// may or may not exist when this subroutine is called — either the symlink
-/// branch has already `create_dir_all`'d it, or it doesn't yet. Populating the
-/// package's own files is safe in both cases: `link_file` calls
-/// `fs::create_dir_all` on every target's parent before importing, so any
-/// missing ancestor is materialised on demand.
+/// Symlinks don't depend on CAS file contents, only on the resolved dep graph,
+/// so overlapping them with the import saves the serial symlink time per
+/// snapshot (~1-3 ms). Across a big lockfile those savings stack up on the
+/// install's critical-path tail.
 #[must_use]
 pub struct CreateVirtualDirBySnapshot<'a> {
     pub virtual_store_dir: &'a Path,
     pub cas_paths: &'a HashMap<String, PathBuf>,
     pub import_method: PackageImportMethod,
     pub package_key: &'a PackageKey,
+    pub snapshot: &'a SnapshotEntry,
 }
 
 /// Error type of [`CreateVirtualDirBySnapshot`].
 #[derive(Debug, Display, Error, Diagnostic)]
 pub enum CreateVirtualDirError {
+    #[display("Failed to recursively create node_modules directory at {dir:?}: {error}")]
+    #[diagnostic(code(pacquet_package_manager::create_node_modules_dir))]
+    CreateNodeModulesDir {
+        dir: PathBuf,
+        #[error(source)]
+        error: io::Error,
+    },
+
     #[diagnostic(transparent)]
     CreateCasFiles(#[error(source)] CreateCasFilesError),
+
+    #[diagnostic(transparent)]
+    SymlinkPackage(#[error(source)] SymlinkPackageError),
 }
 
 impl<'a> CreateVirtualDirBySnapshot<'a> {
     /// Execute the subroutine.
     pub fn run(self) -> Result<(), CreateVirtualDirError> {
-        let CreateVirtualDirBySnapshot { virtual_store_dir, cas_paths, import_method, package_key } =
-            self;
+        let CreateVirtualDirBySnapshot {
+            virtual_store_dir,
+            cas_paths,
+            import_method,
+            package_key,
+            snapshot,
+        } = self;
 
-        let save_path = virtual_store_dir
-            .join(package_key.to_virtual_store_name())
-            .join("node_modules")
-            .join(package_key.name.to_string());
-        create_cas_files(import_method, &save_path, cas_paths)
-            .map_err(CreateVirtualDirError::CreateCasFiles)
+        let virtual_node_modules_dir =
+            virtual_store_dir.join(package_key.to_virtual_store_name()).join("node_modules");
+        fs::create_dir_all(&virtual_node_modules_dir).map_err(|error| {
+            CreateVirtualDirError::CreateNodeModulesDir {
+                dir: virtual_node_modules_dir.clone(),
+                error,
+            }
+        })?;
+
+        let save_path = virtual_node_modules_dir.join(package_key.name.to_string());
+
+        // `rayon::join` runs both closures in parallel on rayon's pool,
+        // returning only once both finish. `create_cas_files` is itself a
+        // rayon par_iter over CAS entries; `create_symlink_layout` is a
+        // small serial loop over dep refs. Overlapping them saves the
+        // symlink time from the per-snapshot critical path without any
+        // cross-thread data marshaling — both closures borrow from the
+        // current stack frame.
+        let (cas_result, symlink_result) = rayon::join(
+            || {
+                create_cas_files(import_method, &save_path, cas_paths)
+                    .map_err(CreateVirtualDirError::CreateCasFiles)
+            },
+            || match snapshot.dependencies.as_ref() {
+                Some(dependencies) => create_symlink_layout(
+                    dependencies,
+                    virtual_store_dir,
+                    &virtual_node_modules_dir,
+                )
+                .map_err(CreateVirtualDirError::SymlinkPackage),
+                None => Ok(()),
+            },
+        );
+        cas_result?;
+        symlink_result?;
+        Ok(())
     }
 }

--- a/crates/package-manager/src/create_virtual_store.rs
+++ b/crates/package-manager/src/create_virtual_store.rs
@@ -9,7 +9,6 @@ use pacquet_lockfile::{PackageKey, PackageMetadata, PkgName, SnapshotDepRef, Sna
 use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
 use pacquet_store_dir::{StoreIndex, StoreIndexWriter};
-use rayon::prelude::*;
 use std::{
     collections::HashMap,
     io,
@@ -172,14 +171,20 @@ impl<'a> CreateVirtualStore<'a> {
         //   await Promise.all([linkAllModules(...), linkAllPkgs(...)])
         //
         // See `pnpm/pkg-manager/headless/src/index.ts` and
-        // `pnpm/pkg-manager/core/src/install/link.ts`. We dispatch the whole
-        // symlink branch through a single `spawn_blocking` so a rayon
-        // `par_iter` over all snapshots does the real work on rayon's pool;
-        // the tokio task just awaits the join handle, which cannot starve
-        // `fetch_fut` and is safe on any runtime flavor.
+        // `pnpm/pkg-manager/core/src/install/link.ts`. We run the whole
+        // symlink pass on a single `spawn_blocking` thread using plain
+        // serial iteration — no rayon inside. That mirrors pnpm's
+        // `symlinkAllModules` (`worker/src/start.ts:493-501`), which
+        // executes a synchronous nested `for` loop inside one worker
+        // thread. Going wider with rayon would steal workers from the
+        // fetch branch's concurrent `create_cas_files` par_iter calls
+        // during the hot part of the install; pnpm already learned that
+        // lesson by shipping the symlink stage as a single-threaded
+        // coroutine. Serial on one CPU for ~6-7k symlink syscalls is
+        // still well under the cold-cache fetch budget.
         let symlink_handle =
             tokio::task::spawn_blocking(move || -> Result<(), CreateVirtualStoreError> {
-                snapshot_symlink_tasks.par_iter().try_for_each(|task| {
+                for task in &snapshot_symlink_tasks {
                     std::fs::create_dir_all(&task.virtual_node_modules_dir).map_err(|error| {
                         CreateVirtualStoreError::CreateNodeModulesDir {
                             dir: task.virtual_node_modules_dir.clone(),
@@ -194,8 +199,8 @@ impl<'a> CreateVirtualStore<'a> {
                         )
                         .map_err(CreateVirtualStoreError::SymlinkPackage)?;
                     }
-                    Ok(())
-                })
+                }
+                Ok(())
             });
 
         let fetch_result: Result<(), CreateVirtualStoreError> =

--- a/crates/package-manager/src/create_virtual_store.rs
+++ b/crates/package-manager/src/create_virtual_store.rs
@@ -1,14 +1,15 @@
 use crate::{
     create_symlink_layout, store_init::init_store_dir_best_effort, InstallPackageBySnapshot,
-    InstallPackageBySnapshotError,
+    InstallPackageBySnapshotError, SymlinkPackageError,
 };
 use derive_more::{Display, Error};
 use futures_util::future;
 use miette::Diagnostic;
-use pacquet_lockfile::{PackageKey, PackageMetadata, SnapshotEntry};
+use pacquet_lockfile::{PackageKey, PackageMetadata, PkgName, SnapshotDepRef, SnapshotEntry};
 use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
 use pacquet_store_dir::{StoreIndex, StoreIndexWriter};
+use rayon::prelude::*;
 use std::{
     collections::HashMap,
     io,
@@ -36,6 +37,16 @@ pub enum CreateVirtualStoreError {
         dir: PathBuf,
         #[error(source)]
         error: io::Error,
+    },
+
+    #[diagnostic(transparent)]
+    SymlinkPackage(#[error(source)] SymlinkPackageError),
+
+    #[display("Symlink task panicked or was cancelled: {error}")]
+    #[diagnostic(code(pacquet_package_manager::symlink_task_join))]
+    SymlinkTaskJoin {
+        #[error(source)]
+        error: tokio::task::JoinError,
     },
 
     #[display("Lockfile has a snapshot entry `{snapshot_key}` with no matching metadata entry (`{metadata_key}`) in `packages:`.")]
@@ -127,12 +138,32 @@ impl<'a> CreateVirtualStore<'a> {
         let (store_index_writer, writer_task) = StoreIndexWriter::spawn(store_dir);
         let store_index_writer_ref = Some(&store_index_writer);
 
-        let virtual_store_dir: &Path = &config.virtual_store_dir;
+        // `config: &'static Npmrc`, so `virtual_store_dir` is borrowable for
+        // the full process lifetime — we lean on that to move the whole
+        // symlink pass into a `spawn_blocking` task below without having to
+        // clone the root path per snapshot.
+        let virtual_store_dir: &'static Path = &config.virtual_store_dir;
+
+        // Collect owned per-snapshot data for the symlink branch. Only the
+        // dep map (`Option<HashMap<PkgName, SnapshotDepRef>>`) is cloned;
+        // the rest is small owned values. For the 1352-package fixture
+        // this adds up to a few tens of ms of one-off clone work and moves
+        // the whole symlink pass onto the blocking pool with no 'static /
+        // runtime-flavor fragility. `SnapshotDepRef::resolve` and path
+        // composition stay inside `create_symlink_layout` so the per-dep
+        // logic is trivial to cross-reference against pnpm.
+        let snapshot_symlink_tasks: Vec<SnapshotSymlinkTask> = snapshots
+            .iter()
+            .map(|(key, snapshot)| SnapshotSymlinkTask {
+                virtual_node_modules_dir: virtual_node_modules_dir_for(virtual_store_dir, key),
+                dependencies: snapshot.dependencies.clone(),
+            })
+            .collect();
 
         // Run intra-package symlink creation concurrently with tarball fetch
-        // + CAS import. Symlinks only depend on the resolved dep graph
-        // (already in `snapshots`), not on any tarball contents, so there's
-        // no reason to serialise them behind downloads.
+        // + CAS import. Symlinks only depend on the resolved dep graph, not
+        // on any tarball contents, so there's no reason to serialise them
+        // behind downloads.
         //
         // Matches pnpm's `headless` installer, which forks the same two
         // branches off the resolved graph:
@@ -140,43 +171,36 @@ impl<'a> CreateVirtualStore<'a> {
         //   await Promise.all([linkAllModules(...), linkAllPkgs(...)])
         //
         // See `pnpm/pkg-manager/headless/src/index.ts` and
-        // `pnpm/pkg-manager/core/src/install/link.ts`.
-        let symlink_fut = async {
-            future::try_join_all(snapshots.iter().map(|(snapshot_key, snapshot)| {
-                let virtual_node_modules_dir =
-                    virtual_node_modules_dir_for(virtual_store_dir, snapshot_key);
-                async move {
-                    // The per-snapshot body is entirely synchronous — mkdir
-                    // plus a rayon-parallel symlink sweep — with no `.await`
-                    // points. `try_join_all` polls its children on the same
-                    // task, so without a blocking hint every symlink future
-                    // would run to completion on the worker thread before
-                    // the runtime got a chance to poll `fetch_fut`. That
-                    // couples download progress to symlink wall-time on a
-                    // multi-threaded runtime and defeats the whole point of
-                    // forking the two branches. `block_in_place` signals
-                    // the executor to hand `fetch_fut` (and any other tasks)
-                    // off to sibling workers while this thread blocks.
-                    tokio::task::block_in_place(|| {
-                        std::fs::create_dir_all(&virtual_node_modules_dir).map_err(|error| {
-                            CreateVirtualStoreError::CreateNodeModulesDir {
-                                dir: virtual_node_modules_dir.clone(),
-                                error,
-                            }
-                        })?;
-                        if let Some(dependencies) = &snapshot.dependencies {
-                            create_symlink_layout(
-                                dependencies,
-                                virtual_store_dir,
-                                &virtual_node_modules_dir,
-                            );
+        // `pnpm/pkg-manager/core/src/install/link.ts`. We dispatch the whole
+        // symlink branch through a single `spawn_blocking` so a rayon
+        // `par_iter` over all snapshots does the real work on rayon's pool;
+        // the tokio task just awaits the join handle, which cannot starve
+        // `fetch_fut` and is safe on any runtime flavor.
+        let symlink_handle =
+            tokio::task::spawn_blocking(move || -> Result<(), CreateVirtualStoreError> {
+                snapshot_symlink_tasks.par_iter().try_for_each(|task| {
+                    std::fs::create_dir_all(&task.virtual_node_modules_dir).map_err(|error| {
+                        CreateVirtualStoreError::CreateNodeModulesDir {
+                            dir: task.virtual_node_modules_dir.clone(),
+                            error,
                         }
-                        Ok::<_, CreateVirtualStoreError>(())
-                    })
-                }
-            }))
-            .await
-            .map(drop)
+                    })?;
+                    if let Some(dependencies) = &task.dependencies {
+                        create_symlink_layout(
+                            dependencies,
+                            virtual_store_dir,
+                            &task.virtual_node_modules_dir,
+                        )
+                        .map_err(CreateVirtualStoreError::SymlinkPackage)?;
+                    }
+                    Ok(())
+                })
+            });
+        let symlink_fut = async {
+            match symlink_handle.await {
+                Ok(result) => result,
+                Err(error) => Err(CreateVirtualStoreError::SymlinkTaskJoin { error }),
+            }
         };
 
         let fetch_fut = async {
@@ -227,6 +251,17 @@ impl<'a> CreateVirtualStore<'a> {
 
         Ok(())
     }
+}
+
+/// Owned snapshot data handed off to the symlink `spawn_blocking` task.
+///
+/// Kept deliberately small: just the virtual-store package dir path and a
+/// cloned copy of the snapshot's `dependencies` map. The rest of the data
+/// `create_symlink_layout` needs (virtual store root, `PkgName`/`SnapshotDepRef`
+/// resolution) is either `'static`-borrowable or lives inside this clone.
+struct SnapshotSymlinkTask {
+    virtual_node_modules_dir: PathBuf,
+    dependencies: Option<HashMap<PkgName, SnapshotDepRef>>,
 }
 
 fn virtual_node_modules_dir_for(virtual_store_dir: &Path, package_key: &PackageKey) -> PathBuf {

--- a/crates/package-manager/src/create_virtual_store.rs
+++ b/crates/package-manager/src/create_virtual_store.rs
@@ -1,19 +1,15 @@
 use crate::{
-    create_symlink_layout, store_init::init_store_dir_best_effort, InstallPackageBySnapshot,
-    InstallPackageBySnapshotError, SymlinkPackageError,
+    store_init::init_store_dir_best_effort, InstallPackageBySnapshot, InstallPackageBySnapshotError,
 };
 use derive_more::{Display, Error};
 use futures_util::future;
 use miette::Diagnostic;
-use pacquet_lockfile::{PackageKey, PackageMetadata, PkgName, SnapshotDepRef, SnapshotEntry};
+use pacquet_lockfile::{PackageKey, PackageMetadata, SnapshotEntry};
 use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
 use pacquet_store_dir::{StoreIndex, StoreIndexWriter};
-use std::{
-    collections::HashMap,
-    io,
-    path::{Path, PathBuf},
-};
+use pipe_trait::Pipe;
+use std::collections::HashMap;
 
 /// This subroutine generates filesystem layout for the virtual store at `node_modules/.pacquet`.
 #[must_use]
@@ -29,24 +25,6 @@ pub struct CreateVirtualStore<'a> {
 pub enum CreateVirtualStoreError {
     #[diagnostic(transparent)]
     InstallPackageBySnapshot(#[error(source)] InstallPackageBySnapshotError),
-
-    #[display("Failed to recursively create node_modules directory at {dir:?}: {error}")]
-    #[diagnostic(code(pacquet_package_manager::create_node_modules_dir))]
-    CreateNodeModulesDir {
-        dir: PathBuf,
-        #[error(source)]
-        error: io::Error,
-    },
-
-    #[diagnostic(transparent)]
-    SymlinkPackage(#[error(source)] SymlinkPackageError),
-
-    #[display("Symlink task panicked or was cancelled: {error}")]
-    #[diagnostic(code(pacquet_package_manager::symlink_task_join))]
-    SymlinkTaskJoin {
-        #[error(source)]
-        error: tokio::task::JoinError,
-    },
 
     #[display("Lockfile has a snapshot entry `{snapshot_key}` with no matching metadata entry (`{metadata_key}`) in `packages:`.")]
     #[diagnostic(code(pacquet_package_manager::missing_package_metadata))]
@@ -128,83 +106,26 @@ impl<'a> CreateVirtualStore<'a> {
         // blocking pool grew to 500+ threads to service them.
         //
         // We drop our own copy of the `Arc<StoreIndexWriter>` after the
-        // fetch `try_join_all` and the symlink `spawn_blocking` have both
-        // been awaited, so the channel can close once every tarball task
-        // has dropped its clone; then `.await` on `writer_task` waits for
-        // the final batch to flush before returning. A writer-side
-        // `JoinError` or open failure is surfaced at `warn!` and degraded
-        // to "no writer" — the install still succeeds, missing rows just
-        // force a re-download on the next install.
+        // `try_join_all` below so the channel can close once every tarball
+        // task has dropped its clone; then `.await` on the join handle
+        // waits for the final batch to flush before returning. A writer-
+        // side `JoinError` or open failure is surfaced at `warn!` and
+        // degraded to "no writer" — the install still succeeds, missing
+        // rows just force a re-download on the next install.
         let (store_index_writer, writer_task) = StoreIndexWriter::spawn(store_dir);
         let store_index_writer_ref = Some(&store_index_writer);
 
-        // `config: &'static Npmrc`, so `virtual_store_dir` is borrowable for
-        // the full process lifetime — we lean on that to move the whole
-        // symlink pass into a `spawn_blocking` task below without having to
-        // clone the root path per snapshot.
-        let virtual_store_dir: &'static Path = &config.virtual_store_dir;
-
-        // Collect owned per-snapshot data for the symlink branch. Only the
-        // dep map (`Option<HashMap<PkgName, SnapshotDepRef>>`) is cloned;
-        // the rest is small owned values. For the 1352-package fixture
-        // this adds up to a few tens of ms of one-off clone work and moves
-        // the whole symlink pass onto the blocking pool with no 'static /
-        // runtime-flavor fragility. `SnapshotDepRef::resolve` and path
-        // composition stay inside `create_symlink_layout` so the per-dep
-        // logic is trivial to cross-reference against pnpm.
-        let snapshot_symlink_tasks: Vec<SnapshotSymlinkTask> = snapshots
+        // Each snapshot gets a tokio task that awaits its tarball fetch and
+        // then runs `CreateVirtualDirBySnapshot` — which in turn does the
+        // CAS-import / symlink-layout pair concurrently on rayon via
+        // `rayon::join`. Cross-snapshot concurrency stays with tokio's
+        // `try_join_all`; within-snapshot concurrency lives inside
+        // `CreateVirtualDirBySnapshot::run`. Pnpm's `deps-restorer`
+        // installer uses the same "fetch/import per package + overlap
+        // symlinks with import" shape (`installing/deps-restorer/src/index.ts`).
+        snapshots
             .iter()
-            .map(|(key, snapshot)| SnapshotSymlinkTask {
-                virtual_node_modules_dir: virtual_node_modules_dir_for(virtual_store_dir, key),
-                dependencies: snapshot.dependencies.clone(),
-            })
-            .collect();
-
-        // Run intra-package symlink creation concurrently with tarball fetch
-        // + CAS import. Symlinks only depend on the resolved dep graph, not
-        // on any tarball contents, so there's no reason to serialise them
-        // behind downloads.
-        //
-        // Matches pnpm's `headless` installer, which forks the same two
-        // branches off the resolved graph:
-        //
-        //   await Promise.all([linkAllModules(...), linkAllPkgs(...)])
-        //
-        // See `pnpm/pkg-manager/headless/src/index.ts` and
-        // `pnpm/pkg-manager/core/src/install/link.ts`. We run the whole
-        // symlink pass on a single `spawn_blocking` thread using plain
-        // serial iteration — no rayon inside. That mirrors pnpm's
-        // `symlinkAllModules` (`worker/src/start.ts:493-501`), which
-        // executes a synchronous nested `for` loop inside one worker
-        // thread. Going wider with rayon would steal workers from the
-        // fetch branch's concurrent `create_cas_files` par_iter calls
-        // during the hot part of the install; pnpm already learned that
-        // lesson by shipping the symlink stage as a single-threaded
-        // coroutine. Serial on one CPU for ~6-7k symlink syscalls is
-        // still well under the cold-cache fetch budget.
-        let symlink_handle =
-            tokio::task::spawn_blocking(move || -> Result<(), CreateVirtualStoreError> {
-                for task in &snapshot_symlink_tasks {
-                    std::fs::create_dir_all(&task.virtual_node_modules_dir).map_err(|error| {
-                        CreateVirtualStoreError::CreateNodeModulesDir {
-                            dir: task.virtual_node_modules_dir.clone(),
-                            error,
-                        }
-                    })?;
-                    if let Some(dependencies) = &task.dependencies {
-                        create_symlink_layout(
-                            dependencies,
-                            virtual_store_dir,
-                            &task.virtual_node_modules_dir,
-                        )
-                        .map_err(CreateVirtualStoreError::SymlinkPackage)?;
-                    }
-                }
-                Ok(())
-            });
-
-        let fetch_result: Result<(), CreateVirtualStoreError> =
-            future::try_join_all(snapshots.keys().map(|snapshot_key| async move {
+            .map(|(snapshot_key, snapshot)| async move {
                 let metadata_key = snapshot_key.without_peer();
                 let metadata = packages.get(&metadata_key).ok_or_else(|| {
                     CreateVirtualStoreError::MissingPackageMetadata {
@@ -219,33 +140,14 @@ impl<'a> CreateVirtualStore<'a> {
                     store_index_writer: store_index_writer_ref,
                     package_key: snapshot_key,
                     metadata,
+                    snapshot,
                 }
                 .run()
                 .await
                 .map_err(CreateVirtualStoreError::InstallPackageBySnapshot)
-            }))
-            .await
-            .map(drop);
-
-        // Always await the symlink task, even if fetching failed. Dropping
-        // the `JoinHandle` would detach the `spawn_blocking` closure — tokio
-        // cannot abort a blocking task, and a detached one would keep
-        // mutating `.pacquet/*/node_modules/` in the background after
-        // `CreateVirtualStore::run` has already returned the fetch error.
-        // Letting it finish first is cheap (worst case: a handful of mkdirs
-        // and symlinks complete on a failing install) and keeps the
-        // filesystem quiescent when the caller inspects or cleans up state.
-        let symlink_result = match symlink_handle.await {
-            Ok(result) => result,
-            Err(error) => Err(CreateVirtualStoreError::SymlinkTaskJoin { error }),
-        };
-
-        // Surface fetch errors first — a network / tarball failure is almost
-        // always the root cause and more actionable than a downstream
-        // symlink error that happened while the fetch branch was already
-        // failing. If only the symlink branch failed, surface that.
-        fetch_result?;
-        symlink_result?;
+            })
+            .pipe(future::try_join_all)
+            .await?;
 
         // Drop the orchestration's sender so the channel closes once every
         // per-tarball clone has also dropped; then wait for the writer task
@@ -268,19 +170,4 @@ impl<'a> CreateVirtualStore<'a> {
 
         Ok(())
     }
-}
-
-/// Owned snapshot data handed off to the symlink `spawn_blocking` task.
-///
-/// Kept deliberately small: just the virtual-store package dir path and a
-/// cloned copy of the snapshot's `dependencies` map. The rest of the data
-/// `create_symlink_layout` needs (virtual store root, `PkgName`/`SnapshotDepRef`
-/// resolution) is either `'static`-borrowable or lives inside this clone.
-struct SnapshotSymlinkTask {
-    virtual_node_modules_dir: PathBuf,
-    dependencies: Option<HashMap<PkgName, SnapshotDepRef>>,
-}
-
-fn virtual_node_modules_dir_for(virtual_store_dir: &Path, package_key: &PackageKey) -> PathBuf {
-    virtual_store_dir.join(package_key.to_virtual_store_name()).join("node_modules")
 }

--- a/crates/package-manager/src/create_virtual_store.rs
+++ b/crates/package-manager/src/create_virtual_store.rs
@@ -1,5 +1,6 @@
 use crate::{
-    store_init::init_store_dir_best_effort, InstallPackageBySnapshot, InstallPackageBySnapshotError,
+    create_symlink_layout, store_init::init_store_dir_best_effort, InstallPackageBySnapshot,
+    InstallPackageBySnapshotError,
 };
 use derive_more::{Display, Error};
 use futures_util::future;
@@ -8,8 +9,11 @@ use pacquet_lockfile::{PackageKey, PackageMetadata, SnapshotEntry};
 use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
 use pacquet_store_dir::{StoreIndex, StoreIndexWriter};
-use pipe_trait::Pipe;
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    io,
+    path::{Path, PathBuf},
+};
 
 /// This subroutine generates filesystem layout for the virtual store at `node_modules/.pacquet`.
 #[must_use]
@@ -25,6 +29,14 @@ pub struct CreateVirtualStore<'a> {
 pub enum CreateVirtualStoreError {
     #[diagnostic(transparent)]
     InstallPackageBySnapshot(#[error(source)] InstallPackageBySnapshotError),
+
+    #[display("Failed to recursively create node_modules directory at {dir:?}: {error}")]
+    #[diagnostic(code(pacquet_package_manager::create_node_modules_dir))]
+    CreateNodeModulesDir {
+        dir: PathBuf,
+        #[error(source)]
+        error: io::Error,
+    },
 
     #[display("Lockfile has a snapshot entry `{snapshot_key}` with no matching metadata entry (`{metadata_key}`) in `packages:`.")]
     #[diagnostic(code(pacquet_package_manager::missing_package_metadata))]
@@ -106,7 +118,7 @@ impl<'a> CreateVirtualStore<'a> {
         // blocking pool grew to 500+ threads to service them.
         //
         // We drop our own copy of the `Arc<StoreIndexWriter>` after the
-        // `try_join_all` below so the channel can close once every tarball
+        // `try_join!` below so the channel can close once every tarball
         // task has dropped its clone; then `.await` on the join handle
         // waits for the final batch to flush before returning. A writer-
         // side `JoinError` or open failure is surfaced at `warn!` and
@@ -115,9 +127,51 @@ impl<'a> CreateVirtualStore<'a> {
         let (store_index_writer, writer_task) = StoreIndexWriter::spawn(store_dir);
         let store_index_writer_ref = Some(&store_index_writer);
 
-        snapshots
-            .iter()
-            .map(|(snapshot_key, snapshot)| async move {
+        let virtual_store_dir: &Path = &config.virtual_store_dir;
+
+        // Run intra-package symlink creation concurrently with tarball fetch
+        // + CAS import. Symlinks only depend on the resolved dep graph
+        // (already in `snapshots`), not on any tarball contents, so there's
+        // no reason to serialise them behind downloads.
+        //
+        // Matches pnpm's `headless` installer, which forks the same two
+        // branches off the resolved graph:
+        //
+        //   await Promise.all([linkAllModules(...), linkAllPkgs(...)])
+        //
+        // See `pnpm/pkg-manager/headless/src/index.ts` and
+        // `pnpm/pkg-manager/core/src/install/link.ts`.
+        let symlink_fut = async {
+            future::try_join_all(snapshots.iter().map(|(snapshot_key, snapshot)| {
+                let virtual_node_modules_dir =
+                    virtual_node_modules_dir_for(virtual_store_dir, snapshot_key);
+                async move {
+                    std::fs::create_dir_all(&virtual_node_modules_dir).map_err(|error| {
+                        CreateVirtualStoreError::CreateNodeModulesDir {
+                            dir: virtual_node_modules_dir.clone(),
+                            error,
+                        }
+                    })?;
+                    if let Some(dependencies) = &snapshot.dependencies {
+                        // `create_symlink_layout` is synchronous + rayon-parallel
+                        // internally. It runs on rayon's worker threads, so the
+                        // current tokio task just parks until rayon finishes —
+                        // same blocking behavior the old per-snapshot code had.
+                        create_symlink_layout(
+                            dependencies,
+                            virtual_store_dir,
+                            &virtual_node_modules_dir,
+                        );
+                    }
+                    Ok::<_, CreateVirtualStoreError>(())
+                }
+            }))
+            .await
+            .map(drop)
+        };
+
+        let fetch_fut = async {
+            future::try_join_all(snapshots.keys().map(|snapshot_key| async move {
                 let metadata_key = snapshot_key.without_peer();
                 let metadata = packages.get(&metadata_key).ok_or_else(|| {
                     CreateVirtualStoreError::MissingPackageMetadata {
@@ -132,14 +186,16 @@ impl<'a> CreateVirtualStore<'a> {
                     store_index_writer: store_index_writer_ref,
                     package_key: snapshot_key,
                     metadata,
-                    snapshot,
                 }
                 .run()
                 .await
                 .map_err(CreateVirtualStoreError::InstallPackageBySnapshot)
-            })
-            .pipe(future::try_join_all)
-            .await?;
+            }))
+            .await
+            .map(drop)
+        };
+
+        tokio::try_join!(symlink_fut, fetch_fut)?;
 
         // Drop the orchestration's sender so the channel closes once every
         // per-tarball clone has also dropped; then wait for the writer task
@@ -162,4 +218,8 @@ impl<'a> CreateVirtualStore<'a> {
 
         Ok(())
     }
+}
+
+fn virtual_node_modules_dir_for(virtual_store_dir: &Path, package_key: &PackageKey) -> PathBuf {
+    virtual_store_dir.join(package_key.to_virtual_store_name()).join("node_modules")
 }

--- a/crates/package-manager/src/create_virtual_store.rs
+++ b/crates/package-manager/src/create_virtual_store.rs
@@ -129,12 +129,13 @@ impl<'a> CreateVirtualStore<'a> {
         // blocking pool grew to 500+ threads to service them.
         //
         // We drop our own copy of the `Arc<StoreIndexWriter>` after the
-        // `try_join!` below so the channel can close once every tarball
-        // task has dropped its clone; then `.await` on the join handle
-        // waits for the final batch to flush before returning. A writer-
-        // side `JoinError` or open failure is surfaced at `warn!` and
-        // degraded to "no writer" — the install still succeeds, missing
-        // rows just force a re-download on the next install.
+        // fetch `try_join_all` and the symlink `spawn_blocking` have both
+        // been awaited, so the channel can close once every tarball task
+        // has dropped its clone; then `.await` on `writer_task` waits for
+        // the final batch to flush before returning. A writer-side
+        // `JoinError` or open failure is surfaced at `warn!` and degraded
+        // to "no writer" — the install still succeeds, missing rows just
+        // force a re-download on the next install.
         let (store_index_writer, writer_task) = StoreIndexWriter::spawn(store_dir);
         let store_index_writer_ref = Some(&store_index_writer);
 

--- a/crates/package-manager/src/create_virtual_store.rs
+++ b/crates/package-manager/src/create_virtual_store.rs
@@ -146,24 +146,33 @@ impl<'a> CreateVirtualStore<'a> {
                 let virtual_node_modules_dir =
                     virtual_node_modules_dir_for(virtual_store_dir, snapshot_key);
                 async move {
-                    std::fs::create_dir_all(&virtual_node_modules_dir).map_err(|error| {
-                        CreateVirtualStoreError::CreateNodeModulesDir {
-                            dir: virtual_node_modules_dir.clone(),
-                            error,
+                    // The per-snapshot body is entirely synchronous — mkdir
+                    // plus a rayon-parallel symlink sweep — with no `.await`
+                    // points. `try_join_all` polls its children on the same
+                    // task, so without a blocking hint every symlink future
+                    // would run to completion on the worker thread before
+                    // the runtime got a chance to poll `fetch_fut`. That
+                    // couples download progress to symlink wall-time on a
+                    // multi-threaded runtime and defeats the whole point of
+                    // forking the two branches. `block_in_place` signals
+                    // the executor to hand `fetch_fut` (and any other tasks)
+                    // off to sibling workers while this thread blocks.
+                    tokio::task::block_in_place(|| {
+                        std::fs::create_dir_all(&virtual_node_modules_dir).map_err(|error| {
+                            CreateVirtualStoreError::CreateNodeModulesDir {
+                                dir: virtual_node_modules_dir.clone(),
+                                error,
+                            }
+                        })?;
+                        if let Some(dependencies) = &snapshot.dependencies {
+                            create_symlink_layout(
+                                dependencies,
+                                virtual_store_dir,
+                                &virtual_node_modules_dir,
+                            );
                         }
-                    })?;
-                    if let Some(dependencies) = &snapshot.dependencies {
-                        // `create_symlink_layout` is synchronous + rayon-parallel
-                        // internally. It runs on rayon's worker threads, so the
-                        // current tokio task just parks until rayon finishes —
-                        // same blocking behavior the old per-snapshot code had.
-                        create_symlink_layout(
-                            dependencies,
-                            virtual_store_dir,
-                            &virtual_node_modules_dir,
-                        );
-                    }
-                    Ok::<_, CreateVirtualStoreError>(())
+                        Ok::<_, CreateVirtualStoreError>(())
+                    })
                 }
             }))
             .await

--- a/crates/package-manager/src/create_virtual_store.rs
+++ b/crates/package-manager/src/create_virtual_store.rs
@@ -196,14 +196,8 @@ impl<'a> CreateVirtualStore<'a> {
                     Ok(())
                 })
             });
-        let symlink_fut = async {
-            match symlink_handle.await {
-                Ok(result) => result,
-                Err(error) => Err(CreateVirtualStoreError::SymlinkTaskJoin { error }),
-            }
-        };
 
-        let fetch_fut = async {
+        let fetch_result: Result<(), CreateVirtualStoreError> =
             future::try_join_all(snapshots.keys().map(|snapshot_key| async move {
                 let metadata_key = snapshot_key.without_peer();
                 let metadata = packages.get(&metadata_key).ok_or_else(|| {
@@ -225,10 +219,27 @@ impl<'a> CreateVirtualStore<'a> {
                 .map_err(CreateVirtualStoreError::InstallPackageBySnapshot)
             }))
             .await
-            .map(drop)
+            .map(drop);
+
+        // Always await the symlink task, even if fetching failed. Dropping
+        // the `JoinHandle` would detach the `spawn_blocking` closure — tokio
+        // cannot abort a blocking task, and a detached one would keep
+        // mutating `.pacquet/*/node_modules/` in the background after
+        // `CreateVirtualStore::run` has already returned the fetch error.
+        // Letting it finish first is cheap (worst case: a handful of mkdirs
+        // and symlinks complete on a failing install) and keeps the
+        // filesystem quiescent when the caller inspects or cleans up state.
+        let symlink_result = match symlink_handle.await {
+            Ok(result) => result,
+            Err(error) => Err(CreateVirtualStoreError::SymlinkTaskJoin { error }),
         };
 
-        tokio::try_join!(symlink_fut, fetch_fut)?;
+        // Surface fetch errors first — a network / tarball failure is almost
+        // always the root cause and more actionable than a downstream
+        // symlink error that happened while the fetch branch was already
+        // failing. If only the symlink branch failed, surface that.
+        fetch_result?;
+        symlink_result?;
 
         // Drop the orchestration's sender so the channel closes once every
         // per-tarball clone has also dropped; then wait for the writer task

--- a/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/crates/package-manager/src/install_package_by_snapshot.rs
@@ -1,7 +1,7 @@
 use crate::{CreateVirtualDirBySnapshot, CreateVirtualDirError};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
-use pacquet_lockfile::{LockfileResolution, PackageKey, PackageMetadata};
+use pacquet_lockfile::{LockfileResolution, PackageKey, PackageMetadata, SnapshotEntry};
 use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
 use pacquet_store_dir::{SharedReadonlyStoreIndex, StoreIndexWriter};
@@ -9,13 +9,10 @@ use pacquet_tarball::{DownloadTarballToStore, TarballError};
 use pipe_trait::Pipe;
 use std::{borrow::Cow, sync::Arc};
 
-/// Download a package tarball, extract it, and import the extracted files into
-/// the package's slot in the virtual store.
-///
-/// The virtual-store package directory and its intra-package symlinks are
-/// created separately by [`CreateVirtualStore`](crate::CreateVirtualStore) so
-/// that symlinking can run concurrently with fetching — see that module's
-/// `run` method for the pnpm reference.
+/// This subroutine downloads a package tarball, extracts it, installs it to a
+/// virtual dir, then creates the symlink layout for the package. CAS file
+/// import and symlink creation run concurrently via `rayon::join` inside
+/// [`CreateVirtualDirBySnapshot::run`].
 #[must_use]
 pub struct InstallPackageBySnapshot<'a> {
     pub http_client: &'a ThrottledClient,
@@ -24,6 +21,7 @@ pub struct InstallPackageBySnapshot<'a> {
     pub store_index_writer: Option<&'a Arc<StoreIndexWriter>>,
     pub package_key: &'a PackageKey,
     pub metadata: &'a PackageMetadata,
+    pub snapshot: &'a SnapshotEntry,
 }
 
 /// Error type of [`InstallPackageBySnapshot`].
@@ -58,6 +56,7 @@ impl<'a> InstallPackageBySnapshot<'a> {
             store_index_writer,
             package_key,
             metadata,
+            snapshot,
         } = self;
 
         let (tarball_url, integrity) = match &metadata.resolution {
@@ -114,6 +113,7 @@ impl<'a> InstallPackageBySnapshot<'a> {
             cas_paths: &cas_paths,
             import_method: config.package_import_method,
             package_key,
+            snapshot,
         }
         .run()
         .map_err(InstallPackageBySnapshotError::CreateVirtualDir)?;

--- a/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/crates/package-manager/src/install_package_by_snapshot.rs
@@ -1,7 +1,7 @@
 use crate::{CreateVirtualDirBySnapshot, CreateVirtualDirError};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
-use pacquet_lockfile::{LockfileResolution, PackageKey, PackageMetadata, SnapshotEntry};
+use pacquet_lockfile::{LockfileResolution, PackageKey, PackageMetadata};
 use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
 use pacquet_store_dir::{SharedReadonlyStoreIndex, StoreIndexWriter};
@@ -9,8 +9,13 @@ use pacquet_tarball::{DownloadTarballToStore, TarballError};
 use pipe_trait::Pipe;
 use std::{borrow::Cow, sync::Arc};
 
-/// This subroutine downloads a package tarball, extracts it, installs it to a virtual dir,
-/// then creates the symlink layout for the package.
+/// Download a package tarball, extract it, and import the extracted files into
+/// the package's slot in the virtual store.
+///
+/// The virtual-store package directory and its intra-package symlinks are
+/// created separately by [`CreateVirtualStore`](crate::CreateVirtualStore) so
+/// that symlinking can run concurrently with fetching — see that module's
+/// `run` method for the pnpm reference.
 #[must_use]
 pub struct InstallPackageBySnapshot<'a> {
     pub http_client: &'a ThrottledClient,
@@ -19,7 +24,6 @@ pub struct InstallPackageBySnapshot<'a> {
     pub store_index_writer: Option<&'a Arc<StoreIndexWriter>>,
     pub package_key: &'a PackageKey,
     pub metadata: &'a PackageMetadata,
-    pub snapshot: &'a SnapshotEntry,
 }
 
 /// Error type of [`InstallPackageBySnapshot`].
@@ -54,7 +58,6 @@ impl<'a> InstallPackageBySnapshot<'a> {
             store_index_writer,
             package_key,
             metadata,
-            snapshot,
         } = self;
 
         let (tarball_url, integrity) = match &metadata.resolution {
@@ -111,7 +114,6 @@ impl<'a> InstallPackageBySnapshot<'a> {
             cas_paths: &cas_paths,
             import_method: config.package_import_method,
             package_key,
-            snapshot,
         }
         .run()
         .map_err(InstallPackageBySnapshotError::CreateVirtualDir)?;


### PR DESCRIPTION
## Summary

Adds **per-snapshot** parallelism between the two post-extract tasks (`create_cas_files` and `create_symlink_layout`) via `rayon::join` inside `CreateVirtualDirBySnapshot::run`.

- **Baseline shape preserved**: `CreateVirtualStore::run` is still a `try_join_all` over snapshots, one tokio task per snapshot. No global symlink phase, no upfront clone, no `spawn_blocking` dance.
- **New parallelism**: inside each snapshot's post-extract step, `create_cas_files` (rayon par_iter over files) and `create_symlink_layout` (serial loop over deps) run concurrently on rayon's pool. Neither closure needs data the other produces — CAS import reads `cas_paths`, symlinks read `snapshot.dependencies` — so overlapping them saves the serial symlink time per snapshot.
- **Error propagation cleanup**: `create_symlink_layout` now returns `Result<(), SymlinkPackageError>` instead of `expect`-panicking on filesystem errors. `CreateVirtualDirError` grows a `SymlinkPackage` variant so a symlink failure surfaces as a structured miette diagnostic instead of crashing the process mid-install.

**History note**: Earlier commits on this branch (`cb41db0` through `106f944`) tried a "symlink-all ‖ fetch-all" global split to match pnpm's `deps-restorer` shape. Benchmarks on the 1352-package cold-install scenario showed a ~3% regression from the upfront `snapshot.dependencies.clone()` loop required for the `spawn_blocking` + `'static` handoff. `1004683` reverts to this cleaner per-snapshot design, which is within noise of main (44 ms gap, ~1.4σ at n=10, vs. main's own 49 ms run-to-run variance).

## Test plan

- [x] `just ready` (typos, fmt, check, 28 package-manager tests, 188 total tests, clippy --deny warnings) — all green
- [x] `cargo nextest run -p pacquet-cli --test install --run-ignored=ignored-only frozen_lockfile_should_be_able_to_handle_big_lockfile` — passes against the 1352-snapshot fixture in ~58 s
- [x] Linux integrated-benchmark, FrozenLockfile scenario: `pacquet@HEAD 2.981 ± 0.089 s` vs `pacquet@main 2.937 ± 0.038 s` vs `pnpm 6.563 ± 0.098 s`