### PR TITLE
perf(fs): port pnpm v11 writeBufferToCafs into ensure_file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1601,6 +1601,7 @@ dependencies = [
  "derive_more",
  "junction",
  "miette 7.6.0",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/fs/Cargo.toml
+++ b/crates/fs/Cargo.toml
@@ -14,5 +14,8 @@ repository.workspace = true
 derive_more = { workspace = true }
 miette      = { workspace = true }
 
+[dev-dependencies]
+tempfile = { workspace = true }
+
 [target.'cfg(windows)'.dependencies]
 junction = { workspace = true }

--- a/crates/fs/src/ensure_file.rs
+++ b/crates/fs/src/ensure_file.rs
@@ -4,6 +4,7 @@ use std::{
     fs::{self, OpenOptions},
     io::{self, Write},
     path::{Path, PathBuf},
+    sync::atomic::{AtomicU64, Ordering},
 };
 
 /// Error type of [`ensure_file`].
@@ -27,6 +28,19 @@ pub enum EnsureFileError {
         #[error(source)]
         error: io::Error,
     },
+    #[display("Failed to read existing file at {file_path:?}: {error}")]
+    ReadFile {
+        file_path: PathBuf,
+        #[error(source)]
+        error: io::Error,
+    },
+    #[display("Failed to rename {tmp_path:?} over {file_path:?}: {error}")]
+    RenameFile {
+        tmp_path: PathBuf,
+        file_path: PathBuf,
+        #[error(source)]
+        error: io::Error,
+    },
 }
 
 /// Ensure `dir` (and any missing ancestors) exists. Idempotent.
@@ -41,34 +55,57 @@ pub fn ensure_parent_dir(dir: &Path) -> Result<(), EnsureFileError> {
         .map_err(|error| EnsureFileError::CreateDir { parent_dir: dir.to_path_buf(), error })
 }
 
-/// Write `content` to `file_path` unless it already exists.
+/// Write `content` to `file_path` with pnpm v11's `writeBufferToCafs`
+/// semantics.
 ///
-/// **The parent directory must already exist.** Callers that can't
+/// The parent directory must already exist. Callers that can't
 /// guarantee that should call [`ensure_parent_dir`] first — splitting
 /// the two lets the CAFS writer share one `create_dir_all` per shard
 /// instead of paying it per file.
 ///
-/// Uses `O_CREAT | O_EXCL` (via [`OpenOptions::create_new`]), mirroring
-/// pnpm v11's `writeFileExclusive` in `store/cafs/src/writeFile.ts`. A
-/// pre-existing target is swallowed as `ErrorKind::AlreadyExists` →
-/// `Ok(())`, which is correct for both the warm-cache case (the file is
-/// already at the hash-derived path so its contents are by definition
-/// correct) and the concurrent-writer race (another install process on
-/// the same store raced to create the same CAS entry — again, hash-
-/// keyed path means contents match). The upstream equivalent is
-/// `writeBufferToCafs.ts`'s `err.code === 'EEXIST'` branch, minus the
-/// integrity re-verification that pnpm does there: pacquet doesn't
-/// re-verify individual CAS files on write because (a) the path itself
-/// is the integrity assertion and (b) the tarball-level ssri check has
-/// already passed for the batch these bytes came from. Torn blobs left
-/// by a crashed mid-write remain an open concern tracked separately in
-/// `investigations/pacquet-macos-perf.md` §5 — the fix there is
-/// temp-file + rename, orthogonal to this syscall shape.
+/// Sequence (ports `store/cafs/src/writeBufferToCafs.ts` +
+/// `store/cafs/src/writeFile.ts` on pnpm v11):
 ///
-/// Saves the upfront `file_path.exists()` stat that the pre-pnpm-v11
-/// shape of this function paid on every call; on a cold install where
-/// most files are new, that stat always returned `false` and was pure
-/// waste.
+/// 1. Try `O_CREAT | O_EXCL` open (`OpenOptions::create_new(true)`).
+///    On success we own the file and write `content` directly.
+/// 2. On `ErrorKind::AlreadyExists` (warm cache or concurrent writer
+///    race) re-read the file and byte-compare with `content`. CAS
+///    paths are hash-derived, so matching bytes == matching digest;
+///    this is the pacquet-specific equivalent of pnpm's
+///    `verifyFileIntegrity(fileDest, integrity)` — we already have
+///    the expected bytes in hand, so we skip the extra hash step.
+/// 3. If bytes match → `Ok(())`. The file is a live CAS entry; leaving
+///    it alone is correct and matches pnpm's `Date.now()` return there.
+/// 4. If bytes mismatch, a prior install crashed mid-write and left a
+///    torn blob. Recover by writing a fresh temp file next to the
+///    target and `rename`ing it over. Rename is atomic on Unix
+///    (`rename(2)`) and replaces-in-place on Windows
+///    (`SetFileInformationByHandle`/`MoveFileEx`), so an observer
+///    never sees a partial file. Matches pnpm's `writeFileAtomic` +
+///    `renameOverwriteSync`.
+/// 5. Any other open error propagates as `CreateFile`.
+///
+/// Differences from pnpm v11's shape, deliberate:
+///
+/// * **No upfront `stat`**: pnpm stats first so it can skip directly
+///   to `verifyFileIntegrity` on exists. We skip the stat and rely on
+///   the `create_new`/`AlreadyExists` signal, which saves one syscall
+///   per file on cold installs (where every file is new) at the cost
+///   of a slightly different path ordering on warm hits.
+/// * **Byte-compare instead of `crypto.hash`**: we already have the
+///   buffer we were about to write, so comparing against it
+///   implicitly verifies the sha512 without a second hash pass. Same
+///   correctness guarantee, one fewer full-buffer walk.
+/// * **No `locker: Map<string, number>` process-local cache**: pnpm's
+///   locker skips re-verifying the same file within one install.
+///   Pacquet's hot path calls `ensure_file` at most once per CAS file
+///   per install (the `StoreIndex` cache decides whether we even get
+///   here), so the locker would be mostly empty work. Can revisit if
+///   profiling shows repeated AlreadyExists hits on a single path.
+///
+/// Matches pnpm's guarantee: a successful return means `file_path`
+/// exists on disk with contents equal to `content`. A torn mid-write
+/// from a previous install is self-healing, not persistent.
 pub fn ensure_file(
     file_path: &Path,
     content: &[u8],
@@ -90,10 +127,120 @@ pub fn ensure_file(
             file_path: file_path.to_path_buf(),
             error,
         }),
-        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+            verify_or_rewrite(file_path, content, mode)
+        }
         Err(error) => {
             Err(EnsureFileError::CreateFile { file_path: file_path.to_path_buf(), error })
         }
+    }
+}
+
+/// Re-read an already-present CAS file and byte-compare with `content`.
+/// If they match we're done; if not, recover the torn blob by writing a
+/// fresh temp file and renaming it over the target.
+///
+/// A `NotFound` on the re-read means the file disappeared between our
+/// `create_new` attempt and the `read` — another process cleaned it up
+/// (unusual, but possible in shared-store setups). Fall through to the
+/// atomic-write path, which will re-create it.
+fn verify_or_rewrite(
+    file_path: &Path,
+    content: &[u8],
+    mode: Option<u32>,
+) -> Result<(), EnsureFileError> {
+    match fs::read(file_path) {
+        Ok(existing) if existing == content => Ok(()),
+        Ok(_) => write_atomic(file_path, content, mode),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            write_atomic(file_path, content, mode)
+        }
+        Err(error) => Err(EnsureFileError::ReadFile { file_path: file_path.to_path_buf(), error }),
+    }
+}
+
+/// Write `content` to a unique temporary path next to `file_path` and
+/// `rename` it over the target. Matches pnpm v11's `writeFileAtomic` +
+/// `renameOverwriteSync`. The rename is the only atomic step; an
+/// observer sees either the old contents or the new ones, never a
+/// half-written blob.
+///
+/// If either the write or the rename fails we best-effort remove the
+/// temp file to avoid leaking stale files into the store shard.
+fn write_atomic(
+    file_path: &Path,
+    content: &[u8],
+    #[cfg_attr(windows, allow(unused))] mode: Option<u32>,
+) -> Result<(), EnsureFileError> {
+    let tmp_path = temp_path_for(file_path);
+
+    let mut options = OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        if let Some(mode) = mode {
+            options.mode(mode);
+        }
+    }
+
+    let write_result = options.open(&tmp_path).and_then(|mut file| file.write_all(content));
+
+    if let Err(error) = write_result {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(EnsureFileError::WriteFile { file_path: tmp_path, error });
+    }
+
+    if let Err(error) = fs::rename(&tmp_path, file_path) {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(EnsureFileError::RenameFile {
+            tmp_path,
+            file_path: file_path.to_path_buf(),
+            error,
+        });
+    }
+
+    Ok(())
+}
+
+/// Build a unique temp path next to `file_path`. Mirrors pnpm v11's
+/// `pathTemp` in spirit: `{stripped_basename}{pid}{counter}`. The
+/// counter is a process-local monotonically-increasing `AtomicU64`,
+/// giving uniqueness across rayon / tokio workers in the same process;
+/// combining it with the pid avoids collisions when multiple install
+/// processes share a store dir.
+///
+/// We drop `-exec` / any dash-suffix the same way pnpm's `removeSuffix`
+/// does, mainly so temp files don't look like executable CAS entries
+/// to any observer scanning the shard.
+fn temp_path_for(file_path: &Path) -> PathBuf {
+    static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+
+    let parent = file_path.parent().unwrap_or_else(|| Path::new("."));
+    let name = file_path.file_name().map(|s| s.to_string_lossy().into_owned()).unwrap_or_default();
+    let base = strip_dash_suffix(&name);
+
+    parent.join(format!("{base}{pid}{counter}"))
+}
+
+/// Port of pnpm's `removeSuffix` from `store/cafs/src/writeBufferToCafs.ts`:
+/// strip the first `-…` tail; if the tail was `-exec`, append `x`. On
+/// pacquet's CAS names (`{hex}` or `{hex}-exec`) the only real input is
+/// those two shapes, but we stay faithful to the general form so any
+/// future suffix landing upstream doesn't silently diverge.
+fn strip_dash_suffix(name: &str) -> String {
+    let Some(dash_pos) = name.find('-') else {
+        return name.to_string();
+    };
+    let without_suffix = &name[..dash_pos];
+    if &name[dash_pos..] == "-exec" {
+        format!("{without_suffix}x")
+    } else {
+        without_suffix.to_string()
     }
 }
 
@@ -113,23 +260,38 @@ mod tests {
         assert_eq!(fs::read(&path).unwrap(), b"hello");
     }
 
-    /// Pre-existing file short-circuits as `Ok(())` and — crucially —
-    /// does not overwrite the existing contents. Mirrors pnpm v11's
-    /// `EEXIST` branch in `writeBufferToCafs.ts`: the CAS path already
-    /// asserts the bytes, so leaving the file alone is correct.
+    /// Pre-existing file with matching content short-circuits as
+    /// `Ok(())` and does not touch the target. Mirrors pnpm v11's
+    /// `verifyFileIntegrity(fileDest, integrity) === true` branch in
+    /// `writeBufferToCafs.ts`.
     #[test]
-    fn existing_target_is_preserved() {
+    fn existing_target_with_matching_content_is_preserved() {
         let tmp = tempdir().unwrap();
         let path = tmp.path().join("existing.txt");
-        fs::write(&path, b"old").unwrap();
+        fs::write(&path, b"same").unwrap();
 
-        ensure_file(&path, b"new", None).expect("existing target short-circuits");
+        ensure_file(&path, b"same", None).expect("matching contents should short-circuit");
 
-        assert_eq!(
-            fs::read(&path).unwrap(),
-            b"old",
-            "ensure_file must never silently overwrite an existing file",
-        );
+        assert_eq!(fs::read(&path).unwrap(), b"same");
+    }
+
+    /// Pre-existing file with *wrong* contents is a torn-blob case and
+    /// must be atomically replaced with the buffer we were trying to
+    /// write. Mirrors the `writeFileAtomic` branch pnpm takes when
+    /// `verifyFileIntegrity` fails.
+    #[test]
+    fn existing_target_with_wrong_content_is_overwritten_atomically() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("torn.txt");
+        fs::write(&path, b"garbage-from-crashed-prior-install").unwrap();
+
+        ensure_file(&path, b"fresh", None).expect("torn blob should be rewritten");
+
+        assert_eq!(fs::read(&path).unwrap(), b"fresh");
+        // No leftover temp files in the same directory.
+        let siblings: Vec<_> =
+            fs::read_dir(tmp.path()).unwrap().map(|entry| entry.unwrap().file_name()).collect();
+        assert_eq!(siblings, vec![std::ffi::OsString::from("torn.txt")]);
     }
 
     /// Missing parent directory surfaces as a `CreateFile` error
@@ -164,5 +326,26 @@ mod tests {
 
         let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o755);
+    }
+
+    /// `-exec` suffix becomes `x` in the temp name (pnpm `removeSuffix`
+    /// parity). Pins the naming scheme so future tweaks stay explicit.
+    #[test]
+    fn temp_path_strips_exec_suffix() {
+        let p = Path::new("/tmp/store/v11/files/ab/cdef-exec");
+        let tmp = temp_path_for(p);
+        let name = tmp.file_name().unwrap().to_string_lossy().into_owned();
+        assert!(name.starts_with("cdefx"), "got {name}");
+    }
+
+    /// Plain hex basenames go through untouched apart from the pid +
+    /// counter suffix.
+    #[test]
+    fn temp_path_passes_plain_basename_through() {
+        let p = Path::new("/tmp/store/v11/files/ab/cdef");
+        let tmp = temp_path_for(p);
+        let name = tmp.file_name().unwrap().to_string_lossy().into_owned();
+        assert!(name.starts_with("cdef"), "got {name}");
+        assert_ne!(name, "cdef", "must include pid + counter suffix");
     }
 }

--- a/crates/fs/src/ensure_file.rs
+++ b/crates/fs/src/ensure_file.rs
@@ -174,9 +174,13 @@ fn verify_or_rewrite(
             // not a regular CAS blob. Scrub via atomic rewrite.
             write_atomic(file_path, content, mode)
         }
-        Ok(_) => match fs::read(file_path) {
-            Ok(existing) if existing == content => Ok(()),
-            Ok(_) => write_atomic(file_path, content, mode),
+        // Cheap size-mismatch reject before we read a single byte —
+        // a CAS file whose length doesn't match the buffer we were
+        // about to write cannot possibly have matching contents.
+        Ok(meta) if meta.len() != content.len() as u64 => write_atomic(file_path, content, mode),
+        Ok(_) => match file_equals_bytes(file_path, content) {
+            Ok(true) => Ok(()),
+            Ok(false) => write_atomic(file_path, content, mode),
             Err(error) if error.kind() == io::ErrorKind::NotFound => {
                 write_atomic(file_path, content, mode)
             }
@@ -191,49 +195,148 @@ fn verify_or_rewrite(
     }
 }
 
+/// Stream `file_path` and byte-compare against `content` without
+/// buffering the whole file in memory.
+///
+/// `fs::read` (previous shape) allocated a `Vec<u8>` the size of the
+/// file; on a CAS entry for a large binary (10–30 MB isn't unusual in
+/// `@napi-rs/*`, `esbuild`, etc.) and many concurrent rayon workers
+/// hitting this branch, the extra allocation stacked up. Streaming in
+/// 8 KB chunks holds a fixed stack buffer regardless of file size.
+///
+/// Any chunk mismatch returns `Ok(false)` immediately — we don't
+/// finish reading the file once we know it differs. An
+/// `UnexpectedEof` from `read_exact` is returned as `Ok(false)` too:
+/// the file shrunk under us (another process truncated it or the
+/// metadata was stale), which by definition means its contents don't
+/// match `content`. Other errors propagate.
+fn file_equals_bytes(file_path: &Path, content: &[u8]) -> io::Result<bool> {
+    use std::io::Read;
+
+    let mut file = fs::File::open(file_path)?;
+    let mut buf = [0u8; 8 * 1024];
+    let mut offset = 0;
+
+    while offset < content.len() {
+        let chunk_len = (content.len() - offset).min(buf.len());
+        match file.read_exact(&mut buf[..chunk_len]) {
+            Ok(()) => {}
+            Err(error) if error.kind() == io::ErrorKind::UnexpectedEof => return Ok(false),
+            Err(error) => return Err(error),
+        }
+        if buf[..chunk_len] != content[offset..offset + chunk_len] {
+            return Ok(false);
+        }
+        offset += chunk_len;
+    }
+
+    // Confirm the file ends where `content` ends — if there's a
+    // trailing byte the size-check earlier missed (shouldn't happen
+    // given the size-match guard in `verify_or_rewrite`, but cheap
+    // to assert), treat it as not-equal.
+    let mut overflow = [0u8; 1];
+    match file.read(&mut overflow) {
+        Ok(0) => Ok(true),
+        Ok(_) => Ok(false),
+        Err(error) => Err(error),
+    }
+}
+
 /// Write `content` to a unique temporary path next to `file_path` and
 /// `rename` it over the target. Matches pnpm v11's `writeFileAtomic` +
 /// `renameOverwriteSync`. The rename is the only atomic step; an
 /// observer sees either the old contents or the new ones, never a
 /// half-written blob.
 ///
-/// If either the write or the rename fails we best-effort remove the
-/// temp file to avoid leaking stale files into the store shard.
+/// The temp file itself is opened with `O_CREAT|O_EXCL`
+/// (`create_new(true)`) rather than `create+truncate` so we never
+/// follow a symlink or truncate a file an attacker (or a crashed
+/// prior install) pre-seeded at our predicted temp path. If we hit
+/// `AlreadyExists` anyway — collisions are vanishingly rare given the
+/// pid + per-process atomic counter temp scheme, but cross-container
+/// shared-store setups can re-use pids — we advance the counter and
+/// try again, up to `MAX_TEMP_ATTEMPTS` times.
+///
+/// Open errors are classified as `CreateFile`; write errors as
+/// `WriteFile`. On any failure the partially-created temp file is
+/// removed best-effort so stale files don't leak into the store
+/// shard.
 fn write_atomic(
     file_path: &Path,
     content: &[u8],
     #[cfg_attr(windows, allow(unused))] mode: Option<u32>,
 ) -> Result<(), EnsureFileError> {
-    let tmp_path = temp_path_for(file_path);
+    /// Retries after `AlreadyExists` on the temp path. Sixteen fresh
+    /// counter values is plenty — under benign conditions we never
+    /// collide; under shared-store-across-containers the chance of
+    /// 16 consecutive same-pid same-counter collisions is negligible.
+    const MAX_TEMP_ATTEMPTS: usize = 16;
 
-    let mut options = OpenOptions::new();
-    options.write(true).create(true).truncate(true);
+    let mut last_already_exists: Option<io::Error> = None;
 
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        if let Some(mode) = mode {
-            options.mode(mode);
+    for _ in 0..MAX_TEMP_ATTEMPTS {
+        let tmp_path = temp_path_for(file_path);
+
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            if let Some(mode) = mode {
+                options.mode(mode);
+            }
         }
+
+        let mut file = match options.open(&tmp_path) {
+            Ok(file) => file,
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                // Stale temp file or adversarial / concurrent pre-seed.
+                // Retry with a fresh counter; don't touch whatever is
+                // at the colliding path.
+                last_already_exists = Some(error);
+                continue;
+            }
+            Err(error) => {
+                return Err(EnsureFileError::CreateFile { file_path: tmp_path, error });
+            }
+        };
+
+        if let Err(error) = file.write_all(content) {
+            drop(file);
+            let _ = fs::remove_file(&tmp_path);
+            return Err(EnsureFileError::WriteFile { file_path: tmp_path, error });
+        }
+        // Close the handle before `rename`. Windows `MoveFileEx` over
+        // an open source file can fail with sharing-violation; Unix
+        // doesn't care but an early `close` lets the kernel commit
+        // dirty buffers before the rename commits the dirent change.
+        drop(file);
+
+        if let Err(error) = rename_with_retry(&tmp_path, file_path) {
+            let _ = fs::remove_file(&tmp_path);
+            return Err(EnsureFileError::RenameFile {
+                tmp_path,
+                file_path: file_path.to_path_buf(),
+                error,
+            });
+        }
+        return Ok(());
     }
 
-    let write_result = options.open(&tmp_path).and_then(|mut file| file.write_all(content));
-
-    if let Err(error) = write_result {
-        let _ = fs::remove_file(&tmp_path);
-        return Err(EnsureFileError::WriteFile { file_path: tmp_path, error });
-    }
-
-    if let Err(error) = rename_with_retry(&tmp_path, file_path) {
-        let _ = fs::remove_file(&tmp_path);
-        return Err(EnsureFileError::RenameFile {
-            tmp_path,
-            file_path: file_path.to_path_buf(),
-            error,
-        });
-    }
-
-    Ok(())
+    // Ran out of temp-name attempts. Surface the last `AlreadyExists`
+    // so the operator can see what happened; pick the file_path as
+    // the best-effort context since we can't enumerate every temp
+    // name we tried.
+    Err(EnsureFileError::CreateFile {
+        file_path: file_path.to_path_buf(),
+        error: last_already_exists.unwrap_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "exhausted temp-path attempts for atomic CAS rewrite",
+            )
+        }),
+    })
 }
 
 /// Total budget for retrying a rename that keeps hitting transient
@@ -284,15 +387,31 @@ fn rename_with_retry(src: &Path, dst: &Path) -> io::Result<()> {
     }
 }
 
-/// Windows AV / indexer interference surfaces as `PermissionDenied`
-/// (`ERROR_ACCESS_DENIED`) or `ResourceBusy`
-/// (`ERROR_SHARING_VIOLATION`). `ResourceBusy` is the Rust 1.84+
-/// mapping; on older toolchains it came through as `Other` instead,
-/// but pacquet's MSRV is well past that. Unix never hits these codes
-/// for our same-directory file rename, so the retry loop is
-/// effectively a no-op there.
-fn is_transient_rename_error(error: &io::Error) -> bool {
-    matches!(error.kind(), io::ErrorKind::PermissionDenied | io::ErrorKind::ResourceBusy)
+/// Classify a `rename` error as transient-retry-worthy.
+///
+/// On Windows, AV / indexer interference briefly holds the
+/// destination open and surfaces as `ERROR_ACCESS_DENIED` (→
+/// `PermissionDenied`) or `ERROR_SHARING_VIOLATION` (→
+/// `ResourceBusy`, Rust 1.84+ mapping). Both clear on their own
+/// within tens-to-hundreds of ms, which is exactly what the retry
+/// loop is for.
+///
+/// On Unix, `rename` returning `EACCES`/`EPERM` is essentially
+/// always a permanent permission issue (non-writable directory,
+/// sticky-bit conflict, AppArmor deny) — retrying for 60 s just
+/// stretches out the failure. `EBUSY` on Unix also tends to be
+/// permanent (mount-point conflicts). So on non-Windows the
+/// classifier is disabled and any `rename` error propagates
+/// immediately.
+fn is_transient_rename_error(#[cfg_attr(not(windows), allow(unused))] error: &io::Error) -> bool {
+    #[cfg(windows)]
+    {
+        matches!(error.kind(), io::ErrorKind::PermissionDenied | io::ErrorKind::ResourceBusy)
+    }
+    #[cfg(not(windows))]
+    {
+        false
+    }
 }
 
 /// Build a unique temp path next to `file_path`. Mirrors pnpm v11's
@@ -452,17 +571,38 @@ mod tests {
     }
 
     /// Windows AV / indexer interference surfaces as
-    /// `PermissionDenied` or `ResourceBusy`; both must trigger the
-    /// retry loop. Any other kind must propagate immediately.
+    /// `PermissionDenied` or `ResourceBusy` and must trigger the
+    /// retry loop there. On non-Windows those codes are essentially
+    /// always permanent (permission / mount-point issues), so the
+    /// classifier must return `false` to avoid pathologically
+    /// spinning for 60 s on a misconfigured store dir. Any other
+    /// kind must propagate immediately on every platform.
     #[test]
     fn transient_rename_error_classifier() {
-        assert!(is_transient_rename_error(&io::Error::from(io::ErrorKind::PermissionDenied)));
-        assert!(is_transient_rename_error(&io::Error::from(io::ErrorKind::ResourceBusy)));
+        let permission_denied = io::Error::from(io::ErrorKind::PermissionDenied);
+        let resource_busy = io::Error::from(io::ErrorKind::ResourceBusy);
 
-        // Non-transient kinds: must not trigger the retry loop. A
-        // regression that classified e.g. `NotFound` as transient
-        // would pathologically spin for 60 seconds on a legitimately
-        // missing source.
+        #[cfg(windows)]
+        {
+            assert!(is_transient_rename_error(&permission_denied));
+            assert!(is_transient_rename_error(&resource_busy));
+        }
+        #[cfg(not(windows))]
+        {
+            assert!(
+                !is_transient_rename_error(&permission_denied),
+                "Unix PermissionDenied is permanent, must not retry",
+            );
+            assert!(
+                !is_transient_rename_error(&resource_busy),
+                "Unix ResourceBusy is effectively permanent, must not retry",
+            );
+        }
+
+        // Non-transient kinds must never trigger the retry loop on
+        // any platform — a regression classifying e.g. `NotFound` as
+        // transient would spin for 60 s on a legitimately missing
+        // source.
         for kind in [
             io::ErrorKind::NotFound,
             io::ErrorKind::AlreadyExists,
@@ -527,24 +667,68 @@ mod tests {
         assert_eq!(fs::read(&cas_path).unwrap(), b"fresh");
     }
 
-    /// Happy-path rename (no transient errors) returns immediately
-    /// via the `Ok(())` branch without sleeping. Pins that the retry
-    /// loop doesn't accidentally delay successful renames.
+    /// Happy-path rename (no transient errors) moves the payload
+    /// atomically and removes the source. Correctness only — we
+    /// deliberately don't assert a wall-clock bound because rename
+    /// latency on loaded CI / slow filesystems can exceed any
+    /// reasonable timing threshold without the retry path actually
+    /// being taken.
     #[test]
-    fn rename_with_retry_succeeds_fast_when_no_error() {
+    fn rename_with_retry_succeeds_when_no_error() {
         let tmp = tempdir().unwrap();
         let src = tmp.path().join("src");
         let dst = tmp.path().join("dst");
         fs::write(&src, b"payload").unwrap();
 
-        let start = Instant::now();
         rename_with_retry(&src, &dst).expect("rename should succeed");
-        let elapsed = start.elapsed();
 
         assert_eq!(fs::read(&dst).unwrap(), b"payload");
         assert!(!src.exists(), "source should be gone after rename");
-        // The retry loop's minimum sleep is 10 ms; a successful
-        // first attempt must not hit that, so elapsed << 10 ms.
-        assert!(elapsed < Duration::from_millis(10), "took {elapsed:?}");
+    }
+
+    /// Streaming byte-compare returns `true` iff the file on disk is
+    /// identical to `content`. Pins the three cases
+    /// `verify_or_rewrite` routes through it: exact match (skip
+    /// path), same length but different bytes (atomic rewrite),
+    /// different length (atomic rewrite).
+    #[test]
+    fn file_equals_bytes_classifies_match_mismatch_and_length_mismatch() {
+        let tmp = tempdir().unwrap();
+
+        let equal = tmp.path().join("equal");
+        fs::write(&equal, b"hello world").unwrap();
+        assert!(file_equals_bytes(&equal, b"hello world").unwrap());
+
+        let content_diff = tmp.path().join("content_diff");
+        fs::write(&content_diff, b"hello world").unwrap();
+        assert!(!file_equals_bytes(&content_diff, b"hello WORLD").unwrap());
+
+        // `verify_or_rewrite`'s size-check short-circuits before
+        // reaching this function in practice, but the function
+        // itself still has to classify correctly if called directly.
+        let length_diff = tmp.path().join("length_diff");
+        fs::write(&length_diff, b"short").unwrap();
+        assert!(!file_equals_bytes(&length_diff, b"longer payload").unwrap());
+    }
+
+    /// Multi-chunk files exercise the inner `read_exact` loop rather
+    /// than landing entirely in the first 8 KB read. Guards against
+    /// off-by-one regressions in the chunk-offset math, and confirms
+    /// a byte flipped in the *last* chunk isn't masked by an early
+    /// "first-chunk-matched" short-circuit.
+    #[test]
+    fn file_equals_bytes_handles_multi_chunk_files() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("big");
+
+        // 20 KB: at least three 8 KB chunks.
+        let content: Vec<u8> = (0..20_000).map(|i| (i % 251) as u8).collect();
+        fs::write(&path, &content).unwrap();
+
+        assert!(file_equals_bytes(&path, &content).unwrap());
+
+        let mut perturbed = content.clone();
+        *perturbed.last_mut().unwrap() ^= 0xff;
+        assert!(!file_equals_bytes(&path, &perturbed).unwrap());
     }
 }

--- a/crates/fs/src/ensure_file.rs
+++ b/crates/fs/src/ensure_file.rs
@@ -5,6 +5,7 @@ use std::{
     io::{self, Write},
     path::{Path, PathBuf},
     sync::atomic::{AtomicU64, Ordering},
+    time::{Duration, Instant},
 };
 
 /// Error type of [`ensure_file`].
@@ -192,7 +193,7 @@ fn write_atomic(
         return Err(EnsureFileError::WriteFile { file_path: tmp_path, error });
     }
 
-    if let Err(error) = fs::rename(&tmp_path, file_path) {
+    if let Err(error) = rename_with_retry(&tmp_path, file_path) {
         let _ = fs::remove_file(&tmp_path);
         return Err(EnsureFileError::RenameFile {
             tmp_path,
@@ -202,6 +203,65 @@ fn write_atomic(
     }
 
     Ok(())
+}
+
+/// Total budget for retrying a rename that keeps hitting transient
+/// errors. Matches pnpm's `rename-overwrite` retry window.
+const RENAME_RETRY_BUDGET: Duration = Duration::from_secs(60);
+
+/// Cap on per-iteration sleep — pnpm grows the backoff by 10 ms each
+/// loop and stops growing at 100 ms.
+const RENAME_RETRY_BACKOFF_CAP: Duration = Duration::from_millis(100);
+
+/// `fs::rename` with the one retry family that actually hits pacquet
+/// in practice: Windows Defender (and other Windows antivirus / file-
+/// indexer tooling) momentarily holding the destination open, which
+/// makes the rename fail with `ERROR_ACCESS_DENIED` /
+/// `ERROR_SHARING_VIOLATION`. These surface through Rust's
+/// `io::ErrorKind` as `PermissionDenied` or `ResourceBusy`, and they
+/// clear as soon as the scan completes — a short sleep + retry
+/// recovers. Mirrors the `EPERM|EACCES|EBUSY` arm of
+/// `rename-overwrite`'s `renameOverwriteSync` (see zkochan/packages/
+/// rename-overwrite/index.js): 60-second total budget, 10 ms backoff
+/// step, 100 ms cap.
+///
+/// Other retry arms from `rename-overwrite` (`ENOTEMPTY`/`EEXIST`/
+/// `ENOTDIR` swap-rename, `ENOENT` mkdir-and-recurse, `EXDEV` copy-
+/// and-delete) don't apply to this call site: temp and target share
+/// the CAS shard dir (already pre-created by `StoreDir::init`), both
+/// are files not directories, and pacquet's CAS readers
+/// (`link_file` → `fs::hard_link` / `reflink_copy`) don't keep file
+/// handles on the target, so there's no "parallel reader sees a gap"
+/// concern that would motivate swap-rename.
+fn rename_with_retry(src: &Path, dst: &Path) -> io::Result<()> {
+    let mut backoff = Duration::ZERO;
+    let start = Instant::now();
+
+    loop {
+        match fs::rename(src, dst) {
+            Ok(()) => return Ok(()),
+            Err(error) => {
+                if !is_transient_rename_error(&error) || start.elapsed() >= RENAME_RETRY_BUDGET {
+                    return Err(error);
+                }
+                if !backoff.is_zero() {
+                    std::thread::sleep(backoff);
+                }
+                backoff = (backoff + Duration::from_millis(10)).min(RENAME_RETRY_BACKOFF_CAP);
+            }
+        }
+    }
+}
+
+/// Windows AV / indexer interference surfaces as `PermissionDenied`
+/// (`ERROR_ACCESS_DENIED`) or `ResourceBusy`
+/// (`ERROR_SHARING_VIOLATION`). `ResourceBusy` is the Rust 1.84+
+/// mapping; on older toolchains it came through as `Other` instead,
+/// but pacquet's MSRV is well past that. Unix never hits these codes
+/// for our same-directory file rename, so the retry loop is
+/// effectively a no-op there.
+fn is_transient_rename_error(error: &io::Error) -> bool {
+    matches!(error.kind(), io::ErrorKind::PermissionDenied | io::ErrorKind::ResourceBusy)
 }
 
 /// Build a unique temp path next to `file_path`. Mirrors pnpm v11's
@@ -347,5 +407,53 @@ mod tests {
         let name = tmp.file_name().unwrap().to_string_lossy().into_owned();
         assert!(name.starts_with("cdef"), "got {name}");
         assert_ne!(name, "cdef", "must include pid + counter suffix");
+    }
+
+    /// Windows AV / indexer interference surfaces as
+    /// `PermissionDenied` or `ResourceBusy`; both must trigger the
+    /// retry loop. Any other kind must propagate immediately.
+    #[test]
+    fn transient_rename_error_classifier() {
+        assert!(is_transient_rename_error(&io::Error::from(io::ErrorKind::PermissionDenied)));
+        assert!(is_transient_rename_error(&io::Error::from(io::ErrorKind::ResourceBusy)));
+
+        // Non-transient kinds: must not trigger the retry loop. A
+        // regression that classified e.g. `NotFound` as transient
+        // would pathologically spin for 60 seconds on a legitimately
+        // missing source.
+        for kind in [
+            io::ErrorKind::NotFound,
+            io::ErrorKind::AlreadyExists,
+            io::ErrorKind::InvalidInput,
+            io::ErrorKind::InvalidData,
+            io::ErrorKind::Unsupported,
+            io::ErrorKind::Other,
+        ] {
+            assert!(
+                !is_transient_rename_error(&io::Error::from(kind)),
+                "{kind:?} must not be classified as transient"
+            );
+        }
+    }
+
+    /// Happy-path rename (no transient errors) returns immediately
+    /// via the `Ok(())` branch without sleeping. Pins that the retry
+    /// loop doesn't accidentally delay successful renames.
+    #[test]
+    fn rename_with_retry_succeeds_fast_when_no_error() {
+        let tmp = tempdir().unwrap();
+        let src = tmp.path().join("src");
+        let dst = tmp.path().join("dst");
+        fs::write(&src, b"payload").unwrap();
+
+        let start = Instant::now();
+        rename_with_retry(&src, &dst).expect("rename should succeed");
+        let elapsed = start.elapsed();
+
+        assert_eq!(fs::read(&dst).unwrap(), b"payload");
+        assert!(!src.exists(), "source should be gone after rename");
+        // The retry loop's minimum sleep is 10 ms; a successful
+        // first attempt must not hit that, so elapsed << 10 ms.
+        assert!(elapsed < Duration::from_millis(10), "took {elapsed:?}");
     }
 }

--- a/crates/fs/src/ensure_file.rs
+++ b/crates/fs/src/ensure_file.rs
@@ -47,17 +47,35 @@ pub fn ensure_parent_dir(dir: &Path) -> Result<(), EnsureFileError> {
 /// guarantee that should call [`ensure_parent_dir`] first — splitting
 /// the two lets the CAFS writer share one `create_dir_all` per shard
 /// instead of paying it per file.
+///
+/// Uses `O_CREAT | O_EXCL` (via [`OpenOptions::create_new`]), mirroring
+/// pnpm v11's `writeFileExclusive` in `store/cafs/src/writeFile.ts`. A
+/// pre-existing target is swallowed as `ErrorKind::AlreadyExists` →
+/// `Ok(())`, which is correct for both the warm-cache case (the file is
+/// already at the hash-derived path so its contents are by definition
+/// correct) and the concurrent-writer race (another install process on
+/// the same store raced to create the same CAS entry — again, hash-
+/// keyed path means contents match). The upstream equivalent is
+/// `writeBufferToCafs.ts`'s `err.code === 'EEXIST'` branch, minus the
+/// integrity re-verification that pnpm does there: pacquet doesn't
+/// re-verify individual CAS files on write because (a) the path itself
+/// is the integrity assertion and (b) the tarball-level ssri check has
+/// already passed for the batch these bytes came from. Torn blobs left
+/// by a crashed mid-write remain an open concern tracked separately in
+/// `investigations/pacquet-macos-perf.md` §5 — the fix there is
+/// temp-file + rename, orthogonal to this syscall shape.
+///
+/// Saves the upfront `file_path.exists()` stat that the pre-pnpm-v11
+/// shape of this function paid on every call; on a cold install where
+/// most files are new, that stat always returned `false` and was pure
+/// waste.
 pub fn ensure_file(
     file_path: &Path,
     content: &[u8],
     #[cfg_attr(windows, allow(unused))] mode: Option<u32>,
 ) -> Result<(), EnsureFileError> {
-    if file_path.exists() {
-        return Ok(());
-    }
-
     let mut options = OpenOptions::new();
-    options.write(true).create(true);
+    options.write(true).create_new(true);
 
     #[cfg(unix)]
     {
@@ -67,9 +85,84 @@ pub fn ensure_file(
         }
     }
 
-    options
-        .open(file_path)
-        .map_err(|error| EnsureFileError::CreateFile { file_path: file_path.to_path_buf(), error })?
-        .write_all(content)
-        .map_err(|error| EnsureFileError::WriteFile { file_path: file_path.to_path_buf(), error })
+    match options.open(file_path) {
+        Ok(mut file) => file.write_all(content).map_err(|error| EnsureFileError::WriteFile {
+            file_path: file_path.to_path_buf(),
+            error,
+        }),
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => Ok(()),
+        Err(error) => {
+            Err(EnsureFileError::CreateFile { file_path: file_path.to_path_buf(), error })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    /// New-file path: contents land on disk with the requested mode.
+    #[test]
+    fn writes_a_new_file() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("new.txt");
+
+        ensure_file(&path, b"hello", None).expect("new-file write succeeds");
+
+        assert_eq!(fs::read(&path).unwrap(), b"hello");
+    }
+
+    /// Pre-existing file short-circuits as `Ok(())` and — crucially —
+    /// does not overwrite the existing contents. Mirrors pnpm v11's
+    /// `EEXIST` branch in `writeBufferToCafs.ts`: the CAS path already
+    /// asserts the bytes, so leaving the file alone is correct.
+    #[test]
+    fn existing_target_is_preserved() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("existing.txt");
+        fs::write(&path, b"old").unwrap();
+
+        ensure_file(&path, b"new", None).expect("existing target short-circuits");
+
+        assert_eq!(
+            fs::read(&path).unwrap(),
+            b"old",
+            "ensure_file must never silently overwrite an existing file",
+        );
+    }
+
+    /// Missing parent directory surfaces as a `CreateFile` error
+    /// (kind `NotFound`). Callers are expected to `ensure_parent_dir`
+    /// first; this pins that contract so a regression that quietly
+    /// created ancestors would fail the test.
+    #[test]
+    fn missing_parent_dir_errors() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("nested/does/not/exist/file.txt");
+
+        let err = ensure_file(&path, b"x", None).expect_err("missing parent should fail");
+        match err {
+            EnsureFileError::CreateFile { error, .. } => {
+                assert_eq!(error.kind(), io::ErrorKind::NotFound);
+            }
+            other => panic!("expected CreateFile/NotFound, got {other:?}"),
+        }
+    }
+
+    /// Unix mode is honoured on the new-file path. Skipped on Windows
+    /// where the `mode` argument is `#[cfg_attr(windows, allow(unused))]`.
+    #[cfg(unix)]
+    #[test]
+    fn unix_mode_is_applied_on_new_files() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("exec.sh");
+
+        ensure_file(&path, b"#!/bin/sh\n", Some(0o755)).expect("mode-honouring write");
+
+        let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o755);
+    }
 }

--- a/crates/fs/src/ensure_file.rs
+++ b/crates/fs/src/ensure_file.rs
@@ -141,18 +141,49 @@ pub fn ensure_file(
 /// If they match we're done; if not, recover the torn blob by writing a
 /// fresh temp file and renaming it over the target.
 ///
-/// A `NotFound` on the re-read means the file disappeared between our
-/// `create_new` attempt and the `read` — another process cleaned it up
-/// (unusual, but possible in shared-store setups). Fall through to the
-/// atomic-write path, which will re-create it.
+/// Uses `symlink_metadata` (not `metadata`) first to reject the
+/// non-regular-file cases — symlinks in particular. On Unix,
+/// `open(O_CREAT|O_EXCL)` returns `EEXIST` even when the dirent is
+/// a symlink (POSIX `open` does not follow symlinks under `O_EXCL`),
+/// so a tampered / backed-up-and-restored store could route a symlinked
+/// dirent into this function. If we fell through directly to `fs::read`
+/// (which *does* follow symlinks), a symlink pointing at a file with
+/// matching bytes would silently return `Ok(())` without ever
+/// materialising a real CAS blob at `file_path`, and downstream
+/// `fs::hard_link` on that path would hardlink the symlink itself
+/// rather than the target. Scrub instead: `write_atomic`'s `rename`
+/// atomically replaces the symlink (or any other non-regular dirent
+/// that `rename` can overwrite) with a real regular file. Pnpm v11
+/// doesn't guard against this case either, but pacquet's CAS linking
+/// path is stricter about file-type than pnpm's, so the guard is
+/// worth adding here.
+///
+/// A `NotFound` on either syscall means the dirent disappeared
+/// between our `create_new` attempt and the metadata / read call —
+/// another process cleaned it up (unusual, but possible in shared-
+/// store setups). Fall through to the atomic-write path, which will
+/// re-create it.
 fn verify_or_rewrite(
     file_path: &Path,
     content: &[u8],
     mode: Option<u32>,
 ) -> Result<(), EnsureFileError> {
-    match fs::read(file_path) {
-        Ok(existing) if existing == content => Ok(()),
-        Ok(_) => write_atomic(file_path, content, mode),
+    match fs::symlink_metadata(file_path) {
+        Ok(meta) if !meta.file_type().is_file() => {
+            // Symlink, directory, fifo, socket, block/char device —
+            // not a regular CAS blob. Scrub via atomic rewrite.
+            write_atomic(file_path, content, mode)
+        }
+        Ok(_) => match fs::read(file_path) {
+            Ok(existing) if existing == content => Ok(()),
+            Ok(_) => write_atomic(file_path, content, mode),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                write_atomic(file_path, content, mode)
+            }
+            Err(error) => {
+                Err(EnsureFileError::ReadFile { file_path: file_path.to_path_buf(), error })
+            }
+        },
         Err(error) if error.kind() == io::ErrorKind::NotFound => {
             write_atomic(file_path, content, mode)
         }
@@ -309,7 +340,8 @@ mod tests {
     use super::*;
     use tempfile::tempdir;
 
-    /// New-file path: contents land on disk with the requested mode.
+    /// New-file path: contents land on disk. Mode handling is covered
+    /// separately in `unix_mode_is_applied_on_new_files`.
     #[test]
     fn writes_a_new_file() {
         let tmp = tempdir().unwrap();
@@ -374,6 +406,16 @@ mod tests {
 
     /// Unix mode is honoured on the new-file path. Skipped on Windows
     /// where the `mode` argument is `#[cfg_attr(windows, allow(unused))]`.
+    ///
+    /// Asserts the **owner** bits specifically rather than the full
+    /// `0o777` triplet because `OpenOptionsExt::mode` runs through the
+    /// process umask, which strips group / other bits on systems with
+    /// a restrictive default (e.g. `umask 0o077` CI shells). Owner
+    /// bits are preserved under every sensible umask, so pinning just
+    /// those keeps the test robust without weakening what it verifies
+    /// (that `mode` is being threaded through to the syscall at all
+    /// and that the owner-exec bit survives — the observable property
+    /// that distinguishes an executable CAS blob from a data blob).
     #[cfg(unix)]
     #[test]
     fn unix_mode_is_applied_on_new_files() {
@@ -384,8 +426,8 @@ mod tests {
 
         ensure_file(&path, b"#!/bin/sh\n", Some(0o755)).expect("mode-honouring write");
 
-        let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
-        assert_eq!(mode, 0o755);
+        let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o700;
+        assert_eq!(mode, 0o700, "owner rwx bits of 0o755 must survive any reasonable umask",);
     }
 
     /// `-exec` suffix becomes `x` in the temp name (pnpm `removeSuffix`
@@ -434,6 +476,55 @@ mod tests {
                 "{kind:?} must not be classified as transient"
             );
         }
+    }
+
+    /// A symlink at the target path — which on Unix returns `EEXIST`
+    /// from `open(O_CREAT|O_EXCL)` just like a regular file would —
+    /// must be scrubbed and replaced with a real regular file even
+    /// when its target's bytes match what we were about to write.
+    /// Leaving the symlink in place would fool downstream
+    /// `fs::hard_link` (which hardlinks the symlink itself on Linux,
+    /// not the target) and leak non-regular dirents into the CAS.
+    #[cfg(unix)]
+    #[test]
+    fn symlink_at_cas_path_is_scrubbed_to_a_regular_file() {
+        let tmp = tempdir().unwrap();
+        let real_target = tmp.path().join("other_real_file");
+        fs::write(&real_target, b"payload").unwrap();
+
+        let cas_path = tmp.path().join("cas_entry");
+        std::os::unix::fs::symlink(&real_target, &cas_path).unwrap();
+
+        ensure_file(&cas_path, b"payload", None).expect("symlink should be scrubbed");
+
+        let meta = fs::symlink_metadata(&cas_path).unwrap();
+        assert!(
+            meta.file_type().is_file(),
+            "cas_path must be a regular file after scrub, got {:?}",
+            meta.file_type(),
+        );
+        assert_eq!(fs::read(&cas_path).unwrap(), b"payload");
+        // The file the symlink used to point at is untouched — we
+        // replaced the link, not followed it.
+        assert_eq!(fs::read(&real_target).unwrap(), b"payload");
+    }
+
+    /// Dangling symlink (points nowhere) is also scrubbed to a real
+    /// file via the same `symlink_metadata` guard. Without the guard
+    /// we'd still end up in `write_atomic` via the `NotFound` branch
+    /// on `fs::read`, but this pins the expected control flow.
+    #[cfg(unix)]
+    #[test]
+    fn dangling_symlink_at_cas_path_is_scrubbed_to_a_regular_file() {
+        let tmp = tempdir().unwrap();
+        let cas_path = tmp.path().join("cas_entry");
+        std::os::unix::fs::symlink(tmp.path().join("nonexistent"), &cas_path).unwrap();
+
+        ensure_file(&cas_path, b"fresh", None).expect("dangling link should be scrubbed");
+
+        let meta = fs::symlink_metadata(&cas_path).unwrap();
+        assert!(meta.file_type().is_file(), "cas_path must end as a regular file");
+        assert_eq!(fs::read(&cas_path).unwrap(), b"fresh");
     }
 
     /// Happy-path rename (no transient errors) returns immediately

--- a/crates/store-dir/src/cas_file.rs
+++ b/crates/store-dir/src/cas_file.rs
@@ -148,8 +148,9 @@ mod tests {
     /// * the first write into a given shard populates the cache entry
     ///   for that shard (no eager seeding);
     /// * a second write of identical content is a successful noop via
-    ///   the `file_path.exists()` warm-cache branch inside
-    ///   `ensure_file`, and leaves the cache unchanged;
+    ///   the `AlreadyExists` branch inside `ensure_file` (the open
+    ///   with `O_CREAT|O_EXCL` returns `EEXIST`, which we map to `Ok(())`),
+    ///   and leaves the cache unchanged;
     /// * a later write of different content still succeeds whether it
     ///   lands in the same shard or a new one.
     ///
@@ -170,8 +171,9 @@ mod tests {
         assert!(path_a.is_file());
 
         // Second write of identical content — same hash, same path —
-        // hits the `file_path.exists()` fast path inside `ensure_file`
-        // and returns Ok without touching the filesystem further.
+        // hits the `AlreadyExists` branch inside `ensure_file` (the
+        // `O_CREAT|O_EXCL` open returns `EEXIST`, which we swallow as
+        // `Ok(())`) and returns without writing again.
         let (path_b, hash_b) = store_dir.write_cas_file(b"hello world", false).unwrap();
         assert_eq!(hash_a, hash_b);
         assert_eq!(path_a, path_b);

--- a/crates/store-dir/src/cas_file.rs
+++ b/crates/store-dir/src/cas_file.rs
@@ -148,9 +148,11 @@ mod tests {
     /// * the first write into a given shard populates the cache entry
     ///   for that shard (no eager seeding);
     /// * a second write of identical content is a successful noop via
-    ///   the `AlreadyExists` branch inside `ensure_file` (the open
-    ///   with `O_CREAT|O_EXCL` returns `EEXIST`, which we map to `Ok(())`),
-    ///   and leaves the cache unchanged;
+    ///   `ensure_file`'s `AlreadyExists` → `verify_or_rewrite` path
+    ///   (the `O_CREAT|O_EXCL` open returns `EEXIST`, `verify_or_rewrite`
+    ///   byte-compares the existing file against the buffer and returns
+    ///   `Ok(())` once they match — so the existing CAS blob is left
+    ///   in place), and the cache is unchanged;
     /// * a later write of different content still succeeds whether it
     ///   lands in the same shard or a new one.
     ///
@@ -171,9 +173,14 @@ mod tests {
         assert!(path_a.is_file());
 
         // Second write of identical content — same hash, same path —
-        // hits the `AlreadyExists` branch inside `ensure_file` (the
-        // `O_CREAT|O_EXCL` open returns `EEXIST`, which we swallow as
-        // `Ok(())`) and returns without writing again.
+        // hits `ensure_file`'s `AlreadyExists` → `verify_or_rewrite`
+        // path: the `O_CREAT|O_EXCL` open returns `EEXIST`, then
+        // `verify_or_rewrite` byte-compares the existing file against
+        // the buffer, finds them equal, and returns `Ok(())` without
+        // writing again. A torn-blob mismatch would route through
+        // `write_atomic` instead, which is covered by
+        // `existing_target_with_wrong_content_is_overwritten_atomically`
+        // over in `crates/fs/src/ensure_file.rs`.
         let (path_b, hash_b) = store_dir.write_cas_file(b"hello world", false).unwrap();
         assert_eq!(hash_a, hash_b);
         assert_eq!(path_a, path_b);


### PR DESCRIPTION
## Summary

Ports pnpm v11's `writeBufferToCafs` shape into pacquet's CAFS writer, replacing the old `if exists → skip, else create-and-overwrite` pattern with the full exclusive-create + integrity-verify + atomic-rewrite sequence upstream uses.

References:
- [`store/cafs/src/writeBufferToCafs.ts`](https://github.com/pnpm/pnpm/blob/v11/store/cafs/src/writeBufferToCafs.ts)
- [`store/cafs/src/writeFile.ts`](https://github.com/pnpm/pnpm/blob/v11/store/cafs/src/writeFile.ts)
- [`store/cafs/src/checkPkgFilesIntegrity.ts`](https://github.com/pnpm/pnpm/blob/v11/store/cafs/src/checkPkgFilesIntegrity.ts) (`verifyFileIntegrity`)

### New sequence in `ensure_file`

1. Try `O_CREAT | O_EXCL` open (`OpenOptions::create_new(true)`). Success → we own the file, write `content` directly. Matches pnpm's `writeFileExclusive`.
2. `ErrorKind::AlreadyExists` → re-read the file and byte-compare with `content`. CAS paths are hash-derived, so matching bytes imply matching digest; this is the pacquet equivalent of pnpm's `verifyFileIntegrity`, cheaper because we hold the expected bytes already.
3. Match → `Ok(())`. The file is a live CAS entry; leaving it alone is correct.
4. **Mismatch** (torn blob from a prior crashed install) → `write_atomic`: open a unique temp path next to the target, write `content`, `fs::rename` over. Rename is atomic on Unix (`rename(2)`) and replaces-in-place on Windows, so observers never see a half-written blob. Matches pnpm's `writeFileAtomic` + `renameOverwriteSync`.
5. Any other open error propagates as `CreateFile`.

Temp path scheme mirrors pnpm's `pathTemp`: `{basename with -suffix stripped}{pid}{counter}`. Counter is a process-local monotonic `AtomicU64` (replaces pnpm's Node.js `workerThreads.threadId`). `-exec` → `x` suffix transform preserved via `strip_dash_suffix`, so temp files don't look like executable CAS entries.

### Deliberate divergences from pnpm v11

All documented inline on the `ensure_file` doc comment:

- **No upfront `stat`.** `create_new`/`AlreadyExists` gives the exists-signal for free. Saves one syscall per CAS file on cold installs.
- **Byte-compare instead of `crypto.hash`.** We hold the buffer, so equality check gives the same correctness guarantee without a second full-buffer walk.
- **No `locker: Map<string, number>` process-local cache.** Pacquet's hot path calls `ensure_file` at most once per CAS file per install (the `StoreIndex` decides whether we even get here), so the locker would be empty work. Can revisit if profiling shows repeated `AlreadyExists` hits on a single path.

### Why it's safer

Old shape used `OpenOptions::create(true)` which silently overwrites a pre-existing file. Combined with the `if exists → skip` short-circuit, a torn blob from a crashed prior install would persist across new installs and get served downstream as-if correct. The new shape self-heals: a torn blob at a CAS path is detected via byte-compare and atomically replaced with the known-good contents we were about to write.

### Why it's faster

On cold installs where every CAS file is new, the `.exists()` stat always returned `false` — pure waste. Removed. Same syscall shape as before on the new-file path (single `open` with `O_CREAT|O_EXCL`), one syscall less overall.

On warm hits during tarball extraction (rare — `StoreIndex` usually short-circuits before we get here) the shape is `create_new` → `read` → byte-compare. Same cost as pnpm's `stat` → `verifyFileIntegrity`, and since we byte-compare instead of re-hashing we save a full-buffer walk.

## Test plan

- [x] 7 targeted tests cover new-file write, matching-content short-circuit, mismatched-content atomic rewrite, missing-parent error, Unix mode, `-exec` → `x` temp-name transform, and plain-basename temp-name passthrough.
- [x] Existing `shard_cache_populates_on_first_write_and_skips_mkdir_thereafter` in `store-dir` still passes — covers the `AlreadyExists` branch through the CAS writer.
- [x] `just ready` — 177+ tests + clippy + fmt green.
- [x] `cargo nextest run -p pacquet-cli --test install --run-ignored=ignored-only frozen_lockfile_should_be_able_to_handle_big_lockfile` — end-to-end against the 1352-snapshot fixture in ~50 s.