### PR TITLE
ci(benchmark): skip benchmark workflows on PRs that can't affect timings

### DIFF
--- a/.github/workflows/integrated-benchmark.yml
+++ b/.github/workflows/integrated-benchmark.yml
@@ -13,6 +13,7 @@ on:
       - 'tasks/registry-mock/package.json'
       - 'tasks/registry-mock/pnpm-lock.yaml'
       - 'tasks/registry-mock/pnpm-workspace.yaml'
+      - 'tasks/integrated-benchmark/src/fixtures/**'
       - '.github/actions/**'
       - '.github/workflows/integrated-benchmark.yml'
 

--- a/.github/workflows/integrated-benchmark.yml
+++ b/.github/workflows/integrated-benchmark.yml
@@ -4,9 +4,6 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize]
-    # Only run when something that can affect install timings changes.
-    # Docs, the npm wrapper, other workflows, and editor/lint config
-    # never reach the benchmark binary or the verdaccio fixtures.
     paths:
       - '**/*.rs'
       - '**/Cargo.toml'

--- a/.github/workflows/integrated-benchmark.yml
+++ b/.github/workflows/integrated-benchmark.yml
@@ -4,6 +4,20 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize]
+    # Only run when something that can affect install timings changes.
+    # Docs, the npm wrapper, other workflows, and editor/lint config
+    # never reach the benchmark binary or the verdaccio fixtures.
+    paths:
+      - '**/*.rs'
+      - '**/Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - 'justfile'
+      - 'tasks/registry-mock/package.json'
+      - 'tasks/registry-mock/pnpm-lock.yaml'
+      - 'tasks/registry-mock/pnpm-workspace.yaml'
+      - '.github/actions/**'
+      - '.github/workflows/integrated-benchmark.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}

--- a/.github/workflows/micro-benchmark.yml
+++ b/.github/workflows/micro-benchmark.yml
@@ -4,10 +4,6 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize]
-    # Criterion only sees Rust code, the workspace lockfile, the
-    # toolchain version, and the local tarball fixture. Everything
-    # else (docs, the npm wrapper, other workflows, justfile recipes,
-    # registry-mock fixtures) is invisible to the benchmark.
     paths:
       - '**/*.rs'
       - '**/Cargo.toml'

--- a/.github/workflows/micro-benchmark.yml
+++ b/.github/workflows/micro-benchmark.yml
@@ -4,6 +4,18 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize]
+    # Criterion only sees Rust code, the workspace lockfile, the
+    # toolchain version, and the local tarball fixture. Everything
+    # else (docs, the npm wrapper, other workflows, justfile recipes,
+    # registry-mock fixtures) is invisible to the benchmark.
+    paths:
+      - '**/*.rs'
+      - '**/Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - 'tasks/micro-benchmark/fixtures/**'
+      - '.github/actions/**'
+      - '.github/workflows/micro-benchmark.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}


### PR DESCRIPTION
Both Integrated-Benchmark and Micro-Benchmark used to run on every pull_request, even when the diff was docs-only or touched only the npm wrapper / other workflows. Add a `paths:` allow-list so the jobs trigger only on changes that can actually move benchmark numbers: Rust sources, Cargo manifests / lockfile, the toolchain pin, the shared CI actions, and the workflow file itself.

Integrated-Benchmark additionally watches `justfile` (used by `just install` / `just integrated-benchmark`) and the registry-mock manifest files (which decide what verdaccio serves). Micro-Benchmark additionally watches its local `fixtures/` tarball.

Resolves https://github.com/pnpm/pacquet/issues/293.