### PR TITLE
refactor: replace `serde_yaml` with `serde_saphyr`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,6 +53,17 @@ name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "annotate-snippets"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92570a3f9c98e7e84df84b71d0965ac99b1871fcd75a3773a3bd1bad13f64cf7"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width 0.2.2",
+]
 
 [[package]]
 name = "anstream"
@@ -96,6 +120,12 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "assert-json-diff"
@@ -578,6 +608,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -770,9 +818,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1513,6 +1563,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1764,7 +1820,8 @@ dependencies = [
  "pipe-trait",
  "pretty_assertions",
  "serde",
- "serde_yaml",
+ "serde-saphyr",
+ "serde_json",
  "split-first-char",
  "ssri",
  "tempfile",
@@ -1808,8 +1865,8 @@ dependencies = [
  "pipe-trait",
  "pretty_assertions",
  "serde",
+ "serde-saphyr",
  "serde_ini",
- "serde_yaml",
  "tempfile",
 ]
 
@@ -1838,7 +1895,7 @@ dependencies = [
  "pretty_assertions",
  "rayon",
  "reflink-copy",
- "serde_yaml",
+ "serde-saphyr",
  "ssri",
  "tempfile",
  "tokio",
@@ -2471,6 +2528,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "saphyr-parser-bw"
+version = "0.0.611"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dec0c833db75dc98957956b303fe447ffc5eb13f2325ef4c2350f7f3aa69e3"
+dependencies = [
+ "arraydeque",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2522,6 +2590,25 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-saphyr"
+version = "0.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e214449d107a81daf1453eb46c9314457660509534883e82db6faca2034a8a"
+dependencies = [
+ "ahash",
+ "annotate-snippets",
+ "base64 0.22.1",
+ "encoding_rs_io",
+ "getrandom 0.3.4",
+ "nohash-hasher",
+ "num-traits",
+ "saphyr-parser-bw",
+ "serde",
+ "smallvec",
+ "zmij",
 ]
 
 [[package]]
@@ -2579,19 +2666,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
 ]
 
 [[package]]
@@ -3158,12 +3232,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ rusqlite = { version = "0.38.0", features = ["bundled"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_ini = { version = "0.2.0" }
 serde_json = { version = "1.0.149", features = ["preserve_order"] }
-serde_yaml = { version = "0.9.34" }
+serde-saphyr = { version = "0.0.25" }
 # 0.11 removes the LowerHex impl on Output; revisit after upstream/consumers catch up
 sha2               = { version = "0.10.9" }
 split-first-char   = { version = "2.0.1" }

--- a/crates/lockfile/Cargo.toml
+++ b/crates/lockfile/Cargo.toml
@@ -18,7 +18,8 @@ derive_more      = { workspace = true }
 node-semver      = { workspace = true }
 pipe-trait       = { workspace = true }
 serde            = { workspace = true }
-serde_yaml       = { workspace = true }
+serde-saphyr     = { workspace = true }
+serde_json       = { workspace = true }
 ssri             = { workspace = true }
 split-first-char = { workspace = true }
 

--- a/crates/lockfile/src/lib.rs
+++ b/crates/lockfile/src/lib.rs
@@ -11,6 +11,7 @@ mod project_snapshot;
 mod resolution;
 mod resolved_dependency;
 mod save_lockfile;
+mod serialize_yaml;
 mod snapshot_dep_ref;
 mod snapshot_entry;
 

--- a/crates/lockfile/src/load_lockfile.rs
+++ b/crates/lockfile/src/load_lockfile.rs
@@ -21,7 +21,7 @@ pub enum LoadLockfileError {
 
     #[display("Failed to parse lockfile content as YAML: {_0}")]
     #[diagnostic(code(pacquet_lockfile::parse_yaml))]
-    ParseYaml(serde_yaml::Error),
+    ParseYaml(serde_saphyr::Error),
 }
 
 impl Lockfile {
@@ -34,6 +34,6 @@ impl Lockfile {
             Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
             Err(error) => return error.pipe(LoadLockfileError::ReadFile).pipe(Err),
         };
-        content.pipe_as_ref(serde_yaml::from_str).map_err(LoadLockfileError::ParseYaml)
+        content.pipe_as_ref(serde_saphyr::from_str).map_err(LoadLockfileError::ParseYaml)
     }
 }

--- a/crates/lockfile/src/lockfile_version.rs
+++ b/crates/lockfile/src/lockfile_version.rs
@@ -45,7 +45,7 @@ mod tests {
                 const MAJOR: u16 = $major;
                 let input = $input;
                 eprintln!("CASE: LockfileVersion::<{MAJOR}>::try_from({input:?})");
-                let received: LockfileVersion<MAJOR> = serde_yaml::from_str(input).unwrap();
+                let received: LockfileVersion<MAJOR> = serde_saphyr::from_str(input).unwrap();
                 let expected = LockfileVersion::<MAJOR>($output);
                 assert_eq!(&received, &expected);
             }};

--- a/crates/lockfile/src/pkg_name.rs
+++ b/crates/lockfile/src/pkg_name.rs
@@ -108,7 +108,7 @@ mod tests {
     fn deserialize_ok() {
         fn case(input: &'static str, output: PkgName) {
             eprintln!("CASE: {input:?}");
-            let actual: PkgName = serde_yaml::from_str(input).unwrap();
+            let actual: PkgName = serde_saphyr::from_str(input).unwrap();
             assert_eq!(&actual, &output);
         }
 
@@ -148,9 +148,11 @@ mod tests {
     fn serialize() {
         fn case(input: PkgName, output: &'static str) {
             eprintln!("CASE: {input:?}");
-            let received = serde_yaml::to_value(&input).unwrap();
-            let expected = output.to_string().pipe(serde_yaml::Value::String);
-            assert_eq!(&received, &expected);
+            let received = serde_saphyr::to_string(&input).unwrap();
+            let received = received.trim();
+            let reparsed: PkgName = serde_saphyr::from_str(received).expect("reparse");
+            assert_eq!(&reparsed, &input);
+            assert_eq!(reparsed.to_string(), output);
         }
 
         case(PkgName { scope: Some("foo".to_string()), bare: "bar".to_string() }, "@foo/bar");

--- a/crates/lockfile/src/pkg_name.rs
+++ b/crates/lockfile/src/pkg_name.rs
@@ -148,14 +148,11 @@ mod tests {
     fn serialize() {
         fn case(input: PkgName, output: &'static str) {
             eprintln!("CASE: {input:?}");
-            let received = serde_saphyr::to_string(&input).unwrap();
-            let received = received.trim();
-            let reparsed: PkgName = serde_saphyr::from_str(received).expect("reparse");
-            assert_eq!(&reparsed, &input);
-            assert_eq!(reparsed.to_string(), output);
+            let received = input.pipe_ref(serde_saphyr::to_string).unwrap();
+            assert_eq!(received, output);
         }
 
-        case(PkgName { scope: Some("foo".to_string()), bare: "bar".to_string() }, "@foo/bar");
-        case(PkgName { scope: None, bare: "foo-bar".to_string() }, "foo-bar");
+        case(PkgName { scope: Some("foo".to_string()), bare: "bar".to_string() }, "\"@foo/bar\"\n");
+        case(PkgName { scope: None, bare: "foo-bar".to_string() }, "foo-bar\n");
     }
 }

--- a/crates/lockfile/src/pkg_name_ver.rs
+++ b/crates/lockfile/src/pkg_name_ver.rs
@@ -12,6 +12,7 @@ pub type ParsePkgNameVerError = ParsePkgNameSuffixError<SemverError>;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pipe_trait::Pipe;
     use pretty_assertions::assert_eq;
 
     fn name_ver(name: &str, ver: impl Into<Version>) -> PkgNameVer {
@@ -80,11 +81,8 @@ mod tests {
 
     #[test]
     fn serialize() {
-        let input = name_ver("ts-node", (10, 9, 1));
-        let received = serde_saphyr::to_string(&input).unwrap();
-        let received = received.trim();
-        let reparsed: PkgNameVer = serde_saphyr::from_str(received).expect("reparse");
-        assert_eq!(reparsed, input);
-        assert_eq!(reparsed.to_string(), "ts-node@10.9.1");
+        let received = name_ver("ts-node", (10, 9, 1)).pipe_ref(serde_saphyr::to_string).unwrap();
+        let expected = "ts-node@10.9.1\n";
+        assert_eq!(received, expected);
     }
 }

--- a/crates/lockfile/src/pkg_name_ver.rs
+++ b/crates/lockfile/src/pkg_name_ver.rs
@@ -12,9 +12,7 @@ pub type ParsePkgNameVerError = ParsePkgNameSuffixError<SemverError>;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pipe_trait::Pipe;
     use pretty_assertions::assert_eq;
-    use serde_yaml::Value as YamlValue;
 
     fn name_ver(name: &str, ver: impl Into<Version>) -> PkgNameVer {
         PkgNameVer::new(name.parse().unwrap(), ver.into())
@@ -39,7 +37,7 @@ mod tests {
     fn deserialize_ok() {
         fn case(input: &'static str, expected: PkgNameVer) {
             eprintln!("CASE: {input:?}");
-            let received: PkgNameVer = serde_yaml::from_str(input).unwrap();
+            let received: PkgNameVer = serde_saphyr::from_str(input).unwrap();
             assert_eq!(&received, &expected);
         }
 
@@ -82,8 +80,11 @@ mod tests {
 
     #[test]
     fn serialize() {
-        let received = name_ver("ts-node", (10, 9, 1)).pipe_ref(serde_yaml::to_value).unwrap();
-        let expected = "ts-node@10.9.1".to_string().pipe(YamlValue::String);
-        assert_eq!(received, expected);
+        let input = name_ver("ts-node", (10, 9, 1));
+        let received = serde_saphyr::to_string(&input).unwrap();
+        let received = received.trim();
+        let reparsed: PkgNameVer = serde_saphyr::from_str(received).expect("reparse");
+        assert_eq!(reparsed, input);
+        assert_eq!(reparsed.to_string(), "ts-node@10.9.1");
     }
 }

--- a/crates/lockfile/src/pkg_ver_peer.rs
+++ b/crates/lockfile/src/pkg_ver_peer.rs
@@ -161,7 +161,11 @@ mod tests {
             Peer: Into<String>,
         {
             eprintln!("CASE: {input:?}");
-            assert_ver_peer(serde_yaml::from_str(input).unwrap(), expected_version, expected_peer);
+            assert_ver_peer(
+                serde_saphyr::from_str(input).unwrap(),
+                expected_version,
+                expected_peer,
+            );
         }
 
         case(
@@ -193,8 +197,8 @@ mod tests {
         let case = |input| {
             decode_encode_case(
                 input,
-                |input| serde_yaml::from_str(input).unwrap(),
-                |ver_peer| serde_yaml::to_string(&ver_peer).unwrap().trim().to_string(),
+                |input| serde_saphyr::from_str(input).unwrap(),
+                |ver_peer| serde_saphyr::to_string(&ver_peer).unwrap().trim().to_string(),
             )
         };
         case("1.21.3(@types/react@17.0.49)(react-dom@17.0.2)(react@17.0.2)");

--- a/crates/lockfile/src/project_snapshot.rs
+++ b/crates/lockfile/src/project_snapshot.rs
@@ -16,7 +16,7 @@ pub struct ProjectSnapshot {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dev_dependencies: Option<ResolvedDependencyMap>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub dependencies_meta: Option<serde_yaml::Value>, // TODO: DependenciesMeta
+    pub dependencies_meta: Option<serde_json::Value>, // TODO: DependenciesMeta
     #[serde(skip_serializing_if = "Option::is_none")]
     pub publish_directory: Option<String>,
 }
@@ -69,7 +69,7 @@ mod tests {
     };
 
     fn fixture_project_snapshot() -> ProjectSnapshot {
-        serde_yaml::from_str(YAML).unwrap()
+        serde_saphyr::from_str(YAML).unwrap()
     }
 
     #[test]

--- a/crates/lockfile/src/resolution.rs
+++ b/crates/lockfile/src/resolution.rs
@@ -112,7 +112,7 @@ mod tests {
         let yaml = text_block! {
             "tarball: file:ts-pipe-compose-0.2.1.tgz"
         };
-        let received: LockfileResolution = serde_yaml::from_str(yaml).unwrap();
+        let received: LockfileResolution = serde_saphyr::from_str(yaml).unwrap();
         dbg!(&received);
         let expected = LockfileResolution::Tarball(TarballResolution {
             tarball: "file:ts-pipe-compose-0.2.1.tgz".to_string(),
@@ -125,7 +125,7 @@ mod tests {
             "tarball: file:ts-pipe-compose-0.2.1.tgz"
             "integrity: sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg=="
         };
-        let received: LockfileResolution = serde_yaml::from_str(yaml).unwrap();
+        let received: LockfileResolution = serde_saphyr::from_str(yaml).unwrap();
         dbg!(&received);
         let expected = LockfileResolution::Tarball(TarballResolution {
             tarball: "file:ts-pipe-compose-0.2.1.tgz".to_string(),
@@ -141,7 +141,7 @@ mod tests {
             tarball: "file:ts-pipe-compose-0.2.1.tgz".to_string(),
             integrity: None,
         });
-        let received = serde_yaml::to_string(&resolution).unwrap();
+        let received = crate::serialize_yaml::to_string(&resolution).unwrap();
         let received = received.trim();
         eprintln!("RECEIVED:\n{received}");
         let expected = text_block! {
@@ -154,7 +154,7 @@ mod tests {
             tarball: "file:ts-pipe-compose-0.2.1.tgz".to_string(),
             integrity: integrity("sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==").into()
         });
-        let received = serde_yaml::to_string(&resolution).unwrap();
+        let received = crate::serialize_yaml::to_string(&resolution).unwrap();
         let received = received.trim();
         eprintln!("RECEIVED:\n{received}");
         let expected = text_block! {
@@ -169,7 +169,7 @@ mod tests {
         let yaml = text_block! {
             "integrity: sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg=="
         };
-        let received: LockfileResolution = serde_yaml::from_str(yaml).unwrap();
+        let received: LockfileResolution = serde_saphyr::from_str(yaml).unwrap();
         dbg!(&received);
         let expected = LockfileResolution::Registry(RegistryResolution {
             integrity: integrity("sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==")
@@ -182,7 +182,7 @@ mod tests {
         let resolution = LockfileResolution::Registry(RegistryResolution {
             integrity: integrity("sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==")
         });
-        let received = serde_yaml::to_string(&resolution).unwrap();
+        let received = crate::serialize_yaml::to_string(&resolution).unwrap();
         let received = received.trim();
         eprintln!("RECEIVED:\n{received}");
         let expected = text_block! {
@@ -197,7 +197,7 @@ mod tests {
             "type: directory"
             "directory: ts-pipe-compose-0.2.1/package"
         };
-        let received: LockfileResolution = serde_yaml::from_str(yaml).unwrap();
+        let received: LockfileResolution = serde_saphyr::from_str(yaml).unwrap();
         dbg!(&received);
         let expected = LockfileResolution::Directory(DirectoryResolution {
             directory: "ts-pipe-compose-0.2.1/package".to_string(),
@@ -210,7 +210,7 @@ mod tests {
         let resolution = LockfileResolution::Directory(DirectoryResolution {
             directory: "ts-pipe-compose-0.2.1/package".to_string(),
         });
-        let received = serde_yaml::to_string(&resolution).unwrap();
+        let received = crate::serialize_yaml::to_string(&resolution).unwrap();
         let received = received.trim();
         eprintln!("RECEIVED:\n{received}");
         let expected = text_block! {
@@ -227,7 +227,7 @@ mod tests {
             "repo: https://github.com/ksxnodemodules/ts-pipe-compose.git"
             "commit: e63c09e460269b0c535e4c34debf69bb91d57b22"
         };
-        let received: LockfileResolution = serde_yaml::from_str(yaml).unwrap();
+        let received: LockfileResolution = serde_saphyr::from_str(yaml).unwrap();
         dbg!(&received);
         let expected = LockfileResolution::Git(GitResolution {
             repo: "https://github.com/ksxnodemodules/ts-pipe-compose.git".to_string(),
@@ -242,7 +242,7 @@ mod tests {
             repo: "https://github.com/ksxnodemodules/ts-pipe-compose.git".to_string(),
             commit: "e63c09e460269b0c535e4c34debf69bb91d57b22".to_string(),
         });
-        let received = serde_yaml::to_string(&resolution).unwrap();
+        let received = crate::serialize_yaml::to_string(&resolution).unwrap();
         let received = received.trim();
         eprintln!("RECEIVED:\n{received}");
         let expected = text_block! {

--- a/crates/lockfile/src/resolution.rs
+++ b/crates/lockfile/src/resolution.rs
@@ -99,6 +99,7 @@ impl From<LockfileResolution> for ResolutionSerde {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::serialize_yaml;
     use pretty_assertions::assert_eq;
     use text_block_macros::text_block;
 
@@ -141,7 +142,7 @@ mod tests {
             tarball: "file:ts-pipe-compose-0.2.1.tgz".to_string(),
             integrity: None,
         });
-        let received = crate::serialize_yaml::to_string(&resolution).unwrap();
+        let received = serialize_yaml::to_string(&resolution).unwrap();
         let received = received.trim();
         eprintln!("RECEIVED:\n{received}");
         let expected = text_block! {
@@ -154,7 +155,7 @@ mod tests {
             tarball: "file:ts-pipe-compose-0.2.1.tgz".to_string(),
             integrity: integrity("sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==").into()
         });
-        let received = crate::serialize_yaml::to_string(&resolution).unwrap();
+        let received = serialize_yaml::to_string(&resolution).unwrap();
         let received = received.trim();
         eprintln!("RECEIVED:\n{received}");
         let expected = text_block! {
@@ -182,7 +183,7 @@ mod tests {
         let resolution = LockfileResolution::Registry(RegistryResolution {
             integrity: integrity("sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==")
         });
-        let received = crate::serialize_yaml::to_string(&resolution).unwrap();
+        let received = serialize_yaml::to_string(&resolution).unwrap();
         let received = received.trim();
         eprintln!("RECEIVED:\n{received}");
         let expected = text_block! {
@@ -210,7 +211,7 @@ mod tests {
         let resolution = LockfileResolution::Directory(DirectoryResolution {
             directory: "ts-pipe-compose-0.2.1/package".to_string(),
         });
-        let received = crate::serialize_yaml::to_string(&resolution).unwrap();
+        let received = serialize_yaml::to_string(&resolution).unwrap();
         let received = received.trim();
         eprintln!("RECEIVED:\n{received}");
         let expected = text_block! {
@@ -242,7 +243,7 @@ mod tests {
             repo: "https://github.com/ksxnodemodules/ts-pipe-compose.git".to_string(),
             commit: "e63c09e460269b0c535e4c34debf69bb91d57b22".to_string(),
         });
-        let received = crate::serialize_yaml::to_string(&resolution).unwrap();
+        let received = serialize_yaml::to_string(&resolution).unwrap();
         let received = received.trim();
         eprintln!("RECEIVED:\n{received}");
         let expected = text_block! {

--- a/crates/lockfile/src/save_lockfile.rs
+++ b/crates/lockfile/src/save_lockfile.rs
@@ -1,4 +1,4 @@
-use crate::Lockfile;
+use crate::{serialize_yaml, Lockfile};
 use derive_more::{Display, Error};
 use pacquet_diagnostics::miette::{self, Diagnostic};
 use std::{env, fs, io, path::Path};
@@ -13,7 +13,7 @@ pub enum SaveLockfileError {
 
     #[display("Failed to serialize lockfile to YAML: {_0}")]
     #[diagnostic(code(pacquet_lockfile::serialize_yaml))]
-    SerializeYaml(serde_yaml::Error),
+    SerializeYaml(serde_saphyr::ser::Error),
 
     #[display("Failed to write lockfile content: {_0}")]
     #[diagnostic(code(pacquet_lockfile::write_file))]
@@ -23,7 +23,7 @@ pub enum SaveLockfileError {
 impl Lockfile {
     /// Save lockfile to a specific path.
     pub fn save_to_path(&self, path: &Path) -> Result<(), SaveLockfileError> {
-        let content = serde_yaml::to_string(self).map_err(SaveLockfileError::SerializeYaml)?;
+        let content = serialize_yaml::to_string(self).map_err(SaveLockfileError::SerializeYaml)?;
         fs::write(path, content).map_err(SaveLockfileError::WriteFile)
     }
 
@@ -98,14 +98,14 @@ mod tests {
     #[test]
     fn round_trip_parse_save_parse_preserves_lockfile() {
         let original: Lockfile =
-            serde_yaml::from_str(LOCKFILE_YAML).expect("parse fixture lockfile");
+            serde_saphyr::from_str(LOCKFILE_YAML).expect("parse fixture lockfile");
 
         let tmp = tempdir().expect("create tempdir");
         let path = tmp.path().join("pnpm-lock.yaml");
         original.save_to_path(&path).expect("save lockfile");
 
         let saved_bytes = std::fs::read_to_string(&path).expect("read saved lockfile");
-        let reparsed: Lockfile = serde_yaml::from_str(&saved_bytes).expect("reparse lockfile");
+        let reparsed: Lockfile = serde_saphyr::from_str(&saved_bytes).expect("reparse lockfile");
 
         assert_eq!(original, reparsed);
     }
@@ -113,7 +113,7 @@ mod tests {
     #[test]
     fn save_fails_with_wrapped_io_error_when_path_is_invalid() {
         let empty_lockfile: Lockfile =
-            serde_yaml::from_str("lockfileVersion: '9.0'\n").expect("parse minimal lockfile");
+            serde_saphyr::from_str("lockfileVersion: '9.0'\n").expect("parse minimal lockfile");
 
         // Attempt to write under a non-existent directory; fs::write returns NotFound.
         let bad_path = std::path::Path::new("/nonexistent-pacquet-dir/pnpm-lock.yaml");

--- a/crates/lockfile/src/save_lockfile.rs
+++ b/crates/lockfile/src/save_lockfile.rs
@@ -105,6 +105,19 @@ mod tests {
         original.save_to_path(&path).expect("save lockfile");
 
         let saved_bytes = std::fs::read_to_string(&path).expect("read saved lockfile");
+
+        // Long single-line scalars (notably `integrity: sha512-…`) must stay plain;
+        // pnpm-lock.yaml never uses folded block scalars (`>-`) for them. Guard the
+        // formatting invariant that `serialize_yaml` exists to enforce.
+        assert!(
+            !saved_bytes.contains(">-"),
+            "saved lockfile must not contain folded block scalars (`>-`):\n{saved_bytes}",
+        );
+        assert!(
+            saved_bytes.contains("integrity: sha512-"),
+            "saved lockfile must keep `integrity: sha512-` as a plain scalar:\n{saved_bytes}",
+        );
+
         let reparsed: Lockfile = serde_saphyr::from_str(&saved_bytes).expect("reparse lockfile");
 
         assert_eq!(original, reparsed);

--- a/crates/lockfile/src/serialize_yaml.rs
+++ b/crates/lockfile/src/serialize_yaml.rs
@@ -1,0 +1,23 @@
+//! Serializer options that match pnpm's lockfile YAML formatting.
+//!
+//! pnpm's `pnpm-lock.yaml` is emitted by `js-yaml` with default options, which
+//! keeps long single-line scalars (notably `integrity: sha512-…` hashes) as
+//! plain scalars. `serde_saphyr` defaults to folding long single-line strings
+//! into block style (`>-`), so we explicitly disable that to preserve byte-
+//! level parity with what pnpm produces.
+
+use serde::Serialize;
+use serde_saphyr::{ser, ser_options, to_string_with_options, SerializerOptions};
+
+/// Serializer options matching pnpm's lockfile output.
+fn options() -> SerializerOptions {
+    ser_options! {
+        prefer_block_scalars: false,
+    }
+}
+
+/// Serialize `value` to a YAML string with options that match pnpm's lockfile
+/// formatting.
+pub(crate) fn to_string<T: Serialize>(value: &T) -> Result<String, ser::Error> {
+    to_string_with_options(value, options())
+}

--- a/crates/lockfile/src/snapshot_dep_ref.rs
+++ b/crates/lockfile/src/snapshot_dep_ref.rs
@@ -210,7 +210,7 @@ mod tests {
             ("string-width@4.2.3", "string-width@4.2.3"),
             ("\"17.0.2(react@17.0.2)\"", "17.0.2(react@17.0.2)"),
         ] {
-            let dep: SnapshotDepRef = serde_yaml::from_str(yaml).unwrap();
+            let dep: SnapshotDepRef = serde_saphyr::from_str(yaml).unwrap();
             assert_eq!(dep.to_string(), expected);
         }
     }

--- a/crates/npmrc/Cargo.toml
+++ b/crates/npmrc/Cargo.toml
@@ -13,11 +13,11 @@ repository.workspace  = true
 [dependencies]
 pacquet-store-dir = { workspace = true }
 
-home       = { workspace = true }
-pipe-trait = { workspace = true }
-serde      = { workspace = true }
-serde_ini  = { workspace = true }
-serde_yaml = { workspace = true }
+home         = { workspace = true }
+pipe-trait   = { workspace = true }
+serde        = { workspace = true }
+serde_ini    = { workspace = true }
+serde-saphyr = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/crates/npmrc/src/workspace_yaml.rs
+++ b/crates/npmrc/src/workspace_yaml.rs
@@ -60,7 +60,7 @@ pub const WORKSPACE_MANIFEST_FILENAME: &str = "pnpm-workspace.yaml";
 #[non_exhaustive]
 pub enum LoadWorkspaceYamlError {
     ReadFile(io::Error),
-    ParseYaml(serde_yaml::Error),
+    ParseYaml(serde_saphyr::Error),
 }
 
 impl WorkspaceSettings {
@@ -79,7 +79,7 @@ impl WorkspaceSettings {
         };
         let text = fs::read_to_string(&path).map_err(LoadWorkspaceYamlError::ReadFile)?;
         let settings: WorkspaceSettings =
-            serde_yaml::from_str(&text).map_err(LoadWorkspaceYamlError::ParseYaml)?;
+            serde_saphyr::from_str(&text).map_err(LoadWorkspaceYamlError::ParseYaml)?;
         Ok(Some((path, settings)))
     }
 
@@ -212,7 +212,7 @@ nodeLinker: hoisted
 packages:
   - packages/*
 "#;
-        let settings: WorkspaceSettings = serde_yaml::from_str(yaml).unwrap();
+        let settings: WorkspaceSettings = serde_saphyr::from_str(yaml).unwrap();
         assert_eq!(settings.store_dir.as_deref(), Some("../my-store"));
         assert_eq!(settings.registry.as_deref(), Some("https://reg.example"));
         assert_eq!(settings.lockfile, Some(false));
@@ -235,7 +235,7 @@ packages:
         // allow-lists, …). This guards against regressions that would make
         // serde reject those unknown keys during deserialization — i.e.
         // someone adding `deny_unknown_fields` to the struct.
-        let _settings: WorkspaceSettings = serde_yaml::from_str(yaml).unwrap();
+        let _settings: WorkspaceSettings = serde_saphyr::from_str(yaml).unwrap();
     }
 
     #[test]
@@ -245,7 +245,7 @@ storeDir: /absolute/store
 lockfile: false
 registry: https://reg.example
 "#;
-        let settings: WorkspaceSettings = serde_yaml::from_str(yaml).unwrap();
+        let settings: WorkspaceSettings = serde_saphyr::from_str(yaml).unwrap();
         let mut npmrc = Npmrc::new();
         npmrc.lockfile = true;
         let before_registry = npmrc.registry.clone();
@@ -261,7 +261,7 @@ registry: https://reg.example
     #[test]
     fn apply_resolves_relative_paths_against_base_dir() {
         let yaml = "storeDir: ../shared-store\n";
-        let settings: WorkspaceSettings = serde_yaml::from_str(yaml).unwrap();
+        let settings: WorkspaceSettings = serde_saphyr::from_str(yaml).unwrap();
         let mut npmrc = Npmrc::new();
         let base = Path::new("/workspace/root");
 
@@ -288,7 +288,7 @@ fetchRetryFactor: 3
 fetchRetryMintimeout: 1000
 fetchRetryMaxtimeout: 4000
 "#;
-        let settings: WorkspaceSettings = serde_yaml::from_str(yaml).unwrap();
+        let settings: WorkspaceSettings = serde_saphyr::from_str(yaml).unwrap();
         assert_eq!(settings.fetch_retries, Some(5));
         assert_eq!(settings.fetch_retry_factor, Some(3));
         assert_eq!(settings.fetch_retry_mintimeout, Some(1000));
@@ -312,7 +312,7 @@ fetchRetryMaxtimeout: 4000
     #[test]
     fn parses_verify_store_integrity_from_yaml_and_applies() {
         let yaml = "verifyStoreIntegrity: false\n";
-        let settings: WorkspaceSettings = serde_yaml::from_str(yaml).unwrap();
+        let settings: WorkspaceSettings = serde_saphyr::from_str(yaml).unwrap();
         assert_eq!(settings.verify_store_integrity, Some(false));
 
         let mut npmrc = Npmrc::new();
@@ -324,7 +324,7 @@ fetchRetryMaxtimeout: 4000
     #[test]
     fn apply_leaves_unset_fields_alone() {
         let yaml = "storeDir: /s\n";
-        let settings: WorkspaceSettings = serde_yaml::from_str(yaml).unwrap();
+        let settings: WorkspaceSettings = serde_saphyr::from_str(yaml).unwrap();
         let mut npmrc = Npmrc::new();
         let before =
             (npmrc.hoist, npmrc.lockfile, npmrc.registry.clone(), npmrc.auto_install_peers);

--- a/crates/package-manager/Cargo.toml
+++ b/crates/package-manager/Cargo.toml
@@ -39,7 +39,7 @@ pacquet-testing-utils = { workspace = true }
 node-semver       = { workspace = true }
 insta             = { workspace = true }
 pretty_assertions = { workspace = true }
-serde_yaml        = { workspace = true }
+serde-saphyr      = { workspace = true }
 ssri              = { workspace = true }
 tempfile          = { workspace = true }
 walkdir           = { workspace = true }

--- a/crates/package-manager/src/install.rs
+++ b/crates/package-manager/src/install.rs
@@ -301,7 +301,7 @@ mod tests {
         // run through `CreateVirtualStore` with an empty snapshot set,
         // which is a successful no-op. That's enough to prove we took
         // the frozen branch.
-        let lockfile: Lockfile = serde_yaml::from_str(concat!(
+        let lockfile: Lockfile = serde_saphyr::from_str(concat!(
             "lockfileVersion: '9.0'\n",
             "importers:\n",
             "  .:\n",


### PR DESCRIPTION
Resolves <https://github.com/pnpm/pacquet/issues/311>.

`serde_yaml` is deprecated and unmaintained. Switch to `serde-saphyr`, which offers panic-free YAML parsing and is the replacement recommended in pnpm/pacquet#311.

The new crate's API differs from `serde_yaml` in two places:

- It has no `Value` type. The single use site, `ProjectSnapshot::dependencies_meta`, holds a passthrough YAML blob that ports cleanly to `serde_json::Value`.
- Its serializer folds long single-line scalars into block style (`>-`) by default, which would garble the `integrity` hashes in `pnpm-lock.yaml`. A small `serialize_yaml` helper turns that off via `prefer_block_scalars: false` so the output continues to match the plain-scalar format `js-yaml` (and therefore pnpm) emits.