### PR TITLE
perf(tarball): match pnpm v11 post-download concurrency cap

### DIFF
--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -30,12 +30,26 @@ use zune_inflate::{errors::InflateDecodeErrors, DeflateDecoder, DeflateOptions};
 /// fires hundreds of these at once on a 1352-snapshot install, which
 /// thrashes small CI runners. Past "Download completed" a 2-CPU GitHub
 /// Actions runner wedged between decompress-close and `Checksum verified`
-/// on #269 until the step timeout. `num_cpus * 2` (floor 4) keeps enough
-/// work in flight to overlap per-file FS writes with SHA on another task
-/// without oversubscribing the cores.
+/// on #269 until the step timeout.
+///
+/// Sizing matches pnpm v11's `worker/src/index.ts:71`
+/// `Math.max(1, availableParallelism() - 1)` (#280, item 4), lifted to a
+/// floor of 2 so a single-CPU or 2-CPU GHA runner still has two tasks in
+/// flight and can overlap per-file FS writes with SHA on another task:
+///
+/// ```text
+/// num_cpus.saturating_sub(1).max(2)
+/// ```
+///
+/// On a 10P-core M3 that's 9 concurrent bodies instead of the old 20.
+/// Each body is CPU-bound, so oversubscription on Apple Silicon (where
+/// some tasks land on the slower efficiency cores and stretch the tail)
+/// costs more than the extra parallelism buys. The #269 2-CPU floor
+/// still holds — 2 tasks is enough for the SHA/FS overlap we need to
+/// avoid the decompress wedge.
 fn post_download_semaphore() -> &'static Semaphore {
     static SEM: OnceLock<Semaphore> = OnceLock::new();
-    SEM.get_or_init(|| Semaphore::new(num_cpus::get().saturating_mul(2).max(4)))
+    SEM.get_or_init(|| Semaphore::new(num_cpus::get().saturating_sub(1).max(2)))
 }
 
 #[derive(Debug, Display, Error, Diagnostic)]


### PR DESCRIPTION
Closes item 4 of #280 (default path only).

## Summary

The post-download semaphore capped concurrent tarball bodies at `num_cpus.saturating_mul(2).max(4)`. Each body is CPU-bound (SHA-512 over the compressed tarball, gzip inflate, per-file SHA-512) with interleaved blocking FS I/O. On a 10P-core M3 Max that's **20** concurrent CPU workers; pnpm v11's default path caps at `Math.max(1, availableParallelism() - 1)` = **9** on the same machine.

Oversubscribing on Apple Silicon hurts harder than on Linux: context switches are slower, and the P+E core mix means some workers land on slower efficiency cores and stretch the install tail.

Switch to:

```rust
num_cpus.saturating_sub(1).max(2)
```

Table:

| Cores | Old formula | New formula | Pnpm default |
|---|---|---|---|
| 10P-core M3 Max | 20 | **9** | 9 |
| 4-core GHA | 8 | 3 | 3 |
| 2-core GHA | 4 | 2 | 1 |
| 1-core | 4 | 2 | 1 |

The `.max(2)` floor preserves the #269 wedge-avoidance property: two concurrent bodies is enough for the SHA/FS-write overlap that prevents the decompress-close → checksum-verified wedge the original `floor 4` was chosen to fix. Pnpm runs as low as 1 on 2-core machines without wedging, so 2 on pacquet stays comfortable.

## What this PR does *not* do

Two pnpm behaviors are deliberately out of scope:

1. **Env-var overrides** — pnpm's `calcMaxWorkers` in [`worker/src/index.ts:63-72`](https://github.com/pnpm/pnpm/blob/v11/worker/src/index.ts) honors `PNPM_MAX_WORKERS` (explicit count) and `PNPM_WORKERS` (idle-core count). This PR ports only the default path. The env-var surface can be added under `PACQUET_*` names if/when someone needs it.

2. **Import-concurrency limit** — pnpm *also* has a separate `limitImportingPackage = pLimit(4)` (`worker/src/index.ts:281`) that caps concurrent `importPackage` (CAFS → `node_modules/pkg/`) operations at 4, independent of the worker pool size. The comment there reads:

   > The workers are doing lots of file system operations so, running them in parallel helps only to a point. With local experimenting it was discovered that running 4 workers gives the best results. Adding more workers actually makes installation slower.

   Pacquet's equivalent is the `create_cas_files` → `link_file` chain inside `CreateVirtualDirBySnapshot::run`, which today fans out concurrently across all snapshots (up to 1352 concurrent imports on the big-lockfile fixture) with no dedicated cap. Worth porting but deliberately out of this PR — it's a distinct concern from the decompress/CAS-write cap this PR retunes, and it'll be easier to bisect if one of them regresses. Follow-up PR incoming.

## Test plan

- [x] `just ready` — all tests + clippy + fmt green
- [x] `cargo nextest run -p pacquet-cli --test install --run-ignored=ignored-only frozen_lockfile_should_be_able_to_handle_big_lockfile` — 1352-snapshot fixture passes end-to-end in ~49 s on this local Apple Silicon box (was ~47 s before the change — within noise; the change is expected to help on network-bound cold installs more than on this local-verdaccio bench)
- [ ] CI `integrated-benchmark` will give a directional number on Linux 4-core
- [ ] Apple Silicon benchmark against a real registry, cold store — the scenario this change is targeting