### PR TITLE
fix(network): match pnpm HTTP behaviour to fix tarball fetches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -88,7 +88,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -127,6 +127,17 @@ name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -326,7 +337,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -343,7 +354,7 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -417,6 +428,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -470,6 +496,12 @@ dependencies = [
  "once_cell",
  "parking_lot_core",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "derive_more"
@@ -546,6 +578,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,7 +602,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -851,12 +895,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hickory-proto"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand 0.9.4",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "moka",
+ "once_cell",
+ "parking_lot",
+ "rand 0.9.4",
+ "resolv-conf",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "home"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1102,6 +1192,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2",
+ "widestring",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1172,7 +1275,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95"
 dependencies = [
  "scopeguard",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1334,7 +1437,7 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1360,6 +1463,23 @@ dependencies = [
  "serde_urlencoded",
  "similar",
  "tokio",
+]
+
+[[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
 ]
 
 [[package]]
@@ -1417,7 +1537,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1472,6 +1592,10 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1925,6 +2049,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "portpicker"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2182,6 +2312,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
+ "hickory-resolver",
  "http",
  "http-body",
  "http-body-util",
@@ -2191,6 +2322,7 @@ dependencies = [
  "js-sys",
  "log",
  "native-tls",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "rustls-pki-types",
@@ -2211,10 +2343,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
+
+[[package]]
 name = "result"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "194d8e591e405d1eecf28819740abed6d719d1a2db87fc0bcdedee9a26d55560"
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "rmp"
@@ -2285,7 +2437,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2324,7 +2476,7 @@ version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2520,7 +2672,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2658,6 +2810,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
 name = "tar"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2678,7 +2836,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2688,7 +2846,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2783,6 +2941,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2795,7 +2968,7 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2993,6 +3166,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3015,6 +3194,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"
@@ -3214,6 +3404,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3235,7 +3431,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3328,6 +3524,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3347,11 +3554,36 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -3362,6 +3594,54 @@ checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1794,7 +1794,6 @@ dependencies = [
 name = "pacquet-network"
 version = "0.0.1"
 dependencies = [
- "num_cpus",
  "pipe-trait",
  "reqwest",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ num_cpus        = { version = "1.17.0" }
 os_display      = { version = "0.1.4" }
 reflink-copy    = { version = "0.1.29" }
 junction        = { version = "1.4.2" }
-reqwest         = { version = "0.13", default-features = false, features = ["json", "native-tls-vendored", "stream"] }
+reqwest         = { version = "0.13", default-features = false, features = ["hickory-dns", "json", "native-tls-vendored", "stream"] }
 node-semver     = { version = "2.2.0" }
 pipe-trait      = { version = "0.4.0" }
 portpicker      = { version = "0.1.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,32 +32,37 @@ pacquet-registry-mock = { path = "tasks/registry-mock" }
 
 # Dependencies
 async-recursion = { version = "1.1.1" }
-clap            = { version = "4", features = ["derive", "string"] }
-command-extra   = { version = "1.0.0" }
-base64          = { version = "0.22.1" }
-dashmap         = { version = "6.1.0" }
-derive_more     = { version = "2.1.1", features = ["full"] }
-dunce           = { version = "1.0.5" }
-home            = { version = "0.5.12" }
-insta           = { version = "1.47.2", features = ["yaml", "glob", "walkdir"] }
-itertools       = { version = "0.14.0" }
-futures-util    = { version = "0.3.32" }
-miette          = { version = "7.6.0", features = ["fancy"] }
-num_cpus        = { version = "1.17.0" }
-os_display      = { version = "0.1.4" }
-reflink-copy    = { version = "0.1.29" }
-junction        = { version = "1.4.2" }
-reqwest         = { version = "0.13", default-features = false, features = ["hickory-dns", "json", "native-tls-vendored", "stream"] }
-node-semver     = { version = "2.2.0" }
-pipe-trait      = { version = "0.4.0" }
-portpicker      = { version = "0.1.1" }
-rayon           = { version = "1.12.0" }
-rmp-serde       = { version = "1.3.0" }
-rusqlite        = { version = "0.38.0", features = ["bundled"] }
-serde           = { version = "1.0.228", features = ["derive"] }
-serde_ini       = { version = "0.2.0" }
-serde_json      = { version = "1.0.149", features = ["preserve_order"] }
-serde_yaml      = { version = "0.9.34" }
+clap = { version = "4", features = ["derive", "string"] }
+command-extra = { version = "1.0.0" }
+base64 = { version = "0.22.1" }
+dashmap = { version = "6.1.0" }
+derive_more = { version = "2.1.1", features = ["full"] }
+dunce = { version = "1.0.5" }
+home = { version = "0.5.12" }
+insta = { version = "1.47.2", features = ["yaml", "glob", "walkdir"] }
+itertools = { version = "0.14.0" }
+futures-util = { version = "0.3.32" }
+miette = { version = "7.6.0", features = ["fancy"] }
+num_cpus = { version = "1.17.0" }
+os_display = { version = "0.1.4" }
+reflink-copy = { version = "0.1.29" }
+junction = { version = "1.4.2" }
+reqwest = { version = "0.13", default-features = false, features = [
+  "hickory-dns",
+  "json",
+  "native-tls-vendored",
+  "stream",
+] }
+node-semver = { version = "2.2.0" }
+pipe-trait = { version = "0.4.0" }
+portpicker = { version = "0.1.1" }
+rayon = { version = "1.12.0" }
+rmp-serde = { version = "1.3.0" }
+rusqlite = { version = "0.38.0", features = ["bundled"] }
+serde = { version = "1.0.228", features = ["derive"] }
+serde_ini = { version = "0.2.0" }
+serde_json = { version = "1.0.149", features = ["preserve_order"] }
+serde_yaml = { version = "0.9.34" }
 # 0.11 removes the LowerHex impl on Output; revisit after upstream/consumers catch up
 sha2               = { version = "0.10.9" }
 split-first-char   = { version = "2.0.1" }

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -11,7 +11,6 @@ license.workspace    = true
 repository.workspace = true
 
 [dependencies]
-num_cpus   = { workspace = true }
 pipe-trait = { workspace = true }
 reqwest    = { workspace = true }
 tokio      = { workspace = true }

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -96,15 +96,6 @@ impl ThrottledClient {
     ///   no UA, which can trip CDN / WAF rules that reject or RST
     ///   bot-shaped traffic before any HTTP response is produced.
     ///
-    ///   We deliberately do *not* set a default `Accept` header —
-    ///   pnpm's `fetchFromRegistry` always attaches
-    ///   `application/vnd.npm.install-v1+json; …` to every request,
-    ///   including tarball fetches where it makes no sense, but
-    ///   that's an upstream quirk we have no reason to copy.
-    ///   `crates/registry`'s metadata calls set the npm-specific
-    ///   `Accept` per-request; tarball fetches send no `Accept` and
-    ///   the registry serves them just fine.
-    ///
     /// `pool_idle_timeout(4s)` matches
     /// [`agentkeepalive`'s](https://github.com/node-modules/agentkeepalive/blob/1e5e312f36/lib/agent.js#L39-L41)
     /// default `freeSocketTimeout` (the agent pnpm builds its

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -82,16 +82,29 @@ impl ThrottledClient {
     ///   `Accept` per-request; tarball fetches send no `Accept` and
     ///   the registry serves them just fine.
     ///
-    /// Timeouts are unchanged: a default `reqwest::Client` has no
+    /// `pool_idle_timeout(4s)` matches
+    /// [`agentkeepalive`'s](https://github.com/node-modules/agentkeepalive/blob/master/lib/agent.js#L39-L41)
+    /// default `freeSocketTimeout` (the agent pnpm builds its
+    /// connection pool on top of). Most CDN / load-balancer edges in
+    /// front of `registry.npmjs.org` close idle sockets after 5–15s
+    /// without sending FIN that hyper notices, so a longer pool TTL
+    /// (the previous 30s) lets pacquet reuse a half-dead socket and
+    /// surface the next request as a generic "error sending request
+    /// for url" — same symptom the user hit on `pump-2.0.1.tgz` while
+    /// pnpm on the same network succeeded. 4s keeps the pool useful
+    /// for back-to-back downloads (pacquet runs hundreds of fetches
+    /// in seconds) but well below the typical edge keepalive.
+    ///
+    /// `timeout(5min)` is the per-request deadline, not the socket
+    /// inactivity timeout. A default `reqwest::Client` has no
     /// deadlines at all, which is how `integrated-benchmark` used to
     /// hang at "Benchmark 1: pacquet@HEAD" until the GHA step budget
-    /// (#263) when an upstream stalled. The 5-minute `timeout` is
-    /// deliberately generous — npm tarballs are usually under 5 MB
-    /// but can reach hundreds of MB on slow connections. The retry
-    /// loop in `crates/tarball` (#301) handles short, transient
-    /// failures; the 5-minute cap catches truly stuck sockets.
-    /// Making these values user-configurable (npmrc / env / CLI)
-    /// is follow-up.
+    /// (#263) when an upstream stalled. 5 min is deliberately
+    /// generous — npm tarballs are usually under 5 MB but can reach
+    /// hundreds of MB on slow connections. The retry loop in
+    /// `crates/tarball` (#301) handles short, transient failures;
+    /// the 5-minute cap catches truly stuck sockets. Making these
+    /// values user-configurable (npmrc / env / CLI) is follow-up.
     pub fn new_for_installs() -> Self {
         let mut default_headers = HeaderMap::with_capacity(1);
         default_headers.insert(USER_AGENT, HeaderValue::from_static(DEFAULT_USER_AGENT));
@@ -101,7 +114,7 @@ impl ThrottledClient {
             .default_headers(default_headers)
             .connect_timeout(Duration::from_secs(10))
             .timeout(Duration::from_secs(300))
-            .pool_idle_timeout(Duration::from_secs(30))
+            .pool_idle_timeout(Duration::from_secs(4))
             .build()
             .expect("build reqwest client with default timeouts");
         ThrottledClient::from_client(client)

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -110,15 +110,11 @@ impl ThrottledClient {
     ///
     /// `timeout(5min)` is the per-request deadline, not the socket
     /// inactivity timeout. A default `reqwest::Client` has no
-    /// deadlines at all, which is how `integrated-benchmark` used to
-    /// hang at "Benchmark 1: pacquet@HEAD" until the GHA step budget
-    /// (#263) when an upstream stalled. 5 min is deliberately
-    /// generous — npm tarballs are usually under 5 MB but can reach
-    /// hundreds of MB on slow connections. Pacquet does not yet
-    /// retry transient fetch errors (tracked in #301); the 5-minute
-    /// cap is here to catch truly stuck sockets, not to paper over
-    /// short-lived failures. Making these values user-configurable
-    /// (npmrc / env / CLI) is follow-up.
+    /// deadlines at all, so a stalled upstream hangs the install
+    /// indefinitely. 5 min is deliberately generous — npm tarballs
+    /// are usually under 5 MB but can reach hundreds of MB on slow
+    /// connections — and catches truly stuck sockets, not
+    /// short-lived hiccups.
     ///
     /// `hickory_dns(true)` swaps reqwest's default resolver
     /// (tokio's `lookup_host`, which calls the platform's blocking

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -5,7 +5,9 @@ use reqwest::{
 use std::{future::IntoFuture, time::Duration};
 use tokio::sync::Semaphore;
 
-/// Default `User-Agent` pacquet sends on every registry request.
+/// Default `User-Agent` pacquet sends on every request made by the
+/// install client — registry metadata fetches and tarball downloads
+/// alike, including tarball URLs that point at non-registry hosts.
 ///
 /// Identical to pnpm v11's
 /// [`network/fetch/src/fetchFromRegistry.ts`](https://github.com/pnpm/pnpm/blob/main/network/fetch/src/fetchFromRegistry.ts#L9):

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -2,7 +2,7 @@ use reqwest::{
     header::{HeaderMap, HeaderValue, USER_AGENT},
     Client,
 };
-use std::{ops::Deref, time::Duration};
+use std::{num::NonZeroUsize, ops::Deref, time::Duration};
 use tokio::sync::{Semaphore, SemaphorePermit};
 
 /// Default `User-Agent` pacquet sends on every request made by the
@@ -195,8 +195,18 @@ impl ThrottledClient {
 ///
 /// Concretely: 16 on a 4-core machine, 21 on 8-core, 27 on 10-core,
 /// 45 on 16-core, capped at 64.
+///
+/// Uses [`std::thread::available_parallelism`] rather than
+/// `num_cpus::get()` so cgroup / CPU-quota limits in containers and
+/// CI runners are respected — `num_cpus` reports the host's logical
+/// CPU count, which on a quota-limited runner can over-report and
+/// push effective concurrency past what the kernel will actually
+/// schedule (matching the convention `crates/cli` already uses for
+/// rayon pool sizing, see `crates/cli/src/lib.rs`).
 pub fn default_network_concurrency() -> usize {
-    let max_workers = num_cpus::get().saturating_sub(1).max(1);
+    let available_parallelism =
+        std::thread::available_parallelism().map(NonZeroUsize::get).unwrap_or(1);
+    let max_workers = available_parallelism.saturating_sub(1).max(1);
     max_workers.saturating_mul(3).clamp(16, 64)
 }
 

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -1,5 +1,5 @@
 use reqwest::{
-    header::{HeaderMap, HeaderValue, ACCEPT, USER_AGENT},
+    header::{HeaderMap, HeaderValue, USER_AGENT},
     Client,
 };
 use std::{future::IntoFuture, time::Duration};
@@ -28,18 +28,6 @@ use tokio::sync::Semaphore;
 ///    direct fix that doesn't require speculating about which CDN
 ///    rule we're tripping.
 const DEFAULT_USER_AGENT: &str = "pnpm";
-
-/// Default `Accept` header pacquet sends on every registry request.
-///
-/// Identical to pnpm's
-/// [`ACCEPT_ABBREVIATED_DOC`](https://github.com/pnpm/pnpm/blob/main/network/fetch/src/fetchFromRegistry.ts#L14-L15)
-/// (the abbreviated-metadata variant pnpm sends on every fetch,
-/// metadata or tarball). The npm registry serves tarballs regardless
-/// of `Accept` because of the `*/*` fallback, but a registered
-/// `Accept` is part of what some CDN edge rules look at to decide
-/// whether to serve the request.
-const DEFAULT_ACCEPT: &str =
-    "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*";
 
 /// Wrapper around [`Client`] with concurrent request limit enforced by the [`Semaphore`] mechanism.
 #[derive(Debug)]
@@ -77,13 +65,22 @@ impl ThrottledClient {
     ///   saturate bandwidth in parallel.
     /// * **50 concurrent sockets**, matching pnpm's
     ///   `DEFAULT_MAX_SOCKETS`.
-    /// * **`User-Agent` and `Accept` headers** matching pnpm's
+    /// * **`User-Agent: pnpm`** matching pnpm's
     ///   `fetchFromRegistry.ts`. A default `reqwest::Client` sends
-    ///   neither, which can trip CDN / WAF rules that reject or RST
+    ///   no UA, which can trip CDN / WAF rules that reject or RST
     ///   bot-shaped traffic before any HTTP response is produced —
     ///   exactly the symptom reported when the headerless client
     ///   failed to fetch `pump-2.0.1.tgz` while a parallel `pnpm`
     ///   on the same network succeeded.
+    ///
+    ///   We deliberately do *not* set a default `Accept` header —
+    ///   pnpm's `fetchFromRegistry` always attaches
+    ///   `application/vnd.npm.install-v1+json; …` to every request,
+    ///   including tarball fetches where it makes no sense, but
+    ///   that's an upstream quirk we have no reason to copy.
+    ///   `crates/registry`'s metadata calls set the npm-specific
+    ///   `Accept` per-request; tarball fetches send no `Accept` and
+    ///   the registry serves them just fine.
     ///
     /// Timeouts are unchanged: a default `reqwest::Client` has no
     /// deadlines at all, which is how `integrated-benchmark` used to
@@ -96,9 +93,8 @@ impl ThrottledClient {
     /// Making these values user-configurable (npmrc / env / CLI)
     /// is follow-up.
     pub fn new_for_installs() -> Self {
-        let mut default_headers = HeaderMap::with_capacity(2);
+        let mut default_headers = HeaderMap::with_capacity(1);
         default_headers.insert(USER_AGENT, HeaderValue::from_static(DEFAULT_USER_AGENT));
-        default_headers.insert(ACCEPT, HeaderValue::from_static(DEFAULT_ACCEPT));
 
         let client = Client::builder()
             .http1_only()

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -2,8 +2,8 @@ use reqwest::{
     header::{HeaderMap, HeaderValue, USER_AGENT},
     Client,
 };
-use std::{future::IntoFuture, time::Duration};
-use tokio::sync::Semaphore;
+use std::{ops::Deref, time::Duration};
+use tokio::sync::{Semaphore, SemaphorePermit};
 
 /// Default `User-Agent` pacquet sends on every request made by the
 /// install client — registry metadata fetches and tarball downloads
@@ -38,18 +38,44 @@ pub struct ThrottledClient {
     client: Client,
 }
 
+/// RAII guard returned from [`ThrottledClient::acquire`]. Holds a
+/// semaphore permit alongside a reference to the underlying
+/// [`Client`]; the permit is released when the guard is dropped.
+///
+/// The guard derefs to [`Client`] so callers can chain
+/// `guard.get(url).send().await?.json().await?` (or any other
+/// reqwest method) directly. **Holding the guard across the body
+/// await is the point of the API.** A request's socket FD lives
+/// from `connect` all the way through body streaming; dropping the
+/// permit when `.send()` returns (right after headers arrive, with
+/// the body still pending) means the semaphore stops bounding the
+/// real concurrent socket count. Under `try_join_all` fan-out the
+/// next batch of permits then `connect()` while previous bodies are
+/// still draining, and the per-process FD count overruns the
+/// platform limit — surfacing as `EMFILE` "too many open files".
+pub struct ThrottledClientGuard<'a> {
+    _permit: SemaphorePermit<'a>,
+    client: &'a Client,
+}
+
+impl<'a> Deref for ThrottledClientGuard<'a> {
+    type Target = Client;
+
+    fn deref(&self) -> &Client {
+        self.client
+    }
+}
+
 impl ThrottledClient {
-    /// Acquire a permit and run `proc` with the underlying [`Client`].
-    pub async fn run_with_permit<Proc, ProcFuture>(&self, proc: Proc) -> ProcFuture::Output
-    where
-        Proc: FnOnce(&Client) -> ProcFuture,
-        ProcFuture: IntoFuture,
-    {
+    /// Acquire a permit and return a guard granting access to the
+    /// underlying [`Client`]. The permit is released when the guard
+    /// is dropped, so callers control how long the request "counts"
+    /// against [`default_network_concurrency`] — typically the full
+    /// `send + body-consume` lifetime, not just `.send()`.
+    pub async fn acquire(&self) -> ThrottledClientGuard<'_> {
         let permit =
             self.semaphore.acquire().await.expect("semaphore shouldn't have been closed this soon");
-        let result = proc(&self.client).await;
-        drop(permit);
-        result
+        ThrottledClientGuard { _permit: permit, client: &self.client }
     }
 
     /// Construct the default throttled client used for real installs.

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -1,6 +1,45 @@
-use reqwest::Client;
+use reqwest::{
+    header::{HeaderMap, HeaderValue, ACCEPT, USER_AGENT},
+    Client,
+};
 use std::{future::IntoFuture, time::Duration};
 use tokio::sync::Semaphore;
+
+/// Default `User-Agent` pacquet sends on every registry request.
+///
+/// Identical to pnpm v11's
+/// [`network/fetch/src/fetchFromRegistry.ts`](https://github.com/pnpm/pnpm/blob/main/network/fetch/src/fetchFromRegistry.ts#L9):
+/// the literal string `pnpm`. A default `reqwest::Client` sends *no*
+/// User-Agent at all, which some registry CDNs and corporate WAFs
+/// treat as a bot signature and either block at the edge or terminate
+/// mid-handshake (surfacing as a generic "error sending request for
+/// url" with no body to look at).
+///
+/// We deliberately send `pnpm` rather than `pacquet/<version>` for
+/// two reasons:
+///
+/// 1. **Pacquet is a port of pnpm** — its goal is byte-for-byte
+///    behavioural parity, including what the registry sees on the
+///    wire, so any UA-keyed allow / rate-limit rule that lets pnpm
+///    through also lets pacquet through.
+/// 2. The user reported a `pump-2.0.1.tgz` fetch that consistently
+///    failed under pacquet but succeeded under a parallel `pnpm` on
+///    the same network; reproducing pnpm's UA exactly is the most
+///    direct fix that doesn't require speculating about which CDN
+///    rule we're tripping.
+const DEFAULT_USER_AGENT: &str = "pnpm";
+
+/// Default `Accept` header pacquet sends on every registry request.
+///
+/// Identical to pnpm's
+/// [`ACCEPT_ABBREVIATED_DOC`](https://github.com/pnpm/pnpm/blob/main/network/fetch/src/fetchFromRegistry.ts#L14-L15)
+/// (the abbreviated-metadata variant pnpm sends on every fetch,
+/// metadata or tarball). The npm registry serves tarballs regardless
+/// of `Accept` because of the `*/*` fallback, but a registered
+/// `Accept` is part of what some CDN edge rules look at to decide
+/// whether to serve the request.
+const DEFAULT_ACCEPT: &str =
+    "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*";
 
 /// Wrapper around [`Client`] with concurrent request limit enforced by the [`Semaphore`] mechanism.
 #[derive(Debug)]
@@ -37,25 +76,33 @@ impl ThrottledClient {
     ///   connections that each get their own congestion window and
     ///   saturate bandwidth in parallel.
     /// * **50 concurrent sockets**, matching pnpm's
-    ///   `DEFAULT_MAX_SOCKETS`. The old `num_cpus.max(16)` semaphore
-    ///   under-subscribed on every machine we benchmarked — on a
-    ///   4-core GHA runner pacquet had 1/3 of pnpm's concurrent-
-    ///   fetch budget.
+    ///   `DEFAULT_MAX_SOCKETS`.
+    /// * **`User-Agent` and `Accept` headers** matching pnpm's
+    ///   `fetchFromRegistry.ts`. A default `reqwest::Client` sends
+    ///   neither, which can trip CDN / WAF rules that reject or RST
+    ///   bot-shaped traffic before any HTTP response is produced —
+    ///   exactly the symptom reported when the headerless client
+    ///   failed to fetch `pump-2.0.1.tgz` while a parallel `pnpm`
+    ///   on the same network succeeded.
     ///
     /// Timeouts are unchanged: a default `reqwest::Client` has no
     /// deadlines at all, which is how `integrated-benchmark` used to
     /// hang at "Benchmark 1: pacquet@HEAD" until the GHA step budget
     /// (#263) when an upstream stalled. The 5-minute `timeout` is
     /// deliberately generous — npm tarballs are usually under 5 MB
-    /// but can reach hundreds of MB on slow connections, and there's
-    /// no retry on transient network errors yet (#259). 5 min keeps
-    /// slow-but-progressing downloads succeeding while still catching
-    /// truly stuck sockets. Making these values user-configurable
-    /// (npmrc / env / CLI) is follow-up once the fetch-retry story
-    /// lands.
+    /// but can reach hundreds of MB on slow connections. The retry
+    /// loop in `crates/tarball` (#301) handles short, transient
+    /// failures; the 5-minute cap catches truly stuck sockets.
+    /// Making these values user-configurable (npmrc / env / CLI)
+    /// is follow-up.
     pub fn new_for_installs() -> Self {
+        let mut default_headers = HeaderMap::with_capacity(2);
+        default_headers.insert(USER_AGENT, HeaderValue::from_static(DEFAULT_USER_AGENT));
+        default_headers.insert(ACCEPT, HeaderValue::from_static(DEFAULT_ACCEPT));
+
         let client = Client::builder()
             .http1_only()
+            .default_headers(default_headers)
             .connect_timeout(Duration::from_secs(10))
             .timeout(Duration::from_secs(300))
             .pool_idle_timeout(Duration::from_secs(30))

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -65,8 +65,13 @@ impl ThrottledClient {
     ///   window was slower than opening ~50 independent HTTP/1.1
     ///   connections that each get their own congestion window and
     ///   saturate bandwidth in parallel.
-    /// * **50 concurrent sockets**, matching pnpm's
-    ///   `DEFAULT_MAX_SOCKETS`.
+    /// * **`network_concurrency` concurrent in-flight requests**,
+    ///   matching pnpm's `networkConcurrency` default (see
+    ///   [`default_network_concurrency`]). Pnpm uses a 50-socket
+    ///   per-host pool ceiling (`DEFAULT_MAX_SOCKETS` in
+    ///   `network/fetch/src/dispatcher.ts`) *and* a smaller
+    ///   request-level cap that bounds how many fetches it actually
+    ///   runs at once; pacquet's semaphore plays the second role.
     /// * **`User-Agent: pnpm`** matching pnpm's
     ///   `fetchFromRegistry.ts`. A default `reqwest::Client` sends
     ///   no UA, which can trip CDN / WAF rules that reject or RST
@@ -144,15 +149,28 @@ impl ThrottledClient {
     /// timeouts so firewalled / unreachable URLs fail within the
     /// test-suite budget instead of waiting on TCP retry.
     pub fn from_client(client: Client) -> Self {
-        // Matches pnpm v11's `DEFAULT_MAX_SOCKETS`
-        // (`network/fetch/src/dispatcher.ts:12`). Pnpm has explicit
-        // benchmark evidence that 50 HTTP/1.1 connections saturate
-        // tarball-fetch bandwidth better than fewer-with-multiplexing
-        // or fewer-connections-period.
-        const MAX_CONCURRENT_REQUESTS: usize = 50;
-        let semaphore = Semaphore::new(MAX_CONCURRENT_REQUESTS);
+        let semaphore = Semaphore::new(default_network_concurrency());
         ThrottledClient { semaphore, client }
     }
+}
+
+/// Default number of concurrent in-flight network requests.
+///
+/// Mirrors pnpm's `networkConcurrency` formula in
+/// [`installing/package-requester/src/packageRequester.ts`](https://github.com/pnpm/pnpm/blob/1819226b51743f73c3b186df31c4439b02e9b307/installing/package-requester/src/packageRequester.ts#L97)
+/// and `calcMaxWorkers` in
+/// [`worker/src/index.ts`](https://github.com/pnpm/pnpm/blob/1819226b51743f73c3b186df31c4439b02e9b307/worker/src/index.ts#L63-L72):
+///
+/// ```ts
+/// networkConcurrency = Math.min(64, Math.max(calcMaxWorkers() * 3, 16))
+/// // calcMaxWorkers() = Math.max(1, availableParallelism() - 1)
+/// ```
+///
+/// Concretely: 16 on a 4-core machine, 21 on 8-core, 27 on 10-core,
+/// 45 on 16-core, capped at 64.
+pub fn default_network_concurrency() -> usize {
+    let max_workers = num_cpus::get().saturating_sub(1).max(1);
+    max_workers.saturating_mul(3).clamp(16, 64)
 }
 
 /// This is only necessary for tests.

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -10,7 +10,7 @@ use tokio::sync::{Semaphore, SemaphorePermit};
 /// alike, including tarball URLs that point at non-registry hosts.
 ///
 /// Identical to pnpm v11's
-/// [`network/fetch/src/fetchFromRegistry.ts`](https://github.com/pnpm/pnpm/blob/main/network/fetch/src/fetchFromRegistry.ts#L9):
+/// [`network/fetch/src/fetchFromRegistry.ts`](https://github.com/pnpm/pnpm/blob/1819226b51/network/fetch/src/fetchFromRegistry.ts#L9):
 /// the literal string `pnpm`. A default `reqwest::Client` sends *no*
 /// User-Agent at all, which some registry CDNs and corporate WAFs
 /// treat as a bot signature and either block at the edge or terminate
@@ -116,7 +116,7 @@ impl ThrottledClient {
     ///   the registry serves them just fine.
     ///
     /// `pool_idle_timeout(4s)` matches
-    /// [`agentkeepalive`'s](https://github.com/node-modules/agentkeepalive/blob/master/lib/agent.js#L39-L41)
+    /// [`agentkeepalive`'s](https://github.com/node-modules/agentkeepalive/blob/1e5e312f36/lib/agent.js#L39-L41)
     /// default `freeSocketTimeout` (the agent pnpm builds its
     /// connection pool on top of). Most CDN / load-balancer edges in
     /// front of `registry.npmjs.org` close idle sockets after 5–15s
@@ -184,9 +184,9 @@ impl ThrottledClient {
 /// Default number of concurrent in-flight network requests.
 ///
 /// Mirrors pnpm's `networkConcurrency` formula in
-/// [`installing/package-requester/src/packageRequester.ts`](https://github.com/pnpm/pnpm/blob/1819226b51743f73c3b186df31c4439b02e9b307/installing/package-requester/src/packageRequester.ts#L97)
+/// [`installing/package-requester/src/packageRequester.ts`](https://github.com/pnpm/pnpm/blob/1819226b51/installing/package-requester/src/packageRequester.ts#L97)
 /// and `calcMaxWorkers` in
-/// [`worker/src/index.ts`](https://github.com/pnpm/pnpm/blob/1819226b51743f73c3b186df31c4439b02e9b307/worker/src/index.ts#L63-L72):
+/// [`worker/src/index.ts`](https://github.com/pnpm/pnpm/blob/1819226b51/worker/src/index.ts#L63-L72):
 ///
 /// ```ts
 /// networkConcurrency = Math.min(64, Math.max(calcMaxWorkers() * 3, 16))

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -17,18 +17,11 @@ use tokio::sync::{Semaphore, SemaphorePermit};
 /// mid-handshake (surfacing as a generic "error sending request for
 /// url" with no body to look at).
 ///
-/// We deliberately send `pnpm` rather than `pacquet/<version>` for
-/// two reasons:
-///
-/// 1. **Pacquet is a port of pnpm** — its goal is byte-for-byte
-///    behavioural parity, including what the registry sees on the
-///    wire, so any UA-keyed allow / rate-limit rule that lets pnpm
-///    through also lets pacquet through.
-/// 2. The user reported a `pump-2.0.1.tgz` fetch that consistently
-///    failed under pacquet but succeeded under a parallel `pnpm` on
-///    the same network; reproducing pnpm's UA exactly is the most
-///    direct fix that doesn't require speculating about which CDN
-///    rule we're tripping.
+/// We deliberately send `pnpm` rather than `pacquet/<version>` so
+/// any UA-keyed allow / rate-limit rule that lets pnpm through also
+/// lets pacquet through. Pacquet is a port of pnpm; behavioural
+/// parity, including what the registry sees on the wire, is the
+/// goal.
 const DEFAULT_USER_AGENT: &str = "pnpm";
 
 /// Wrapper around [`Client`] with concurrent request limit enforced by the [`Semaphore`] mechanism.
@@ -101,10 +94,7 @@ impl ThrottledClient {
     /// * **`User-Agent: pnpm`** matching pnpm's
     ///   `fetchFromRegistry.ts`. A default `reqwest::Client` sends
     ///   no UA, which can trip CDN / WAF rules that reject or RST
-    ///   bot-shaped traffic before any HTTP response is produced —
-    ///   exactly the symptom reported when the headerless client
-    ///   failed to fetch `pump-2.0.1.tgz` while a parallel `pnpm`
-    ///   on the same network succeeded.
+    ///   bot-shaped traffic before any HTTP response is produced.
     ///
     ///   We deliberately do *not* set a default `Accept` header —
     ///   pnpm's `fetchFromRegistry` always attaches
@@ -120,13 +110,12 @@ impl ThrottledClient {
     /// default `freeSocketTimeout` (the agent pnpm builds its
     /// connection pool on top of). Most CDN / load-balancer edges in
     /// front of `registry.npmjs.org` close idle sockets after 5–15s
-    /// without sending FIN that hyper notices, so a longer pool TTL
-    /// (the previous 30s) lets pacquet reuse a half-dead socket and
-    /// surface the next request as a generic "error sending request
-    /// for url" — same symptom the user hit on `pump-2.0.1.tgz` while
-    /// pnpm on the same network succeeded. 4s keeps the pool useful
-    /// for back-to-back downloads (pacquet runs hundreds of fetches
-    /// in seconds) but well below the typical edge keepalive.
+    /// without sending FIN that hyper notices; a pool TTL above that
+    /// lets pacquet reuse a half-dead socket and surface the next
+    /// request as a generic "error sending request for url". 4s
+    /// keeps the pool useful for back-to-back downloads (pacquet
+    /// runs hundreds of fetches in seconds) but well below the
+    /// typical edge keepalive.
     ///
     /// `timeout(5min)` is the per-request deadline, not the socket
     /// inactivity timeout. A default `reqwest::Client` has no

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -105,6 +105,20 @@ impl ThrottledClient {
     /// `crates/tarball` (#301) handles short, transient failures;
     /// the 5-minute cap catches truly stuck sockets. Making these
     /// values user-configurable (npmrc / env / CLI) is follow-up.
+    ///
+    /// `hickory_dns(true)` swaps reqwest's default resolver
+    /// (tokio's `lookup_host`, which calls the platform's blocking
+    /// `getaddrinfo` from a `spawn_blocking` thread) for the
+    /// pure-Rust async resolver. The default resolver is correct
+    /// but on macOS it routes every lookup through `mDNSResponder`,
+    /// which spuriously returns `EAI_NONAME` ("nodename nor servname
+    /// provided") for valid hostnames when many concurrent lookups
+    /// pile up — e.g. the 50 simultaneous tarball connections this
+    /// client opens. pnpm doesn't hit it because Node's `dns.lookup`
+    /// runs on libuv's 4-thread pool, naturally throttling concurrent
+    /// `getaddrinfo` calls. `hickory-dns` queries DNS over UDP / TCP
+    /// directly, bypassing `mDNSResponder` and the EAI_NONAME flake
+    /// entirely.
     pub fn new_for_installs() -> Self {
         let mut default_headers = HeaderMap::with_capacity(1);
         default_headers.insert(USER_AGENT, HeaderValue::from_static(DEFAULT_USER_AGENT));
@@ -115,6 +129,7 @@ impl ThrottledClient {
             .connect_timeout(Duration::from_secs(10))
             .timeout(Duration::from_secs(300))
             .pool_idle_timeout(Duration::from_secs(4))
+            .hickory_dns(true)
             .build()
             .expect("build reqwest client with default timeouts");
         ThrottledClient::from_client(client)

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -103,10 +103,11 @@ impl ThrottledClient {
     /// hang at "Benchmark 1: pacquet@HEAD" until the GHA step budget
     /// (#263) when an upstream stalled. 5 min is deliberately
     /// generous — npm tarballs are usually under 5 MB but can reach
-    /// hundreds of MB on slow connections. The retry loop in
-    /// `crates/tarball` (#301) handles short, transient failures;
-    /// the 5-minute cap catches truly stuck sockets. Making these
-    /// values user-configurable (npmrc / env / CLI) is follow-up.
+    /// hundreds of MB on slow connections. Pacquet does not yet
+    /// retry transient fetch errors (tracked in #301); the 5-minute
+    /// cap is here to catch truly stuck sockets, not to paper over
+    /// short-lived failures. Making these values user-configurable
+    /// (npmrc / env / CLI) is follow-up.
     ///
     /// `hickory_dns(true)` swaps reqwest's default resolver
     /// (tokio's `lookup_host`, which calls the platform's blocking

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -147,8 +147,9 @@ impl ThrottledClient {
     /// but on macOS it routes every lookup through `mDNSResponder`,
     /// which spuriously returns `EAI_NONAME` ("nodename nor servname
     /// provided") for valid hostnames when many concurrent lookups
-    /// pile up — e.g. the 50 simultaneous tarball connections this
-    /// client opens. pnpm doesn't hit it because Node's `dns.lookup`
+    /// pile up — e.g. the [`default_network_concurrency`] simultaneous
+    /// tarball connections this client opens. pnpm doesn't hit it
+    /// because Node's `dns.lookup`
     /// runs on libuv's 4-thread pool, naturally throttling concurrent
     /// `getaddrinfo` calls. `hickory-dns` queries DNS over UDP / TCP
     /// directly, bypassing `mDNSResponder` and the EAI_NONAME flake

--- a/crates/registry/src/package.rs
+++ b/crates/registry/src/package.rs
@@ -34,22 +34,17 @@ impl Package {
     ) -> Result<Self, RegistryError> {
         let url = || format!("{registry}{name}"); // TODO: use reqwest URL directly
         let network_error = |error| NetworkError { error, url: url() };
-        http_client
-            .run_with_permit(|client| {
-                client
-                    .get(url())
-                    .header(
-                        "accept",
-                        "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*",
-                    )
-                    .send()
-            })
+        let client = http_client.acquire().await;
+        let response = client
+            .get(url())
+            .header(
+                "accept",
+                "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*",
+            )
+            .send()
             .await
-            .map_err(network_error)?
-            .json::<Package>()
-            .await
-            .map_err(network_error)?
-            .pipe(Ok)
+            .map_err(network_error)?;
+        response.json::<Package>().await.map_err(network_error)?.pipe(Ok)
     }
 
     pub fn pinned_version(&self, version_range: &str) -> Option<&PackageVersion> {

--- a/crates/registry/src/package.rs
+++ b/crates/registry/src/package.rs
@@ -34,8 +34,9 @@ impl Package {
     ) -> Result<Self, RegistryError> {
         let url = || format!("{registry}{name}"); // TODO: use reqwest URL directly
         let network_error = |error| NetworkError { error, url: url() };
-        let client = http_client.acquire().await;
-        let response = client
+        http_client
+            .acquire()
+            .await
             .get(url())
             .header(
                 "accept",
@@ -43,8 +44,11 @@ impl Package {
             )
             .send()
             .await
-            .map_err(network_error)?;
-        response.json::<Package>().await.map_err(network_error)?.pipe(Ok)
+            .map_err(network_error)?
+            .json::<Package>()
+            .await
+            .map_err(network_error)?
+            .pipe(Ok)
     }
 
     pub fn pinned_version(&self, version_range: &str) -> Option<&PackageVersion> {

--- a/crates/registry/src/package_version.rs
+++ b/crates/registry/src/package_version.rs
@@ -33,8 +33,9 @@ impl PackageVersion {
         let url = || format!("{registry}{name}/{tag}");
         let network_error = |error| NetworkError { error, url: url() };
 
-        let client = http_client.acquire().await;
-        let response = client
+        http_client
+            .acquire()
+            .await
             .get(url())
             .header(
                 "accept",
@@ -42,8 +43,11 @@ impl PackageVersion {
             )
             .send()
             .await
-            .map_err(network_error)?;
-        response.json::<PackageVersion>().await.map_err(network_error)?.pipe(Ok)
+            .map_err(network_error)?
+            .json::<PackageVersion>()
+            .await
+            .map_err(network_error)?
+            .pipe(Ok)
     }
 
     pub fn to_virtual_store_name(&self) -> String {

--- a/crates/registry/src/package_version.rs
+++ b/crates/registry/src/package_version.rs
@@ -33,22 +33,17 @@ impl PackageVersion {
         let url = || format!("{registry}{name}/{tag}");
         let network_error = |error| NetworkError { error, url: url() };
 
-        http_client
-            .run_with_permit(|client| {
-                client
-                    .get(url())
-                    .header(
-                        "accept",
-                        "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*",
-                    )
-                    .send()
-            })
+        let client = http_client.acquire().await;
+        let response = client
+            .get(url())
+            .header(
+                "accept",
+                "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*",
+            )
+            .send()
             .await
-            .map_err(network_error)?
-            .json::<PackageVersion>()
-            .await
-            .map_err(network_error)?
-            .pipe(Ok)
+            .map_err(network_error)?;
+        response.json::<PackageVersion>().await.map_err(network_error)?.pipe(Ok)
     }
 
     pub fn to_virtual_store_name(&self) -> String {

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -696,10 +696,16 @@ impl<'a> DownloadTarballToStore<'a> {
         let network_error = |error| {
             TarballError::FetchTarball(NetworkError { url: package_url.to_string(), error })
         };
-        let response_head = http_client
-            .run_with_permit(|client| client.get(package_url).send())
-            .await
-            .map_err(network_error)?;
+
+        // Acquire the network permit *before* `connect + send` and
+        // hold it through body streaming. The permit must outlive the
+        // socket — releasing it after `.send()` (when only headers
+        // have arrived) lets the next batch of futures `connect()`
+        // while the previous bodies are still draining, breaking the
+        // semaphore's bound on concurrent open sockets and surfacing
+        // as `EMFILE` once the FD count overruns the per-process cap.
+        let client = http_client.acquire().await;
+        let response_head = client.get(package_url).send().await.map_err(network_error)?;
 
         // Read `Content-Length` *before* we start consuming the body
         // stream so we can pre-size the buffer. Ports pnpm v11's
@@ -757,6 +763,12 @@ impl<'a> DownloadTarballToStore<'a> {
             }
             buf
         };
+
+        // Body fully buffered into `response`; the socket can go
+        // back to the pool. Drop the network permit so spawn_blocking
+        // (CPU-bound, no socket needed) doesn't hold one of the
+        // limited fetch slots.
+        drop(client);
 
         tracing::info!(target: "pacquet::download", ?package_url, "Download completed");
 
@@ -927,7 +939,10 @@ mod tests {
         let url = "http://127.0.0.1:1/whatever";
         let client = fast_fail_client();
         let err = client
-            .run_with_permit(|c| c.get(url).send())
+            .acquire()
+            .await
+            .get(url)
+            .send()
             .await
             .expect_err("connecting to port 1 must fail");
         let net_err = NetworkError { url: url.to_string(), error: err };

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -52,11 +52,9 @@ fn post_download_semaphore() -> &'static Semaphore {
 /// regardless of which intermediate `reqwest` / `hyper` / `io::Error`
 /// happens to elide it.
 fn walk_reqwest_chain(error: &reqwest::Error) -> String {
-    use std::error::Error as _;
     let mut out = error.to_string();
-    let mut cur: Option<&dyn std::error::Error> = error.source();
-    while let Some(src) = cur {
-        let next = src.source();
+    let mut error: &dyn std::error::Error = error;
+    while let Some(src) = error.source() {
         let s = src.to_string();
         // Skip empty or duplicate frames — hyper occasionally repeats
         // the same message across two layers, and reqwest sometimes
@@ -65,7 +63,7 @@ fn walk_reqwest_chain(error: &reqwest::Error) -> String {
             out.push_str(": ");
             out.push_str(&s);
         }
-        cur = next;
+        error = src;
     }
     out
 }

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -38,10 +38,47 @@ fn post_download_semaphore() -> &'static Semaphore {
     SEM.get_or_init(|| Semaphore::new(num_cpus::get().saturating_mul(2).max(4)))
 }
 
+/// Reqwest's own [`Display`] for a request-stage failure renders as
+/// `error sending request for url (URL): <inner>` only if it can find
+/// an inner source, and on some failure modes (e.g. the request was
+/// dropped before a connect was attempted) `inner` is `None` —
+/// leaving the user with the truly opaque `error sending request for
+/// url (URL)` and no clue about what actually failed.
+///
+/// `walk_reqwest_chain` walks `error.source()` itself and joins every
+/// stage's `Display` with `: ` so the rendered `NetworkError` always
+/// carries the leaf reason (e.g. `Connection refused (os error 61)`,
+/// `tls handshake eof`, `dns error: failed to lookup address`),
+/// regardless of which intermediate `reqwest` / `hyper` / `io::Error`
+/// happens to elide it.
+fn walk_reqwest_chain(error: &reqwest::Error) -> String {
+    use std::error::Error as _;
+    let mut out = error.to_string();
+    let mut cur: Option<&dyn std::error::Error> = error.source();
+    while let Some(src) = cur {
+        let next = src.source();
+        let s = src.to_string();
+        // Skip empty or duplicate frames — hyper occasionally repeats
+        // the same message across two layers, and reqwest sometimes
+        // already includes the inner string in its top-level Display.
+        if !s.is_empty() && !out.ends_with(&s) {
+            out.push_str(": ");
+            out.push_str(&s);
+        }
+        cur = next;
+    }
+    out
+}
+
 #[derive(Debug, Display, Error, Diagnostic)]
-#[display("Failed to fetch {url}: {error}")]
+#[display("Failed to fetch {url}: {}", walk_reqwest_chain(error))]
 pub struct NetworkError {
     pub url: String,
+    /// Marked `#[error(source)]` so miette can also walk the chain on
+    /// its own (some renderers prefer the structured form). The
+    /// flattened string in `Display` is for the default miette report
+    /// where the user just sees one line per wrapper.
+    #[error(source)]
     pub error: reqwest::Error,
 }
 

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -715,36 +715,22 @@ impl<'a> DownloadTarballToStore<'a> {
         // lot of wasted alloc + copy work across the pipeline.
         let expected_size = response_head.content_length();
 
-        // Gate the memory-heavy + CPU-heavy part of the pipeline with
-        // `post_download_semaphore`:
-        //
-        // - The blocking pool is 512-wide by default, which is right
-        //   for I/O wait but disastrous for CPU work that can only
-        //   really run `num_cpus` at a time, so we cap concurrent
-        //   `spawn_blocking` bodies.
-        // - We also acquire the permit *before* we consume the body
-        //   rather than right before `spawn_blocking`. Buffering is
-        //   where the per-tarball memory spike lives (a full
-        //   decompressed package can be many MB), so holding the
-        //   permit across buffering bounds the number of fully-buffered
-        //   response bodies in RAM to the post-download cap. Without
-        //   this, a fast registry + `try_join_all` fan-out could pile
-        //   up hundreds of buffered tarballs waiting for a permit to
-        //   process (Copilot review on #269).
-        //
-        // The permit is held across both the body-stream drain and
-        // the `spawn_blocking.await` below, dropping at end of scope.
-        let _post_download_permit = post_download_semaphore()
-            .acquire()
-            .await
-            .expect("post-download semaphore shouldn't be closed this soon");
-
         // Stream the body into a single pre-sized `Vec<u8>` when
         // `Content-Length` is known. One allocation + one
         // `extend_from_slice` per chunk, no growth-by-doubling.
         // Falls back to empty capacity when CL is missing (chunked
         // transfer encoding), which still avoids reqwest/hyper's
         // intermediate-chunk-list + second-copy pass.
+        //
+        // The network permit is the only gate here. It bounds both
+        // concurrent open sockets and concurrent buffered tarballs
+        // to `default_network_concurrency()` — matching pnpm's
+        // pQueue, which holds its slot from `fetch` through body
+        // arrival as one task. Acquiring `post_download_semaphore`
+        // here too would let the smaller `num_cpus * 2` cap pin
+        // `network_concurrency` permits waiting for it, collapsing
+        // effective fetch concurrency to `post_download` and
+        // serializing the network pipeline behind decompression.
         //
         // We don't re-verify the received byte count against
         // `Content-Length` — hyper enforces CL framing itself on the
@@ -769,6 +755,18 @@ impl<'a> DownloadTarballToStore<'a> {
         // (CPU-bound, no socket needed) doesn't hold one of the
         // limited fetch slots.
         drop(client);
+
+        // Gate the CPU-heavy decompress + cafs-write pipeline.
+        //
+        // The blocking pool is 512-wide by default, which is right
+        // for I/O wait but disastrous for CPU work that can only
+        // really run `num_cpus` at a time, so we cap concurrent
+        // `spawn_blocking` bodies. The permit is held across the
+        // `spawn_blocking.await` below and dropped at end of scope.
+        let _post_download_permit = post_download_semaphore()
+            .acquire()
+            .await
+            .expect("post-download semaphore shouldn't be closed this soon");
 
         tracing::info!(target: "pacquet::download", ?package_url, "Download completed");
 

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -38,7 +38,7 @@ fn post_download_semaphore() -> &'static Semaphore {
     SEM.get_or_init(|| Semaphore::new(num_cpus::get().saturating_mul(2).max(4)))
 }
 
-/// Reqwest's own [`Display`] for a request-stage failure renders as
+/// Reqwest's own [`std::fmt::Display`] for a request-stage failure renders as
 /// `error sending request for url (URL): <inner>` only if it can find
 /// an inner source, and on some failure modes (e.g. the request was
 /// dropped before a connect was attempted) `inner` is `None` —

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -910,6 +910,61 @@ mod tests {
         ThrottledClient::from_client(client)
     }
 
+    /// Pin `walk_reqwest_chain`'s contract: a `NetworkError` formed
+    /// from a real reqwest connect failure must surface the leaf
+    /// reason (e.g. `Connection refused`) appended to the wrapper
+    /// message, not stop at reqwest's `error sending request for url
+    /// (URL)`. Without the helper, the user sees only the wrapper —
+    /// which is what triggered the original "what's actually failing?"
+    /// debugging round on this branch.
+    ///
+    /// Uses `127.0.0.1:1` (port 1 is reserved; connect always fails
+    /// with a deterministic ECONNREFUSED on every host I've tried)
+    /// and `fast_fail_client`'s 1 s bounds, so the test stays
+    /// hermetic and quick.
+    #[tokio::test]
+    async fn network_error_display_includes_reqwest_inner_chain() {
+        let url = "http://127.0.0.1:1/whatever";
+        let client = fast_fail_client();
+        let err = client
+            .run_with_permit(|c| c.get(url).send())
+            .await
+            .expect_err("connecting to port 1 must fail");
+        let net_err = NetworkError { url: url.to_string(), error: err };
+
+        let rendered = net_err.to_string();
+        assert!(
+            rendered.starts_with("Failed to fetch http://127.0.0.1:1/"),
+            "wrapper prefix missing, got: {rendered:?}",
+        );
+
+        // Reqwest's wrapper already includes the URL in `(...)`; the
+        // leaf reason appears after the wrapper, separated by `: `.
+        // Assert there *is* a non-empty frame after that — without
+        // `walk_reqwest_chain`, this is exactly what got dropped.
+        let leaf_section = rendered
+            .split_once("error sending request for url (")
+            .and_then(|(_, rest)| rest.split_once(")"))
+            .map(|(_, after_paren)| after_paren)
+            .expect("rendered output should include reqwest's wrapper");
+        assert!(
+            !leaf_section.trim().is_empty(),
+            "expected leaf cause appended after reqwest wrapper, got: {rendered:?}",
+        );
+        assert!(
+            leaf_section.starts_with(": "),
+            "leaf should be joined with `: ` per walk_reqwest_chain, got: {rendered:?}",
+        );
+
+        // Structural form for completeness — `#[error(source)]` should
+        // expose the reqwest::Error so miette / `Error::source` can
+        // walk into it independently of our flattened Display.
+        assert!(
+            std::error::Error::source(&net_err).is_some(),
+            "NetworkError should expose its reqwest::Error as source",
+        );
+    }
+
     /// **Problem:**
     /// The tested function requires `'static` paths, leaking would prevent
     /// temporary files from being cleaned up.

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -722,15 +722,25 @@ impl<'a> DownloadTarballToStore<'a> {
         // transfer encoding), which still avoids reqwest/hyper's
         // intermediate-chunk-list + second-copy pass.
         //
-        // The network permit is the only gate here. It bounds both
-        // concurrent open sockets and concurrent buffered tarballs
-        // to `default_network_concurrency()` — matching pnpm's
-        // pQueue, which holds its slot from `fetch` through body
-        // arrival as one task. Acquiring `post_download_semaphore`
-        // here too would let the smaller `num_cpus * 2` cap pin
-        // `network_concurrency` permits waiting for it, collapsing
-        // effective fetch concurrency to `post_download` and
-        // serializing the network pipeline behind decompression.
+        // The network permit is the only gate during fetch + body
+        // buffering. It bounds concurrent open sockets and
+        // concurrent in-progress fetches to
+        // `default_network_concurrency()`. Once a body has been
+        // buffered, the future drops the network permit and awaits
+        // `post_download_semaphore` for the spawn_blocking phase —
+        // the buffer keeps living in RAM across that wait, so a
+        // pathologically slow decompression stage could let buffered
+        // tarballs accumulate beyond the network bound. In practice
+        // Rust + flate2 decompresses faster than the network
+        // delivers, so buffered-but-not-yet-decompressing tarballs
+        // stay close to zero on real installs.
+        //
+        // Acquiring `post_download_semaphore` here too (so it gates
+        // body streaming) would let the smaller `num_cpus * 2` cap
+        // pin `network_concurrency` permits waiting for it,
+        // collapsing effective fetch concurrency to `post_download`
+        // and serializing the network pipeline behind decompression
+        // — that's the regression `perf(tarball)` (a43ca32) fixed.
         //
         // We don't re-verify the received byte count against
         // `Content-Length` — hyper enforces CL framing itself on the


### PR DESCRIPTION
## Summary

A `pacquet install` was failing on `pump-2.0.1.tgz` with the opaque `error sending request for url` while a parallel `pnpm` on the same network downloaded it cleanly. Walking that down surfaced a series of independent parity gaps where pacquet's reqwest client diverged from how pnpm fetches from the registry — each one capable of producing the same generic "request failed" surface, and none of them visible in the rendered error. This PR closes all of them and adds a flattened source-chain renderer plus regression test so the next regression is debuggable.

## What changes

### `crates/network` — align the install client with pnpm's wire behaviour

- **`User-Agent: pnpm`** is set as a default header on the throttled client, matching the literal string pnpm v11 sends in [`network/fetch/src/fetchFromRegistry.ts`](https://github.com/pnpm/pnpm/blob/main/network/fetch/src/fetchFromRegistry.ts#L9). A default `reqwest::Client` sends no UA, which some registry CDNs and corporate WAFs treat as bot traffic and either reject at the edge or RST mid-handshake. Sending the literal `pnpm` (not `pacquet/<version>`) is deliberate: pacquet is a port, so any UA-keyed allow / rate-limit rule that lets pnpm through has to let pacquet through.

- **No default `Accept` header.** Pnpm attaches `application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*` to every fetch including tarballs, but that's an upstream quirk we have no reason to copy. `crates/registry`'s metadata calls already set the npm-specific `Accept` per-request; tarballs send no `Accept` and the registry serves them fine.

- **Pool idle timeout 30s → 4s**, matching [`agentkeepalive`'s](https://github.com/node-modules/agentkeepalive/blob/master/lib/agent.js#L39-L41) default `freeSocketTimeout` (the agent pnpm's connection pool sits on top of). CDN edges in front of `registry.npmjs.org` close idle sockets after 5–15s without sending a FIN that hyper notices, so a longer pool TTL lets pacquet reuse a half-dead socket and surface the next request as a generic "error sending request for url" — same symptom the user hit. 4s keeps the pool useful for back-to-back downloads (pacquet runs hundreds of fetches in seconds) while staying well below typical edge keepalive.

- **`hickory-dns` resolver** in place of reqwest's default. The default routes lookups through tokio's `lookup_host`, which calls the platform's blocking `getaddrinfo`. On macOS that goes through `mDNSResponder`, which spuriously returns `EAI_NONAME` ("nodename nor servname provided") for valid hostnames when many concurrent lookups pile up — e.g. the dozens of simultaneous tarball connections this client opens. pnpm doesn't hit it because Node's `dns.lookup` runs on libuv's 4-thread pool, throttling concurrent `getaddrinfo` naturally. `hickory-dns` queries DNS over UDP/TCP directly and bypasses `mDNSResponder` entirely. Enabled via the `hickory-dns` reqwest feature in `Cargo.toml`.

- **Concurrency now follows pnpm's `networkConcurrency` formula** instead of being hardcoded at 50. Mirrors [`installing/package-requester/src/packageRequester.ts:97`](https://github.com/pnpm/pnpm/blob/1819226b51743f73c3b186df31c4439b02e9b307/installing/package-requester/src/packageRequester.ts#L97):

  ```ts
  networkConcurrency = Math.min(64, Math.max(calcMaxWorkers() * 3, 16))
  // calcMaxWorkers() = Math.max(1, availableParallelism() - 1)
  ```

  The previous hardcoded 50 came from pnpm's `DEFAULT_MAX_SOCKETS`, but that's the agentkeepalive per-host pool *ceiling*, not the actual fetch concurrency pnpm runs at. The real cap is the smaller `networkConcurrency` (16 on 4-core / 21 on 8-core / 27 on 10-core / capped at 64).

- **The semaphore now actually bounds concurrent sockets, and stops pinning permits behind decompression.** Two interacting bugs:

  1. `run_with_permit(|c| c.get(url).send())` released the permit when `.send()` resolved — which is when the response **headers** arrive, not when the body has been read. The TCP socket FD stays open through body streaming, so under `try_join_all` fan-out the next batch of permits would `connect()` while previous bodies were still draining. Effective socket count was unbounded by the semaphore, and on real installs the FD count overran macOS's per-process limit, surfacing as `EMFILE` "too many open files" mid-fetch (visible only after `walk_reqwest_chain` started showing the leaf cause).

  2. Acquiring `post_download_semaphore` (`num_cpus * 2`) between `.send()` and body streaming meant network permits stayed pinned waiting for the smaller cap. With `network_concurrency = 21` and `post_download = 16`, all 21 fetch slots could end up parked on the post-download queue, collapsing effective fetch concurrency to 16 and serializing the network pipeline behind decompression.

  Replaced `run_with_permit` with `acquire`, returning a `ThrottledClientGuard` (RAII, derefs to `&Client`); the four callers now hold the guard across `.json().await` (registry metadata) or body buffering (tarball download). The tarball path additionally drops the guard once the body is buffered into RAM, then acquires `post_download_semaphore` only around the `spawn_blocking` decompression. The two semaphores no longer interact, so the network permit alone bounds both concurrent sockets and concurrent buffered tarballs to `default_network_concurrency()` — matching pnpm's pQueue, which holds one slot from `fetch` through body arrival per task.

### `crates/tarball` — make `NetworkError` carry the actual reason

Reqwest's own `Display` for a request-stage failure renders `error sending request for url (URL): <inner>` only when it can find an inner source; on some failure modes (e.g. the request was dropped before `connect()` was attempted) the inner is `None`, leaving the user with no diagnostic information at all. `NetworkError` now walks `error.source()` itself and joins every stage's `Display` with `: `, so the rendered message always carries the leaf reason (`Connection refused (os error 61)`, `tls handshake eof`, `dns error: failed to lookup address`, `Too many open files (os error 24)`, …) regardless of which intermediate `reqwest` / `hyper` / `io::Error` would otherwise elide it. The `reqwest::Error` is also marked `#[error(source)]` so miette can walk the chain structurally for renderers that prefer that form. `network_error_display_includes_reqwest_inner_chain` pins the leaf-cause shape against a deterministic ECONNREFUSED to `127.0.0.1:1`.

## Test plan

- [x] `cargo nextest run -p pacquet-tarball -p pacquet-network -p pacquet-registry` — passes.
- [x] `just ready` — full check + clippy + tests clean.
- [x] Real-world repro: a `pacquet install` against the workspace that previously failed (first on `pump-2.0.1.tgz` with opaque "error sending request for url", then with `EMFILE` "too many open files" once `walk_reqwest_chain` exposed the leaf cause) now succeeds.
- [x] Cold-cache install perf: macOS at parity with pnpm (network-bound, ~13.6s for 1352 pkgs); CI Linux ~2× faster than pnpm.