### PR TITLE
test(integrated-benchmark): add headless-install-with-hot-cache scenario

### DIFF
--- a/.github/workflows/integrated-benchmark.yml
+++ b/.github/workflows/integrated-benchmark.yml
@@ -144,6 +144,22 @@ jobs:
           cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_FROZEN_LOCKFILE.md
           cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_FROZEN_LOCKFILE.json
 
+      - name: 'Benchmark: Frozen Lockfile (Hot Cache)'
+        shell: bash
+        # Same timeout / tracing rationale as the cold-cache step above.
+        # Mirrors pnpm's "Headless install (frozen lockfile, warm
+        # store+cache)" benchmark: each timed run wipes only
+        # `node_modules`, the per-revision store survives, and
+        # hyperfine's warmup run is what populates it on the first
+        # iteration so timed runs all see a hot store.
+        timeout-minutes: 10
+        env:
+          TRACE: pacquet=info
+        run: |
+          just integrated-benchmark --show-output --scenario=frozen-lockfile-hot-cache --verdaccio --with-pnpm HEAD main
+          cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_FROZEN_LOCKFILE_HOT_CACHE.md
+          cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_FROZEN_LOCKFILE_HOT_CACHE.json
+
       # - name: 'Benchmark: Clean Install'
       #   shell: bash
       #   run: |
@@ -165,6 +181,18 @@ jobs:
             echo
             echo '```json'
             cat bench-work-env/BENCHMARK_REPORT_FROZEN_LOCKFILE.json
+            echo '```'
+            echo
+            echo '</details>'
+            echo
+            echo '### Scenario: Frozen Lockfile (Hot Cache)'
+            echo
+            cat bench-work-env/BENCHMARK_REPORT_FROZEN_LOCKFILE_HOT_CACHE.md
+            echo
+            echo '<details><summary>BENCHMARK_REPORT.json</summary>'
+            echo
+            echo '```json'
+            cat bench-work-env/BENCHMARK_REPORT_FROZEN_LOCKFILE_HOT_CACHE.json
             echo '```'
             echo
             echo '</details>'

--- a/tasks/integrated-benchmark/src/cli_args.rs
+++ b/tasks/integrated-benchmark/src/cli_args.rs
@@ -47,6 +47,14 @@ pub enum BenchmarkScenario {
     CleanInstall,
     /// Benchmark install with a frozen lockfile and without local cache.
     FrozenLockfile,
+    /// Benchmark install with a frozen lockfile and a *warm* local store —
+    /// the "fresh clone of an existing repo" / "CI install where the
+    /// runner-level store cache is hit" path. Mirrors pnpm's
+    /// `Headless install (frozen lockfile, warm store+cache)` benchmark
+    /// in [`pnpm/v11/benchmarks/bench.sh`](https://github.com/pnpm/pnpm/blob/main/benchmarks/bench.sh).
+    /// Hyperfine's `--warmup` run primes the store; subsequent timed
+    /// runs delete only `node_modules` and reuse the populated store.
+    FrozenLockfileHotCache,
 }
 
 impl BenchmarkScenario {
@@ -54,7 +62,9 @@ impl BenchmarkScenario {
     pub fn install_args(self) -> impl IntoIterator<Item = &'static str> {
         match self {
             BenchmarkScenario::CleanInstall => Vec::new(),
-            BenchmarkScenario::FrozenLockfile => vec!["--frozen-lockfile"],
+            BenchmarkScenario::FrozenLockfile | BenchmarkScenario::FrozenLockfileHotCache => {
+                vec!["--frozen-lockfile"]
+            }
         }
     }
 
@@ -62,7 +72,9 @@ impl BenchmarkScenario {
     pub fn npmrc_lockfile_setting(self) -> &'static str {
         match self {
             BenchmarkScenario::CleanInstall => "lockfile=false",
-            BenchmarkScenario::FrozenLockfile => "lockfile=true",
+            BenchmarkScenario::FrozenLockfile | BenchmarkScenario::FrozenLockfileHotCache => {
+                "lockfile=true"
+            }
         }
     }
 
@@ -74,7 +86,24 @@ impl BenchmarkScenario {
     {
         match self {
             BenchmarkScenario::CleanInstall => None,
-            BenchmarkScenario::FrozenLockfile => load_lockfile().into().pipe(Some),
+            BenchmarkScenario::FrozenLockfile | BenchmarkScenario::FrozenLockfileHotCache => {
+                load_lockfile().into().pipe(Some)
+            }
+        }
+    }
+
+    /// Per-iteration cleanup paths that hyperfine's `--prepare` command
+    /// will `rm -rf` before each timed run (and before each warmup).
+    /// Cold-cache scenarios wipe the per-revision store along with
+    /// `node_modules` so every iteration starts from scratch; the
+    /// hot-cache scenario only wipes `node_modules`, letting the
+    /// warmup populate the store and timed iterations reuse it.
+    pub fn cleanup_paths(self) -> &'static [&'static str] {
+        match self {
+            BenchmarkScenario::CleanInstall | BenchmarkScenario::FrozenLockfile => {
+                &["node_modules", "store-dir"]
+            }
+            BenchmarkScenario::FrozenLockfileHotCache => &["node_modules"],
         }
     }
 }

--- a/tasks/integrated-benchmark/src/work_env.rs
+++ b/tasks/integrated-benchmark/src/work_env.rs
@@ -279,12 +279,16 @@ fn create_pnpm_workspace(dst_dir: &Path, src_dir: Option<&Path>) {
 
 fn create_npmrc(dir: &Path, registry: &str, scenario: BenchmarkScenario) {
     let path = dir.join(".npmrc");
-    let store_dir = dir.join("store-dir");
-    let store_dir = store_dir.to_str().expect("path to store-dir is valid UTF-8");
     eprintln!("Creating config file {path:?}...");
     let mut file = File::create(path).expect("create .npmrc");
     writeln!(file, "registry={registry}").unwrap();
-    writeln!(file, "store-dir={store_dir}").unwrap();
+    // `store-dir` is read from `pnpm-workspace.yaml` (`storeDir`) by both
+    // pnpm and pacquet, not from `.npmrc`. Pacquet's `.npmrc` parser
+    // (`crates/npmrc/src/npmrc_auth.rs`) explicitly ignores `store-dir`
+    // and a test there pins that behaviour. The static fixture's
+    // `storeDir: ./store-dir` already resolves to `{bench_dir}/store-dir`
+    // under each per-revision CWD, which gives the same per-revision
+    // isolation the redundant `.npmrc` line was supposedly providing.
     writeln!(file, "auto-install-peers=false").unwrap();
     writeln!(file, "ignore-scripts=true").unwrap();
     writeln!(file, "{}", scenario.npmrc_lockfile_setting()).unwrap();

--- a/tasks/integrated-benchmark/src/work_env.rs
+++ b/tasks/integrated-benchmark/src/work_env.rs
@@ -173,6 +173,30 @@ impl WorkEnv {
     }
 
     fn benchmark(&self) {
+        // Pre-benchmark wipe of `node_modules` *and* `store-dir` for
+        // every benchmark target, regardless of scenario. The
+        // hot-cache scenario's per-iteration `--prepare` intentionally
+        // preserves `store-dir` so subsequent iterations can reuse
+        // it, which means whatever a previous run / scenario / partial
+        // invocation left in `store-dir` would otherwise carry into
+        // the warmup — and the warmup wouldn't actually be what
+        // primes the store. Wiping once upfront makes the warmup the
+        // priming run no matter what state the work-env was in. For
+        // cold-cache scenarios this is redundant with the per-iteration
+        // wipe but harmless (Copilot review on #296).
+        for dir in self
+            .revision_ids()
+            .chain(self.with_pnpm.then_some(WorkEnv::PNPM))
+            .map(|id| self.bench_dir(id))
+        {
+            for name in ["node_modules", "store-dir"] {
+                let path = dir.join(name);
+                if path.exists() {
+                    fs::remove_dir_all(&path).expect("pre-benchmark wipe");
+                }
+            }
+        }
+
         // hyperfine runs `--prepare` before *each* timed invocation, so
         // cleanup must cover every bench dir we're about to measure.
         // Previously this only wiped the pacquet revisions — if

--- a/tasks/integrated-benchmark/src/work_env.rs
+++ b/tasks/integrated-benchmark/src/work_env.rs
@@ -261,20 +261,68 @@ fn create_package_json(dst_dir: &Path, src_dir: Option<&Path>) {
 /// would have fired — the workspace file's `allowBuilds: {core-js: false,
 /// es5-ext: false}` silences those specific warnings and keeps pnpm's
 /// output clean so hyperfine doesn't see stderr noise.
+///
+/// Always guarantees `storeDir: ./store-dir` ends up in the destination.
+/// Both pnpm and pacquet read the store path from this file (pacquet
+/// since the `.npmrc` parser explicitly ignores `store-dir`); without
+/// that key, both fall through to the global default store and the
+/// benchmark's per-iteration / pre-benchmark cleanup wipes a directory
+/// the install never wrote to. That silently invalidates cold/hot-cache
+/// semantics and lets state from previous runs leak in (Copilot review
+/// on #296).
+///
+/// If a custom fixture's workspace file already declares `storeDir`,
+/// trust it — that's the user opting into a different store layout
+/// (e.g. shared store across revisions to test a specific scenario).
+/// Only inject our default when the key is absent.
 fn create_pnpm_workspace(dst_dir: &Path, src_dir: Option<&Path>) {
     let dst = dst_dir.join("pnpm-workspace.yaml");
-    if let Some(src_dir) = src_dir {
+    let base = if let Some(src_dir) = src_dir {
         let src = src_dir.join("pnpm-workspace.yaml");
-        // The workspace file is optional when a custom fixture directory
-        // is provided — only copy if present, so existing fixture dirs
-        // that predate this helper don't start erroring out.
         if src.is_file() {
             assert_ne!(src, dst);
-            fs::copy(src, dst).expect("copy pnpm-workspace.yaml for the revision");
+            fs::read_to_string(src).expect("read fixture pnpm-workspace.yaml")
+        } else {
+            String::new()
         }
     } else {
-        fs::write(dst, PNPM_WORKSPACE).expect("write pnpm-workspace.yaml for the revision");
-    }
+        PNPM_WORKSPACE.to_string()
+    };
+    let content = if has_top_level_store_dir(&base) {
+        base
+    } else {
+        if !base.is_empty() {
+            eprintln!(
+                "warn: fixture's pnpm-workspace.yaml has no top-level `storeDir:` — \
+                 prepending `storeDir: ./store-dir` so per-revision store isolation works"
+            );
+        }
+        if base.is_empty() {
+            "storeDir: ./store-dir\n".to_string()
+        } else {
+            format!("storeDir: ./store-dir\n{base}")
+        }
+    };
+    fs::write(dst, content).expect("write pnpm-workspace.yaml for the revision");
+}
+
+/// Detect a top-level `storeDir:` key in a YAML document. We only look
+/// at lines whose first byte is a non-whitespace, non-`#` character so
+/// nested keys (`foo:\n  storeDir: …`) and comments don't count. This
+/// is a deliberately tiny scan, not a real YAML parse — the workspace
+/// files we ship and accept are flat enough that line-level matching
+/// covers the practical cases.
+fn has_top_level_store_dir(yaml: &str) -> bool {
+    yaml.lines().any(|line| {
+        let first = match line.as_bytes().first() {
+            Some(&b) => b,
+            None => return false,
+        };
+        if first.is_ascii_whitespace() || first == b'#' {
+            return false;
+        }
+        line.starts_with("storeDir:")
+    })
 }
 
 fn create_npmrc(dir: &Path, registry: &str, scenario: BenchmarkScenario) {

--- a/tasks/integrated-benchmark/src/work_env.rs
+++ b/tasks/integrated-benchmark/src/work_env.rs
@@ -179,11 +179,17 @@ impl WorkEnv {
         // `--with-pnpm` was set, pnpm's `node_modules` survived between
         // iterations, and after the warmup pnpm just hit a no-op
         // "already installed" code path instead of doing real work.
+        //
+        // Per-iteration cleanup paths come from the scenario: cold-cache
+        // scenarios wipe `node_modules` and `store-dir`, hot-cache wipes
+        // only `node_modules` so the warmup-populated store survives
+        // into the timed runs.
+        let cleanup_paths = self.scenario.cleanup_paths();
         let cleanup_targets = self
             .revision_ids()
             .chain(self.with_pnpm.then_some(WorkEnv::PNPM))
             .map(|id| self.bench_dir(id))
-            .flat_map(|dir| [dir.join("node_modules"), dir.join("store-dir")])
+            .flat_map(|dir| cleanup_paths.iter().map(move |name| dir.join(name)))
             .map(|path| path.maybe_quote().to_string())
             .join(" ");
         let cleanup_command = format!("rm -rf {cleanup_targets}");


### PR DESCRIPTION
## Summary

Adds a third benchmark scenario that mirrors pnpm v11's *Headless install (frozen lockfile, warm store+cache)* benchmark in [\`pnpm/v11/benchmarks/bench.sh\`](https://github.com/pnpm/pnpm/blob/main/benchmarks/bench.sh) — the common \"CI install where the runner-level store cache hit\" / \"fresh clone in an existing developer checkout\" path.

| scenario | lockfile | \`node_modules\` wiped? | \`store-dir\` wiped? |
|---|---|---|---|
| \`clean-install\` | absent | per iter | per iter |
| \`frozen-lockfile\` (existing cold-cache) | present | per iter | per iter |
| **\`frozen-lockfile-hot-cache\` (new)** | present | per iter | preserved |

For the new scenario, hyperfine's \`--warmup\` iteration is what populates the store; every timed run after that wipes only \`node_modules\` and reuses the populated store. Each revision (pacquet HEAD / pacquet main / pnpm) gets its own per-revision \`store-dir\` and warms it independently.

## Changes

- \`BenchmarkScenario::FrozenLockfileHotCache\` variant + a \`cleanup_paths\` method that returns \`[\"node_modules\", \"store-dir\"]\` for cold-cache scenarios and \`[\"node_modules\"]\` for hot-cache.
- \`WorkEnv::benchmark\` consumes \`scenario.cleanup_paths()\` to build the \`hyperfine --prepare\` cleanup command, so the same plumbing serves both scenarios.
- \`.github/workflows/integrated-benchmark.yml\`: a second \`Benchmark: Frozen Lockfile (Hot Cache)\` step and a corresponding section in the summary comment that gets posted on PRs.

## Test plan

- [x] \`just ready\` clean.
- [x] \`integrated-benchmark --help\` lists the new \`frozen-lockfile-hot-cache\` scenario value with its docstring.
- [ ] CI integrated-benchmark on Linux posts a PR comment with both Frozen Lockfile (cold) and Frozen Lockfile (Hot Cache) tables — will appear when the workflow runs against this PR.