### PR TITLE
ci(benchmark): remove `exit_codes` fields

### DIFF
--- a/.github/workflows/integrated-benchmark.yml
+++ b/.github/workflows/integrated-benchmark.yml
@@ -169,6 +169,8 @@ jobs:
 
       - name: Generate summary
         shell: bash
+        # `jq 'del(.results[].exit_codes)'` drops hyperfine's
+        # all-zero `exit_codes` array — noise in the PR comment.
         run: |
           (
             echo '## Integrated-Benchmark Report (${{ runner.os }})'
@@ -180,7 +182,7 @@ jobs:
             echo '<details><summary>BENCHMARK_REPORT.json</summary>'
             echo
             echo '```json'
-            cat bench-work-env/BENCHMARK_REPORT_FROZEN_LOCKFILE.json
+            jq 'del(.results[].exit_codes)' bench-work-env/BENCHMARK_REPORT_FROZEN_LOCKFILE.json
             echo '```'
             echo
             echo '</details>'
@@ -192,7 +194,7 @@ jobs:
             echo '<details><summary>BENCHMARK_REPORT.json</summary>'
             echo
             echo '```json'
-            cat bench-work-env/BENCHMARK_REPORT_FROZEN_LOCKFILE_HOT_CACHE.json
+            jq 'del(.results[].exit_codes)' bench-work-env/BENCHMARK_REPORT_FROZEN_LOCKFILE_HOT_CACHE.json
             echo '```'
             echo
             echo '</details>'
@@ -204,7 +206,7 @@ jobs:
             # echo '<details><summary>BENCHMARK_REPORT.json</summary>'
             # echo
             # echo '```json'
-            # cat bench-work-env/BENCHMARK_REPORT_CLEAN_INSTALL.json
+            # jq 'del(.results[].exit_codes)' bench-work-env/BENCHMARK_REPORT_CLEAN_INSTALL.json
             # echo '```'
             # echo
             # echo '</details>'

--- a/.github/workflows/integrated-benchmark.yml
+++ b/.github/workflows/integrated-benchmark.yml
@@ -169,8 +169,6 @@ jobs:
 
       - name: Generate summary
         shell: bash
-        # `jq 'del(.results[].exit_codes)'` drops hyperfine's
-        # all-zero `exit_codes` array — noise in the PR comment.
         run: |
           (
             echo '## Integrated-Benchmark Report (${{ runner.os }})'


### PR DESCRIPTION
Drop `exit_codes` from the benchmark reports.

This field is a long array full of `0`s.

A comment that is too long makes it difficult for AI agents to read.