### PR TITLE
docs: pin github upstream links to commit shas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,20 @@ Before writing code for a feature, bug fix, or behavior change:
 If the upstream behavior is unclear or looks wrong, stop and ask the user
 rather than guessing.
 
-When citing upstream code in a PR description or commit message, link to a
-specific commit on `main` (not a branch tip) so the reference stays stable.
+When citing upstream code anywhere — code comments, doc comments, Markdown
+docs, PR descriptions, or commit messages — link to a specific commit SHA, not
+a branch name. Branch links such as `github.com/<owner>/<repo>/blob/main/...`
+or `.../tree/master/...` are *impermanent*: their target drifts as the branch
+moves and may eventually 404 if the file is renamed or deleted. Permanent
+links pin the commit (`github.com/<owner>/<repo>/blob/<sha>/...`) so the
+reference stays meaningful long after upstream changes. Use the **first 10
+hex characters** of the SHA — full 40-character SHAs make URLs unwieldy on
+narrow displays and in commit logs, and 10 characters is more than enough to
+disambiguate a commit in any real-world repository. Resolve the SHA with
+`git ls-remote https://github.com/<owner>/<repo>.git refs/heads/<branch>`
+(then take the first 10 characters) or by clicking "Copy permalink" (`y`) on
+GitHub and trimming the SHA segment. This rule applies to every GitHub
+repository, not only `pnpm/pnpm`.
 
 ## Follow the project guides
 

--- a/crates/lockfile/src/lib.rs
+++ b/crates/lockfile/src/lib.rs
@@ -47,8 +47,8 @@ pub struct LockfileSettings {
 
 /// A pnpm v9 lockfile.
 ///
-/// Specification: <https://github.com/pnpm/spec/blob/master/lockfile/9.0.md>
-/// Reference: <https://github.com/pnpm/pnpm/blob/main/lockfile/lockfile-types/src/index.ts>
+/// Specification: <https://github.com/pnpm/spec/blob/834f2815cc/lockfile/9.0.md>
+/// Reference: <https://github.com/pnpm/pnpm/blob/1819226b51/lockfile/types/src/index.ts>
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Lockfile {

--- a/crates/lockfile/src/package_metadata.rs
+++ b/crates/lockfile/src/package_metadata.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 /// peer-dependency context — peer-specific information lives in
 /// [`SnapshotEntry`](crate::SnapshotEntry) instead.
 ///
-/// Specification: <https://github.com/pnpm/spec/blob/master/lockfile/9.0.md>
+/// Specification: <https://github.com/pnpm/spec/blob/834f2815cc/lockfile/9.0.md>
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PackageMetadata {

--- a/crates/lockfile/src/snapshot_dep_ref.rs
+++ b/crates/lockfile/src/snapshot_dep_ref.rs
@@ -31,7 +31,7 @@ use std::str::FromStr;
 /// package name appears before the version separator (either the first `@`
 /// occurs before any `(` and `:`, or the reference begins with `@`).
 ///
-/// Reference: <https://github.com/pnpm/pnpm/blob/main/deps/path/src/index.ts>
+/// Reference: <https://github.com/pnpm/pnpm/blob/1819226b51/deps/path/src/index.ts>
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(try_from = "&'de str", into = "String")]
 pub enum SnapshotDepRef {

--- a/crates/lockfile/src/snapshot_entry.rs
+++ b/crates/lockfile/src/snapshot_entry.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 /// which versions its dependencies were resolved to, plus any optional /
 /// transitive-peer metadata needed to recreate the install.
 ///
-/// Specification: <https://github.com/pnpm/spec/blob/master/lockfile/9.0.md>
+/// Specification: <https://github.com/pnpm/spec/blob/834f2815cc/lockfile/9.0.md>
 #[derive(Debug, Default, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SnapshotEntry {

--- a/crates/npmrc/src/workspace_yaml.rs
+++ b/crates/npmrc/src/workspace_yaml.rs
@@ -64,7 +64,7 @@ impl WorkspaceSettings {
     /// `Ok(None)` if none is found before reaching the filesystem root.
     ///
     /// Mirrors pnpm's behaviour in
-    /// [`loadNpmrcFiles.ts`](https://github.com/pnpm/pnpm/blob/main/config/reader/src/loadNpmrcFiles.ts)
+    /// [`loadNpmrcFiles.ts`](https://github.com/pnpm/pnpm/blob/1819226b51/config/reader/src/loadNpmrcFiles.ts)
     /// — the first ancestor containing a `pnpm-workspace.yaml` is the
     /// workspace root, and its config applies.
     pub fn find_and_load(

--- a/crates/store-dir/src/cas_file.rs
+++ b/crates/store-dir/src/cas_file.rs
@@ -19,7 +19,7 @@ impl StoreDir {
 
     /// Path to a content-addressed file given its pre-computed hex digest
     /// (from the SQLite store index) and its POSIX mode. Matches pnpm's
-    /// [`getFilePathByModeInCafs`](https://github.com/pnpm/pnpm/blob/main/store/cafs/src/getFilePathInCafs.ts)
+    /// [`getFilePathByModeInCafs`](https://github.com/pnpm/pnpm/blob/1819226b51/store/cafs/src/getFilePathInCafs.ts)
     /// so index entries written by either tool resolve to the same path.
     ///
     /// Returns `None` when `hex` is too short or not ASCII-hex.

--- a/crates/store-dir/src/check_pkg_files_integrity.rs
+++ b/crates/store-dir/src/check_pkg_files_integrity.rs
@@ -1,5 +1,5 @@
 //! Port of pnpm v11's
-//! [`store/cafs/src/checkPkgFilesIntegrity.ts`](https://github.com/pnpm/pnpm/blob/main/store/cafs/src/checkPkgFilesIntegrity.ts).
+//! [`store/cafs/src/checkPkgFilesIntegrity.ts`](https://github.com/pnpm/pnpm/blob/1819226b51/store/cafs/src/checkPkgFilesIntegrity.ts).
 //!
 //! The store index's `package_index` row lists the CAFS paths a package
 //! expanded into. Before reusing the row the caller checks those files
@@ -44,7 +44,7 @@ pub struct VerifyResult {
 /// Fast path used when `verify-store-integrity` is `false`.
 ///
 /// Port of pnpm's
-/// [`buildFileMapsFromIndex`](https://github.com/pnpm/pnpm/blob/main/store/cafs/src/checkPkgFilesIntegrity.ts).
+/// [`buildFileMapsFromIndex`](https://github.com/pnpm/pnpm/blob/1819226b51/store/cafs/src/checkPkgFilesIntegrity.ts).
 /// No stat syscalls — the caller trusts the index, and any missing /
 /// corrupt CAFS file surfaces lazily at import time (pnpm's `linkOrCopy`
 /// equivalent).

--- a/crates/store-dir/src/msgpackr_records.rs
+++ b/crates/store-dir/src/msgpackr_records.rs
@@ -7,7 +7,7 @@
 //!
 //! pnpm packs every `PackageFilesIndex` with `new Packr({ useRecords: true,
 //! moreTypes: true })` (see
-//! [`store/index/src/index.ts`](https://github.com/pnpm/pnpm/blob/main/store/index/src/index.ts)
+//! [`store/index/src/index.ts`](https://github.com/pnpm/pnpm/blob/1819226b51/store/index/src/index.ts)
 //! line 12). `useRecords` replaces repeated string keys in same-shape
 //! structs with a compact slot reference — roughly, Protobuf field numbers
 //! inline. Plain `rmp_serde` output round-trips through msgpackr badly

--- a/crates/store-dir/src/store_dir.rs
+++ b/crates/store-dir/src/store_dir.rs
@@ -118,7 +118,7 @@ impl StoreDir {
     ///
     /// Gated by an `is_dir()` check on `files/` so we only run when the
     /// store is truly fresh — spiritually matches pnpm's
-    /// [`createPackageStore`](https://github.com/pnpm/pnpm/blob/main/store/package-store/src/storeController/index.ts)
+    /// [`createPackageStore`](https://github.com/pnpm/pnpm/blob/1819226b51/store/controller/src/storeController/index.ts)
     /// guard (`if !fs.existsSync(path.join(storeDir, 'files')) initStoreDir(...)`),
     /// but tightened from `exists()` to `is_dir()` so a non-directory
     /// entry at `files/` doesn't let `init` silently noop past store

--- a/crates/store-dir/src/store_index.rs
+++ b/crates/store-dir/src/store_index.rs
@@ -21,7 +21,7 @@ use std::{
 /// Each row keys a package by its tarball integrity plus a package identifier
 /// and stores a msgpack-encoded [`PackageFilesIndex`]. The schema and PRAGMAs
 /// below mirror pnpm's implementation in
-/// [`store/index/src/index.ts`](https://github.com/pnpm/pnpm/blob/main/store/index/src/index.ts)
+/// [`store/index/src/index.ts`](https://github.com/pnpm/pnpm/blob/1819226b51/store/index/src/index.ts)
 /// so that the two tools can read each other's entries.
 pub struct StoreIndex {
     conn: Connection,
@@ -557,7 +557,7 @@ pub struct PackageFilesIndex {
 }
 
 /// Value of [`PackageFilesIndex::files`]. Mirrors pnpm v11's
-/// [`PackageFileInfo`](https://github.com/pnpm/pnpm/blob/main/store/cafs-types/src/index.ts)
+/// [`PackageFileInfo`](https://github.com/pnpm/pnpm/blob/1819226b51/store/cafs-types/src/index.ts)
 /// field-for-field so that the msgpack payload interops.
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -320,7 +320,7 @@ fn extract_tarball_entries(
 /// [`checkPkgFilesIntegrity`][1] catches corruption via the content hash
 /// and doesn't gate on dirent type.
 ///
-/// [1]: https://github.com/pnpm/pnpm/blob/main/store/cafs/src/checkPkgFilesIntegrity.ts
+/// [1]: https://github.com/pnpm/pnpm/blob/1819226b51/store/cafs/src/checkPkgFilesIntegrity.ts
 ///
 /// Pre-fetched cas-paths map shared across all per-snapshot futures.
 /// Built once at install start by [`prefetch_cas_paths`]; downloads

--- a/npm/pacquet/scripts/generate-packages.mjs
+++ b/npm/pacquet/scripts/generate-packages.mjs
@@ -1,4 +1,4 @@
-// Code copied from [Rome](https://github.com/rome/tools/blob/main/npm/rome/scripts/generate-packages.mjs)
+// Code copied from [Rome](https://github.com/rome/tools/blob/392d188a49/npm/rome/scripts/generate-packages.mjs)
 
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,5 @@
 # Make Rust more readable given most people have wide screens nowadays.
-# This is also the setting used by [rustc](https://github.com/rust-lang/rust/blob/master/rustfmt.toml)
+# This is also the setting used by [rustc](https://github.com/rust-lang/rust/blob/c7fe5e9d1e/rustfmt.toml)
 use_small_heuristics = "Max"
 
 # Use field initialize shorthand if possible

--- a/tasks/integrated-benchmark/src/cli_args.rs
+++ b/tasks/integrated-benchmark/src/cli_args.rs
@@ -51,7 +51,7 @@ pub enum BenchmarkScenario {
     /// the "fresh clone of an existing repo" / "CI install where the
     /// runner-level store cache is hit" path. Mirrors pnpm's
     /// `Headless install (frozen lockfile, warm store+cache)` benchmark
-    /// in [`pnpm/v11/benchmarks/bench.sh`](https://github.com/pnpm/pnpm/blob/main/benchmarks/bench.sh).
+    /// in [`pnpm/v11/benchmarks/bench.sh`](https://github.com/pnpm/pnpm/blob/1819226b51/benchmarks/bench.sh).
     /// Hyperfine's `--warmup` run primes the store; subsequent timed
     /// runs delete only `node_modules` and reuse the populated store.
     FrozenLockfileHotCache,


### PR DESCRIPTION
Branch-tip links such as `github.com/pnpm/pnpm/blob/main/...` drift as the branch moves and 404 once a referenced file is renamed or deleted (two of the existing pacquet links were already pointing at moved paths). Replace every `blob/<branch>/` link in the repo with a `blob/<10-char-sha>/` permalink so the references stay meaningful, and update the AI-facing guidance in AGENTS.md to require permanent links going forward.