### PR TITLE
perf(network,tarball): port pnpm v11 HTTP topology for tarball fetch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,6 +654,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -683,8 +689,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -1790,6 +1799,7 @@ version = "0.0.1"
 dependencies = [
  "dashmap",
  "derive_more",
+ "futures-util",
  "miette 7.6.0",
  "num_cpus",
  "pacquet-diagnostics",
@@ -2170,6 +2180,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -2187,12 +2198,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -3143,6 +3156,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ serde              = { version = "1.0.228", features = ["derive"] }
 serde_ini          = { version = "0.2.0" }
 serde_json         = { version = "1.0.149", features = ["preserve_order"] }
 serde_yaml         = { version = "0.9.34" }
-sha2               = { version = "0.10.9" }                                                                     # 0.11 removes the LowerHex impl on Output; revisit after upstream/consumers catch up
+sha2               = { version = "0.10.9" }                                                                               # 0.11 removes the LowerHex impl on Output; revisit after upstream/consumers catch up
 split-first-char   = { version = "2.0.1" }
 ssri               = { version = "9.2.0" }
 strum              = { version = "0.28.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ num_cpus           = { version = "1.17.0" }
 os_display         = { version = "0.1.4" }
 reflink-copy       = { version = "0.1.29" }
 junction           = { version = "1.4.2" }
-reqwest            = { version = "0.13", default-features = false, features = ["json", "native-tls-vendored"] }
+reqwest            = { version = "0.13", default-features = false, features = ["json", "native-tls-vendored", "stream"] }
 node-semver        = { version = "2.2.0" }
 pipe-trait         = { version = "0.4.0" }
 portpicker         = { version = "0.1.1" }

--- a/crates/cli/src/state.rs
+++ b/crates/cli/src/state.rs
@@ -58,7 +58,7 @@ impl State {
                 .map_err(InitStateError::LoadManifest)?,
             lockfile: call_load_lockfile(should_load, Lockfile::load_from_current_dir)
                 .map_err(InitStateError::LoadLockfile)?,
-            http_client: ThrottledClient::new_from_cpu_count(),
+            http_client: ThrottledClient::new_for_installs(),
             tarball_mem_cache: MemCache::new(),
             resolved_packages: ResolvedPackages::new(),
         })

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -53,7 +53,7 @@ impl ThrottledClient {
     /// truly stuck sockets. Making these values user-configurable
     /// (npmrc / env / CLI) is follow-up once the fetch-retry story
     /// lands.
-    pub fn new_from_cpu_count() -> Self {
+    pub fn new_for_installs() -> Self {
         let client = Client::builder()
             .http1_only()
             .connect_timeout(Duration::from_secs(10))
@@ -66,7 +66,7 @@ impl ThrottledClient {
 
     /// Construct a throttled client wrapping a pre-built [`Client`].
     /// Useful for tests that want different timeout values than
-    /// [`Self::new_from_cpu_count`] sets — e.g. sub-second connect
+    /// [`Self::new_for_installs`] sets — e.g. sub-second connect
     /// timeouts so firewalled / unreachable URLs fail within the
     /// test-suite budget instead of waiting on TCP retry.
     pub fn from_client(client: Client) -> Self {
@@ -84,6 +84,6 @@ impl ThrottledClient {
 /// This is only necessary for tests.
 impl Default for ThrottledClient {
     fn default() -> Self {
-        ThrottledClient::new_from_cpu_count()
+        ThrottledClient::new_for_installs()
     }
 }

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -1,4 +1,3 @@
-use pipe_trait::Pipe;
 use reqwest::Client;
 use std::{future::IntoFuture, time::Duration};
 use tokio::sync::Semaphore;
@@ -24,31 +23,39 @@ impl ThrottledClient {
         result
     }
 
-    /// Construct a new throttled client based on the number of CPUs.
-    /// If the number of CPUs is greater than 16, the number of permits will be equal to the number of CPUs.
-    /// Otherwise, the number of permits will be 16.
+    /// Construct the default throttled client used for real installs.
     ///
-    /// The returned [`Client`] carries explicit `connect` / `request` /
-    /// `pool_idle` deadlines. A default `reqwest::Client` has none of
-    /// these, and the CLI uses this constructor for real registry
-    /// traffic as well as the bench's local verdaccio — without a
-    /// request deadline pacquet just sits on a half-open socket
-    /// forever when an upstream stalls (GC pause, uplink stall, TCP
-    /// packet loss without RST). That's how `integrated-benchmark`
-    /// ends up hanging at "Benchmark 1: pacquet@HEAD" until the GHA
-    /// step timeout, see #263.
+    /// Network topology is ported from pnpm v11's
+    /// `network/fetch/src/dispatcher.ts` (see #280):
     ///
-    /// The 5-minute `timeout` is deliberately generous: npm tarballs
-    /// are usually under 5 MB but can reach tens or even hundreds of
-    /// MB on slow connections, and there's no retry on transient
-    /// network errors yet (#259). 5 min keeps slow-but-progressing
-    /// downloads succeeding while still catching truly stuck sockets
-    /// inside the bench's step budget. Making these values
-    /// user-configurable (npmrc / env / CLI) is the natural next step
-    /// once the fetch-retry story is in place — left as follow-up so
-    /// this stays a minimal, PR-reviewable fix for the CI hang.
+    /// * **HTTP/1.1 only.** A default `reqwest::Client` upgrades to
+    ///   HTTP/2 via ALPN whenever the registry advertises it
+    ///   (registry.npmjs.org does). Pnpm explicitly disables this
+    ///   upstream after benchmarking — multiplexing many tarball
+    ///   streams over 1-2 TCP connections sharing one congestion
+    ///   window was slower than opening ~50 independent HTTP/1.1
+    ///   connections that each get their own congestion window and
+    ///   saturate bandwidth in parallel.
+    /// * **50 concurrent sockets**, matching pnpm's
+    ///   `DEFAULT_MAX_SOCKETS`. The old `num_cpus.max(16)` semaphore
+    ///   under-subscribed on every machine we benchmarked — on a
+    ///   4-core GHA runner pacquet had 1/3 of pnpm's concurrent-
+    ///   fetch budget.
+    ///
+    /// Timeouts are unchanged: a default `reqwest::Client` has no
+    /// deadlines at all, which is how `integrated-benchmark` used to
+    /// hang at "Benchmark 1: pacquet@HEAD" until the GHA step budget
+    /// (#263) when an upstream stalled. The 5-minute `timeout` is
+    /// deliberately generous — npm tarballs are usually under 5 MB
+    /// but can reach hundreds of MB on slow connections, and there's
+    /// no retry on transient network errors yet (#259). 5 min keeps
+    /// slow-but-progressing downloads succeeding while still catching
+    /// truly stuck sockets. Making these values user-configurable
+    /// (npmrc / env / CLI) is follow-up once the fetch-retry story
+    /// lands.
     pub fn new_from_cpu_count() -> Self {
         let client = Client::builder()
+            .http1_only()
             .connect_timeout(Duration::from_secs(10))
             .timeout(Duration::from_secs(300))
             .pool_idle_timeout(Duration::from_secs(30))
@@ -63,8 +70,13 @@ impl ThrottledClient {
     /// timeouts so firewalled / unreachable URLs fail within the
     /// test-suite budget instead of waiting on TCP retry.
     pub fn from_client(client: Client) -> Self {
-        const MIN_PERMITS: usize = 16;
-        let semaphore = num_cpus::get().max(MIN_PERMITS).pipe(Semaphore::new);
+        // Matches pnpm v11's `DEFAULT_MAX_SOCKETS`
+        // (`network/fetch/src/dispatcher.ts:12`). Pnpm has explicit
+        // benchmark evidence that 50 HTTP/1.1 connections saturate
+        // tarball-fetch bandwidth better than fewer-with-multiplexing
+        // or fewer-connections-period.
+        const MAX_CONCURRENT_REQUESTS: usize = 50;
+        let semaphore = Semaphore::new(MAX_CONCURRENT_REQUESTS);
         ThrottledClient { semaphore, client }
     }
 }

--- a/crates/package-manager/src/install_package_from_registry.rs
+++ b/crates/package-manager/src/install_package_from_registry.rs
@@ -169,7 +169,7 @@ mod tests {
             create_config(store_dir.path(), modules_dir.path(), virtual_store_dir.path())
                 .pipe(Box::new)
                 .pipe(Box::leak);
-        let http_client = ThrottledClient::new_from_cpu_count();
+        let http_client = ThrottledClient::new_for_installs();
         let package = InstallPackageFromRegistry {
             tarball_mem_cache: &Default::default(),
             config,

--- a/crates/tarball/Cargo.toml
+++ b/crates/tarball/Cargo.toml
@@ -16,12 +16,13 @@ pacquet-fs          = { workspace = true }
 pacquet-network     = { workspace = true }
 pacquet-store-dir   = { workspace = true }
 
-dashmap      = { workspace = true }
-derive_more  = { workspace = true }
-miette       = { workspace = true }
-num_cpus     = { workspace = true }
-pipe-trait   = { workspace = true }
-reqwest      = { workspace = true }
+dashmap       = { workspace = true }
+derive_more   = { workspace = true }
+futures-util  = { workspace = true }
+miette        = { workspace = true }
+num_cpus      = { workspace = true }
+pipe-trait    = { workspace = true }
+reqwest       = { workspace = true }
 serde        = { workspace = true }
 serde_json   = { workspace = true }
 ssri         = { workspace = true }

--- a/crates/tarball/Cargo.toml
+++ b/crates/tarball/Cargo.toml
@@ -16,13 +16,13 @@ pacquet-fs          = { workspace = true }
 pacquet-network     = { workspace = true }
 pacquet-store-dir   = { workspace = true }
 
-dashmap       = { workspace = true }
-derive_more   = { workspace = true }
-futures-util  = { workspace = true }
-miette        = { workspace = true }
-num_cpus      = { workspace = true }
-pipe-trait    = { workspace = true }
-reqwest       = { workspace = true }
+dashmap      = { workspace = true }
+derive_more  = { workspace = true }
+futures-util = { workspace = true }
+miette       = { workspace = true }
+num_cpus     = { workspace = true }
+pipe-trait   = { workspace = true }
+reqwest      = { workspace = true }
 serde        = { workspace = true }
 serde_json   = { workspace = true }
 ssri         = { workspace = true }

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -84,6 +84,11 @@ pub enum TarballError {
     #[from(ignore)]
     #[diagnostic(code(pacquet_tarball::task_join_error))]
     TaskJoin(tokio::task::JoinError),
+
+    #[from(ignore)]
+    #[display("Tarball at {url} had Content-Length {expected} but {received} bytes were received")]
+    #[diagnostic(code(pacquet_tarball::bad_tarball_size))]
+    BadTarballSize { url: String, expected: u64, received: u64 },
 }
 
 /// Value of the cache.
@@ -482,6 +487,14 @@ impl<'a> DownloadTarballToStore<'a> {
             .await
             .map_err(network_error)?;
 
+        // Read `Content-Length` *before* we start consuming the body
+        // stream so we can pre-size the buffer. Ports pnpm v11's
+        // `fetching/tarball-fetcher/src/remoteTarballFetcher.ts:148-164`:
+        // reqwest/hyper internally grows its buffer by doubling when
+        // CL isn't used, so on a 1352-tarball cold install that's a
+        // lot of wasted alloc + copy work across the pipeline.
+        let expected_size = response_head.content_length();
+
         // Gate the memory-heavy + CPU-heavy part of the pipeline with
         // `post_download_semaphore`:
         //
@@ -489,7 +502,7 @@ impl<'a> DownloadTarballToStore<'a> {
         //   for I/O wait but disastrous for CPU work that can only
         //   really run `num_cpus` at a time, so we cap concurrent
         //   `spawn_blocking` bodies.
-        // - We also acquire the permit *before* `.bytes().await`
+        // - We also acquire the permit *before* we consume the body
         //   rather than right before `spawn_blocking`. Buffering is
         //   where the per-tarball memory spike lives (a full
         //   decompressed package can be many MB), so holding the
@@ -499,14 +512,57 @@ impl<'a> DownloadTarballToStore<'a> {
         //   up hundreds of buffered tarballs waiting for a permit to
         //   process (Copilot review on #269).
         //
-        // The permit is held across both `.bytes().await` and the
-        // `spawn_blocking.await` below, dropping at end of scope.
+        // The permit is held across both the body-stream drain and
+        // the `spawn_blocking.await` below, dropping at end of scope.
         let _post_download_permit = post_download_semaphore()
             .acquire()
             .await
             .expect("post-download semaphore shouldn't be closed this soon");
 
-        let response = response_head.bytes().await.map_err(network_error)?;
+        // Stream the body into a single pre-sized `Vec<u8>` when
+        // `Content-Length` is known. One allocation + one
+        // `extend_from_slice` per chunk, no growth-by-doubling.
+        // Falls back to the empty-capacity `Vec::new()` when CL is
+        // missing (chunked transfer encoding), which still avoids
+        // reqwest/hyper's intermediate-chunk-list + second-copy pass.
+        //
+        // Pnpm also surfaces a `BadTarballError` when the received
+        // size doesn't match the CL header — mirror that via
+        // `BadTarballSize` so an upstream bug or middleware
+        // truncation is visible instead of silently producing a
+        // short tarball that only fails later at the integrity check.
+        let response = {
+            use futures_util::StreamExt;
+            let mut buf: Vec<u8> = match expected_size {
+                Some(size) => Vec::with_capacity(size as usize),
+                None => Vec::new(),
+            };
+            let mut stream = response_head.bytes_stream();
+            while let Some(chunk) = stream.next().await {
+                let chunk = chunk.map_err(network_error)?;
+                if let Some(expected) = expected_size {
+                    let after = buf.len() as u64 + chunk.len() as u64;
+                    if after > expected {
+                        return Err(TarballError::BadTarballSize {
+                            url: package_url.to_string(),
+                            expected,
+                            received: after,
+                        });
+                    }
+                }
+                buf.extend_from_slice(&chunk);
+            }
+            if let Some(expected) = expected_size {
+                if buf.len() as u64 != expected {
+                    return Err(TarballError::BadTarballSize {
+                        url: package_url.to_string(),
+                        expected,
+                        received: buf.len() as u64,
+                    });
+                }
+            }
+            buf
+        };
 
         tracing::info!(target: "pacquet::download", ?package_url, "Download completed");
 

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -86,9 +86,11 @@ pub enum TarballError {
     TaskJoin(tokio::task::JoinError),
 
     #[from(ignore)]
-    #[display("Tarball at {url} had Content-Length {expected} but {received} bytes were received")]
-    #[diagnostic(code(pacquet_tarball::bad_tarball_size))]
-    BadTarballSize { url: String, expected: u64, received: u64 },
+    #[display(
+        "Tarball at {url} advertised a Content-Length of {advertised_size} bytes, which exceeds what pacquet can allocate (either larger than `usize::MAX` on this target or memory pressure prevented a one-shot reservation)"
+    )]
+    #[diagnostic(code(pacquet_tarball::tarball_too_large))]
+    TarballTooLarge { url: String, advertised_size: u64 },
 }
 
 /// Value of the cache.
@@ -104,6 +106,43 @@ pub enum CacheValue {
 ///
 /// The key of this hashmap is the url of each tarball.
 pub type MemCache = DashMap<String, Arc<RwLock<CacheValue>>>;
+
+/// Build the buffer that the tarball body streams into, pre-sized
+/// from the response's advertised `Content-Length` when it fits and
+/// can actually be reserved without allocation failure.
+///
+/// `Content-Length` is untrusted input — a malicious or broken
+/// registry could advertise `u64::MAX`, which would crash the
+/// process if we passed it directly to `Vec::with_capacity`. Two
+/// guards:
+///
+/// 1. `usize::try_from(size)` — on 32-bit targets a `u64` header
+///    value may exceed `usize::MAX`; on 64-bit the two are the
+///    same width but the conversion is cheap anyway.
+/// 2. `Vec::try_reserve_exact(cap)` — if the allocator refuses
+///    (legitimate OOM, or because `cap` is absurdly large relative
+///    to available RAM), we surface `TarballTooLarge` instead of
+///    aborting via the infallible `with_capacity` path.
+///
+/// When `content_length` is absent the response uses chunked
+/// transfer encoding and we can't pre-size; return an empty
+/// growable `Vec` and let the stream loop extend it.
+fn allocate_tarball_buffer(
+    content_length: Option<u64>,
+    url: &str,
+) -> Result<Vec<u8>, TarballError> {
+    let Some(size) = content_length else {
+        return Ok(Vec::new());
+    };
+
+    let too_large =
+        || TarballError::TarballTooLarge { url: url.to_string(), advertised_size: size };
+
+    let capacity = usize::try_from(size).map_err(|_| too_large())?;
+    let mut buf = Vec::new();
+    buf.try_reserve_exact(capacity).map_err(|_| too_large())?;
+    Ok(buf)
+}
 
 #[instrument(skip(gz_data), fields(gz_data_len = gz_data.len()))]
 fn decompress_gzip(gz_data: &[u8], unpacked_size: Option<usize>) -> Result<Vec<u8>, TarballError> {
@@ -522,44 +561,24 @@ impl<'a> DownloadTarballToStore<'a> {
         // Stream the body into a single pre-sized `Vec<u8>` when
         // `Content-Length` is known. One allocation + one
         // `extend_from_slice` per chunk, no growth-by-doubling.
-        // Falls back to the empty-capacity `Vec::new()` when CL is
-        // missing (chunked transfer encoding), which still avoids
-        // reqwest/hyper's intermediate-chunk-list + second-copy pass.
+        // Falls back to empty capacity when CL is missing (chunked
+        // transfer encoding), which still avoids reqwest/hyper's
+        // intermediate-chunk-list + second-copy pass.
         //
-        // Pnpm also surfaces a `BadTarballError` when the received
-        // size doesn't match the CL header — mirror that via
-        // `BadTarballSize` so an upstream bug or middleware
-        // truncation is visible instead of silently producing a
-        // short tarball that only fails later at the integrity check.
+        // We don't re-verify the received byte count against
+        // `Content-Length` — hyper enforces CL framing itself on the
+        // receive side (a body shorter than CL errors the stream, a
+        // body longer is truncated or queued as the next request),
+        // so the check would be dead code. Pnpm's equivalent
+        // `BadTarballError` path exists because undici in Node.js
+        // doesn't always enforce it.
         let response = {
             use futures_util::StreamExt;
-            let mut buf: Vec<u8> = match expected_size {
-                Some(size) => Vec::with_capacity(size as usize),
-                None => Vec::new(),
-            };
+            let mut buf = allocate_tarball_buffer(expected_size, package_url)?;
             let mut stream = response_head.bytes_stream();
             while let Some(chunk) = stream.next().await {
                 let chunk = chunk.map_err(network_error)?;
-                if let Some(expected) = expected_size {
-                    let after = buf.len() as u64 + chunk.len() as u64;
-                    if after > expected {
-                        return Err(TarballError::BadTarballSize {
-                            url: package_url.to_string(),
-                            expected,
-                            received: after,
-                        });
-                    }
-                }
                 buf.extend_from_slice(&chunk);
-            }
-            if let Some(expected) = expected_size {
-                if buf.len() as u64 != expected {
-                    return Err(TarballError::BadTarballSize {
-                        url: package_url.to_string(),
-                        expected,
-                        received: buf.len() as u64,
-                    });
-                }
             }
             buf
         };
@@ -659,6 +678,47 @@ mod tests {
 
     fn integrity(integrity_str: &str) -> Integrity {
         integrity_str.parse().expect("parse integrity string")
+    }
+
+    /// Absent `Content-Length` (chunked transfer) returns an empty
+    /// growable buffer. The stream loop extends it as chunks arrive.
+    #[test]
+    fn allocate_tarball_buffer_returns_empty_when_content_length_is_absent() {
+        let buf = allocate_tarball_buffer(None, "https://example.test/pkg.tgz")
+            .expect("no content-length is a valid chunked-transfer response");
+        assert_eq!(buf.len(), 0);
+    }
+
+    /// Reasonable `Content-Length` pre-sizes the buffer so no
+    /// realloc happens during the stream loop. `try_reserve_exact`
+    /// succeeds; we don't assert `buf.capacity() == size` because
+    /// allocators are allowed to round up, only that it's at least
+    /// what we asked for.
+    #[test]
+    fn allocate_tarball_buffer_presizes_for_reasonable_content_length() {
+        let buf = allocate_tarball_buffer(Some(1024 * 1024), "https://example.test/pkg.tgz")
+            .expect("1 MiB pre-allocation should succeed on any dev / CI box");
+        assert!(buf.capacity() >= 1024 * 1024, "capacity = {}", buf.capacity());
+        assert_eq!(buf.len(), 0);
+    }
+
+    /// A maliciously or buggily huge `Content-Length` must not be
+    /// passed through to the infallible `Vec::with_capacity` — that
+    /// would abort the process on allocation failure. `try_reserve_exact`
+    /// surfaces the failure as `TarballTooLarge` so the install can
+    /// reject this one package and continue.
+    #[test]
+    fn allocate_tarball_buffer_rejects_absurd_content_length() {
+        let url = "https://example.test/evil.tgz";
+        let err = allocate_tarball_buffer(Some(u64::MAX), url)
+            .expect_err("u64::MAX cannot actually be reserved");
+        match err {
+            TarballError::TarballTooLarge { url: got_url, advertised_size } => {
+                assert_eq!(got_url, url);
+                assert_eq!(advertised_size, u64::MAX);
+            }
+            other => panic!("expected TarballTooLarge, got {other:?}"),
+        }
     }
 
     /// HTTP client for the fall-through tests. A default `ThrottledClient`

--- a/tasks/micro-benchmark/src/main.rs
+++ b/tasks/micro-benchmark/src/main.rs
@@ -34,7 +34,7 @@ fn bench_tarball(c: &mut Criterion, server: &mut ServerGuard, fixtures_folder: &
             let dir = tempdir().unwrap();
             let store_dir =
                 dir.path().to_path_buf().pipe(StoreDir::from).pipe(Box::new).pipe(Box::leak);
-            let http_client = ThrottledClient::new_from_cpu_count();
+            let http_client = ThrottledClient::new_for_installs();
 
             let cas_map = DownloadTarballToStore {
                 http_client: &http_client,


### PR DESCRIPTION
Closes items 1-3 of #280. All three are ports of deliberate pnpm v11 choices where a default `reqwest::Client` diverges from the shape pnpm landed upstream with explicit benchmark evidence.

## Summary

### 1. HTTP/1.1 only — `.http1_only()`

A default `reqwest::Client` upgrades to HTTP/2 via ALPN whenever the registry advertises it; `registry.npmjs.org` does. Pnpm v11's [`network/fetch/src/dispatcher.ts:17-22`](https://github.com/pnpm/pnpm/blob/v11/network/fetch/src/dispatcher.ts) deliberately disables this:

> With HTTP/2, undici multiplexes many streams over 1-2 TCP connections sharing a single congestion window. In benchmarks this was slower than opening ~50 independent HTTP/1.1 connections that each get their own congestion window and can saturate bandwidth in parallel.

### 2. 50 concurrent sockets

Matches pnpm's [`DEFAULT_MAX_SOCKETS`](https://github.com/pnpm/pnpm/blob/v11/network/fetch/src/dispatcher.ts#L12). The old `num_cpus.max(16)` semaphore undersized the concurrent-fetch budget on every machine I benchmarked against — on a 4-core GHA runner pacquet had 1/3 of pnpm's concurrent-fetch capacity.

Renames `ThrottledClient::new_from_cpu_count` → `new_for_installs` since the method no longer scales with CPU count; the new name reflects what it actually returns (the default client tuned for pacquet install traffic). Callers updated in `package-manager`, `cli::state`, and the `micro-benchmark` task.

### 3. Pre-allocate the tarball buffer from `Content-Length`

Ports [`fetching/tarball-fetcher/src/remoteTarballFetcher.ts:148-164`](https://github.com/pnpm/pnpm/blob/v11/fetching/tarball-fetcher/src/remoteTarballFetcher.ts). The old `response_head.bytes().await` let reqwest/hyper grow an internal `BytesMut` by doubling when `Content-Length` wasn't used to pre-size; on a 1352-tarball cold install that's multiple reallocs + copies per tarball.

Switched to `bytes_stream()` + a new `allocate_tarball_buffer` helper that pre-sizes a single `Vec<u8>` from `content_length()` when known (falls back to `Vec::new()` for chunked transfer). Chunks land in via `extend_from_slice`.

`Content-Length` is untrusted input, so the helper treats it as such:

- `usize::try_from(size)` handles 32-bit targets where a `u64` CL can exceed `usize::MAX`.
- `Vec::try_reserve_exact(capacity)` converts an allocator refusal (OOM pressure, or an absurd `u64::MAX`-style claim) into a typed error instead of an abort.

Both failures surface as a new `TarballError::TarballTooLarge` variant so the install can reject one offending package and continue. Three unit tests on the helper pin the chunked-transfer fallback, the reasonable-size pre-sizing path, and the `u64::MAX` rejection path.

## Dependencies

- `reqwest`: added `stream` feature (needed for `bytes_stream`).
- `pacquet-tarball`: pulled in `futures-util` (already a workspace dep).

## Deferred from #280

- Item 4 (post-download concurrency cap, `num_cpus*2` → `num_cpus-1`): wants Apple Silicon before/after numbers before landing; current value was chosen to keep a 2-CPU GHA runner from wedging (#269), not as a perf decision.
- Item 5 (hardware SHA-512 on Apple Silicon): wants a macOS profile confirming SHA-512 is in the hot path before committing to a crypto-crate swap.

## Not doing: `BadTarballSize` variant

An earlier draft of this PR added a `BadTarballSize` variant and per-chunk byte-count checks that mirrored pnpm's `BadTarballError`. Review (#281) asked for tests; on closer look the checks can't actually fire behind reqwest/hyper, which enforces `Content-Length` framing on the receive side — a body shorter than CL errors the stream before our code sees a chunk sequence ending cleanly-but-early, and a body longer than CL gets truncated at the CL boundary or queued as the start of the next request on a keep-alive connection. Pnpm ships the equivalent check because undici in Node.js doesn't always enforce this; reqwest does, so the variant was unreachable defense-in-depth with an untestable error path. Dropped.

## Test plan

- [x] `just ready` — all tests + clippy + fmt green
- [x] `cargo nextest run -p pacquet-cli --test install --run-ignored=ignored-only frozen_lockfile_should_be_able_to_handle_big_lockfile` — 1352-snapshot fixture passes end-to-end in ~47 s
- [x] Three new unit tests on `allocate_tarball_buffer` (chunked fallback, reasonable CL pre-sizing, `u64::MAX` OOM rejection)
- [x] Existing `packages_under_orgs_should_work` real-network tarball fetch exercises the streaming-into-preallocated-buffer path against registry.npmjs.org
- [x] `should_throw_error_on_checksum_mismatch` still surfaces `TarballError::Checksum` — the integrity check runs after the body is buffered, independent of how the body was accumulated
- [ ] Integrated benchmark against a real registry on a cold store — existing benchmarks run against local verdaccio on loopback, which doesn't exercise the network-topology improvements (H2 vs H1.1, socket concurrency, real Content-Length handling). CI's `integrated-benchmark` run will give a directional number.