### PR TITLE
docs: reframe project as the official pnpm rewrite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ by crate or name — see below).
 - `just cli -- <args>` — run the pacquet binary.
 - `just registry-mock <args>` — manage the mock registry used by tests.
 - `just integrated-benchmark <args>` — compare revisions or compare against
-  pnpm itself (see `README.md`).
+  pnpm itself (see `CONTRIBUTING.md`).
 
 Warnings are errors (`--deny warnings` in lint). Do not silence them with
 `#[allow(...)]` unless there is a specific, justified reason.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,3 +61,54 @@ This runs `typos`, `cargo fmt`, `just check` (which is `cargo check --locked`), 
 
 > [!NOTE]
 > Some integration tests require the local registry mock. Start it with `just registry-mock launch` before running `just test` if a test needs it.
+
+## Debugging
+
+Set the `TRACE` environment variable to enable trace-level logging for a given module:
+
+```sh
+TRACE=pacquet_tarball just cli add fastify
+```
+
+## Testing
+
+```sh
+just install              # install necessary dependencies
+just registry-mock launch # start a mocked registry server (optional)
+just test                 # run tests
+```
+
+## Benchmarking
+
+First, start a local registry server, such as [verdaccio](https://verdaccio.org/):
+
+```sh
+verdaccio
+```
+
+Then use the `integrated-benchmark` task to run benchmarks. For example:
+
+```sh
+# Compare the branch you are working on against main
+just integrated-benchmark --scenario=frozen-lockfile my-branch main
+```
+
+```sh
+# Compare the current commit against the previous commit
+just integrated-benchmark --scenario=frozen-lockfile HEAD HEAD~
+```
+
+```sh
+# Compare pacquet of the current commit against pnpm
+just integrated-benchmark --scenario=frozen-lockfile --with-pnpm HEAD
+```
+
+```sh
+# Compare pacquet of the current commit, pacquet of main, and pnpm against each other
+just integrated-benchmark --scenario=frozen-lockfile --with-pnpm HEAD main
+```
+
+```sh
+# See more options
+just integrated-benchmark --help
+```

--- a/README.md
+++ b/README.md
@@ -1,73 +1,19 @@
 # pacquet
 
-Experimental package manager for node.js written in rust.
+The official pnpm rewrite in Rust.
 
-### TODO
+pacquet is a port of the [pnpm](https://github.com/pnpm/pnpm) CLI from TypeScript to Rust. It is not a new package manager and not a reimagining of pnpm. Its behavior, flags, defaults, error codes, file formats, and directory layout will match pnpm exactly.
 
-- [x] `.npmrc` support (for supported features [readme.md](./crates/npmrc/README.md))
-- [x] CLI commands (for supported features [readme.md](./crates/cli/README.md))
-- [x] Content addressable file store support
-- [ ] Shrink-file support in sync with `pnpm-lock.yml`
-  - [x] Frozen lockfile
-  - [ ] Update outdated lockfile
-  - [ ] Creating lockfile
-- [ ] Workspace support
-- [ ] Full sync with [pnpm error codes](https://pnpm.io/errors)
-- [ ] Generate a `node_modules/.bin` folder
-- [ ] Add CLI report
+## Roadmap
 
-## Debugging
+pacquet will become the installation engine of pnpm. The transition will happen in two phases.
 
-```shell
-TRACE=pacquet_tarball just cli add fastify
-```
+### Phase 1: fetching and linking
 
-## Testing
+pacquet replaces fetching and linking only. pnpm continues to create the lockfile, and pacquet does the rest. We expect this alone to make pnpm at least twice as fast in most scenarios. Shipping this phase is the current focus.
 
-```sh
-# Install necessary dependencies
-just install
+### Phase 2: resolution
 
-# Start a mocked registry server (optional)
-just registry-mock launch
+pacquet also takes over dependency resolution.
 
-# Run test
-just test
-```
-
-## Benchmarking
-
-### Install between multiple revisions
-
-First, you to start a local registry server, such as [verdaccio](https://verdaccio.org/):
-
-```sh
-verdaccio
-```
-
-Then, you can use the script named `integrated-benchmark` to run the various benchmark, For example:
-
-```sh
-# Comparing the branch you're working on against main
-just integrated-benchmark --scenario=frozen-lockfile my-branch main
-```
-
-```sh
-# Comparing current commit against the previous commit
-just integrated-benchmark --scenario=frozen-lockfile HEAD HEAD~
-```
-
-```sh
-# Comparing pacquet of current commit against pnpm
-just integrated-benchmark --scenario=frozen-lockfile --with-pnpm HEAD
-```
-
-```sh
-# Comparing pacquet of current commit, pacquet of main, and pnpm against each other
-just integrated-benchmark --scenario=frozen-lockfile --with-pnpm HEAD main
-```
-
-```sh
-# See more options
-just integrated-benchmark --help
-```
+See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for development setup, debugging, testing, and benchmarking.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # pacquet
 
+> [!WARNING]
+> **pacquet is under active development and not yet ready for production use.**
+
 The official pnpm rewrite in Rust.
 
 pacquet is a port of the [pnpm](https://github.com/pnpm/pnpm) CLI from TypeScript to Rust. It is not a new package manager and not a reimagining of pnpm. Its behavior, flags, defaults, error codes, file formats, and directory layout will match pnpm exactly.

--- a/npm/pacquet/README.md
+++ b/npm/pacquet/README.md
@@ -1,0 +1,15 @@
+# pacquet
+
+The official pnpm rewrite in Rust.
+
+pacquet is a port of the [pnpm](https://github.com/pnpm/pnpm) CLI from TypeScript to Rust. It is not a new package manager and not a reimagining of pnpm. Its behavior, flags, defaults, error codes, file formats, and directory layout will match pnpm exactly.
+
+pacquet is under active development and not yet ready for production use. See the [project roadmap](https://github.com/pnpm/pacquet/issues/299).
+
+## Installation
+
+```sh
+pnpm add -g pacquet
+```
+
+This package is a thin Node.js wrapper that dispatches to a platform-specific native binary for your operating system and architecture.

--- a/npm/pacquet/README.md
+++ b/npm/pacquet/README.md
@@ -1,10 +1,10 @@
 # pacquet
 
+> **pacquet is under active development and not yet ready for production use.** See the [project roadmap](https://github.com/pnpm/pacquet/issues/299).
+
 The official pnpm rewrite in Rust.
 
 pacquet is a port of the [pnpm](https://github.com/pnpm/pnpm) CLI from TypeScript to Rust. It is not a new package manager and not a reimagining of pnpm. Its behavior, flags, defaults, error codes, file formats, and directory layout will match pnpm exactly.
-
-pacquet is under active development and not yet ready for production use. See the [project roadmap](https://github.com/pnpm/pacquet/issues/299).
 
 ## Installation
 

--- a/npm/pacquet/package.json
+++ b/npm/pacquet/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pacquet",
   "version": "0.2.1",
-  "description": "The official pnpm rewrite in Rust (preview)",
+  "description": "The official pnpm rewrite in Rust (preview, not production-ready)",
   "keywords": [
     "pnpm"
   ],

--- a/npm/pacquet/package.json
+++ b/npm/pacquet/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pacquet",
   "version": "0.2.1",
-  "description": "The official pnpm rewrite in Rust",
+  "description": "The official pnpm rewrite in Rust (preview)",
   "keywords": [
     "pnpm"
   ],

--- a/npm/pacquet/package.json
+++ b/npm/pacquet/package.json
@@ -1,8 +1,10 @@
 {
   "name": "pacquet",
   "version": "0.2.1",
-  "description": "experimental package manager for node.js",
-  "keywords": [],
+  "description": "The official pnpm rewrite in Rust",
+  "keywords": [
+    "pnpm"
+  ],
   "author": {
     "name": "Yagiz Nizipli",
     "email": "yagiz@nizipli.com"


### PR DESCRIPTION
## Summary

- Rewrites the top-level `README.md` around the framing that pacquet is the official pnpm rewrite in Rust, and adds a two-phase roadmap (fetching/linking, then resolution). Drops the stale TODO list.
- Moves the debugging, testing, and benchmarking sections from `README.md` into `CONTRIBUTING.md` so the README focuses on what the project is and the contributor docs are in one place.
- Adds a `README.md` to the `npm/pacquet` package and refreshes its `description` and `keywords` to match the new framing. (npm always includes `README.md` in the published tarball, so no change to `files`.)
- Updates the `AGENTS.md` cross-reference for the relocated benchmark instructions (now in `CONTRIBUTING.md` instead of `README.md`).

## Test plan

- [x] `just ready` (typos, fmt, check, test, lint) passes locally
- [x] Render `README.md`, `CONTRIBUTING.md`, and `npm/pacquet/README.md` on GitHub and confirm formatting and links
- [x] Confirm the `npm/pacquet/README.md` content reads well as a standalone npm registry page