### PR TITLE
chore(rust): edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members  = ["crates/*", "tasks/*"]
 [workspace.package]
 authors     = ["Yagiz Nizipli <yagiz@nizipli.com"]
 description = "Pacquet"
-edition     = "2021"
+edition     = "2024"
 homepage    = "https://github.com/pnpm/pacquet"
 keywords    = ["nodejs", "package", "manager", "pnpm", "npm"]
 license     = "MIT"

--- a/crates/cli/tests/add.rs
+++ b/crates/cli/tests/add.rs
@@ -101,9 +101,10 @@ fn should_add_to_package_json() {
     let (root, dir, anchor) = exec_pacquet_in_temp_cwd(["add", "@pnpm.e2e/hello-world-js-bin"]);
     let file = PackageManifest::from_path(dir.join("package.json")).unwrap();
     eprintln!("Ensure @pnpm.e2e/hello-world-js-bin is added to package.json#dependencies");
-    assert!(file
-        .dependencies([DependencyGroup::Prod])
-        .any(|(k, _)| k == "@pnpm.e2e/hello-world-js-bin"));
+    assert!(
+        file.dependencies([DependencyGroup::Prod])
+            .any(|(k, _)| k == "@pnpm.e2e/hello-world-js-bin")
+    );
     drop((root, anchor)); // cleanup
 }
 
@@ -113,9 +114,9 @@ fn should_add_dev_dependency() {
         exec_pacquet_in_temp_cwd(["add", "@pnpm.e2e/hello-world-js-bin", "--save-dev"]);
     let file = PackageManifest::from_path(dir.join("package.json")).unwrap();
     eprintln!("Ensure @pnpm.e2e/hello-world-js-bin is added to package.json#devDependencies");
-    assert!(file
-        .dependencies([DependencyGroup::Dev])
-        .any(|(k, _)| k == "@pnpm.e2e/hello-world-js-bin"));
+    assert!(
+        file.dependencies([DependencyGroup::Dev]).any(|(k, _)| k == "@pnpm.e2e/hello-world-js-bin")
+    );
     drop((root, anchor)); // cleanup
 }
 
@@ -125,12 +126,13 @@ fn should_add_peer_dependency() {
         exec_pacquet_in_temp_cwd(["add", "@pnpm.e2e/hello-world-js-bin", "--save-peer"]);
     let file = PackageManifest::from_path(dir.join("package.json")).unwrap();
     eprintln!("Ensure @pnpm.e2e/hello-world-js-bin is added to package.json#devDependencies");
-    assert!(file
-        .dependencies([DependencyGroup::Dev])
-        .any(|(k, _)| k == "@pnpm.e2e/hello-world-js-bin"));
+    assert!(
+        file.dependencies([DependencyGroup::Dev]).any(|(k, _)| k == "@pnpm.e2e/hello-world-js-bin")
+    );
     eprintln!("Ensure @pnpm.e2e/hello-world-js-bin is added to package.json#peerDependencies");
-    assert!(file
-        .dependencies([DependencyGroup::Peer])
-        .any(|(k, _)| k == "@pnpm.e2e/hello-world-js-bin"));
+    assert!(
+        file.dependencies([DependencyGroup::Peer])
+            .any(|(k, _)| k == "@pnpm.e2e/hello-world-js-bin")
+    );
     drop((root, anchor)); // cleanup
 }

--- a/crates/diagnostics/src/local_tracing.rs
+++ b/crates/diagnostics/src/local_tracing.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use tracing::Level;
-use tracing_subscriber::{fmt::format::FmtSpan, EnvFilter, Layer};
+use tracing_subscriber::{EnvFilter, Layer, fmt::format::FmtSpan};
 
 pub fn enable_tracing_by_env() {
     let Ok(trace_var) = std::env::var("TRACE") else { return };

--- a/crates/fs/src/ensure_file.rs
+++ b/crates/fs/src/ensure_file.rs
@@ -796,11 +796,7 @@ mod tests {
             let result = retry_on_fd_pressure(|| {
                 let attempt = attempts.get();
                 attempts.set(attempt + 1);
-                if attempt < 2 {
-                    Err(io::Error::from_raw_os_error(errno))
-                } else {
-                    Ok("ok")
-                }
+                if attempt < 2 { Err(io::Error::from_raw_os_error(errno)) } else { Ok("ok") }
             });
             assert_eq!(result.unwrap(), "ok");
             assert_eq!(attempts.get(), 3, "errno {errno} should have been retried twice");

--- a/crates/lockfile/src/resolution.rs
+++ b/crates/lockfile/src/resolution.rs
@@ -172,7 +172,9 @@ mod tests {
         let received: LockfileResolution = serde_yaml::from_str(yaml).unwrap();
         dbg!(&received);
         let expected = LockfileResolution::Registry(RegistryResolution {
-            integrity: integrity("sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==")
+            integrity: integrity(
+                "sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==",
+            ),
         });
         assert_eq!(received, expected);
     }
@@ -180,7 +182,9 @@ mod tests {
     #[test]
     fn serialize_registry_resolution() {
         let resolution = LockfileResolution::Registry(RegistryResolution {
-            integrity: integrity("sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==")
+            integrity: integrity(
+                "sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==",
+            ),
         });
         let received = serde_yaml::to_string(&resolution).unwrap();
         let received = received.trim();

--- a/crates/lockfile/src/save_lockfile.rs
+++ b/crates/lockfile/src/save_lockfile.rs
@@ -1,4 +1,4 @@
-use crate::{serialize_yaml, Lockfile};
+use crate::{Lockfile, serialize_yaml};
 use derive_more::{Display, Error};
 use pacquet_diagnostics::miette::{self, Diagnostic};
 use std::{env, fs, io, path::Path};

--- a/crates/lockfile/src/serialize_yaml.rs
+++ b/crates/lockfile/src/serialize_yaml.rs
@@ -7,7 +7,7 @@
 //! level parity with what pnpm produces.
 
 use serde::Serialize;
-use serde_saphyr::{ser, ser_options, to_string_with_options, SerializerOptions};
+use serde_saphyr::{SerializerOptions, ser, ser_options, to_string_with_options};
 
 /// Serializer options matching pnpm's lockfile output.
 fn options() -> SerializerOptions {

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -1,6 +1,6 @@
 use reqwest::{
-    header::{HeaderMap, HeaderValue, USER_AGENT},
     Client,
+    header::{HeaderMap, HeaderValue, USER_AGENT},
 };
 use std::{num::NonZeroUsize, ops::Deref, time::Duration};
 use tokio::sync::{Semaphore, SemaphorePermit};

--- a/crates/npmrc/src/custom_deserializer.rs
+++ b/crates/npmrc/src/custom_deserializer.rs
@@ -23,12 +23,11 @@ pub fn default_public_hoist_pattern() -> Vec<String> {
 // Get the drive letter from a path on Windows. If it's not a Windows path, return None.
 #[cfg(windows)]
 fn get_drive_letter(current_dir: &Path) -> Option<char> {
-    if let Some(Component::Prefix(prefix_component)) = current_dir.components().next() {
-        if let std::path::Prefix::Disk(disk_byte) | std::path::Prefix::VerbatimDisk(disk_byte) =
+    if let Some(Component::Prefix(prefix_component)) = current_dir.components().next()
+        && let std::path::Prefix::Disk(disk_byte) | std::path::Prefix::VerbatimDisk(disk_byte) =
             prefix_component.kind()
-        {
-            return Some(disk_byte as char);
-        }
+    {
+        return Some(disk_byte as char);
     }
     None
 }

--- a/crates/npmrc/src/custom_deserializer.rs
+++ b/crates/npmrc/src/custom_deserializer.rs
@@ -1,5 +1,5 @@
 use pacquet_store_dir::StoreDir;
-use serde::{de, Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, de};
 use std::{env, path::PathBuf, str::FromStr};
 
 #[cfg(windows)]
@@ -186,7 +186,11 @@ mod tests {
     #[test]
     fn test_default_store_dir_with_pnpm_home_env() {
         let _g = EnvGuard::snapshot(["PNPM_HOME"]);
-        env::set_var("PNPM_HOME", "/tmp/pnpm-home"); // TODO: change this to dependency injection
+        // SAFETY: EnvGuard above serializes the test against other env-mutating
+        // tests in this process; no other thread reads these vars concurrently.
+        unsafe {
+            env::set_var("PNPM_HOME", "/tmp/pnpm-home"); // TODO: change this to dependency injection
+        }
         let store_dir = default_store_dir();
         assert_eq!(display_store_dir(&store_dir), "/tmp/pnpm-home/store");
     }
@@ -202,8 +206,12 @@ mod tests {
         // see the TODO — but this is enough for the failure mode this
         // PR is fixing.
         let _g = EnvGuard::snapshot(["PNPM_HOME", "XDG_DATA_HOME"]);
-        env::remove_var("PNPM_HOME");
-        env::set_var("XDG_DATA_HOME", "/tmp/xdg_data_home");
+        // SAFETY: EnvGuard above serializes the test against other env-mutating
+        // tests in this process; no other thread reads these vars concurrently.
+        unsafe {
+            env::remove_var("PNPM_HOME");
+            env::set_var("XDG_DATA_HOME", "/tmp/xdg_data_home");
+        }
         let store_dir = default_store_dir();
         assert_eq!(display_store_dir(&store_dir), "/tmp/xdg_data_home/pnpm/store");
     }

--- a/crates/npmrc/src/lib.rs
+++ b/crates/npmrc/src/lib.rs
@@ -17,7 +17,7 @@ use crate::custom_deserializer::{
     deserialize_store_dir, deserialize_u32, deserialize_u64,
 };
 pub use workspace_yaml::{
-    workspace_root_or, LoadWorkspaceYamlError, WorkspaceSettings, WORKSPACE_MANIFEST_FILENAME,
+    LoadWorkspaceYamlError, WORKSPACE_MANIFEST_FILENAME, WorkspaceSettings, workspace_root_or,
 };
 
 #[derive(Debug, Deserialize, Default, PartialEq)]
@@ -265,11 +265,11 @@ impl Npmrc {
         // Layer pnpm-workspace.yaml overrides on top. Missing file or
         // unreadable yaml is silently ignored, matching .npmrc's
         // best-effort behaviour above.
-        if let Some(start) = cwd {
-            if let Ok(Some((path, settings))) = WorkspaceSettings::find_and_load(&start) {
-                let base_dir = path.parent().unwrap_or(&start).to_path_buf();
-                settings.apply_to(&mut npmrc, &base_dir);
-            }
+        if let Some(start) = cwd
+            && let Ok(Some((path, settings))) = WorkspaceSettings::find_and_load(&start)
+        {
+            let base_dir = path.parent().unwrap_or(&start).to_path_buf();
+            settings.apply_to(&mut npmrc, &base_dir);
         }
 
         npmrc
@@ -360,7 +360,11 @@ mod tests {
     #[test]
     pub fn should_use_pnpm_home_env_var() {
         let _g = EnvGuard::snapshot(["PNPM_HOME"]);
-        env::set_var("PNPM_HOME", "/hello"); // TODO: change this to dependency injection
+        // SAFETY: EnvGuard above serializes the test against other env-mutating
+        // tests in this process; no other thread reads these vars concurrently.
+        unsafe {
+            env::set_var("PNPM_HOME", "/hello"); // TODO: change this to dependency injection
+        }
         let value: Npmrc = serde_ini::from_str("").unwrap();
         assert_eq!(display_store_dir(&value.store_dir), "/hello/store");
     }
@@ -375,8 +379,12 @@ mod tests {
         // temporarily-unset state. See the companion fix in
         // `custom_deserializer::tests::test_default_store_dir_with_xdg_env`.
         let _g = EnvGuard::snapshot(["PNPM_HOME", "XDG_DATA_HOME"]);
-        env::remove_var("PNPM_HOME"); // TODO: change this to dependency injection
-        env::set_var("XDG_DATA_HOME", "/hello");
+        // SAFETY: EnvGuard above serializes the test against other env-mutating
+        // tests in this process; no other thread reads these vars concurrently.
+        unsafe {
+            env::remove_var("PNPM_HOME"); // TODO: change this to dependency injection
+            env::set_var("XDG_DATA_HOME", "/hello");
+        }
         let value: Npmrc = serde_ini::from_str("").unwrap();
         assert_eq!(display_store_dir(&value.store_dir), "/hello/pnpm/store");
     }

--- a/crates/npmrc/src/test_env_guard.rs
+++ b/crates/npmrc/src/test_env_guard.rs
@@ -69,9 +69,15 @@ impl EnvGuard {
 impl Drop for EnvGuard {
     fn drop(&mut self) {
         for (name, prior) in &self.saved {
-            match prior {
-                Some(value) => env::set_var(name, value),
-                None => env::remove_var(name),
+            // SAFETY: the `_lock` field is still held for the duration of this
+            // `Drop`, so no other env-mutating test in this process is running
+            // concurrently. The variables themselves are only read by tests
+            // that take the same lock.
+            unsafe {
+                match prior {
+                    Some(value) => env::set_var(name, value),
+                    None => env::remove_var(name),
+                }
             }
         }
     }

--- a/crates/npmrc/src/workspace_yaml.rs
+++ b/crates/npmrc/src/workspace_yaml.rs
@@ -167,11 +167,7 @@ impl WorkspaceSettings {
 
 fn resolve(base: &Path, value: &str) -> PathBuf {
     let candidate = PathBuf::from(value);
-    if candidate.is_absolute() {
-        candidate
-    } else {
-        base.join(candidate)
-    }
+    if candidate.is_absolute() { candidate } else { base.join(candidate) }
 }
 
 fn find_workspace_manifest(start: &Path) -> Option<PathBuf> {

--- a/crates/package-manager/src/create_cas_files.rs
+++ b/crates/package-manager/src/create_cas_files.rs
@@ -1,4 +1,4 @@
-use crate::{link_file, LinkFileError};
+use crate::{LinkFileError, link_file};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_npmrc::PackageImportMethod;

--- a/crates/package-manager/src/create_symlink_layout.rs
+++ b/crates/package-manager/src/create_symlink_layout.rs
@@ -1,4 +1,4 @@
-use crate::{symlink_package, SymlinkPackageError};
+use crate::{SymlinkPackageError, symlink_package};
 use pacquet_lockfile::{PkgName, SnapshotDepRef};
 use std::{collections::HashMap, path::Path};
 

--- a/crates/package-manager/src/create_virtual_dir_by_snapshot.rs
+++ b/crates/package-manager/src/create_virtual_dir_by_snapshot.rs
@@ -1,4 +1,4 @@
-use crate::{create_cas_files, create_symlink_layout, CreateCasFilesError, SymlinkPackageError};
+use crate::{CreateCasFilesError, SymlinkPackageError, create_cas_files, create_symlink_layout};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_lockfile::{PackageKey, SnapshotEntry};

--- a/crates/package-manager/src/create_virtual_store.rs
+++ b/crates/package-manager/src/create_virtual_store.rs
@@ -1,5 +1,5 @@
 use crate::{
-    store_init::init_store_dir_best_effort, InstallPackageBySnapshot, InstallPackageBySnapshotError,
+    InstallPackageBySnapshot, InstallPackageBySnapshotError, store_init::init_store_dir_best_effort,
 };
 use derive_more::{Display, Error};
 use futures_util::future;
@@ -7,7 +7,7 @@ use miette::Diagnostic;
 use pacquet_lockfile::{LockfileResolution, PackageKey, PackageMetadata, SnapshotEntry};
 use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
-use pacquet_store_dir::{store_index_key, StoreIndex, StoreIndexWriter};
+use pacquet_store_dir::{StoreIndex, StoreIndexWriter, store_index_key};
 use pacquet_tarball::prefetch_cas_paths;
 use pipe_trait::Pipe;
 use std::collections::HashMap;
@@ -27,7 +27,9 @@ pub enum CreateVirtualStoreError {
     #[diagnostic(transparent)]
     InstallPackageBySnapshot(#[error(source)] InstallPackageBySnapshotError),
 
-    #[display("Lockfile has a snapshot entry `{snapshot_key}` with no matching metadata entry (`{metadata_key}`) in `packages:`.")]
+    #[display(
+        "Lockfile has a snapshot entry `{snapshot_key}` with no matching metadata entry (`{metadata_key}`) in `packages:`."
+    )]
     #[diagnostic(code(pacquet_package_manager::missing_package_metadata))]
     MissingPackageMetadata { snapshot_key: String, metadata_key: String },
 

--- a/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/crates/package-manager/src/install_package_by_snapshot.rs
@@ -1,5 +1,5 @@
 use crate::{
-    retry_config::retry_opts_from_config, CreateVirtualDirBySnapshot, CreateVirtualDirError,
+    CreateVirtualDirBySnapshot, CreateVirtualDirError, retry_config::retry_opts_from_config,
 };
 use derive_more::{Display, Error};
 use miette::Diagnostic;

--- a/crates/package-manager/src/install_package_from_registry.rs
+++ b/crates/package-manager/src/install_package_from_registry.rs
@@ -1,6 +1,6 @@
 use crate::{
-    create_cas_files, retry_config::retry_opts_from_config, symlink_package, CreateCasFilesError,
-    SymlinkPackageError,
+    CreateCasFilesError, SymlinkPackageError, create_cas_files,
+    retry_config::retry_opts_from_config, symlink_package,
 };
 use derive_more::{Display, Error};
 use miette::Diagnostic;

--- a/crates/package-manager/src/install_without_lockfile.rs
+++ b/crates/package-manager/src/install_without_lockfile.rs
@@ -1,6 +1,6 @@
 use crate::{
-    store_init::init_store_dir_best_effort, InstallPackageFromRegistry,
-    InstallPackageFromRegistryError,
+    InstallPackageFromRegistry, InstallPackageFromRegistryError,
+    store_init::init_store_dir_best_effort,
 };
 use async_recursion::async_recursion;
 use dashmap::DashSet;

--- a/crates/package-manager/src/link_file.rs
+++ b/crates/package-manager/src/link_file.rs
@@ -114,13 +114,13 @@ pub fn link_file(
             // / copy doesn't collide with `AlreadyExists` and so the
             // installed package isn't left with a silently-missing
             // file.
-            if let Ok(meta) = fs::symlink_metadata(target_link) {
-                if meta.file_type().is_symlink() {
-                    fs::remove_file(target_link).map_err(|error| LinkFileError::RemoveStale {
-                        path: target_link.to_path_buf(),
-                        error,
-                    })?;
-                }
+            if let Ok(meta) = fs::symlink_metadata(target_link)
+                && meta.file_type().is_symlink()
+            {
+                fs::remove_file(target_link).map_err(|error| LinkFileError::RemoveStale {
+                    path: target_link.to_path_buf(),
+                    error,
+                })?;
             }
         }
         Err(_) => {

--- a/crates/package-manager/src/symlink_package.rs
+++ b/crates/package-manager/src/symlink_package.rs
@@ -51,7 +51,7 @@ pub fn symlink_package(
                     symlink_target: symlink_target.to_path_buf(),
                     symlink_path: symlink_path.to_path_buf(),
                     error,
-                })
+                });
             }
         }
     }

--- a/crates/package-manifest/src/lib.rs
+++ b/crates/package-manifest/src/lib.rs
@@ -7,7 +7,7 @@ use std::{
 use derive_more::{Display, Error, From};
 use miette::Diagnostic;
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Map, Value};
+use serde_json::{Map, Value, json};
 use strum::IntoStaticStr;
 
 #[derive(Debug, Display, Error, From, Diagnostic)]
@@ -203,11 +203,7 @@ impl PackageManifest {
             return Ok(Some(script_str));
         }
 
-        if if_present {
-            Ok(None)
-        } else {
-            Err(PackageManifestError::NoScript(command.to_string()))
-        }
+        if if_present { Ok(None) } else { Err(PackageManifestError::NoScript(command.to_string())) }
     }
 }
 
@@ -218,7 +214,7 @@ mod tests {
     use insta::assert_snapshot;
     use pipe_trait::Pipe;
     use pretty_assertions::assert_eq;
-    use tempfile::{tempdir, NamedTempFile};
+    use tempfile::{NamedTempFile, tempdir};
 
     use super::*;
     use crate::DependencyGroup;

--- a/crates/registry/src/package.rs
+++ b/crates/registry/src/package.rs
@@ -7,7 +7,7 @@ use pacquet_network::ThrottledClient;
 use pipe_trait::Pipe;
 use serde::{Deserialize, Serialize};
 
-use crate::{package_version::PackageVersion, NetworkError, RegistryError};
+use crate::{NetworkError, RegistryError, package_version::PackageVersion};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Package {

--- a/crates/registry/src/package_version.rs
+++ b/crates/registry/src/package_version.rs
@@ -4,7 +4,7 @@ use pacquet_network::ThrottledClient;
 use pipe_trait::Pipe;
 use serde::{Deserialize, Serialize};
 
-use crate::{package_distribution::PackageDistribution, NetworkError, PackageTag, RegistryError};
+use crate::{NetworkError, PackageTag, RegistryError, package_distribution::PackageDistribution};
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq)]
 #[serde(rename_all = "camelCase")]

--- a/crates/store-dir/src/cas_file.rs
+++ b/crates/store-dir/src/cas_file.rs
@@ -2,9 +2,8 @@ use crate::{FileHash, StoreDir};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_fs::{
-    ensure_file, ensure_parent_dir,
-    file_mode::{is_executable, EXEC_MODE},
-    EnsureFileError,
+    EnsureFileError, ensure_file, ensure_parent_dir,
+    file_mode::{EXEC_MODE, is_executable},
 };
 use sha2::{Digest, Sha512};
 use std::path::PathBuf;

--- a/crates/store-dir/src/store_dir.rs
+++ b/crates/store-dir/src/store_dir.rs
@@ -1,6 +1,6 @@
 use dashmap::DashSet;
 use serde::{Deserialize, Serialize};
-use sha2::{digest, Sha512};
+use sha2::{Sha512, digest};
 use std::path::{self, PathBuf};
 
 /// Content hash of a file.

--- a/crates/store-dir/src/store_index.rs
+++ b/crates/store-dir/src/store_index.rs
@@ -7,8 +7,8 @@ use std::{
     collections::HashMap,
     path::{Path, PathBuf},
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
     },
 };
 
@@ -143,14 +143,14 @@ impl StoreIndexWriter {
     /// snapshot install that's a thousand identical warnings drowning
     /// out real diagnostics.
     pub fn queue(&self, key: String, value: PackageFilesIndex) {
-        if let Err(error) = self.tx.send((key, value)) {
-            if self.warn_on_send_failure.swap(false, Ordering::Relaxed) {
-                tracing::warn!(
-                    target: "pacquet::store_index",
-                    ?error,
-                    "store-index writer channel closed; dropping queued row (further failures silenced)",
-                );
-            }
+        if let Err(error) = self.tx.send((key, value))
+            && self.warn_on_send_failure.swap(false, Ordering::Relaxed)
+        {
+            tracing::warn!(
+                target: "pacquet::store_index",
+                ?error,
+                "store-index writer channel closed; dropping queued row (further failures silenced)",
+            );
         }
     }
 }

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -12,15 +12,15 @@ use miette::Diagnostic;
 use pacquet_fs::file_mode;
 use pacquet_network::ThrottledClient;
 use pacquet_store_dir::{
-    store_index_key, CafsFileInfo, PackageFilesIndex, SharedReadonlyStoreIndex, StoreDir,
-    StoreIndexError, StoreIndexWriter, WriteCasFileError,
+    CafsFileInfo, PackageFilesIndex, SharedReadonlyStoreIndex, StoreDir, StoreIndexError,
+    StoreIndexWriter, WriteCasFileError, store_index_key,
 };
 use pipe_trait::Pipe;
 use ssri::Integrity;
 use tar::Archive;
 use tokio::sync::{Notify, RwLock, Semaphore};
 use tracing::instrument;
-use zune_inflate::{errors::InflateDecodeErrors, DeflateDecoder, DeflateOptions};
+use zune_inflate::{DeflateDecoder, DeflateOptions, errors::InflateDecodeErrors};
 
 /// Cap on concurrent post-download tarball work (SHA-512 of the whole
 /// tarball + gzip inflate + per-file SHA-512 + CAFS writes). The body is
@@ -983,16 +983,16 @@ impl<'a> DownloadTarballToStore<'a> {
         // run. Propagating the `Arc` through this signature would
         // require a wider refactor of `DownloadTarballToStore`'s
         // return type.
-        if let Some(prefetched) = prefetched_cas_paths {
-            if let Some(cas_paths) = prefetched.get(&cache_key) {
-                tracing::info!(
-                    target: "pacquet::download",
-                    ?package_url,
-                    ?package_id,
-                    "Reusing prefetched CAFS entry — skipping download",
-                );
-                return Ok((**cas_paths).clone());
-            }
+        if let Some(prefetched) = prefetched_cas_paths
+            && let Some(cas_paths) = prefetched.get(&cache_key)
+        {
+            tracing::info!(
+                target: "pacquet::download",
+                ?package_url,
+                ?package_id,
+                "Reusing prefetched CAFS entry — skipping download",
+            );
+            return Ok((**cas_paths).clone());
         }
         if let Some(cas_paths) =
             load_cached_cas_paths(store_index, store_dir, cache_key, verify_store_integrity).await
@@ -1051,7 +1051,7 @@ mod tests {
     use pacquet_store_dir::StoreIndex;
     use pipe_trait::Pipe;
     use pretty_assertions::assert_eq;
-    use tempfile::{tempdir, TempDir};
+    use tempfile::{TempDir, tempdir};
 
     use super::*;
 
@@ -1285,8 +1285,9 @@ mod tests {
         let (bin_path, bin_hash) =
             store_path.write_cas_file(b"#!/usr/bin/env node\nconsole.log('hi');\n", true).unwrap();
 
-        let pkg_integrity =
-            integrity("sha512-q/IXcMGuF8v7ZLf/JeYfE/pB4Wg1yxT6jXJz8JxRK7a4mJSXV1QKMXDPfZkvMHTZpYxWBDoJiXtptDWFnoCA2w==");
+        let pkg_integrity = integrity(
+            "sha512-q/IXcMGuF8v7ZLf/JeYfE/pB4Wg1yxT6jXJz8JxRK7a4mJSXV1QKMXDPfZkvMHTZpYxWBDoJiXtptDWFnoCA2w==",
+        );
         let pkg_id = "fake@1.0.0";
         let index_key = store_index_key(&pkg_integrity.to_string(), pkg_id);
 
@@ -1358,8 +1359,9 @@ mod tests {
     /// `package_url` proves the network path is also bypassed.
     #[tokio::test]
     async fn reuses_prefetched_cas_paths_when_provided() {
-        let pkg_integrity =
-            integrity("sha512-q/IXcMGuF8v7ZLf/JeYfE/pB4Wg1yxT6jXJz8JxRK7a4mJSXV1QKMXDPfZkvMHTZpYxWBDoJiXtptDWFnoCA2w==");
+        let pkg_integrity = integrity(
+            "sha512-q/IXcMGuF8v7ZLf/JeYfE/pB4Wg1yxT6jXJz8JxRK7a4mJSXV1QKMXDPfZkvMHTZpYxWBDoJiXtptDWFnoCA2w==",
+        );
         let pkg_id = "fake@1.0.0";
         let cache_key = store_index_key(&pkg_integrity.to_string(), pkg_id);
 
@@ -1414,8 +1416,9 @@ mod tests {
         let (pkg_json_path, pkg_json_hash) =
             store_path.write_cas_file(b"{\"name\":\"fake\"}", false).unwrap();
 
-        let pkg_integrity =
-            integrity("sha512-q/IXcMGuF8v7ZLf/JeYfE/pB4Wg1yxT6jXJz8JxRK7a4mJSXV1QKMXDPfZkvMHTZpYxWBDoJiXtptDWFnoCA2w==");
+        let pkg_integrity = integrity(
+            "sha512-q/IXcMGuF8v7ZLf/JeYfE/pB4Wg1yxT6jXJz8JxRK7a4mJSXV1QKMXDPfZkvMHTZpYxWBDoJiXtptDWFnoCA2w==",
+        );
         let pkg_id = "fake@1.0.0";
         let index_key = store_index_key(&pkg_integrity.to_string(), pkg_id);
 
@@ -1463,8 +1466,9 @@ mod tests {
     async fn prefetch_cas_paths_omits_failed_integrity_entries() {
         let (store_dir, store_path) = tempdir_with_leaked_path();
 
-        let pkg_integrity =
-            integrity("sha512-q/IXcMGuF8v7ZLf/JeYfE/pB4Wg1yxT6jXJz8JxRK7a4mJSXV1QKMXDPfZkvMHTZpYxWBDoJiXtptDWFnoCA2w==");
+        let pkg_integrity = integrity(
+            "sha512-q/IXcMGuF8v7ZLf/JeYfE/pB4Wg1yxT6jXJz8JxRK7a4mJSXV1QKMXDPfZkvMHTZpYxWBDoJiXtptDWFnoCA2w==",
+        );
         let pkg_id = "fake@1.0.0";
         let index_key = store_index_key(&pkg_integrity.to_string(), pkg_id);
 
@@ -1502,7 +1506,7 @@ mod tests {
         .await;
 
         assert!(
-            prefetched.get(&index_key).is_none(),
+            !prefetched.contains_key(&index_key),
             "row that fails integrity must not appear in prefetch result",
         );
         drop(store_dir);
@@ -1520,8 +1524,9 @@ mod tests {
     async fn prefetch_cas_paths_skips_filesystem_checks_when_verify_disabled() {
         let (store_dir, store_path) = tempdir_with_leaked_path();
 
-        let pkg_integrity =
-            integrity("sha512-q/IXcMGuF8v7ZLf/JeYfE/pB4Wg1yxT6jXJz8JxRK7a4mJSXV1QKMXDPfZkvMHTZpYxWBDoJiXtptDWFnoCA2w==");
+        let pkg_integrity = integrity(
+            "sha512-q/IXcMGuF8v7ZLf/JeYfE/pB4Wg1yxT6jXJz8JxRK7a4mJSXV1QKMXDPfZkvMHTZpYxWBDoJiXtptDWFnoCA2w==",
+        );
         let pkg_id = "fake@1.0.0";
         let index_key = store_index_key(&pkg_integrity.to_string(), pkg_id);
 
@@ -1573,8 +1578,9 @@ mod tests {
     async fn falls_through_when_cafs_file_missing() {
         let (store_dir, store_path) = tempdir_with_leaked_path();
 
-        let pkg_integrity =
-            integrity("sha512-q/IXcMGuF8v7ZLf/JeYfE/pB4Wg1yxT6jXJz8JxRK7a4mJSXV1QKMXDPfZkvMHTZpYxWBDoJiXtptDWFnoCA2w==");
+        let pkg_integrity = integrity(
+            "sha512-q/IXcMGuF8v7ZLf/JeYfE/pB4Wg1yxT6jXJz8JxRK7a4mJSXV1QKMXDPfZkvMHTZpYxWBDoJiXtptDWFnoCA2w==",
+        );
         let pkg_id = "fake@1.0.0";
         let index_key = store_index_key(&pkg_integrity.to_string(), pkg_id);
 
@@ -1630,8 +1636,9 @@ mod tests {
     async fn falls_through_when_digest_is_malformed() {
         let (store_dir, store_path) = tempdir_with_leaked_path();
 
-        let pkg_integrity =
-            integrity("sha512-q/IXcMGuF8v7ZLf/JeYfE/pB4Wg1yxT6jXJz8JxRK7a4mJSXV1QKMXDPfZkvMHTZpYxWBDoJiXtptDWFnoCA2w==");
+        let pkg_integrity = integrity(
+            "sha512-q/IXcMGuF8v7ZLf/JeYfE/pB4Wg1yxT6jXJz8JxRK7a4mJSXV1QKMXDPfZkvMHTZpYxWBDoJiXtptDWFnoCA2w==",
+        );
         let pkg_id = "fake@1.0.0";
         let index_key = store_index_key(&pkg_integrity.to_string(), pkg_id);
 
@@ -1684,8 +1691,9 @@ mod tests {
     async fn falls_through_when_cafs_path_is_a_directory() {
         let (store_dir, store_path) = tempdir_with_leaked_path();
 
-        let pkg_integrity =
-            integrity("sha512-q/IXcMGuF8v7ZLf/JeYfE/pB4Wg1yxT6jXJz8JxRK7a4mJSXV1QKMXDPfZkvMHTZpYxWBDoJiXtptDWFnoCA2w==");
+        let pkg_integrity = integrity(
+            "sha512-q/IXcMGuF8v7ZLf/JeYfE/pB4Wg1yxT6jXJz8JxRK7a4mJSXV1QKMXDPfZkvMHTZpYxWBDoJiXtptDWFnoCA2w==",
+        );
         let pkg_id = "fake@1.0.0";
         let index_key = store_index_key(&pkg_integrity.to_string(), pkg_id);
 
@@ -1744,8 +1752,9 @@ mod tests {
     async fn falls_through_when_cafs_path_is_a_symlink() {
         let (store_dir, store_path) = tempdir_with_leaked_path();
 
-        let pkg_integrity =
-            integrity("sha512-q/IXcMGuF8v7ZLf/JeYfE/pB4Wg1yxT6jXJz8JxRK7a4mJSXV1QKMXDPfZkvMHTZpYxWBDoJiXtptDWFnoCA2w==");
+        let pkg_integrity = integrity(
+            "sha512-q/IXcMGuF8v7ZLf/JeYfE/pB4Wg1yxT6jXJz8JxRK7a4mJSXV1QKMXDPfZkvMHTZpYxWBDoJiXtptDWFnoCA2w==",
+        );
         let pkg_id = "fake@1.0.0";
         let index_key = store_index_key(&pkg_integrity.to_string(), pkg_id);
 
@@ -1963,8 +1972,7 @@ mod tests {
     /// the retry loop without going to the live registry.
     const FASTIFY_ERROR_TARBALL: &[u8] =
         include_bytes!("../../../tasks/micro-benchmark/fixtures/@fastify+error-3.3.0.tgz");
-    const FASTIFY_ERROR_INTEGRITY: &str =
-        "sha512-dj7vjIn1Ar8sVXj2yAXiMNCJDmS9MQ9XMlIecX2dIzzhjSHCyKo4DdXjXMs7wKW2kj6yvVRSpuQjOZ3YLrh56w==";
+    const FASTIFY_ERROR_INTEGRITY: &str = "sha512-dj7vjIn1Ar8sVXj2yAXiMNCJDmS9MQ9XMlIecX2dIzzhjSHCyKo4DdXjXMs7wKW2kj6yvVRSpuQjOZ3YLrh56w==";
 
     /// `RetryOpts` for the mockito tests below: keep the 2-retry budget
     /// so we exercise the full attempt count, but collapse the backoff

--- a/crates/testing-utils/src/bin.rs
+++ b/crates/testing-utils/src/bin.rs
@@ -2,7 +2,7 @@ use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pacquet_registry_mock::AutoMockInstance;
 use std::{fs, path::PathBuf, process::Command};
-use tempfile::{tempdir, TempDir};
+use tempfile::{TempDir, tempdir};
 use text_block_macros::text_block_fnl;
 
 /// Assets for an integration test involving spawning `pacquet` and/or `pnpm` as

--- a/tasks/registry-mock/src/mock_instance.rs
+++ b/tasks/registry-mock/src/mock_instance.rs
@@ -1,6 +1,6 @@
 use crate::{
-    kill_verdaccio::kill_all_verdaccio_children, node_registry_mock, port_to_url::port_to_url,
     PreparedRegistryInfo, RegistryAnchor, RegistryInfo,
+    kill_verdaccio::kill_all_verdaccio_children, node_registry_mock, port_to_url::port_to_url,
 };
 use assert_cmd::prelude::*;
 use pipe_trait::Pipe;
@@ -12,7 +12,7 @@ use std::{
     process::{Child, Command, Stdio},
 };
 use sysinfo::{Pid, Signal};
-use tokio::time::{sleep, Duration};
+use tokio::time::{Duration, sleep};
 
 /// Handler of a mocked registry server instance.
 ///
@@ -139,15 +139,14 @@ impl AutoMockInstance {
             return AutoMockInstance::Prepared(prepared);
         }
 
-        let anchor = RegistryAnchor::load_or_init({
-            MockInstanceOptions {
-                client: &Client::new(),
-                port: pick_unused_port().expect("pick an unused port"),
-                stdout: None,
-                stderr: None,
-                max_retries: 20,
-                retry_delay: Duration::from_millis(500),
-            }
+        let client = Client::new();
+        let anchor = RegistryAnchor::load_or_init(MockInstanceOptions {
+            client: &client,
+            port: pick_unused_port().expect("pick an unused port"),
+            stdout: None,
+            stderr: None,
+            max_retries: 20,
+            retry_delay: Duration::from_millis(500),
         });
 
         AutoMockInstance::RefCount(anchor)

--- a/tasks/registry-mock/src/registry_anchor.rs
+++ b/tasks/registry-mock/src/registry_anchor.rs
@@ -1,4 +1,4 @@
-use crate::{kill_verdaccio::kill_all_verdaccio_children, MockInstanceOptions, RegistryInfo};
+use crate::{MockInstanceOptions, RegistryInfo, kill_verdaccio::kill_all_verdaccio_children};
 use pipe_trait::Pipe;
 use serde::{Deserialize, Serialize};
 use std::{

--- a/tasks/registry-mock/src/registry_info.rs
+++ b/tasks/registry-mock/src/registry_info.rs
@@ -1,5 +1,5 @@
 use crate::{
-    kill_verdaccio::kill_all_verdaccio_children, port_to_url::port_to_url, MockInstanceOptions,
+    MockInstanceOptions, kill_verdaccio::kill_all_verdaccio_children, port_to_url::port_to_url,
 };
 use pipe_trait::Pipe;
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
## Summary

Bump the workspace `edition` to `2024` in `Cargo.toml`. The toolchain is already pinned at `1.95.0` (latest stable, released 2026-04-14), which has 2024 edition support, so `rust-toolchain.toml` is unchanged.

`main` has been merged in three times as it advanced ahead of the branch (commits `9f5bed4`, `bfc4e6d`, `6f8e8c8`). The first merge picked up the dependabot bumps, the rusqlite 0.39 upgrade, and #319 (`PathBuf::from` → `Path::new`), with two trivial conflicts resolved in `crates/npmrc/src/{custom_deserializer.rs, workspace_yaml.rs}`. The second pulled in #320 (`refactor: replace serde_yaml with serde_saphyr`), whose new files needed import re-sorting under the 2024 style edition. The third pulled in #321 (`refactor: adopt smart-default`), which merged cleanly with no follow-up work.

## Code changes required by edition 2024

- **`unsafe` env mutation** (`crates/npmrc/src/{lib.rs,custom_deserializer.rs,test_env_guard.rs}`) — `env::set_var` / `env::remove_var` now require an `unsafe` block. Wrapped each call site with a `// SAFETY:` comment noting that the test-only `EnvGuard` already serializes mutation against the rest of the process via a `Mutex<()>`, so the safety contract ("no other thread accesses the env concurrently") still holds. The `unsafe` markers just make that contract explicit.
- **Temporary lifetimes** (`tasks/registry-mock/src/mock_instance.rs`) — edition 2024 shortens temporary lifetimes in `let` initializers. The previous `client: &Client::new()` inside a struct literal would have dangled before the borrow ended, so the `Client` is now bound to a named local that outlives `MockInstanceOptions`.
- **`clippy::collapsible_if`** (`crates/store-dir/src/store_index.rs`, `crates/npmrc/src/lib.rs`, `crates/npmrc/src/custom_deserializer.rs`, `crates/tarball/src/lib.rs`, `crates/package-manager/src/link_file.rs`) — collapsed nested `if let { if let { … } }` chains into `if let … && let …`. Let-chains are stable in 2024. The Windows-only `get_drive_letter` helper was caught by Windows CI and fixed in commit `7c0ce21`.
- **`clippy::unnecessary_get_then_check`** (`crates/tarball/src/lib.rs`) — replaced `prefetched.get(&index_key).is_none()` with `!prefetched.contains_key(&index_key)`.
- **Match-arm terminator** (`crates/package-manager/src/symlink_package.rs`) — added a trailing `;` to a diverging `return Err(…)` arm to satisfy the stricter 2024 statement/expression boundary.

## Formatting churn from `cargo fmt` under the 2024 style edition

Most of the remaining diff is mechanical:

- alphabetical reordering of names inside grouped `use { … }` blocks (every crate that grouped multiple imports per `use`). Two of these landed in `crates/lockfile/src/{save_lockfile.rs, serialize_yaml.rs}` only after merging #320 from main (commit `bfc4e6d`), since those files were added by that upstream refactor.
- collapsing trivial `if … { x } else { y }` blocks onto one line (`crates/fs/src/ensure_file.rs`, `crates/npmrc/src/workspace_yaml.rs`, `crates/package-manifest/src/lib.rs`).
- reflowing long struct-literal/`#[display(...)]`/`assert!` argument lists across multiple lines (`crates/lockfile/src/resolution.rs`, `crates/package-manager/src/create_virtual_store.rs`, `crates/tarball/src/lib.rs`, `crates/cli/tests/add.rs`).

## Coverage note

codecov flags 7 lines as missing patch coverage. They are an artifact of how the line counter sees the edition-2024 reshape rather than newly-introduced untested behaviour:

- `crates/npmrc/src/test_env_guard.rs` — the new `unsafe { … }` wrapper around the existing `match` adds an opening line that the line counter records separately from the `match` body it now contains.
- `crates/store-dir/src/store_index.rs`, `crates/package-manager/src/link_file.rs` — the `if let X { if Y { … } }` → `if let X && Y { … }` collapse moves the inner condition onto a new "line" whose short-circuit half is counted as its own branch. The same code paths were already covered before the rewrite.
- `crates/package-manager/src/symlink_package.rs` — the trailing `;` on the diverging `return Err(…)` arm registers as a fresh line.

No covered behaviour was removed and no new branches were introduced; chasing the delta would mean writing tests that exercise rearranged whitespace.

## Test plan

- [x] `cargo check --locked --tests --workspace`
- [x] `cargo clippy --locked --all-targets -- --deny warnings`
- [x] `cargo fmt --all -- --check`
- [x] `taplo format --check`
- [x] `cargo test --locked --lib --workspace` (skipping `should_install_dependencies` and `should_find_package_version_from_registry`, which hit `registry.npmjs.com` — the sandbox blocks external network and these tests are unrelated to the edition change)
- [ ] CI: `just ready` + integration tests with the mock registry running (cannot run locally — `just`, `nextest`, and `pnpm` are unavailable in the sandbox; cross-compiling to Windows fails because `sha2-asm` rejects the target, so the Windows-only fix in `7c0ce21` relied on the next CI run)

https://claude.ai/code/session_0148hrpVtoeyvHpRDyWiGLxV