### PR TITLE
fix(benchmark): fetch resolved sha before checkout

### DIFF
--- a/tasks/integrated-benchmark/src/work_env.rs
+++ b/tasks/integrated-benchmark/src/work_env.rs
@@ -121,6 +121,19 @@ impl WorkEnv {
 
             let repository = self.repository();
             let revision_repo = self.revision_repo(revision);
+
+            // Resolve the revision against the source repository *before*
+            // fetching, so the fetch can request the exact commit. A bare
+            // `git fetch <repo>` only writes the source's `HEAD` to
+            // `FETCH_HEAD`, which means a SHA that isn't reachable from
+            // the source's HEAD (e.g. tip of `main` when the runner is on
+            // a PR branch that's behind `main`) won't end up in the
+            // bench-repo and the subsequent `git checkout <sha>` panics
+            // with `unable to read tree`. See PR #321 comment
+            // <https://github.com/pnpm/pacquet/pull/321#issuecomment-4326141435>.
+            let commit = self.resolve_revision(revision);
+            eprintln!("Resolved {revision:?} to {commit}");
+
             if revision_repo.exists() {
                 if !revision_repo.join(".git").exists() {
                     eprintln!("Initializing a git repository at {revision_repo:?}...");
@@ -132,11 +145,12 @@ impl WorkEnv {
                         .pipe(executor("git init"));
                 }
 
-                eprintln!("Fetching from {repository:?}...");
+                eprintln!("Fetching {commit} from {repository:?}...");
                 Command::new("git")
                     .current_dir(&revision_repo)
                     .arg("fetch")
                     .arg(repository)
+                    .arg(&commit)
                     .pipe(executor("git fetch"));
             } else {
                 eprintln!("Cloning {repository:?} to {revision_repo:?}...");
@@ -148,12 +162,11 @@ impl WorkEnv {
                     .pipe(executor("git clone"));
             }
 
-            let commit = self.resolve_revision(revision);
             eprintln!("Checking out {commit:?}...");
             Command::new("git")
                 .current_dir(&revision_repo)
                 .arg("checkout")
-                .arg(commit)
+                .arg(&commit)
                 .pipe(executor("git checkout"));
 
             eprintln!("List of branches:");


### PR DESCRIPTION
## Summary

Fixes the integrated-benchmark orchestrator's handling of revisions whose SHA is not reachable from the source repository's `HEAD`. When a PR branch is behind `main`, `tasks/integrated-benchmark/src/work_env.rs` would resolve `main` on the runner-repo to a SHA that the bench-repo did not have, and `git checkout` would panic with `unable to read tree`. See the diagnosis in [PR #321 comment](https://github.com/pnpm/pacquet/pull/321#issuecomment-4326141435).

## Root cause

The fetch step ran:

```sh
git fetch /path/to/runner-repo
```

with no refspec. Without a refspec, `git fetch` only writes the source's `HEAD` into `FETCH_HEAD`. The bench-repo therefore only has objects reachable from the runner-repo's HEAD (the PR tip in CI). The next step then ran:

```sh
git checkout <sha-of-main>
```

against a SHA whose tree is not in the bench-repo, and crashed.

## Fix

Resolve the revision against the source repository *before* fetching, then pass the resolved SHA to `git fetch` explicitly:

```sh
git fetch /path/to/runner-repo <resolved-sha>
git checkout <resolved-sha>
```

This keeps the fetch as narrow as before, but the bench-repo is now guaranteed to contain the exact tree the next step is about to check out, regardless of where that SHA lives in the source's ref graph.

## Alternatives considered

- **Refspec covering all branches** (`+refs/heads/*:refs/remotes/upstream/*`): would not bring the runner-repo's *detached* HEAD, so the `HEAD` revision used by `integrated-benchmark.yml` (the PR merge commit, which is not on any branch) would break.
- **`git fetch <repo> <revision-string>`** (literal user input): `validate_revision_list` already accepts expressions like `main~1`, which `git fetch` does not accept as a refspec source.
- **Always re-clone** instead of init+fetch: defeats the cargo build cache, which is the entire reason the bench-repo is preserved across runs.

The chosen approach is also the option called out by the diagnosing comment as the durable fix for the orchestrator.

## Verification

Reproduced the bug locally in a throwaway repo (PR-branch-behind-main scenario plus a detached-HEAD merge-commit scenario). With the fix, both `git checkout` calls succeed. `cargo check`, `cargo clippy --deny warnings`, and `cargo fmt --check` pass for `pacquet-integrated-benchmark`.

## Test plan

- [x] Reproduce `unable to read tree` against the unfixed code in a throwaway repo.
- [x] Verify the fix succeeds for the `main`-tip-not-reachable case.
- [x] Verify the fix succeeds for the detached-HEAD (PR merge commit) case.
- [x] `cargo check --locked -p pacquet-integrated-benchmark`
- [x] `cargo clippy --locked -p pacquet-integrated-benchmark -- --deny warnings`
- [x] `cargo fmt --check -p pacquet-integrated-benchmark`
- [ ] Integrated-Benchmark workflow on this PR succeeds (this is the actual regression test).

https://claude.ai/code/session_01DS9GB92b1Bx9y8Tk9tH1w2