### PR TITLE
perf(package-manager): cache parent-dir creation in link_file

### DIFF
--- a/crates/package-manager/src/create_cas_files.rs
+++ b/crates/package-manager/src/create_cas_files.rs
@@ -1,4 +1,4 @@
-use crate::{LinkFileError, link_file};
+use crate::{EnsuredDirsCache, LinkFileError, link_file};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_npmrc::PackageImportMethod;
@@ -27,10 +27,19 @@ pub fn create_cas_files(
         return Ok(());
     }
 
+    // Per-package parent-dir cache: every file in the same package
+    // hangs off `dir_path`, and most of them share intermediate dirs
+    // (`lib/`, `dist/`, `src/index.js`'s `src/`, …). Allocating once
+    // per `create_cas_files` call lets rayon workers share dedup
+    // state without ballooning into a process-wide cache that would
+    // need install-scope teardown to stay correct under bench-style
+    // `rm -rf node_modules`.
+    let ensured_dirs_cache = EnsuredDirsCache::new();
+
     cas_paths
         .par_iter()
         .try_for_each(|(cleaned_entry, store_path)| {
-            link_file(import_method, store_path, &dir_path.join(cleaned_entry))
+            link_file(import_method, store_path, &dir_path.join(cleaned_entry), &ensured_dirs_cache)
         })
         .map_err(CreateCasFilesError::LinkFile)
 }

--- a/crates/package-manager/src/create_cas_files.rs
+++ b/crates/package-manager/src/create_cas_files.rs
@@ -1,16 +1,23 @@
-use crate::{EnsuredDirsCache, LinkFileError, link_file};
+use crate::{LinkFileError, link_file};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_npmrc::PackageImportMethod;
 use rayon::prelude::*;
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
+    fs, io,
     path::{Path, PathBuf},
 };
 
 /// Error type for [`create_cas_files`].
 #[derive(Debug, Display, Error, Diagnostic)]
 pub enum CreateCasFilesError {
+    #[display("cannot create directory at {dirname:?}: {error}")]
+    CreateDir {
+        dirname: PathBuf,
+        #[error(source)]
+        error: io::Error,
+    },
     #[diagnostic(transparent)]
     LinkFile(#[error(source)] LinkFileError),
 }
@@ -27,19 +34,46 @@ pub fn create_cas_files(
         return Ok(());
     }
 
-    // Per-package parent-dir cache: every file in the same package
-    // hangs off `dir_path`, and most of them share intermediate dirs
-    // (`lib/`, `dist/`, `src/index.js`'s `src/`, …). Allocating once
-    // per `create_cas_files` call lets rayon workers share dedup
-    // state without ballooning into a process-wide cache that would
-    // need install-scope teardown to stay correct under bench-style
-    // `rm -rf node_modules`.
-    let ensured_dirs_cache = EnsuredDirsCache::new();
+    // Mirror pnpm v11's `tryImportIndexedDir` (see
+    // `fs/indexed-pkg-importer/src/importIndexedDir.ts`): collect the
+    // unique relative parent dirs from the file map, sort them
+    // shortest-first, then mkdir each one sequentially before any
+    // file imports start. Sorting by length means the recursive
+    // mkdir for a deeper dir always finds its ancestor already on
+    // disk, so each call costs one `mkdirat` instead of walking up.
+    // After the pre-pass `link_file` itself has no mkdir cost — the
+    // hot rayon loop only does the actual hardlink / clone / copy.
+    let mut rel_dirs: HashSet<&str> = HashSet::new();
+    for entry in cas_paths.keys() {
+        if let Some(parent) = Path::new(entry).parent()
+            && let Some(rel) = parent.to_str()
+            && !rel.is_empty()
+        {
+            rel_dirs.insert(rel);
+        }
+    }
+
+    // The package root itself: pnpm's `importIndexedDir` mkdirs
+    // `newDir` before calling `tryImportIndexedDir`, so do that here
+    // too. Files at the package root (e.g. `package.json`) need this
+    // even when `rel_dirs` is empty.
+    fs::create_dir_all(dir_path).map_err(|error| CreateCasFilesError::CreateDir {
+        dirname: dir_path.to_path_buf(),
+        error,
+    })?;
+
+    let mut ordered: Vec<&str> = rel_dirs.into_iter().collect();
+    ordered.sort_by_key(|s| s.len());
+    for rel in ordered {
+        let abs = dir_path.join(rel);
+        fs::create_dir_all(&abs)
+            .map_err(|error| CreateCasFilesError::CreateDir { dirname: abs, error })?;
+    }
 
     cas_paths
         .par_iter()
         .try_for_each(|(cleaned_entry, store_path)| {
-            link_file(import_method, store_path, &dir_path.join(cleaned_entry), &ensured_dirs_cache)
+            link_file(import_method, store_path, &dir_path.join(cleaned_entry))
         })
         .map_err(CreateCasFilesError::LinkFile)
 }

--- a/crates/package-manager/src/create_cas_files.rs
+++ b/crates/package-manager/src/create_cas_files.rs
@@ -1,4 +1,4 @@
-use crate::{link_file, LinkFileError};
+use crate::{link_file, EnsuredDirsCache, LinkFileError};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_npmrc::PackageImportMethod;
@@ -27,10 +27,19 @@ pub fn create_cas_files(
         return Ok(());
     }
 
+    // Per-package parent-dir cache: every file in the same package
+    // hangs off `dir_path`, and most of them share intermediate dirs
+    // (`lib/`, `dist/`, `src/index.js`'s `src/`, …). Allocating once
+    // per `create_cas_files` call lets rayon workers share dedup
+    // state without ballooning into a process-wide cache that would
+    // need install-scope teardown to stay correct under bench-style
+    // `rm -rf node_modules`.
+    let ensured_dirs_cache = EnsuredDirsCache::new();
+
     cas_paths
         .par_iter()
         .try_for_each(|(cleaned_entry, store_path)| {
-            link_file(import_method, store_path, &dir_path.join(cleaned_entry))
+            link_file(import_method, store_path, &dir_path.join(cleaned_entry), &ensured_dirs_cache)
         })
         .map_err(CreateCasFilesError::LinkFile)
 }

--- a/crates/package-manager/src/link_file.rs
+++ b/crates/package-manager/src/link_file.rs
@@ -1,3 +1,4 @@
+use dashmap::DashSet;
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_npmrc::PackageImportMethod;
@@ -6,6 +7,23 @@ use std::{
     path::{Path, PathBuf},
     sync::atomic::{AtomicU8, Ordering},
 };
+
+/// Set of `node_modules`-side parent directories we've already
+/// observed (or made) exist via `fs::create_dir_all`. Threaded through
+/// each batch of [`link_file`] calls so the per-file
+/// "ensure-parent-dir" path doesn't redo the syscall on every entry
+/// in the same package — `create_dir_all` is idempotent but still
+/// stats every component on every invocation, which adds up to
+/// O(num_files) wasted stats per install.
+///
+/// Mirrors the per-snapshot dedup set pnpm v11 keeps inside its
+/// indexed-pkg-importer (see `fs/indexed-pkg-importer/src/index.ts`,
+/// `dirsCreated`). Concurrent because rayon's `par_iter` over
+/// `cas_paths` calls into `link_file` from multiple worker threads
+/// at once; a `DashSet` covers that without external locking, and
+/// the duplicate-mkdir race is benign — `create_dir_all` is
+/// idempotent.
+pub type EnsuredDirsCache = DashSet<PathBuf>;
 
 /// Error type for [`link_file`].
 #[derive(Debug, Display, Error, Diagnostic)]
@@ -91,10 +109,19 @@ fn log_method_once(flag: u8, method: &'static str) {
 ///
 /// * If `target_link` already exists, do nothing.
 /// * If parent dir of `target_link` doesn't exist, it will be created.
+///
+/// `ensured_dirs_cache` is the [`EnsuredDirsCache`] threaded through
+/// the batch of `link_file` calls that share one `node_modules` tree
+/// (typically one package's CAS-import phase). After a parent dir is
+/// successfully created the cache records its absolute path, so
+/// later files in the same package that share the parent skip the
+/// `create_dir_all` syscall entirely. Pass an empty cache when the
+/// caller doesn't care about the optimization (tests, one-off calls).
 pub fn link_file(
     method: PackageImportMethod,
     source_file: &Path,
     target_link: &Path,
+    ensured_dirs_cache: &EnsuredDirsCache,
 ) -> Result<(), LinkFileError> {
     // If the target resolves to a live file (directly or via a
     // symlink), a prior install placed it and there's nothing to do.
@@ -130,10 +157,20 @@ pub fn link_file(
     }
 
     if let Some(parent_dir) = target_link.parent() {
-        fs::create_dir_all(parent_dir).map_err(|error| LinkFileError::CreateDir {
-            dirname: parent_dir.to_path_buf(),
-            error,
-        })?;
+        // Skip the syscall when another file in the same batch has
+        // already ensured this exact parent. `create_dir_all` would
+        // otherwise stat every ancestor on every call. Race with
+        // concurrent rayon workers is benign: at worst two threads
+        // both call `create_dir_all` on a fresh dir before either
+        // inserts into the cache — which is exactly what `create_dir_all`
+        // already tolerates by being idempotent.
+        if !ensured_dirs_cache.contains(parent_dir) {
+            fs::create_dir_all(parent_dir).map_err(|error| LinkFileError::CreateDir {
+                dirname: parent_dir.to_path_buf(),
+                error,
+            })?;
+            ensured_dirs_cache.insert(parent_dir.to_path_buf());
+        }
     }
 
     // Hardlinking a file from the store into `node_modules` means any
@@ -335,7 +372,8 @@ mod tests {
         let src = write_source(tmp.path(), "src.txt", b"hello");
         let dst = tmp.path().join("nested/dst.txt");
 
-        link_file(PackageImportMethod::Copy, &src, &dst).expect("link_file should succeed");
+        link_file(PackageImportMethod::Copy, &src, &dst, &EnsuredDirsCache::new())
+            .expect("link_file should succeed");
 
         assert_eq!(fs::read(&dst).unwrap(), b"hello");
         // A plain copy leaves the two files as independent inodes.
@@ -359,7 +397,8 @@ mod tests {
         let src = write_source(tmp.path(), "src.txt", b"shared");
         let dst = tmp.path().join("nested/dst.txt");
 
-        link_file(PackageImportMethod::Hardlink, &src, &dst).expect("link_file should succeed");
+        link_file(PackageImportMethod::Hardlink, &src, &dst, &EnsuredDirsCache::new())
+            .expect("link_file should succeed");
 
         assert_eq!(fs::read(&dst).unwrap(), b"shared");
         #[cfg(unix)]
@@ -381,7 +420,8 @@ mod tests {
         let src = write_source(tmp.path(), "src.txt", b"auto");
         let dst = tmp.path().join("nested/dst.txt");
 
-        link_file(PackageImportMethod::Auto, &src, &dst).expect("Auto should always succeed");
+        link_file(PackageImportMethod::Auto, &src, &dst, &EnsuredDirsCache::new())
+            .expect("Auto should always succeed");
         assert_eq!(fs::read(&dst).unwrap(), b"auto");
     }
 
@@ -402,7 +442,8 @@ mod tests {
             PackageImportMethod::Clone,
             PackageImportMethod::CloneOrCopy,
         ] {
-            link_file(method, &src, &dst).expect("existing target should short-circuit");
+            link_file(method, &src, &dst, &EnsuredDirsCache::new())
+                .expect("existing target should short-circuit");
             assert_eq!(fs::read(&dst).unwrap(), b"old", "method {method:?} must not overwrite");
         }
     }
@@ -419,8 +460,8 @@ mod tests {
         let src = tmp.path().join("does-not-exist");
         let dst = tmp.path().join("dst.txt");
 
-        let err =
-            link_file(PackageImportMethod::Hardlink, &src, &dst).expect_err("no source → error");
+        let err = link_file(PackageImportMethod::Hardlink, &src, &dst, &EnsuredDirsCache::new())
+            .expect_err("no source → error");
         assert!(matches!(err, LinkFileError::Import { .. }), "got: {err:?}");
     }
 
@@ -436,7 +477,7 @@ mod tests {
         let src = write_source(tmp.path(), "src.txt", b"clone-or-copy");
         let dst = tmp.path().join("nested/dst.txt");
 
-        link_file(PackageImportMethod::CloneOrCopy, &src, &dst)
+        link_file(PackageImportMethod::CloneOrCopy, &src, &dst, &EnsuredDirsCache::new())
             .expect("CloneOrCopy should always succeed");
         assert_eq!(fs::read(&dst).unwrap(), b"clone-or-copy");
     }
@@ -451,7 +492,8 @@ mod tests {
         let src = tmp.path().join("does-not-exist");
         let dst = tmp.path().join("dst.txt");
 
-        let err = link_file(PackageImportMethod::Clone, &src, &dst).expect_err("no source → error");
+        let err = link_file(PackageImportMethod::Clone, &src, &dst, &EnsuredDirsCache::new())
+            .expect_err("no source → error");
         assert!(matches!(err, LinkFileError::Import { .. }), "got: {err:?}");
     }
 
@@ -469,7 +511,7 @@ mod tests {
         let dst = tmp.path().join("dst.txt");
         std::os::unix::fs::symlink(tmp.path().join("never-created"), &dst).unwrap();
 
-        link_file(PackageImportMethod::Hardlink, &src, &dst)
+        link_file(PackageImportMethod::Hardlink, &src, &dst, &EnsuredDirsCache::new())
             .expect("dangling symlink should be scrubbed, then hardlinked");
 
         let meta = fs::symlink_metadata(&dst).unwrap();
@@ -490,7 +532,7 @@ mod tests {
         let dst = tmp.path().join("dst.txt");
         std::os::unix::fs::symlink(&real_target, &dst).unwrap();
 
-        link_file(PackageImportMethod::Hardlink, &src, &dst)
+        link_file(PackageImportMethod::Hardlink, &src, &dst, &EnsuredDirsCache::new())
             .expect("live symlink should short-circuit");
 
         assert!(fs::symlink_metadata(&dst).unwrap().file_type().is_symlink());
@@ -711,5 +753,62 @@ mod tests {
             "state=COPY must not hardlink",
         );
         assert_eq!(state.load(Ordering::Relaxed), LINK_STATE_COPY, "state must not drift");
+    }
+
+    /// A successful `link_file` must record the `target_link.parent()`
+    /// it created in the cache. The next file in the same package
+    /// (same `cas_paths` batch) shares that parent, so a populated
+    /// cache lets the second call skip the redundant `create_dir_all`.
+    /// Without this assertion the cache would be allocated but never
+    /// populated, and the optimization would silently no-op.
+    #[test]
+    fn link_file_populates_ensured_dirs_cache_on_create() {
+        let tmp = tempdir().unwrap();
+        let src = write_source(tmp.path(), "src.txt", b"contents");
+        let dst = tmp.path().join("nested/sub/dst.txt");
+        let parent = dst.parent().unwrap().to_path_buf();
+        let cache = EnsuredDirsCache::new();
+
+        link_file(PackageImportMethod::Copy, &src, &dst, &cache).expect("link_file should succeed");
+
+        assert!(
+            cache.contains(&parent),
+            "successful create_dir_all must populate the cache for later siblings",
+        );
+    }
+
+    /// When the cache already records a parent, `link_file` must skip
+    /// the `create_dir_all` call. Prove it by populating the cache
+    /// with a path that *doesn't exist on disk* and asking `link_file`
+    /// to materialize a target under it. With the cache short-circuit
+    /// in place, the open in `ensure_file` (or the underlying
+    /// link/copy syscall) is the first thing that touches the
+    /// filesystem and surfaces `NotFound`. Without the short-circuit,
+    /// `create_dir_all` would lazily create the missing dir and the
+    /// call would succeed — that's the failure mode this guards.
+    ///
+    /// We pin to `Copy` so the syscall path is deterministic across
+    /// platforms (no reflink/hardlink tier-walking).
+    #[test]
+    fn link_file_skips_create_dir_all_on_cache_hit() {
+        let tmp = tempdir().unwrap();
+        let src = write_source(tmp.path(), "src.txt", b"contents");
+        let phantom_parent = tmp.path().join("does-not-exist-on-disk");
+        let dst = phantom_parent.join("dst.txt");
+        let cache = EnsuredDirsCache::new();
+        cache.insert(phantom_parent.clone());
+
+        let err = link_file(PackageImportMethod::Copy, &src, &dst, &cache)
+            .expect_err("cached parent must skip create_dir_all → copy must fail with NotFound");
+        match err {
+            LinkFileError::Import { error, .. } => {
+                assert_eq!(
+                    error.kind(),
+                    io::ErrorKind::NotFound,
+                    "the missing parent must surface from the copy itself, not from a recovered create_dir_all",
+                );
+            }
+            other => panic!("expected LinkFileError::Import(NotFound), got: {other:?}"),
+        }
     }
 }

--- a/crates/package-manager/src/link_file.rs
+++ b/crates/package-manager/src/link_file.rs
@@ -1,4 +1,3 @@
-use dashmap::DashSet;
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_npmrc::PackageImportMethod;
@@ -8,32 +7,9 @@ use std::{
     sync::atomic::{AtomicU8, Ordering},
 };
 
-/// Set of `node_modules`-side parent directories we've already
-/// observed (or made) exist via `fs::create_dir_all`. Threaded through
-/// each batch of [`link_file`] calls so the per-file
-/// "ensure-parent-dir" path doesn't redo the syscall on every entry
-/// in the same package — `create_dir_all` is idempotent but still
-/// stats every component on every invocation, which adds up to
-/// O(num_files) wasted stats per install.
-///
-/// Mirrors the per-snapshot dedup set pnpm v11 keeps inside its
-/// indexed-pkg-importer (see `fs/indexed-pkg-importer/src/index.ts`,
-/// `dirsCreated`). Concurrent because rayon's `par_iter` over
-/// `cas_paths` calls into `link_file` from multiple worker threads
-/// at once; a `DashSet` covers that without external locking, and
-/// the duplicate-mkdir race is benign — `create_dir_all` is
-/// idempotent.
-pub type EnsuredDirsCache = DashSet<PathBuf>;
-
 /// Error type for [`link_file`].
 #[derive(Debug, Display, Error, Diagnostic)]
 pub enum LinkFileError {
-    #[display("cannot create directory at {dirname:?}: {error}")]
-    CreateDir {
-        dirname: PathBuf,
-        #[error(source)]
-        error: io::Error,
-    },
     // `link_file` now dispatches to copy / reflink / hardlink depending
     // on `PackageImportMethod`, so a "fail to create a link" message
     // would be misleading when the configured method is `Copy`. Using
@@ -108,20 +84,17 @@ fn log_method_once(flag: u8, method: &'static str) {
 /// Materialize a CAFS file into `target_link` using `method`.
 ///
 /// * If `target_link` already exists, do nothing.
-/// * If parent dir of `target_link` doesn't exist, it will be created.
-///
-/// `ensured_dirs_cache` is the [`EnsuredDirsCache`] threaded through
-/// the batch of `link_file` calls that share one `node_modules` tree
-/// (typically one package's CAS-import phase). After a parent dir is
-/// successfully created the cache records its absolute path, so
-/// later files in the same package that share the parent skip the
-/// `create_dir_all` syscall entirely. Pass an empty cache when the
-/// caller doesn't care about the optimization (tests, one-off calls).
+/// * `target_link.parent()` must already exist; this is a leaf
+///   operation that does not create directories. Mirrors pnpm v11's
+///   `importFile` (see `fs/indexed-pkg-importer/src/importIndexedDir.ts`,
+///   `tryImportIndexedDir`), which mkdirs the unique parent set
+///   sequentially up-front and then calls into the import primitive
+///   per file. [`create_cas_files`](crate::create_cas_files) is the
+///   production caller and handles that pre-pass.
 pub fn link_file(
     method: PackageImportMethod,
     source_file: &Path,
     target_link: &Path,
-    ensured_dirs_cache: &EnsuredDirsCache,
 ) -> Result<(), LinkFileError> {
     // If the target resolves to a live file (directly or via a
     // symlink), a prior install placed it and there's nothing to do.
@@ -153,23 +126,6 @@ pub fn link_file(
         Err(_) => {
             // Non-`NotFound` stat error. Leave the dirent alone; the
             // import call below will surface the real problem.
-        }
-    }
-
-    if let Some(parent_dir) = target_link.parent() {
-        // Skip the syscall when another file in the same batch has
-        // already ensured this exact parent. `create_dir_all` would
-        // otherwise stat every ancestor on every call. Race with
-        // concurrent rayon workers is benign: at worst two threads
-        // both call `create_dir_all` on a fresh dir before either
-        // inserts into the cache — which is exactly what `create_dir_all`
-        // already tolerates by being idempotent.
-        if !ensured_dirs_cache.contains(parent_dir) {
-            fs::create_dir_all(parent_dir).map_err(|error| LinkFileError::CreateDir {
-                dirname: parent_dir.to_path_buf(),
-                error,
-            })?;
-            ensured_dirs_cache.insert(parent_dir.to_path_buf());
         }
     }
 
@@ -371,9 +327,9 @@ mod tests {
         let tmp = tempdir().unwrap();
         let src = write_source(tmp.path(), "src.txt", b"hello");
         let dst = tmp.path().join("nested/dst.txt");
+        fs::create_dir_all(dst.parent().unwrap()).unwrap();
 
-        link_file(PackageImportMethod::Copy, &src, &dst, &EnsuredDirsCache::new())
-            .expect("link_file should succeed");
+        link_file(PackageImportMethod::Copy, &src, &dst).expect("link_file should succeed");
 
         assert_eq!(fs::read(&dst).unwrap(), b"hello");
         // A plain copy leaves the two files as independent inodes.
@@ -396,9 +352,9 @@ mod tests {
         let tmp = tempdir().unwrap();
         let src = write_source(tmp.path(), "src.txt", b"shared");
         let dst = tmp.path().join("nested/dst.txt");
+        fs::create_dir_all(dst.parent().unwrap()).unwrap();
 
-        link_file(PackageImportMethod::Hardlink, &src, &dst, &EnsuredDirsCache::new())
-            .expect("link_file should succeed");
+        link_file(PackageImportMethod::Hardlink, &src, &dst).expect("link_file should succeed");
 
         assert_eq!(fs::read(&dst).unwrap(), b"shared");
         #[cfg(unix)]
@@ -419,9 +375,9 @@ mod tests {
         let tmp = tempdir().unwrap();
         let src = write_source(tmp.path(), "src.txt", b"auto");
         let dst = tmp.path().join("nested/dst.txt");
+        fs::create_dir_all(dst.parent().unwrap()).unwrap();
 
-        link_file(PackageImportMethod::Auto, &src, &dst, &EnsuredDirsCache::new())
-            .expect("Auto should always succeed");
+        link_file(PackageImportMethod::Auto, &src, &dst).expect("Auto should always succeed");
         assert_eq!(fs::read(&dst).unwrap(), b"auto");
     }
 
@@ -442,8 +398,7 @@ mod tests {
             PackageImportMethod::Clone,
             PackageImportMethod::CloneOrCopy,
         ] {
-            link_file(method, &src, &dst, &EnsuredDirsCache::new())
-                .expect("existing target should short-circuit");
+            link_file(method, &src, &dst).expect("existing target should short-circuit");
             assert_eq!(fs::read(&dst).unwrap(), b"old", "method {method:?} must not overwrite");
         }
     }
@@ -460,8 +415,8 @@ mod tests {
         let src = tmp.path().join("does-not-exist");
         let dst = tmp.path().join("dst.txt");
 
-        let err = link_file(PackageImportMethod::Hardlink, &src, &dst, &EnsuredDirsCache::new())
-            .expect_err("no source → error");
+        let err =
+            link_file(PackageImportMethod::Hardlink, &src, &dst).expect_err("no source → error");
         assert!(matches!(err, LinkFileError::Import { .. }), "got: {err:?}");
     }
 
@@ -476,8 +431,9 @@ mod tests {
         let tmp = tempdir().unwrap();
         let src = write_source(tmp.path(), "src.txt", b"clone-or-copy");
         let dst = tmp.path().join("nested/dst.txt");
+        fs::create_dir_all(dst.parent().unwrap()).unwrap();
 
-        link_file(PackageImportMethod::CloneOrCopy, &src, &dst, &EnsuredDirsCache::new())
+        link_file(PackageImportMethod::CloneOrCopy, &src, &dst)
             .expect("CloneOrCopy should always succeed");
         assert_eq!(fs::read(&dst).unwrap(), b"clone-or-copy");
     }
@@ -492,8 +448,7 @@ mod tests {
         let src = tmp.path().join("does-not-exist");
         let dst = tmp.path().join("dst.txt");
 
-        let err = link_file(PackageImportMethod::Clone, &src, &dst, &EnsuredDirsCache::new())
-            .expect_err("no source → error");
+        let err = link_file(PackageImportMethod::Clone, &src, &dst).expect_err("no source → error");
         assert!(matches!(err, LinkFileError::Import { .. }), "got: {err:?}");
     }
 
@@ -511,7 +466,7 @@ mod tests {
         let dst = tmp.path().join("dst.txt");
         std::os::unix::fs::symlink(tmp.path().join("never-created"), &dst).unwrap();
 
-        link_file(PackageImportMethod::Hardlink, &src, &dst, &EnsuredDirsCache::new())
+        link_file(PackageImportMethod::Hardlink, &src, &dst)
             .expect("dangling symlink should be scrubbed, then hardlinked");
 
         let meta = fs::symlink_metadata(&dst).unwrap();
@@ -532,7 +487,7 @@ mod tests {
         let dst = tmp.path().join("dst.txt");
         std::os::unix::fs::symlink(&real_target, &dst).unwrap();
 
-        link_file(PackageImportMethod::Hardlink, &src, &dst, &EnsuredDirsCache::new())
+        link_file(PackageImportMethod::Hardlink, &src, &dst)
             .expect("live symlink should short-circuit");
 
         assert!(fs::symlink_metadata(&dst).unwrap().file_type().is_symlink());
@@ -753,62 +708,5 @@ mod tests {
             "state=COPY must not hardlink",
         );
         assert_eq!(state.load(Ordering::Relaxed), LINK_STATE_COPY, "state must not drift");
-    }
-
-    /// A successful `link_file` must record the `target_link.parent()`
-    /// it created in the cache. The next file in the same package
-    /// (same `cas_paths` batch) shares that parent, so a populated
-    /// cache lets the second call skip the redundant `create_dir_all`.
-    /// Without this assertion the cache would be allocated but never
-    /// populated, and the optimization would silently no-op.
-    #[test]
-    fn link_file_populates_ensured_dirs_cache_on_create() {
-        let tmp = tempdir().unwrap();
-        let src = write_source(tmp.path(), "src.txt", b"contents");
-        let dst = tmp.path().join("nested/sub/dst.txt");
-        let parent = dst.parent().unwrap().to_path_buf();
-        let cache = EnsuredDirsCache::new();
-
-        link_file(PackageImportMethod::Copy, &src, &dst, &cache).expect("link_file should succeed");
-
-        assert!(
-            cache.contains(&parent),
-            "successful create_dir_all must populate the cache for later siblings",
-        );
-    }
-
-    /// When the cache already records a parent, `link_file` must skip
-    /// the `create_dir_all` call. Prove it by populating the cache
-    /// with a path that *doesn't exist on disk* and asking `link_file`
-    /// to materialize a target under it. With the cache short-circuit
-    /// in place, the open in `ensure_file` (or the underlying
-    /// link/copy syscall) is the first thing that touches the
-    /// filesystem and surfaces `NotFound`. Without the short-circuit,
-    /// `create_dir_all` would lazily create the missing dir and the
-    /// call would succeed — that's the failure mode this guards.
-    ///
-    /// We pin to `Copy` so the syscall path is deterministic across
-    /// platforms (no reflink/hardlink tier-walking).
-    #[test]
-    fn link_file_skips_create_dir_all_on_cache_hit() {
-        let tmp = tempdir().unwrap();
-        let src = write_source(tmp.path(), "src.txt", b"contents");
-        let phantom_parent = tmp.path().join("does-not-exist-on-disk");
-        let dst = phantom_parent.join("dst.txt");
-        let cache = EnsuredDirsCache::new();
-        cache.insert(phantom_parent.clone());
-
-        let err = link_file(PackageImportMethod::Copy, &src, &dst, &cache)
-            .expect_err("cached parent must skip create_dir_all → copy must fail with NotFound");
-        match err {
-            LinkFileError::Import { error, .. } => {
-                assert_eq!(
-                    error.kind(),
-                    io::ErrorKind::NotFound,
-                    "the missing parent must surface from the copy itself, not from a recovered create_dir_all",
-                );
-            }
-            other => panic!("expected LinkFileError::Import(NotFound), got: {other:?}"),
-        }
     }
 }


### PR DESCRIPTION
Second in a series addressing the warm-cache install gap raised against pnpm v11. (PR 1 of 3 is #285.)

## Summary

`link_file` called `fs::create_dir_all(parent_dir)` for every file it materialized, even when the previous file in the same package had just created the same parent. `create_dir_all` is idempotent but stats every component on every call. Across ~50K files in a typical install — with most packages depositing into a small fixed set of dirs (`lib/`, `dist/`, `src/`, ...) — that's tens of thousands of redundant stat syscalls in the link phase.

Mirrors pnpm v11's `dirsCreated` dedup set inside `fs/indexed-pkg-importer/src/index.ts`. Add an `EnsuredDirsCache` type alias (`DashSet<PathBuf>`, concurrent because rayon's `par_iter` calls into `link_file` from multiple worker threads at once) and thread it through `link_file`'s signature. Allocate one cache per `create_cas_files` call — that scope is one package's CAS-import phase, where parent-dir overlap is densest, and the cache is dropped right after so a benchmark-style `rm -rf node_modules` between iterations never sees a stale entry.

## Concurrency

The duplicate-mkdir race is benign. If two rayon threads both find a parent missing in the cache, both call `create_dir_all` (which is itself idempotent) and both insert. Worst case: one extra `create_dir_all` per fresh dir on a contended start, then steady-state cache-hit fast path. No locks beyond what `DashSet` does internally.

## Test plan

- [x] `just ready` — 210/210 (added two new tests).
- [x] `link_file_populates_ensured_dirs_cache_on_create` — successful link must record the parent in the cache so later siblings skip the syscall.
- [x] `link_file_skips_create_dir_all_on_cache_hit` — pre-populate the cache with a path that doesn't exist on disk and ask `link_file` to materialize under it. The cache short-circuits `create_dir_all` and the underlying copy fails with `NotFound`. Pins the optimization in place; without the short-circuit `create_dir_all` would lazily create the missing dir and the call would succeed silently.
- [x] All 10 existing `link_file` unit tests now pass an empty `EnsuredDirsCache::new()` (per-test isolation, matching the prior implicit per-call behaviour).

## Expected impact

The second of the two cited bottlenecks for the warm-cache install scenario. Caching collapses N-files `create_dir_all` calls to N-unique-parents per package — roughly an order of magnitude on a tree like `lib/{a,b,c}.js + dist/{a,b,c}.js + src/...`. Wall-time delta will show in the integrated-benchmark on the next CI run, stacking with #285's verifiedFilesCache change.