### PR TITLE
fix(package-manager): handle npm-alias dependency specs

### DIFF
--- a/crates/package-manager/src/install.rs
+++ b/crates/package-manager/src/install.rs
@@ -328,6 +328,80 @@ mod tests {
         drop(dir);
     }
 
+    /// Issue #312: an npm-alias dependency
+    /// (`"<key>": "npm:<real>@<range>"`) used to panic during install
+    /// because the whole `npm:...` spec was fed to
+    /// `node_semver::Range::parse`. Assert that:
+    ///
+    /// * the install completes,
+    /// * the virtual-store directory uses the *real* package name, and
+    /// * the symlink under `node_modules/` uses the alias key.
+    ///
+    /// Mirrors pnpm's `parseBareSpecifier`. Reference:
+    /// <https://github.com/pnpm/pnpm/blob/1819226b51/resolving/npm-resolver/src/parseBareSpecifier.ts>
+    #[tokio::test]
+    async fn npm_alias_dependency_installs_under_alias_key() {
+        let mock_instance = AutoMockInstance::load_or_init();
+
+        let dir = tempdir().unwrap();
+        let store_dir = dir.path().join("pacquet-store");
+        let project_root = dir.path().join("project");
+        let modules_dir = project_root.join("node_modules");
+        let virtual_store_dir = modules_dir.join(".pacquet");
+
+        let manifest_path = dir.path().join("package.json");
+        let mut manifest = PackageManifest::create_if_needed(manifest_path.clone()).unwrap();
+
+        manifest
+            .add_dependency(
+                "hello-world-alias",
+                "npm:@pnpm.e2e/hello-world-js-bin@1.0.0",
+                DependencyGroup::Prod,
+            )
+            .unwrap();
+        manifest.save().unwrap();
+
+        let mut config = Npmrc::new();
+        config.store_dir = store_dir.into();
+        config.modules_dir = modules_dir.to_path_buf();
+        config.virtual_store_dir = virtual_store_dir.to_path_buf();
+        config.registry = mock_instance.url();
+        let config = config.leak();
+
+        Install {
+            tarball_mem_cache: &Default::default(),
+            http_client: &Default::default(),
+            config,
+            manifest: &manifest,
+            lockfile: None,
+            dependency_groups: [DependencyGroup::Prod],
+            frozen_lockfile: false,
+            resolved_packages: &Default::default(),
+        }
+        .run()
+        .await
+        .expect("npm-alias install should succeed");
+
+        // Symlink lives under the alias key, *not* the real package name.
+        let alias_link = project_root.join("node_modules/hello-world-alias");
+        assert!(
+            is_symlink_or_junction(&alias_link).unwrap(),
+            "expected alias symlink at {alias_link:?}",
+        );
+        assert!(
+            !project_root.join("node_modules/@pnpm.e2e/hello-world-js-bin").exists(),
+            "the real package name must not be exposed alongside an unrelated alias",
+        );
+
+        // Virtual-store directory uses the real package name.
+        let virtual_store_path =
+            project_root.join("node_modules/.pacquet/@pnpm.e2e+hello-world-js-bin@1.0.0");
+        assert!(virtual_store_path.is_dir(), "expected real-name virtual store dir");
+        assert!(virtual_store_path.join("node_modules/@pnpm.e2e/hello-world-js-bin").is_dir());
+
+        drop((dir, mock_instance));
+    }
+
     /// Symmetric negative: `--frozen-lockfile` with no lockfile
     /// loadable must surface `NoLockfile`, even when `config.lockfile`
     /// is `false` (which used to fall through to the no-lockfile path

--- a/crates/package-manager/src/install.rs
+++ b/crates/package-manager/src/install.rs
@@ -402,6 +402,87 @@ mod tests {
         drop((dir, mock_instance));
     }
 
+    /// Issue #312, unversioned variant: `"foo": "npm:bar"` (no `@<range>`)
+    /// must default to `latest` without panicking. `resolve_registry_dependency`
+    /// turns `"npm:bar"` into `("bar", "latest")`; the previous code then
+    /// fed `"latest"` to `package.pinned_version()` which panics because
+    /// `node_semver::Range` cannot parse the string. The fix is to route
+    /// `"latest"` (and any `PackageTag`-parseable value) through
+    /// `PackageVersion::fetch_from_registry` directly.
+    ///
+    /// We use the same scoped test package as the pinned-version test above
+    /// but omit the `@1.0.0` suffix to trigger the default-to-`latest` path.
+    #[tokio::test]
+    async fn unversioned_npm_alias_defaults_to_latest() {
+        let mock_instance = AutoMockInstance::load_or_init();
+
+        let dir = tempdir().unwrap();
+        let store_dir = dir.path().join("pacquet-store");
+        let project_root = dir.path().join("project");
+        let modules_dir = project_root.join("node_modules");
+        let virtual_store_dir = modules_dir.join(".pacquet");
+
+        let manifest_path = dir.path().join("package.json");
+        let mut manifest = PackageManifest::create_if_needed(manifest_path.clone()).unwrap();
+
+        // No `@<version>` — should resolve to the `latest` tag.
+        manifest
+            .add_dependency(
+                "hello-world-alias",
+                "npm:@pnpm.e2e/hello-world-js-bin",
+                DependencyGroup::Prod,
+            )
+            .unwrap();
+        manifest.save().unwrap();
+
+        let mut config = Npmrc::new();
+        config.store_dir = store_dir.into();
+        config.modules_dir = modules_dir.to_path_buf();
+        config.virtual_store_dir = virtual_store_dir.to_path_buf();
+        config.registry = mock_instance.url();
+        let config = config.leak();
+
+        Install {
+            tarball_mem_cache: &Default::default(),
+            http_client: &Default::default(),
+            config,
+            manifest: &manifest,
+            lockfile: None,
+            dependency_groups: [DependencyGroup::Prod],
+            frozen_lockfile: false,
+            resolved_packages: &Default::default(),
+        }
+        .run()
+        .await
+        .expect("unversioned npm-alias install should succeed (defaults to latest)");
+
+        // Symlink lives under the alias key, not the real package name.
+        let alias_link = project_root.join("node_modules/hello-world-alias");
+        assert!(
+            is_symlink_or_junction(&alias_link).unwrap(),
+            "expected alias symlink at {alias_link:?}",
+        );
+        assert!(
+            !project_root.join("node_modules/@pnpm.e2e/hello-world-js-bin").exists(),
+            "the real package name must not be exposed alongside the alias",
+        );
+
+        // Virtual-store directory uses the real package name (version resolved
+        // at runtime from `latest` — just assert the real name prefix exists).
+        let virtual_store_dir_path = project_root.join("node_modules/.pacquet");
+        let has_real_name_dir = std::fs::read_dir(&virtual_store_dir_path)
+            .unwrap()
+            .flatten()
+            .any(|e| {
+                e.file_name()
+                    .to_string_lossy()
+                    .starts_with("@pnpm.e2e+hello-world-js-bin@")
+            });
+        assert!(has_real_name_dir, "expected real-name virtual store directory");
+
+        drop((dir, mock_instance));
+    }
+
     /// Symmetric negative: `--frozen-lockfile` with no lockfile
     /// loadable must surface `NoLockfile`, even when `config.lockfile`
     /// is `false` (which used to fall through to the no-lockfile path

--- a/crates/package-manager/src/install.rs
+++ b/crates/package-manager/src/install.rs
@@ -473,11 +473,7 @@ mod tests {
         let has_real_name_dir = std::fs::read_dir(&virtual_store_dir_path)
             .unwrap()
             .flatten()
-            .any(|e| {
-                e.file_name()
-                    .to_string_lossy()
-                    .starts_with("@pnpm.e2e+hello-world-js-bin@")
-            });
+            .any(|e| e.file_name().to_string_lossy().starts_with("@pnpm.e2e+hello-world-js-bin@"));
         assert!(has_real_name_dir, "expected real-name virtual store directory");
 
         drop((dir, mock_instance));

--- a/crates/package-manager/src/install_package_from_registry.rs
+++ b/crates/package-manager/src/install_package_from_registry.rs
@@ -6,6 +6,7 @@ use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
+use pacquet_package_manifest::PackageManifest;
 use pacquet_registry::{Package, PackageTag, PackageVersion, RegistryError};
 use pacquet_store_dir::{SharedReadonlyStoreIndex, StoreIndexWriter};
 use pacquet_tarball::{DownloadTarballToStore, MemCache, TarballError};
@@ -16,8 +17,14 @@ use std::{path::Path, str::FromStr, sync::Arc};
 /// * Extracts the tarball to global store directory (~/Library/../pacquet)
 /// * Links global store directory to virtual dir (node_modules/.pacquet/..)
 ///
-/// `symlink_path` will be appended by the name of the package. Therefore,
-/// it should be resolved into the node_modules folder of a subdependency such as
+/// `name` is the manifest dependency key — the directory name the
+/// package will be exposed as inside `node_modules`. For an npm-alias
+/// entry (`"foo": "npm:bar@^1.0.0"`), `name` is the local alias (`foo`)
+/// and the actual registry package name (`bar`) is parsed out of
+/// `version_range` before the registry lookup.
+///
+/// `symlink_path` will be appended by `name`. Therefore, it should be
+/// resolved into the node_modules folder of a subdependency such as
 /// `node_modules/.pacquet/fastify@1.0.0/node_modules`.
 #[must_use]
 pub struct InstallPackageFromRegistry<'a> {
@@ -48,9 +55,15 @@ impl<'a> InstallPackageFromRegistry<'a> {
     {
         let &InstallPackageFromRegistry { http_client, config, name, version_range, .. } = &self;
 
+        // Strip any `npm:<name>@<range>` alias prefix before talking to
+        // the registry. `name` (the manifest key) stays as the directory
+        // name inside `node_modules`.
+        let (registry_name, version_range) =
+            PackageManifest::resolve_registry_dependency(name, version_range);
+
         Ok(if let Ok(tag) = version_range.parse::<Tag>() {
             let package_version = PackageVersion::fetch_from_registry(
-                name,
+                registry_name,
                 tag.into(),
                 http_client,
                 &config.registry,
@@ -60,9 +73,10 @@ impl<'a> InstallPackageFromRegistry<'a> {
             self.install_package_version(&package_version).await?;
             package_version
         } else {
-            let package = Package::fetch_from_registry(name, http_client, &config.registry)
-                .await
-                .map_err(InstallPackageFromRegistryError::FetchFromRegistry)?;
+            let package =
+                Package::fetch_from_registry(registry_name, http_client, &config.registry)
+                    .await
+                    .map_err(InstallPackageFromRegistryError::FetchFromRegistry)?;
             let package_version = package.pinned_version(version_range).unwrap(); // TODO: propagate error for when no version satisfies range
             self.install_package_version(package_version).await?;
             package_version.clone()
@@ -80,6 +94,7 @@ impl<'a> InstallPackageFromRegistry<'a> {
             store_index,
             store_index_writer,
             node_modules_dir,
+            name,
             ..
         } = self;
 
@@ -108,13 +123,18 @@ impl<'a> InstallPackageFromRegistry<'a> {
         .await
         .map_err(InstallPackageFromRegistryError::DownloadTarballToStore)?;
 
+        // The virtual store always uses the registry-returned name
+        // (`package_version.name`), so npm-alias entries share a single
+        // virtual store directory with their non-aliased counterparts.
+        // The exposed symlink under `node_modules/` uses the manifest
+        // key (`name`) so both forms can coexist in the same parent.
         let save_path = config
             .virtual_store_dir
             .join(store_folder_name)
             .join("node_modules")
             .join(&package_version.name);
 
-        let symlink_path = node_modules_dir.join(&package_version.name);
+        let symlink_path = node_modules_dir.join(name);
 
         tracing::info!(target: "pacquet::import", ?save_path, ?symlink_path, "Import package");
 

--- a/crates/package-manager/src/install_package_from_registry.rs
+++ b/crates/package-manager/src/install_package_from_registry.rs
@@ -10,7 +10,7 @@ use pacquet_package_manifest::PackageManifest;
 use pacquet_registry::{Package, PackageTag, PackageVersion, RegistryError};
 use pacquet_store_dir::{SharedReadonlyStoreIndex, StoreIndexWriter};
 use pacquet_tarball::{DownloadTarballToStore, MemCache, TarballError};
-use std::{path::Path, str::FromStr, sync::Arc};
+use std::{path::Path, sync::Arc};
 
 /// This subroutine executes the following and returns the package
 /// * Retrieves the package from the registry
@@ -49,22 +49,25 @@ pub enum InstallPackageFromRegistryError {
 
 impl<'a> InstallPackageFromRegistry<'a> {
     /// Execute the subroutine.
-    pub async fn run<Tag>(self) -> Result<PackageVersion, InstallPackageFromRegistryError>
-    where
-        Tag: FromStr + Into<PackageTag>,
-    {
+    pub async fn run(self) -> Result<PackageVersion, InstallPackageFromRegistryError> {
         let &InstallPackageFromRegistry { http_client, config, name, version_range, .. } = &self;
 
         // Strip any `npm:<name>@<range>` alias prefix before talking to
         // the registry. `name` (the manifest key) stays as the directory
-        // name inside `node_modules`.
+        // name inside `node_modules`. Unversioned aliases (`npm:foo`) are
+        // resolved to `"latest"` by `resolve_registry_dependency`.
         let (registry_name, version_range) =
             PackageManifest::resolve_registry_dependency(name, version_range);
 
-        Ok(if let Ok(tag) = version_range.parse::<Tag>() {
+        // Try parsing as a `PackageTag` first: this covers both the
+        // `"latest"` tag (including unversioned `npm:` aliases) and
+        // pinned versions like `"1.0.0"`. Semver ranges like `"^1.0.0"`
+        // fail `PackageTag::from_str` and fall through to the range
+        // resolution branch below.
+        Ok(if let Ok(tag) = version_range.parse::<PackageTag>() {
             let package_version = PackageVersion::fetch_from_registry(
                 registry_name,
-                tag.into(),
+                tag,
                 http_client,
                 &config.registry,
             )
@@ -209,7 +212,7 @@ mod tests {
             version_range: "1.0.0",
             node_modules_dir: modules_dir.path(),
         }
-        .run::<Version>()
+        .run()
         .await
         .unwrap();
 

--- a/crates/package-manager/src/install_without_lockfile.rs
+++ b/crates/package-manager/src/install_without_lockfile.rs
@@ -7,7 +7,6 @@ use dashmap::DashSet;
 use derive_more::{Display, Error};
 use futures_util::future;
 use miette::Diagnostic;
-use node_semver::Version;
 use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
@@ -112,7 +111,7 @@ impl<'a, DependencyGroupList> InstallWithoutLockfile<'a, DependencyGroupList> {
                     name,
                     version_range,
                 }
-                .run::<Version>()
+                .run()
                 .await
                 .map_err(InstallWithoutLockfileError::InstallPackageFromRegistry)?;
 
@@ -205,7 +204,7 @@ impl<'a> InstallWithoutLockfile<'a, ()> {
                     name,
                     version_range,
                 }
-                .run::<Version>()
+                .run()
                 .await
                 .map_err(InstallWithoutLockfileError::InstallPackageFromRegistry)?;
                 self.install_dependencies_from_registry(

--- a/crates/package-manifest/src/lib.rs
+++ b/crates/package-manifest/src/lib.rs
@@ -157,6 +157,35 @@ impl PackageManifest {
             .flat_map(|(name, version)| version.as_str().map(|value| (name.as_str(), value)))
     }
 
+    /// Resolve a `(key, bare_specifier)` pair from a `package.json`
+    /// dependency entry into the `(registry_name, version_range)` to send
+    /// to the registry.
+    ///
+    /// For an ordinary entry (`"foo": "^1.2.3"`) the registry name equals
+    /// the entry key. For an npm-alias entry (`"foo": "npm:bar@^1.2.3"`)
+    /// the registry name is parsed from the spec and the entry key is
+    /// only used as the directory name under `node_modules`. An
+    /// unversioned `npm:bar` (or `npm:@scope/bar`) defaults to the
+    /// `latest` tag.
+    ///
+    /// Mirrors pnpm's `parseBareSpecifier`. Reference:
+    /// <https://github.com/pnpm/pnpm/blob/1819226b51/resolving/npm-resolver/src/parseBareSpecifier.ts>
+    pub fn resolve_registry_dependency<'a>(
+        key: &'a str,
+        bare_specifier: &'a str,
+    ) -> (&'a str, &'a str) {
+        let Some(rest) = bare_specifier.strip_prefix("npm:") else {
+            return (key, bare_specifier);
+        };
+        // pnpm's parseBareSpecifier uses `lastIndexOf('@')` and treats
+        // `index < 1` (no `@`, or `@` at position 0 of a scoped name)
+        // as "no version" — the spec is just a package name.
+        match rest.rfind('@') {
+            Some(idx) if idx >= 1 => (&rest[..idx], &rest[idx + 1..]),
+            _ => (rest, "latest"),
+        }
+    }
+
     pub fn bundle_dependencies(&self) -> Result<Option<BundleDependencies>, serde_json::Error> {
         self.value
             .get("bundleDependencies")
@@ -334,5 +363,70 @@ mod tests {
         case!(r#"{ "bundleDependencies": true }"# => true.pipe(BundleDependencies::Boolean).pipe(Some));
         case!(r#"{ "bundledDependencies": true }"# => true.pipe(BundleDependencies::Boolean).pipe(Some));
         case!(r#"{}"# => None);
+    }
+
+    #[test]
+    fn resolve_registry_dependency_passes_through_plain_specs() {
+        for (key, spec) in [
+            ("foo", "^1.0.0"),
+            ("foo", "1.2.3"),
+            ("foo", "latest"),
+            ("@scope/foo", "^1.0.0"),
+            ("foo", "*"),
+            ("foo", ">=1 <2"),
+        ] {
+            assert_eq!(
+                PackageManifest::resolve_registry_dependency(key, spec),
+                (key, spec),
+                "plain spec ({key:?}, {spec:?}) should pass through unchanged",
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_registry_dependency_strips_npm_alias_prefix() {
+        assert_eq!(
+            PackageManifest::resolve_registry_dependency("ansi-strip", "npm:strip-ansi@^6.0.1"),
+            ("strip-ansi", "^6.0.1"),
+        );
+    }
+
+    #[test]
+    fn resolve_registry_dependency_handles_scoped_target() {
+        assert_eq!(
+            PackageManifest::resolve_registry_dependency("react17", "npm:@types/react@^17.0.49"),
+            ("@types/react", "^17.0.49"),
+        );
+    }
+
+    #[test]
+    fn resolve_registry_dependency_handles_pinned_version() {
+        assert_eq!(
+            PackageManifest::resolve_registry_dependency("foo-cjs", "npm:foo@1.2.3"),
+            ("foo", "1.2.3"),
+        );
+    }
+
+    #[test]
+    fn resolve_registry_dependency_unversioned_npm_alias_defaults_to_latest() {
+        // `npm:foo` and `npm:@scope/foo` mean "latest" in pnpm.
+        assert_eq!(
+            PackageManifest::resolve_registry_dependency("foo-cjs", "npm:foo"),
+            ("foo", "latest"),
+        );
+        assert_eq!(
+            PackageManifest::resolve_registry_dependency("react17", "npm:@types/react"),
+            ("@types/react", "latest"),
+        );
+    }
+
+    #[test]
+    fn resolve_registry_dependency_picks_last_at_for_alias() {
+        // Mirrors pnpm's `lastIndexOf('@')` so prerelease/build metadata
+        // containing `@` would still be split at the *final* `@`.
+        assert_eq!(
+            PackageManifest::resolve_registry_dependency("foo-rc", "npm:@scope/foo@1.0.0-rc.1",),
+            ("@scope/foo", "1.0.0-rc.1"),
+        );
     }
 }


### PR DESCRIPTION
## Summary

- `pacquet install` panicked on any `package.json` dep written as `"foo": "npm:bar@<range>"` because the whole alias spec was fed to `node_semver::Range::parse`. Decompose the spec at the install layer so the registry sees the real package name and the resolver only sees the range — mirroring pnpm's [`parseBareSpecifier`](https://github.com/pnpm/pnpm/blob/1819226b51/resolving/npm-resolver/src/parseBareSpecifier.ts).
- The manifest key stays as the directory name under `node_modules/` (the alias the parent's source code imports). The virtual store keeps using the registry-returned name, so an aliased and a plain entry pointing at the same target share one virtual store directory.
- Unversioned `npm:foo` / `npm:@scope/foo` default to the `latest` tag, matching pnpm's `index < 1` branch.

Closes #312.

## Test plan

- [x] New unit tests in `pacquet-package-manifest` cover plain specs, scoped targets, unversioned `npm:` aliases (default to `latest`), and the `lastIndexOf('@')` edge case.
- [x] New end-to-end test `npm_alias_dependency_installs_under_alias_key` in `pacquet-package-manager` installs `"hello-world-alias": "npm:@pnpm.e2e/hello-world-js-bin@1.0.0"` against the registry mock and asserts the symlink lives under the alias key, the real package name is *not* exposed alongside, and the virtual store uses the real name.
- [x] `just ready` (typos, fmt, check, test, lint) — green.