### PR TITLE
ci(release): publish via pnpm using npm trusted publishing

### DIFF
--- a/.github/workflows/release-to-npm.yml
+++ b/.github/workflows/release-to-npm.yml
@@ -120,19 +120,27 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     permissions:
+      # Required for npm provenance attestations via OIDC.
       id-token: write
+      # Required for softprops/action-gh-release to create the release below.
       contents: write
-      discussions: write
     needs:
       - build
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Node.js
-        uses: actions/setup-node@v3
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
         with:
-          node-version: 18
-          registry-url: 'https://registry.npmjs.org'
+          # Match the version pinned in CI; bump together. Pacquet needs a
+          # pnpm that writes lockfile v9, so pin the latest 11.x RC until
+          # stable ships.
+          version: 11.0.0-rc.5
+          standalone: true
+
+      - name: Setup Node
+        run: pnpm runtime -g set node 22
+        timeout-minutes: 2
 
       - name: Download Artifacts
         uses: actions/download-artifact@v4
@@ -154,10 +162,15 @@ jobs:
           for package in npm/pacquet*; do cat $package/package.json ; echo ; done
 
       - name: Publish npm packages as latest
-        # NOTE: The trailing slash on $package/ changes it to publishing the directory
-        run: for package in npm/pacquet*; do npm publish $package/ --tag latest --access public --provenance; done
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        # Auth is via npm's trusted publishing: `id-token: write` above grants
+        # this job an OIDC token that pnpm/npm exchange with the registry,
+        # so no NPM_TOKEN is needed. `--provenance` attaches the same OIDC
+        # token to a provenance attestation on each tarball.
+        # The trailing slash on $package/ changes it to publishing the directory.
+        run: |
+          for package in npm/pacquet*; do
+            pnpm publish "$package/" --tag latest --access public --provenance --no-git-checks
+          done
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
## Summary

- Replaces `npm publish` with `pnpm publish` in the release workflow, installed via `pnpm/action-setup@v6` (`standalone: true`, pinned to `11.0.0-rc.5` to match CI). Node is provisioned through `pnpm runtime -g set node 22`, so the `generate-packages.mjs` step still has `node` on PATH — same approach pnpm/pnpm's [`release.yml`](https://github.com/pnpm/pnpm/blob/d4cb47adba5c01b4ca8e98c61f6cdfc3989a35dd/.github/workflows/release.yml) uses.
- Drops `secrets.NPM_TOKEN`. With `id-token: write` already granted, GitHub Actions mints an OIDC JWT that the npm registry verifies against each package's trusted-publisher config. The same token is what `--provenance` attaches as an attestation, so we get auth and provenance from one mechanism and no long-lived credential lives in the repo.
- Adds `--no-git-checks` because unzipped binary artifacts leave the working tree dirty by the time publish runs, which would otherwise trip pnpm's clean-tree check.
- Removes the unused `discussions: write` permission.

## Test plan

- [x] Confirm each of `pacquet`, `@pacquet/win32-x64`, `@pacquet/win32-arm64`, `@pacquet/linux-x64`, `@pacquet/linux-arm64`, `@pacquet/darwin-x64`, `@pacquet/darwin-arm64` has a trusted-publisher entry on npmjs.com pointing at `pnpm/pacquet` + `release-to-npm.yml`.
- [ ] On the next version bump, watch the `Publish` job: `pnpm publish` should succeed for every package without an `NPM_TOKEN` and each tarball should show a provenance badge on npmjs.com.