### PR TITLE
fix(registry-mock): walk parent chain iteratively, with cycle guard

### DIFF
--- a/tasks/registry-mock/src/kill_verdaccio.rs
+++ b/tasks/registry-mock/src/kill_verdaccio.rs
@@ -1,13 +1,39 @@
 use pipe_trait::Pipe;
+use std::collections::HashSet;
 use sysinfo::{Pid, Process, ProcessRefreshKind, RefreshKind, Signal, System};
 
+/// Walk the parent chain iteratively to decide whether `process`
+/// descends from `suspect_ancestor`.
+///
+/// Two reasons this is a loop rather than the obvious recursion:
+///
+/// 1. **Stack safety on Windows.** A 1 MiB default thread stack
+///    overflowed during cleanup on `windows-latest` (#296 CI: a
+///    `STATUS_STACK_OVERFLOW` from `pacquet-registry-mock end` after
+///    every test passed). Iterating uses constant stack regardless
+///    of process-tree depth.
+/// 2. **Cycle safety.** `Process::parent()` on Windows reports
+///    `dwParentProcessID` as recorded at process-create time and is
+///    never updated when the parent dies — so the recorded parent
+///    PID can be reused by an unrelated later process and, in the
+///    pathological case, observably "loop back" through the snapshot.
+///    A `visited` set bounds the walk regardless.
 fn is_descent_of(process: &Process, suspect_ancestor: Pid, system: &System) -> bool {
-    let Some(parent) = process.parent() else { return false };
-    if parent == suspect_ancestor {
-        return true;
+    let mut current_parent = process.parent();
+    let mut visited: HashSet<Pid> = HashSet::new();
+    while let Some(parent_pid) = current_parent {
+        if parent_pid == suspect_ancestor {
+            return true;
+        }
+        if !visited.insert(parent_pid) {
+            // Cycle in the snapshot's parent chain — no need to walk
+            // further; if `suspect_ancestor` were on this loop we'd
+            // have hit it already.
+            return false;
+        }
+        current_parent = system.processes().get(&parent_pid).and_then(|p| p.parent());
     }
-    let Some(parent) = system.processes().get(&parent) else { return false };
-    is_descent_of(parent, suspect_ancestor, system)
+    false
 }
 
 pub fn kill_all_verdaccio_children_in(root: Pid, signal: Signal, system: &System) -> usize {


### PR DESCRIPTION
## Summary

`is_descent_of` in `tasks/registry-mock/src/kill_verdaccio.rs` recurses up `Process::parent()` to decide whether a process descends from a given ancestor PID. On `windows-latest` during the post-test verdaccio cleanup (`pacquet-registry-mock end`) this overflowed the default 1 MiB thread stack and crashed the cleanup step with \`STATUS_STACK_OVERFLOW\`. Test runs that otherwise passed all 200 tests still failed the CI job because the cleanup is the last step.

Seen on PR #296's CI run [#73030888195](https://github.com/pnpm/pacquet/actions/runs/24939575380/job/73030888195?pr=296).

## Fix

Convert the recursion to a loop, plus a \`HashSet<Pid>\` cycle guard:

- **Stack safety.** Iterating uses constant stack regardless of process-tree depth, so deep ancestor chains can't take cleanup down.
- **Cycle safety.** \`Process::parent()\` on Windows returns \`dwParentProcessID\` as recorded at process-create time and isn't updated when the parent dies, so the recorded parent PID can be reused by an unrelated later process and observably \"loop back\" through a snapshot. The \`visited\` set bounds the walk in that case too.

## Test plan

- [x] \`just ready\` clean (rust formatter, clippy, full nextest).
- [ ] Windows CI cleanup step no longer crashes — will appear when the workflow runs against this PR.