### PR TITLE
perf(package-manager): cap CAS-to-node_modules import concurrency at 4

### DIFF
--- a/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/crates/package-manager/src/install_package_by_snapshot.rs
@@ -7,7 +7,46 @@ use pacquet_npmrc::Npmrc;
 use pacquet_store_dir::{SharedReadonlyStoreIndex, StoreIndexWriter};
 use pacquet_tarball::{DownloadTarballToStore, TarballError};
 use pipe_trait::Pipe;
-use std::{borrow::Cow, sync::Arc};
+use std::{
+    borrow::Cow,
+    sync::{Arc, OnceLock},
+};
+use tokio::sync::Semaphore;
+
+/// Cap on concurrent CAS-to-`node_modules` imports — the
+/// `create_cas_files` → `link_file` chain inside
+/// [`CreateVirtualDirBySnapshot::run`] that reflinks / hardlinks / copies
+/// each package's files out of the store shards and into the per-
+/// package `.pacquet/{pkg}@{ver}/node_modules/{pkg}/` slot.
+///
+/// Ports pnpm v11's `limitImportingPackage = pLimit(4)` from
+/// `worker/src/index.ts:281`, where pnpm records the following
+/// empirical finding:
+///
+/// > The workers are doing lots of file system operations so,
+/// > running them in parallel helps only to a point. With local
+/// > experimenting it was discovered that running 4 workers gives
+/// > the best results. Adding more workers actually makes
+/// > installation slower.
+///
+/// In pnpm this cap is independent of (and tighter than) the
+/// worker-pool size; a 16-core machine still caps imports at 4. The
+/// reasoning holds for pacquet too — each import call does a flurry
+/// of syscalls (stat → link/reflink/copy) that serialise at the
+/// filesystem's metadata journal, and past 4 concurrent packages
+/// the contention dominates any additional parallelism. Ports the
+/// absolute number; widening or narrowing is empirical work for a
+/// follow-up.
+///
+/// Gates only the node_modules import stage, not the upstream
+/// tarball fetch or decompress. Those have their own caps in
+/// `pacquet_tarball` (HTTP socket throttle, post-download
+/// semaphore) that operate on an earlier, less FS-contentious
+/// slice of the install.
+fn cas_import_semaphore() -> &'static Semaphore {
+    static SEM: OnceLock<Semaphore> = OnceLock::new();
+    SEM.get_or_init(|| Semaphore::new(4))
+}
 
 /// This subroutine downloads a package tarball, extracts it, installs it to a
 /// virtual dir, then creates the symlink layout for the package. CAS file
@@ -107,6 +146,18 @@ impl<'a> InstallPackageBySnapshot<'a> {
         .run_without_mem_cache()
         .await
         .map_err(InstallPackageBySnapshotError::DownloadTarball)?;
+
+        // Acquire the CAS-import permit *after* the tarball is on
+        // disk, so the network + decompress + CAS-write stages (all
+        // capped upstream by `post_download_semaphore`) don't also
+        // serialise behind this tighter gate. The permit is held
+        // across the synchronous `CreateVirtualDirBySnapshot::run`
+        // call, which does the `create_cas_files` → `link_file`
+        // sweep + symlink layout.
+        let _import_permit = cas_import_semaphore()
+            .acquire()
+            .await
+            .expect("cas-import semaphore shouldn't be closed this soon");
 
         CreateVirtualDirBySnapshot {
             virtual_store_dir: &config.virtual_store_dir,


### PR DESCRIPTION
Companion to #283. Both ports are from #280's investigation of pnpm v11 defaults pacquet didn't mirror; separating them so either one can land / revert independently.

## Summary

Ports pnpm v11's [`limitImportingPackage = pLimit(4)`](https://github.com/pnpm/pnpm/blob/v11/worker/src/index.ts#L281):

```ts
// The workers are doing lots of file system operations
// so, running them in parallel helps only to a point.
// With local experimenting it was discovered that running 4 workers gives the best results.
// Adding more workers actually makes installation slower.
let limitImportingPackage = pLimit(4)
```

In pnpm this cap is **independent of and tighter than** the worker-pool size — a 16-core machine still caps concurrent `importPackage` (CAFS → `node_modules/pkg/`) at 4. The reasoning is that each import call does a flurry of syscalls (stat + link/reflink/copy) that serialises at the filesystem metadata journal, and past ~4 concurrent packages the contention dominates any additional parallelism.

Pacquet's equivalent is the `create_cas_files` → `link_file` sweep inside `CreateVirtualDirBySnapshot::run`, which today fans out concurrently across every snapshot (up to 1352 in-flight on the big-lockfile fixture) via tokio's `try_join_all` with no dedicated cap. Especially on APFS / macOS where the journal is a tighter serialisation point than on Linux ext4, the uncapped shape is the exact scenario pnpm's comment calls out.

Add a process-global `Semaphore::new(4)` around the `CreateVirtualDirBySnapshot::run` call in `install_package_by_snapshot.rs`. Permit is acquired *after* the tarball is on disk so the upstream network + decompress + CAS-write stages (capped by `ThrottledClient`'s 50-socket semaphore and `pacquet_tarball::post_download_semaphore`, both wider) don't also serialise behind this tighter gate.

## Scope

- Gates only the node_modules import stage.
- Does not change the download/decompress/CAS-write caps — those stay on their existing semaphores and are strictly wider.
- Same absolute value pnpm ships; widening or narrowing is empirical work for a follow-up once we have macOS-cold-cache numbers.

## Test plan

- [x] `just ready` — all tests + clippy + fmt green
- [x] `cargo nextest run -p pacquet-cli --test install --run-ignored=ignored-only frozen_lockfile_should_be_able_to_handle_big_lockfile` — 1352-snapshot fixture passes end-to-end in ~49 s on this local Apple Silicon box (same order of magnitude as pre-change; the benefit is expected on real-FS / macOS, not local verdaccio)
- [ ] CI `integrated-benchmark` for a directional number
- [ ] Apple Silicon + real registry cold install — the scenario pnpm's comment describes