### PR TITLE
perf(store-dir): globalize verifiedFilesCache across the install

### DIFF
--- a/crates/package-manager/src/create_virtual_store.rs
+++ b/crates/package-manager/src/create_virtual_store.rs
@@ -7,7 +7,7 @@ use miette::Diagnostic;
 use pacquet_lockfile::{LockfileResolution, PackageKey, PackageMetadata, SnapshotEntry};
 use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
-use pacquet_store_dir::{StoreIndex, StoreIndexWriter, store_index_key};
+use pacquet_store_dir::{SharedVerifiedFilesCache, StoreIndex, StoreIndexWriter, store_index_key};
 use pacquet_tarball::prefetch_cas_paths;
 use pipe_trait::Pipe;
 use std::collections::HashMap;
@@ -118,6 +118,14 @@ impl<'a> CreateVirtualStore<'a> {
         let (store_index_writer, writer_task) = StoreIndexWriter::spawn(store_dir);
         let store_index_writer_ref = Some(&store_index_writer);
 
+        // Install-scoped `verifiedFilesCache`. One `Arc<DashSet>` lives
+        // for the duration of the install; every per-snapshot fetch
+        // gets the same handle. A CAFS path verified on snapshot A
+        // populates the set so snapshot B's verify pass skips the stat
+        // / re-hash cost. Ports pnpm's `verifiedFilesCache: Set<string>`
+        // threading in `store/cafs/src/checkPkgFilesIntegrity.ts`.
+        let verified_files_cache = SharedVerifiedFilesCache::default();
+
         // Batch every cache lookup the per-snapshot futures would otherwise
         // each fan into `tokio::task::spawn_blocking`. With 1352 snapshots
         // hitting the default 512-thread blocking pool, each task's actual
@@ -176,6 +184,7 @@ impl<'a> CreateVirtualStore<'a> {
             store_dir,
             cache_keys,
             config.verify_store_integrity,
+            SharedVerifiedFilesCache::clone(&verified_files_cache),
         )
         .await;
 
@@ -266,6 +275,7 @@ impl<'a> CreateVirtualStore<'a> {
         // existing tokio + download path.
         if !cold.is_empty() {
             let prefetched_ref = Some(&prefetched);
+            let verified_files_cache_ref = &verified_files_cache;
             cold.iter()
                 .map(|(snapshot_key, snapshot)| async move {
                     let metadata_key = snapshot_key.without_peer();
@@ -281,6 +291,7 @@ impl<'a> CreateVirtualStore<'a> {
                         store_index: store_index_ref,
                         store_index_writer: store_index_writer_ref,
                         prefetched_cas_paths: prefetched_ref,
+                        verified_files_cache: verified_files_cache_ref,
                         package_key: snapshot_key,
                         metadata,
                         snapshot,

--- a/crates/package-manager/src/create_virtual_store.rs
+++ b/crates/package-manager/src/create_virtual_store.rs
@@ -7,7 +7,7 @@ use miette::Diagnostic;
 use pacquet_lockfile::{PackageKey, PackageMetadata, SnapshotEntry};
 use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
-use pacquet_store_dir::{StoreIndex, StoreIndexWriter};
+use pacquet_store_dir::{SharedVerifiedFilesCache, StoreIndex, StoreIndexWriter};
 use pipe_trait::Pipe;
 use std::collections::HashMap;
 
@@ -115,6 +115,14 @@ impl<'a> CreateVirtualStore<'a> {
         let (store_index_writer, writer_task) = StoreIndexWriter::spawn(store_dir);
         let store_index_writer_ref = Some(&store_index_writer);
 
+        // Install-scoped `verifiedFilesCache`. One `Arc<DashSet>` lives
+        // for the duration of the install; every per-snapshot fetch
+        // gets the same handle. A CAFS path verified on snapshot A
+        // populates the set so snapshot B's verify pass skips the stat
+        // / re-hash cost. Ports pnpm's `verifiedFilesCache: Set<string>`
+        // threading in `store/cafs/src/checkPkgFilesIntegrity.ts`.
+        let verified_files_cache = SharedVerifiedFilesCache::default();
+
         // Each snapshot gets a tokio task that awaits its tarball fetch and
         // then runs `CreateVirtualDirBySnapshot` — which in turn does the
         // CAS-import / symlink-layout pair concurrently on rayon via
@@ -125,26 +133,36 @@ impl<'a> CreateVirtualStore<'a> {
         // symlinks with import" shape (`installing/deps-restorer/src/index.ts`).
         snapshots
             .iter()
-            .map(|(snapshot_key, snapshot)| async move {
-                let metadata_key = snapshot_key.without_peer();
-                let metadata = packages.get(&metadata_key).ok_or_else(|| {
-                    CreateVirtualStoreError::MissingPackageMetadata {
-                        snapshot_key: snapshot_key.to_string(),
-                        metadata_key: metadata_key.to_string(),
+            .map(|(snapshot_key, snapshot)| {
+                // The closure runs once per snapshot before any future
+                // is awaited, so a borrow into the surrounding scope
+                // would need to outlive the resulting `async move`.
+                // Bind a same-Arc copy here instead — the inner `async
+                // move` then captures an owned `SharedVerifiedFilesCache`
+                // that all per-snapshot futures still share.
+                let verified_files_cache = SharedVerifiedFilesCache::clone(&verified_files_cache);
+                async move {
+                    let metadata_key = snapshot_key.without_peer();
+                    let metadata = packages.get(&metadata_key).ok_or_else(|| {
+                        CreateVirtualStoreError::MissingPackageMetadata {
+                            snapshot_key: snapshot_key.to_string(),
+                            metadata_key: metadata_key.to_string(),
+                        }
+                    })?;
+                    InstallPackageBySnapshot {
+                        http_client,
+                        config,
+                        store_index: store_index_ref,
+                        store_index_writer: store_index_writer_ref,
+                        verified_files_cache: &verified_files_cache,
+                        package_key: snapshot_key,
+                        metadata,
+                        snapshot,
                     }
-                })?;
-                InstallPackageBySnapshot {
-                    http_client,
-                    config,
-                    store_index: store_index_ref,
-                    store_index_writer: store_index_writer_ref,
-                    package_key: snapshot_key,
-                    metadata,
-                    snapshot,
+                    .run()
+                    .await
+                    .map_err(CreateVirtualStoreError::InstallPackageBySnapshot)
                 }
-                .run()
-                .await
-                .map_err(CreateVirtualStoreError::InstallPackageBySnapshot)
             })
             .pipe(future::try_join_all)
             .await?;

--- a/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/crates/package-manager/src/install_package_by_snapshot.rs
@@ -6,7 +6,7 @@ use miette::Diagnostic;
 use pacquet_lockfile::{LockfileResolution, PackageKey, PackageMetadata, SnapshotEntry};
 use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
-use pacquet_store_dir::{SharedReadonlyStoreIndex, StoreIndexWriter};
+use pacquet_store_dir::{SharedReadonlyStoreIndex, SharedVerifiedFilesCache, StoreIndexWriter};
 use pacquet_tarball::{DownloadTarballToStore, PrefetchedCasPaths, TarballError};
 use pipe_trait::Pipe;
 use std::{borrow::Cow, sync::Arc};
@@ -24,6 +24,10 @@ pub struct InstallPackageBySnapshot<'a> {
     /// Install-scoped batched cache lookup result. See
     /// [`pacquet_tarball::prefetch_cas_paths`].
     pub prefetched_cas_paths: Option<&'a PrefetchedCasPaths>,
+    /// Install-scoped `verifiedFilesCache` shared across every
+    /// per-snapshot fetch. See `DownloadTarballToStore::verified_files_cache`
+    /// for the rationale.
+    pub verified_files_cache: &'a SharedVerifiedFilesCache,
     pub package_key: &'a PackageKey,
     pub metadata: &'a PackageMetadata,
     pub snapshot: &'a SnapshotEntry,
@@ -60,6 +64,7 @@ impl<'a> InstallPackageBySnapshot<'a> {
             store_index,
             store_index_writer,
             prefetched_cas_paths,
+            verified_files_cache,
             package_key,
             metadata,
             snapshot,
@@ -105,6 +110,7 @@ impl<'a> InstallPackageBySnapshot<'a> {
             store_index: store_index.cloned(),
             store_index_writer: store_index_writer.cloned(),
             verify_store_integrity: config.verify_store_integrity,
+            verified_files_cache: Arc::clone(verified_files_cache),
             package_integrity: integrity,
             package_unpacked_size: None,
             package_url: &tarball_url,

--- a/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/crates/package-manager/src/install_package_by_snapshot.rs
@@ -4,7 +4,7 @@ use miette::Diagnostic;
 use pacquet_lockfile::{LockfileResolution, PackageKey, PackageMetadata, SnapshotEntry};
 use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
-use pacquet_store_dir::{SharedReadonlyStoreIndex, StoreIndexWriter};
+use pacquet_store_dir::{SharedReadonlyStoreIndex, SharedVerifiedFilesCache, StoreIndexWriter};
 use pacquet_tarball::{DownloadTarballToStore, TarballError};
 use pipe_trait::Pipe;
 use std::{borrow::Cow, sync::Arc};
@@ -19,6 +19,10 @@ pub struct InstallPackageBySnapshot<'a> {
     pub config: &'static Npmrc,
     pub store_index: Option<&'a SharedReadonlyStoreIndex>,
     pub store_index_writer: Option<&'a Arc<StoreIndexWriter>>,
+    /// Install-scoped `verifiedFilesCache` shared across every
+    /// per-snapshot fetch. See `DownloadTarballToStore::verified_files_cache`
+    /// for the rationale.
+    pub verified_files_cache: &'a SharedVerifiedFilesCache,
     pub package_key: &'a PackageKey,
     pub metadata: &'a PackageMetadata,
     pub snapshot: &'a SnapshotEntry,
@@ -54,6 +58,7 @@ impl<'a> InstallPackageBySnapshot<'a> {
             config,
             store_index,
             store_index_writer,
+            verified_files_cache,
             package_key,
             metadata,
             snapshot,
@@ -99,6 +104,7 @@ impl<'a> InstallPackageBySnapshot<'a> {
             store_index: store_index.cloned(),
             store_index_writer: store_index_writer.cloned(),
             verify_store_integrity: config.verify_store_integrity,
+            verified_files_cache: Arc::clone(verified_files_cache),
             package_integrity: integrity,
             package_unpacked_size: None,
             package_url: &tarball_url,

--- a/crates/package-manager/src/install_package_from_registry.rs
+++ b/crates/package-manager/src/install_package_from_registry.rs
@@ -8,7 +8,7 @@ use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
 use pacquet_package_manifest::PackageManifest;
 use pacquet_registry::{Package, PackageTag, PackageVersion, RegistryError};
-use pacquet_store_dir::{SharedReadonlyStoreIndex, StoreIndexWriter};
+use pacquet_store_dir::{SharedReadonlyStoreIndex, SharedVerifiedFilesCache, StoreIndexWriter};
 use pacquet_tarball::{DownloadTarballToStore, MemCache, TarballError};
 use std::{path::Path, sync::Arc};
 
@@ -33,6 +33,10 @@ pub struct InstallPackageFromRegistry<'a> {
     pub config: &'static Npmrc,
     pub store_index: Option<&'a SharedReadonlyStoreIndex>,
     pub store_index_writer: Option<&'a Arc<StoreIndexWriter>>,
+    /// Install-scoped `verifiedFilesCache` shared across every
+    /// per-package fetch. See `DownloadTarballToStore::verified_files_cache`
+    /// for the rationale.
+    pub verified_files_cache: &'a SharedVerifiedFilesCache,
     pub node_modules_dir: &'a Path,
     pub name: &'a str,
     pub version_range: &'a str,
@@ -96,6 +100,7 @@ impl<'a> InstallPackageFromRegistry<'a> {
             config,
             store_index,
             store_index_writer,
+            verified_files_cache,
             node_modules_dir,
             name,
             ..
@@ -111,6 +116,7 @@ impl<'a> InstallPackageFromRegistry<'a> {
             store_index: store_index.cloned(),
             store_index_writer: store_index_writer.cloned(),
             verify_store_integrity: config.verify_store_integrity,
+            verified_files_cache: SharedVerifiedFilesCache::clone(verified_files_cache),
             package_integrity: package_version
                 .dist
                 .integrity
@@ -202,12 +208,14 @@ mod tests {
                 .pipe(Box::new)
                 .pipe(Box::leak);
         let http_client = ThrottledClient::new_for_installs();
+        let verified_files_cache = SharedVerifiedFilesCache::default();
         let package = InstallPackageFromRegistry {
             tarball_mem_cache: &Default::default(),
             config,
             http_client: &http_client,
             store_index: None,
             store_index_writer: None,
+            verified_files_cache: &verified_files_cache,
             name: "fast-querystring",
             version_range: "1.0.0",
             node_modules_dir: modules_dir.path(),

--- a/crates/package-manager/src/install_package_from_registry.rs
+++ b/crates/package-manager/src/install_package_from_registry.rs
@@ -4,7 +4,7 @@ use miette::Diagnostic;
 use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
 use pacquet_registry::{Package, PackageTag, PackageVersion, RegistryError};
-use pacquet_store_dir::{SharedReadonlyStoreIndex, StoreIndexWriter};
+use pacquet_store_dir::{SharedReadonlyStoreIndex, SharedVerifiedFilesCache, StoreIndexWriter};
 use pacquet_tarball::{DownloadTarballToStore, MemCache, TarballError};
 use std::{path::Path, str::FromStr, sync::Arc};
 
@@ -23,6 +23,10 @@ pub struct InstallPackageFromRegistry<'a> {
     pub config: &'static Npmrc,
     pub store_index: Option<&'a SharedReadonlyStoreIndex>,
     pub store_index_writer: Option<&'a Arc<StoreIndexWriter>>,
+    /// Install-scoped `verifiedFilesCache` shared across every
+    /// per-package fetch. See `DownloadTarballToStore::verified_files_cache`
+    /// for the rationale.
+    pub verified_files_cache: &'a SharedVerifiedFilesCache,
     pub node_modules_dir: &'a Path,
     pub name: &'a str,
     pub version_range: &'a str,
@@ -76,6 +80,7 @@ impl<'a> InstallPackageFromRegistry<'a> {
             config,
             store_index,
             store_index_writer,
+            verified_files_cache,
             node_modules_dir,
             ..
         } = self;
@@ -90,6 +95,7 @@ impl<'a> InstallPackageFromRegistry<'a> {
             store_index: store_index.cloned(),
             store_index_writer: store_index_writer.cloned(),
             verify_store_integrity: config.verify_store_integrity,
+            verified_files_cache: SharedVerifiedFilesCache::clone(verified_files_cache),
             package_integrity: package_version
                 .dist
                 .integrity
@@ -170,12 +176,14 @@ mod tests {
                 .pipe(Box::new)
                 .pipe(Box::leak);
         let http_client = ThrottledClient::new_for_installs();
+        let verified_files_cache = SharedVerifiedFilesCache::default();
         let package = InstallPackageFromRegistry {
             tarball_mem_cache: &Default::default(),
             config,
             http_client: &http_client,
             store_index: None,
             store_index_writer: None,
+            verified_files_cache: &verified_files_cache,
             name: "fast-querystring",
             version_range: "1.0.0",
             node_modules_dir: modules_dir.path(),

--- a/crates/package-manager/src/install_without_lockfile.rs
+++ b/crates/package-manager/src/install_without_lockfile.rs
@@ -12,7 +12,7 @@ use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_registry::PackageVersion;
-use pacquet_store_dir::{StoreIndex, StoreIndexWriter};
+use pacquet_store_dir::{SharedVerifiedFilesCache, StoreIndex, StoreIndexWriter};
 use pacquet_tarball::MemCache;
 use pipe_trait::Pipe;
 
@@ -99,39 +99,54 @@ impl<'a, DependencyGroupList> InstallWithoutLockfile<'a, DependencyGroupList> {
         let (store_index_writer, writer_task) = StoreIndexWriter::spawn(store_dir);
         let store_index_writer_ref = Some(&store_index_writer);
 
+        // Install-scoped `verifiedFilesCache`. See the matching block
+        // in `create_virtual_store.rs` for the full rationale — pnpm
+        // threads one `Set<string>` through every package's verify
+        // pass so a CAFS path stat'd for one package skips the stat
+        // for any later package referencing the same blob.
+        let verified_files_cache = SharedVerifiedFilesCache::default();
+
         manifest
             .dependencies(dependency_groups)
-            .map(|(name, version_range)| async move {
-                let dependency = InstallPackageFromRegistry {
-                    tarball_mem_cache,
-                    http_client,
-                    config,
-                    store_index: store_index_ref,
-                    store_index_writer: store_index_writer_ref,
-                    node_modules_dir: &config.modules_dir,
-                    name,
-                    version_range,
-                }
-                .run::<Version>()
-                .await
-                .map_err(InstallWithoutLockfileError::InstallPackageFromRegistry)?;
+            .map(|(name, version_range)| {
+                // Same pattern as `create_virtual_store.rs`: an
+                // `async move` can't borrow into the surrounding
+                // scope, so bind a same-Arc copy outside the future.
+                let verified_files_cache = SharedVerifiedFilesCache::clone(&verified_files_cache);
+                async move {
+                    let dependency = InstallPackageFromRegistry {
+                        tarball_mem_cache,
+                        http_client,
+                        config,
+                        store_index: store_index_ref,
+                        store_index_writer: store_index_writer_ref,
+                        verified_files_cache: &verified_files_cache,
+                        node_modules_dir: &config.modules_dir,
+                        name,
+                        version_range,
+                    }
+                    .run::<Version>()
+                    .await
+                    .map_err(InstallWithoutLockfileError::InstallPackageFromRegistry)?;
 
-                InstallWithoutLockfile {
-                    tarball_mem_cache,
-                    http_client,
-                    config,
-                    manifest,
-                    dependency_groups: (),
-                    resolved_packages,
-                }
-                .install_dependencies_from_registry(
-                    &dependency,
-                    store_index_ref,
-                    store_index_writer_ref,
-                )
-                .await?;
+                    InstallWithoutLockfile {
+                        tarball_mem_cache,
+                        http_client,
+                        config,
+                        manifest,
+                        dependency_groups: (),
+                        resolved_packages,
+                    }
+                    .install_dependencies_from_registry(
+                        &dependency,
+                        store_index_ref,
+                        store_index_writer_ref,
+                        &verified_files_cache,
+                    )
+                    .await?;
 
-                Ok::<_, InstallWithoutLockfileError>(())
+                    Ok::<_, InstallWithoutLockfileError>(())
+                }
             })
             .pipe(future::try_join_all)
             .await?;
@@ -168,6 +183,7 @@ impl<'a> InstallWithoutLockfile<'a, ()> {
         store_index_writer: Option<
             &'async_recursion std::sync::Arc<pacquet_store_dir::StoreIndexWriter>,
         >,
+        verified_files_cache: &'async_recursion SharedVerifiedFilesCache,
     ) -> Result<(), InstallWithoutLockfileError> {
         let InstallWithoutLockfile {
             tarball_mem_cache,
@@ -201,6 +217,7 @@ impl<'a> InstallWithoutLockfile<'a, ()> {
                     config,
                     store_index,
                     store_index_writer,
+                    verified_files_cache,
                     node_modules_dir: node_modules_path_ref,
                     name,
                     version_range,
@@ -212,6 +229,7 @@ impl<'a> InstallWithoutLockfile<'a, ()> {
                     &dependency,
                     store_index,
                     store_index_writer,
+                    verified_files_cache,
                 )
                 .await?;
                 Ok::<_, InstallWithoutLockfileError>(())

--- a/crates/package-manager/src/install_without_lockfile.rs
+++ b/crates/package-manager/src/install_without_lockfile.rs
@@ -108,9 +108,10 @@ impl<'a, DependencyGroupList> InstallWithoutLockfile<'a, DependencyGroupList> {
         manifest
             .dependencies(dependency_groups)
             .map(|(name, version_range)| {
-                // Same pattern as `create_virtual_store.rs`: an
-                // `async move` can't borrow into the surrounding
-                // scope, so bind a same-Arc copy outside the future.
+                // Same pattern as `create_virtual_store.rs`: clone the
+                // shared cache handle so each per-dependency future owns
+                // a handle it can move into the `async move` block and
+                // then reference from within the future.
                 let verified_files_cache = SharedVerifiedFilesCache::clone(&verified_files_cache);
                 async move {
                     let dependency = InstallPackageFromRegistry {

--- a/crates/package-manager/src/install_without_lockfile.rs
+++ b/crates/package-manager/src/install_without_lockfile.rs
@@ -11,7 +11,7 @@ use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_registry::PackageVersion;
-use pacquet_store_dir::{StoreIndex, StoreIndexWriter};
+use pacquet_store_dir::{SharedVerifiedFilesCache, StoreIndex, StoreIndexWriter};
 use pacquet_tarball::MemCache;
 use pipe_trait::Pipe;
 
@@ -98,39 +98,54 @@ impl<'a, DependencyGroupList> InstallWithoutLockfile<'a, DependencyGroupList> {
         let (store_index_writer, writer_task) = StoreIndexWriter::spawn(store_dir);
         let store_index_writer_ref = Some(&store_index_writer);
 
+        // Install-scoped `verifiedFilesCache`. See the matching block
+        // in `create_virtual_store.rs` for the full rationale — pnpm
+        // threads one `Set<string>` through every package's verify
+        // pass so a CAFS path stat'd for one package skips the stat
+        // for any later package referencing the same blob.
+        let verified_files_cache = SharedVerifiedFilesCache::default();
+
         manifest
             .dependencies(dependency_groups)
-            .map(|(name, version_range)| async move {
-                let dependency = InstallPackageFromRegistry {
-                    tarball_mem_cache,
-                    http_client,
-                    config,
-                    store_index: store_index_ref,
-                    store_index_writer: store_index_writer_ref,
-                    node_modules_dir: &config.modules_dir,
-                    name,
-                    version_range,
-                }
-                .run()
-                .await
-                .map_err(InstallWithoutLockfileError::InstallPackageFromRegistry)?;
+            .map(|(name, version_range)| {
+                // Same pattern as `create_virtual_store.rs`: an
+                // `async move` can't borrow into the surrounding
+                // scope, so bind a same-Arc copy outside the future.
+                let verified_files_cache = SharedVerifiedFilesCache::clone(&verified_files_cache);
+                async move {
+                    let dependency = InstallPackageFromRegistry {
+                        tarball_mem_cache,
+                        http_client,
+                        config,
+                        store_index: store_index_ref,
+                        store_index_writer: store_index_writer_ref,
+                        verified_files_cache: &verified_files_cache,
+                        node_modules_dir: &config.modules_dir,
+                        name,
+                        version_range,
+                    }
+                    .run()
+                    .await
+                    .map_err(InstallWithoutLockfileError::InstallPackageFromRegistry)?;
 
-                InstallWithoutLockfile {
-                    tarball_mem_cache,
-                    http_client,
-                    config,
-                    manifest,
-                    dependency_groups: (),
-                    resolved_packages,
-                }
-                .install_dependencies_from_registry(
-                    &dependency,
-                    store_index_ref,
-                    store_index_writer_ref,
-                )
-                .await?;
+                    InstallWithoutLockfile {
+                        tarball_mem_cache,
+                        http_client,
+                        config,
+                        manifest,
+                        dependency_groups: (),
+                        resolved_packages,
+                    }
+                    .install_dependencies_from_registry(
+                        &dependency,
+                        store_index_ref,
+                        store_index_writer_ref,
+                        &verified_files_cache,
+                    )
+                    .await?;
 
-                Ok::<_, InstallWithoutLockfileError>(())
+                    Ok::<_, InstallWithoutLockfileError>(())
+                }
             })
             .pipe(future::try_join_all)
             .await?;
@@ -167,6 +182,7 @@ impl<'a> InstallWithoutLockfile<'a, ()> {
         store_index_writer: Option<
             &'async_recursion std::sync::Arc<pacquet_store_dir::StoreIndexWriter>,
         >,
+        verified_files_cache: &'async_recursion SharedVerifiedFilesCache,
     ) -> Result<(), InstallWithoutLockfileError> {
         let InstallWithoutLockfile {
             tarball_mem_cache,
@@ -200,6 +216,7 @@ impl<'a> InstallWithoutLockfile<'a, ()> {
                     config,
                     store_index,
                     store_index_writer,
+                    verified_files_cache,
                     node_modules_dir: node_modules_path_ref,
                     name,
                     version_range,
@@ -211,6 +228,7 @@ impl<'a> InstallWithoutLockfile<'a, ()> {
                     &dependency,
                     store_index,
                     store_index_writer,
+                    verified_files_cache,
                 )
                 .await?;
                 Ok::<_, InstallWithoutLockfileError>(())

--- a/crates/store-dir/src/check_pkg_files_integrity.rs
+++ b/crates/store-dir/src/check_pkg_files_integrity.rs
@@ -12,14 +12,39 @@
 //! cheap.
 
 use crate::{CafsFileInfo, PackageFilesIndex, StoreDir};
+use dashmap::DashSet;
 use sha2::{Digest, Sha512};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     fs,
     io::{self, BufReader, Read},
     path::{Path, PathBuf},
+    sync::Arc,
     time::UNIX_EPOCH,
 };
+
+/// Set of CAFS paths whose on-disk integrity has already been verified
+/// during the current install. Mirrors pnpm's
+/// [`verifiedFilesCache: Set<string>`](https://github.com/pnpm/pnpm/blob/main/store/cafs/src/checkPkgFilesIntegrity.ts):
+/// the caller threads one cache through every
+/// [`check_pkg_files_integrity`] invocation so a CAFS blob that has
+/// already been verified by package A doesn't get stat'd / re-hashed
+/// again by package B.
+///
+/// Concurrent: the install fans `check_pkg_files_integrity` calls out
+/// across tokio's blocking pool, so the cache must tolerate parallel
+/// readers and writers. `DashSet` gives us that without any external
+/// locking. Race-window duplicate verifies are benign (the `verify_file`
+/// path is idempotent) and rare in practice.
+pub type VerifiedFilesCache = DashSet<PathBuf>;
+
+/// Shared handle to a [`VerifiedFilesCache`] — what every install-scope
+/// caller passes around. `Arc` so the same cache survives across the
+/// lockfile-driven and registry-driven install loops without
+/// per-call clones, and so the value lives long enough to outlive the
+/// individual `tokio::task::spawn_blocking` closures the verifier
+/// dispatches into.
+pub type SharedVerifiedFilesCache = Arc<VerifiedFilesCache>;
 
 /// `in-tarball filename` → `CAFS path`. Return value of the two verify
 /// entry points below.
@@ -101,16 +126,22 @@ pub fn build_file_maps_from_index(store_dir: &StoreDir, entry: PackageFilesIndex
 /// reject non-regular-file dirents preemptively — the integrity hash
 /// catches real corruption, and pnpm doesn't guard against it in this
 /// function either.
-pub fn check_pkg_files_integrity(store_dir: &StoreDir, entry: PackageFilesIndex) -> VerifyResult {
+pub fn check_pkg_files_integrity(
+    store_dir: &StoreDir,
+    entry: PackageFilesIndex,
+    verified_files_cache: &VerifiedFilesCache,
+) -> VerifyResult {
     // Destructure so the owned `files` HashMap and `algo` String can be
     // consumed below; moving beats the extra per-file `filename.clone()`
     // the old borrow-based signature forced on the hot path.
     let PackageFilesIndex { files, algo, .. } = entry;
     let mut all_verified = true;
     let mut files_map = HashMap::with_capacity(files.len());
-    // pnpm's `verifiedFilesCache: Set<string>` dedups within a single
-    // entry so two in-tarball filenames pointing at the same CAFS blob
-    // cost one stat, not two.
+    // `verified_files_cache` is the install-scoped
+    // [`VerifiedFilesCache`] — pnpm's `verifiedFilesCache: Set<string>`.
+    // Threading it through every call dedups across packages, not just
+    // within one entry: a CAFS blob seen by package A's verify pass
+    // skips the stat / re-hash when package B references it later.
     //
     // Key the set by the resolved CAFS path, not by `info.digest`. The
     // path factors in `info.mode` (via `-exec` suffix for executables
@@ -119,7 +150,6 @@ pub fn check_pkg_files_integrity(store_dir: &StoreDir, entry: PackageFilesIndex)
     // tarball ships it with different executable bits. Digest-only
     // dedup would skip verifying the second path and happily return
     // `passed: true` with a stale / missing blob still on disk.
-    let mut verified: HashSet<PathBuf> = HashSet::new();
     for (filename, info) in files {
         let Some(path) = store_dir.cas_file_path_by_mode(&info.digest, info.mode) else {
             tracing::debug!(
@@ -131,12 +161,19 @@ pub fn check_pkg_files_integrity(store_dir: &StoreDir, entry: PackageFilesIndex)
             all_verified = false;
             continue;
         };
-        if !verified.contains(&path) {
+        if !verified_files_cache.contains(&path) {
             if verify_file(&path, &filename, &info, &algo) {
                 // One `PathBuf` clone per unique CAFS path we actually
                 // verified; zero for dedup hits. Strictly better than
                 // the per-filename clone the borrow-based version had.
-                verified.insert(path.clone());
+                //
+                // Concurrency note: another thread may verify the same
+                // path between the `contains` check and our `insert`,
+                // doing the stat twice. That's benign — `verify_file`
+                // is idempotent and the cache converges to the same
+                // state either way. Pnpm's worker_threads cache has
+                // the same race-window for the same reason.
+                verified_files_cache.insert(path.clone());
             } else {
                 all_verified = false;
             }
@@ -371,7 +408,7 @@ mod tests {
             "sha512",
             vec![("index.js", info(&digest, content.len() as u64, 0o644, Some(future)))],
         );
-        let result = check_pkg_files_integrity(&store_dir, entry);
+        let result = check_pkg_files_integrity(&store_dir, entry, &VerifiedFilesCache::new());
         assert!(result.passed);
         assert_eq!(result.files_map.len(), 1);
     }
@@ -384,7 +421,7 @@ mod tests {
         let store_dir = StoreDir::new(tmp.path());
         let digest = sha512_hex(b"nope");
         let entry = index_with("sha512", vec![("README", info(&digest, 4, 0o644, None))]);
-        let result = check_pkg_files_integrity(&store_dir, entry);
+        let result = check_pkg_files_integrity(&store_dir, entry, &VerifiedFilesCache::new());
         assert!(!result.passed, "missing file → fail");
         assert_eq!(result.files_map.len(), 1);
     }
@@ -405,7 +442,7 @@ mod tests {
             "sha512",
             vec![("whatever", info(&fake_digest, actual.len() as u64, 0o644, Some(0)))],
         );
-        let result = check_pkg_files_integrity(&store_dir, entry);
+        let result = check_pkg_files_integrity(&store_dir, entry, &VerifiedFilesCache::new());
         assert!(!result.passed, "bad hash → fail");
         assert!(!path.exists(), "mismatched file is removed so the next call re-fetches");
     }
@@ -422,7 +459,7 @@ mod tests {
         let digest = sha512_hex(content);
         let path = plant_cafs_file(&store_dir, &digest, 0o644, content);
         let entry = index_with("sha512", vec![("mismatch", info(&digest, 999, 0o644, Some(0)))]);
-        let result = check_pkg_files_integrity(&store_dir, entry);
+        let result = check_pkg_files_integrity(&store_dir, entry, &VerifiedFilesCache::new());
         assert!(!result.passed);
         assert!(!path.exists(), "size mismatch removes the file so a re-fetch starts clean");
     }
@@ -442,9 +479,50 @@ mod tests {
             "sha512",
             vec![("a.txt", info_shared.clone_for_test()), ("b.txt", info_shared.clone_for_test())],
         );
-        let result = check_pkg_files_integrity(&store_dir, entry);
+        let result = check_pkg_files_integrity(&store_dir, entry, &VerifiedFilesCache::new());
         assert!(result.passed);
         assert_eq!(result.files_map.len(), 2);
+    }
+
+    /// A CAFS path verified during one `check_pkg_files_integrity` call
+    /// must not be re-verified by the next call when both share the
+    /// same `VerifiedFilesCache`. Ports pnpm's install-scoped
+    /// `verifiedFilesCache: Set<string>` semantics.
+    ///
+    /// The proof: plant the file, run a successful first verify against
+    /// it (populates the cache), then *delete* the file and run a
+    /// second verify. If the cache short-circuits the second call, it
+    /// returns `passed: true` despite the missing file — that's the
+    /// observable signal that the stat was skipped. Real installs
+    /// don't delete files mid-install, so this artificial setup is
+    /// purely a test handle for the dedup behaviour.
+    #[test]
+    fn careful_path_dedups_across_calls_via_shared_cache() {
+        let tmp = tempdir().unwrap();
+        let store_dir = StoreDir::new(tmp.path());
+        let content = b"shared-across-packages";
+        let digest = sha512_hex(content);
+        let path = plant_cafs_file(&store_dir, &digest, 0o644, content);
+        let future = now_ms() + 3_600_000;
+        let info_shared = info(&digest, content.len() as u64, 0o644, Some(future));
+
+        let cache = VerifiedFilesCache::new();
+
+        let entry_a = index_with("sha512", vec![("a-pkg/index.js", info_shared.clone_for_test())]);
+        let result_a = check_pkg_files_integrity(&store_dir, entry_a, &cache);
+        assert!(result_a.passed, "first call verifies the live file");
+        assert!(cache.contains(&path), "successful verify populates the shared cache");
+
+        // Pull the rug out from under the second call. Without the
+        // shared cache we'd stat-and-fail; with it, the path is
+        // already in `cache` so the inner `verify_file` is skipped.
+        std::fs::remove_file(&path).unwrap();
+        let entry_b = index_with("sha512", vec![("b-pkg/index.js", info_shared.clone_for_test())]);
+        let result_b = check_pkg_files_integrity(&store_dir, entry_b, &cache);
+        assert!(
+            result_b.passed,
+            "second call should short-circuit via the shared cache and skip the now-missing file",
+        );
     }
 
     /// Same digest with different `mode` resolves to two distinct CAFS
@@ -473,7 +551,7 @@ mod tests {
                 ("bin/app", info(&digest, content.len() as u64, 0o755, Some(future))),
             ],
         );
-        let result = check_pkg_files_integrity(&store_dir, entry);
+        let result = check_pkg_files_integrity(&store_dir, entry, &VerifiedFilesCache::new());
         assert!(
             !result.passed,
             "same digest + different mode = different CAFS path; missing exec blob must fail",
@@ -493,7 +571,7 @@ mod tests {
         let path = plant_cafs_file(&store_dir, &digest, 0o644, content);
         let entry =
             index_with("sha256", vec![("x", info(&digest, content.len() as u64, 0o644, Some(0)))]);
-        let result = check_pkg_files_integrity(&store_dir, entry);
+        let result = check_pkg_files_integrity(&store_dir, entry, &VerifiedFilesCache::new());
         assert!(!result.passed);
         assert!(!path.exists(), "unknown algo → treated as corrupt → removed");
     }
@@ -516,7 +594,7 @@ mod tests {
         // mismatches the row, we hit the `remove_stale_cafs_entry` path.
         let entry =
             index_with("sha512", vec![("impostor", info(&digest, 1_000_000, 0o644, Some(0)))]);
-        let result = check_pkg_files_integrity(&store_dir, entry);
+        let result = check_pkg_files_integrity(&store_dir, entry, &VerifiedFilesCache::new());
         assert!(!result.passed);
         assert!(
             !cafs_path.exists(),

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -12,8 +12,8 @@ use miette::Diagnostic;
 use pacquet_fs::file_mode;
 use pacquet_network::ThrottledClient;
 use pacquet_store_dir::{
-    store_index_key, CafsFileInfo, PackageFilesIndex, SharedReadonlyStoreIndex, StoreDir,
-    StoreIndexError, StoreIndexWriter, WriteCasFileError,
+    store_index_key, CafsFileInfo, PackageFilesIndex, SharedReadonlyStoreIndex,
+    SharedVerifiedFilesCache, StoreDir, StoreIndexError, StoreIndexWriter, WriteCasFileError,
 };
 use pipe_trait::Pipe;
 use ssri::Integrity;
@@ -330,6 +330,7 @@ async fn load_cached_cas_paths(
     store_dir: &'static StoreDir,
     cache_key: String,
     verify_store_integrity: bool,
+    verified_files_cache: SharedVerifiedFilesCache,
 ) -> Option<HashMap<String, PathBuf>> {
     let index = index?;
     // Hold on to a copy of the cache key for the outer `JoinError` log,
@@ -355,7 +356,7 @@ async fn load_cached_cas_paths(
         }?;
 
         let verify_result = if verify_store_integrity {
-            pacquet_store_dir::check_pkg_files_integrity(store_dir, entry)
+            pacquet_store_dir::check_pkg_files_integrity(store_dir, entry, &verified_files_cache)
         } else {
             pacquet_store_dir::build_file_maps_from_index(store_dir, entry)
         };
@@ -431,6 +432,16 @@ pub struct DownloadTarballToStore<'a> {
     /// isn't the bottleneck on the benchmarks this repo tracks (see
     /// #273), but cutting the syscall count is still correct.
     pub verify_store_integrity: bool,
+    /// Install-scoped dedup cache shared across every cached-tarball
+    /// lookup. Ports pnpm's `verifiedFilesCache: Set<string>`: a CAFS
+    /// path that one snapshot's verify pass has already stat'ed (and
+    /// optionally re-hashed) gets skipped when the next snapshot
+    /// touches the same blob. Without it pacquet was paying the
+    /// per-file stat in `check_pkg_files_integrity` once per
+    /// (snapshot × file) instead of once per (file). Allocate one
+    /// `Arc<DashSet<PathBuf>>` at install bootstrap and pass the same
+    /// handle to every `DownloadTarballToStore`.
+    pub verified_files_cache: SharedVerifiedFilesCache,
     pub package_integrity: &'a Integrity,
     pub package_unpacked_size: Option<usize>,
     pub package_url: &'a str,
@@ -497,6 +508,7 @@ impl<'a> DownloadTarballToStore<'a> {
         } = self;
         let store_index = self.store_index.clone();
         let store_index_writer = self.store_index_writer.clone();
+        let verified_files_cache = Arc::clone(&self.verified_files_cache);
 
         // Before hitting the network, check the SQLite store index: if the
         // tarball is already in the CAFS we can reuse its per-file paths
@@ -509,8 +521,14 @@ impl<'a> DownloadTarballToStore<'a> {
         // an undecodable entry, or any CAFS file that has gone missing
         // from disk all fall through to the download path below.
         let cache_key = store_index_key(&package_integrity.to_string(), package_id);
-        if let Some(cas_paths) =
-            load_cached_cas_paths(store_index, store_dir, cache_key, verify_store_integrity).await
+        if let Some(cas_paths) = load_cached_cas_paths(
+            store_index,
+            store_dir,
+            cache_key,
+            verify_store_integrity,
+            verified_files_cache,
+        )
+        .await
         {
             tracing::info!(target: "pacquet::download", ?package_url, ?package_id, "Reusing cached CAFS entry — skipping download");
             return Ok(cas_paths);
@@ -762,6 +780,7 @@ mod tests {
             store_index: None,
             store_index_writer: None,
             verify_store_integrity: true,
+            verified_files_cache: SharedVerifiedFilesCache::default(),
             package_integrity: &integrity("sha512-dj7vjIn1Ar8sVXj2yAXiMNCJDmS9MQ9XMlIecX2dIzzhjSHCyKo4DdXjXMs7wKW2kj6yvVRSpuQjOZ3YLrh56w=="),
             package_unpacked_size: Some(16697),
             package_url: "https://registry.npmjs.org/@fastify/error/-/error-3.3.0.tgz",
@@ -805,6 +824,7 @@ mod tests {
             store_index: None,
             store_index_writer: None,
             verify_store_integrity: true,
+            verified_files_cache: SharedVerifiedFilesCache::default(),
             package_integrity: &integrity("sha512-aaaan1Ar8sVXj2yAXiMNCJDmS9MQ9XMlIecX2dIzzhjSHCyKo4DdXjXMs7wKW2kj6yvVRSpuQjOZ3YLrh56w=="),
             package_unpacked_size: Some(16697),
             package_url: "https://registry.npmjs.org/@fastify/error/-/error-3.3.0.tgz",
@@ -875,6 +895,7 @@ mod tests {
             store_index: StoreIndex::shared_readonly_in(store_path),
             store_index_writer: None,
             verify_store_integrity: true,
+            verified_files_cache: SharedVerifiedFilesCache::default(),
             package_integrity: &pkg_integrity,
             package_unpacked_size: None,
             // Any request that reaches the network here would fail the
@@ -936,6 +957,7 @@ mod tests {
             store_index: StoreIndex::shared_readonly_in(store_path),
             store_index_writer: None,
             verify_store_integrity: true,
+            verified_files_cache: SharedVerifiedFilesCache::default(),
             package_integrity: &pkg_integrity,
             package_unpacked_size: None,
             package_url: "http://127.0.0.1:1/unreachable.tgz",
@@ -989,6 +1011,7 @@ mod tests {
             store_index: StoreIndex::shared_readonly_in(store_path),
             store_index_writer: None,
             verify_store_integrity: true,
+            verified_files_cache: SharedVerifiedFilesCache::default(),
             package_integrity: &pkg_integrity,
             package_unpacked_size: None,
             package_url: "http://127.0.0.1:1/unreachable.tgz",
@@ -1045,6 +1068,7 @@ mod tests {
             store_index: StoreIndex::shared_readonly_in(store_path),
             store_index_writer: None,
             verify_store_integrity: true,
+            verified_files_cache: SharedVerifiedFilesCache::default(),
             package_integrity: &pkg_integrity,
             package_unpacked_size: None,
             package_url: "http://127.0.0.1:1/unreachable.tgz",
@@ -1111,6 +1135,7 @@ mod tests {
             store_index: StoreIndex::shared_readonly_in(store_path),
             store_index_writer: None,
             verify_store_integrity: true,
+            verified_files_cache: SharedVerifiedFilesCache::default(),
             package_integrity: &pkg_integrity,
             package_unpacked_size: None,
             package_url: "http://127.0.0.1:1/unreachable.tgz",

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -12,8 +12,8 @@ use miette::Diagnostic;
 use pacquet_fs::file_mode;
 use pacquet_network::ThrottledClient;
 use pacquet_store_dir::{
-    CafsFileInfo, PackageFilesIndex, SharedReadonlyStoreIndex, StoreDir, StoreIndexError,
-    StoreIndexWriter, WriteCasFileError, store_index_key,
+    CafsFileInfo, PackageFilesIndex, SharedReadonlyStoreIndex, SharedVerifiedFilesCache, StoreDir,
+    StoreIndexError, StoreIndexWriter, WriteCasFileError, store_index_key,
 };
 use pipe_trait::Pipe;
 use smart_default::SmartDefault;
@@ -479,6 +479,7 @@ pub async fn prefetch_cas_paths(
     store_dir: &'static StoreDir,
     cache_keys: Vec<String>,
     verify_store_integrity: bool,
+    verified_files_cache: SharedVerifiedFilesCache,
 ) -> PrefetchedCasPaths {
     let Some(index) = index else { return HashMap::new() };
     if cache_keys.is_empty() {
@@ -515,7 +516,11 @@ pub async fn prefetch_cas_paths(
         let mut out = HashMap::with_capacity(entries.len());
         for (cache_key, entry) in entries {
             let verify_result = if verify_store_integrity {
-                pacquet_store_dir::check_pkg_files_integrity(store_dir, entry)
+                pacquet_store_dir::check_pkg_files_integrity(
+                    store_dir,
+                    entry,
+                    &verified_files_cache,
+                )
             } else {
                 pacquet_store_dir::build_file_maps_from_index(store_dir, entry)
             };
@@ -544,6 +549,7 @@ async fn load_cached_cas_paths(
     store_dir: &'static StoreDir,
     cache_key: String,
     verify_store_integrity: bool,
+    verified_files_cache: SharedVerifiedFilesCache,
 ) -> Option<HashMap<String, PathBuf>> {
     let index = index?;
     // Hold on to a copy of the cache key for the outer `JoinError` log,
@@ -569,7 +575,7 @@ async fn load_cached_cas_paths(
         }?;
 
         let verify_result = if verify_store_integrity {
-            pacquet_store_dir::check_pkg_files_integrity(store_dir, entry)
+            pacquet_store_dir::check_pkg_files_integrity(store_dir, entry, &verified_files_cache)
         } else {
             pacquet_store_dir::build_file_maps_from_index(store_dir, entry)
         };
@@ -645,6 +651,16 @@ pub struct DownloadTarballToStore<'a> {
     /// isn't the bottleneck on the benchmarks this repo tracks (see
     /// #273), but cutting the syscall count is still correct.
     pub verify_store_integrity: bool,
+    /// Install-scoped dedup cache shared across every cached-tarball
+    /// lookup. Ports pnpm's `verifiedFilesCache: Set<string>`: a CAFS
+    /// path that one snapshot's verify pass has already stat'ed (and
+    /// optionally re-hashed) gets skipped when the next snapshot
+    /// touches the same blob. Without it pacquet was paying the
+    /// per-file stat in `check_pkg_files_integrity` once per
+    /// (snapshot × file) instead of once per (file). Allocate one
+    /// `Arc<DashSet<PathBuf>>` at install bootstrap and pass the same
+    /// handle to every `DownloadTarballToStore`.
+    pub verified_files_cache: SharedVerifiedFilesCache,
     pub package_integrity: &'a Integrity,
     pub package_unpacked_size: Option<usize>,
     pub package_url: &'a str,
@@ -947,6 +963,7 @@ impl<'a> DownloadTarballToStore<'a> {
         } = self;
         let store_index = self.store_index.clone();
         let store_index_writer = self.store_index_writer.clone();
+        let verified_files_cache = Arc::clone(&self.verified_files_cache);
 
         // Before hitting the network, check the SQLite store index: if the
         // tarball is already in the CAFS we can reuse its per-file paths
@@ -989,8 +1006,14 @@ impl<'a> DownloadTarballToStore<'a> {
             );
             return Ok((**cas_paths).clone());
         }
-        if let Some(cas_paths) =
-            load_cached_cas_paths(store_index, store_dir, cache_key, verify_store_integrity).await
+        if let Some(cas_paths) = load_cached_cas_paths(
+            store_index,
+            store_dir,
+            cache_key,
+            verify_store_integrity,
+            verified_files_cache,
+        )
+        .await
         {
             tracing::info!(target: "pacquet::download", ?package_url, ?package_id, "Reusing cached CAFS entry — skipping download");
             return Ok(cas_paths);

--- a/crates/tarball/src/tests.rs
+++ b/crates/tarball/src/tests.rs
@@ -1,4 +1,4 @@
-use pacquet_store_dir::StoreIndex;
+use pacquet_store_dir::{SharedVerifiedFilesCache, StoreIndex};
 use pipe_trait::Pipe;
 use pretty_assertions::assert_eq;
 use tempfile::{TempDir, tempdir};
@@ -161,6 +161,7 @@ async fn packages_under_orgs_should_work() {
         package_url: "https://registry.npmjs.org/@fastify/error/-/error-3.3.0.tgz",
         package_id: "@fastify/error@3.3.0",
         prefetched_cas_paths: None,
+        verified_files_cache: SharedVerifiedFilesCache::default(),
         retry_opts: test_retry_opts(),
     }
     .run_without_mem_cache()
@@ -206,6 +207,7 @@ async fn should_throw_error_on_checksum_mismatch() {
         package_url: "https://registry.npmjs.org/@fastify/error/-/error-3.3.0.tgz",
         package_id: "@fastify/error@3.3.0",
         prefetched_cas_paths: None,
+        verified_files_cache: SharedVerifiedFilesCache::default(),
         retry_opts: test_retry_opts(),
     }
     .run_without_mem_cache()
@@ -278,6 +280,7 @@ async fn reuses_cached_cas_paths_when_index_entry_is_live() {
         package_url: "http://127.0.0.1:1/unreachable.tgz",
         package_id: pkg_id,
         prefetched_cas_paths: None,
+        verified_files_cache: SharedVerifiedFilesCache::default(),
         retry_opts: test_retry_opts(),
     }
     .run_without_mem_cache()
@@ -334,6 +337,7 @@ async fn reuses_prefetched_cas_paths_when_provided() {
         package_url: "http://127.0.0.1:1/unreachable.tgz",
         package_id: pkg_id,
         prefetched_cas_paths: Some(&prefetched),
+        verified_files_cache: SharedVerifiedFilesCache::default(),
         retry_opts: test_retry_opts(),
     }
     .run_without_mem_cache()
@@ -388,6 +392,7 @@ async fn prefetch_cas_paths_returns_hits_for_live_index_rows() {
         store_path,
         vec![index_key.clone()],
         true,
+        SharedVerifiedFilesCache::default(),
     )
     .await;
 
@@ -442,6 +447,7 @@ async fn prefetch_cas_paths_omits_failed_integrity_entries() {
         // `check_pkg_files_integrity`'s "scrub & re-fetch" path,
         // which turns the row into a miss.
         true,
+        SharedVerifiedFilesCache::default(),
     )
     .await;
 
@@ -498,6 +504,7 @@ async fn prefetch_cas_paths_skips_filesystem_checks_when_verify_disabled() {
         store_path,
         vec![index_key.clone()],
         false,
+        SharedVerifiedFilesCache::default(),
     )
     .await;
 
@@ -555,6 +562,7 @@ async fn falls_through_when_cafs_file_missing() {
         package_url: "http://127.0.0.1:1/unreachable.tgz",
         package_id: pkg_id,
         prefetched_cas_paths: None,
+        verified_files_cache: SharedVerifiedFilesCache::default(),
         retry_opts: test_retry_opts(),
     }
     .run_without_mem_cache()
@@ -611,6 +619,7 @@ async fn falls_through_when_digest_is_malformed() {
         package_url: "http://127.0.0.1:1/unreachable.tgz",
         package_id: pkg_id,
         prefetched_cas_paths: None,
+        verified_files_cache: SharedVerifiedFilesCache::default(),
         retry_opts: test_retry_opts(),
     }
     .run_without_mem_cache()
@@ -670,6 +679,7 @@ async fn falls_through_when_cafs_path_is_a_directory() {
         package_url: "http://127.0.0.1:1/unreachable.tgz",
         package_id: pkg_id,
         prefetched_cas_paths: None,
+        verified_files_cache: SharedVerifiedFilesCache::default(),
         retry_opts: test_retry_opts(),
     }
     .run_without_mem_cache()
@@ -739,6 +749,7 @@ async fn falls_through_when_cafs_path_is_a_symlink() {
         package_url: "http://127.0.0.1:1/unreachable.tgz",
         package_id: pkg_id,
         prefetched_cas_paths: None,
+        verified_files_cache: SharedVerifiedFilesCache::default(),
         retry_opts: test_retry_opts(),
     }
     .run_without_mem_cache()
@@ -1212,6 +1223,7 @@ fn run_with_mem_cache_does_not_deadlock_on_dashmap_shard_contention() {
                     package_url: url,
                     package_id: "fastify-error@3.3.0",
                     prefetched_cas_paths: None,
+                    verified_files_cache: SharedVerifiedFilesCache::default(),
                     retry_opts: RetryOpts { retries: 0, ..RetryOpts::default() },
                 };
 

--- a/tasks/micro-benchmark/src/main.rs
+++ b/tasks/micro-benchmark/src/main.rs
@@ -42,6 +42,7 @@ fn bench_tarball(c: &mut Criterion, server: &mut ServerGuard, fixtures_folder: &
                 store_index: None,
                 store_index_writer: None,
                 verify_store_integrity: true,
+                verified_files_cache: pacquet_store_dir::SharedVerifiedFilesCache::default(),
                 package_integrity: &package_integrity,
                 package_unpacked_size: Some(16697),
                 package_url: url,


### PR DESCRIPTION
First in a series addressing the warm-cache install gap raised against pnpm v11.

## Summary

`check_pkg_files_integrity` allocated a fresh `HashSet<PathBuf>` for `verifiedFilesCache` dedup on every call, so a CAFS blob shared across N packages paid the per-file stat / mtime-check / re-hash N times. Pnpm's [`store/cafs/src/checkPkgFilesIntegrity.ts`](https://github.com/pnpm/pnpm/blob/main/store/cafs/src/checkPkgFilesIntegrity.ts) takes the cache as a parameter (`verifiedFilesCache: Set<string>`) and threads one set through the whole install — common shared blobs (LICENSE / README / empty `.npmignore` / etc.) cost one stat for the whole install instead of one stat per consuming package.

This PR ports that semantics:

- New types in `pacquet-store-dir`: `VerifiedFilesCache` (`DashSet<PathBuf>`, concurrent because the verifier fans out across tokio's blocking pool) and `SharedVerifiedFilesCache` (`Arc<…>`).
- `check_pkg_files_integrity` takes `&VerifiedFilesCache`. Per-file logic unchanged otherwise.
- `DownloadTarballToStore` grows a `verified_files_cache` field; `InstallPackageBySnapshot` / `InstallPackageFromRegistry` / `InstallWithoutLockfile` all thread `&SharedVerifiedFilesCache` through.
- `CreateVirtualStore::run` and `InstallWithoutLockfile::run` allocate the cache once and clone the `Arc` into each per-snapshot future (the `async move` closures can't borrow the outer var, so clone-then-move).

## Test plan

- [x] `just ready` — 209/209 (added one new test).
- [x] `careful_path_dedups_across_calls_via_shared_cache` — plants a file, verifies it (populates the cache), then deletes the file and verifies a second time with the same cache. Without the shared cache the second call would stat-and-fail; with it, the path is already in the cache so the short-circuit returns `passed: true` despite the missing blob. Proof that the cross-call dedup actually skips the stat.
- [x] All other `check_pkg_files_integrity` tests pass an empty `VerifiedFilesCache::new()` (per-test isolation).

## Expected impact

Warm-cache install scenarios — install fixtures where `index.db` is fully populated and pacquet is meant to skip download and just import. Worst-case collapses from N-files × N-packages stats to N-files. The cited gap (12-13 s pacquet vs ~7 s pnpm on a hot store) named the per-file stat in `verify-store-integrity` as one suspect; this is the structural fix.

Wall-time delta will show in the integrated-benchmark on the next CI run.

## Sequencing

Part 1 of three planned PRs against the warm-cache path. The other two — parent-dir cache in `link_file`, and an investigation into rayon par_iter overhead — will land separately.