### PR TITLE
ci(benchmark): drop `--show-output`

### DIFF
--- a/.github/workflows/integrated-benchmark.yml
+++ b/.github/workflows/integrated-benchmark.yml
@@ -128,35 +128,22 @@ jobs:
         # timeout (6 h). A normal run is ~2 min — 10 min is generous
         # headroom, and a failure surfaces fast enough to iterate on.
         timeout-minutes: 10
-        # Enable pacquet's tracing at `info` so the next hang shows
-        # which phase the stalled install was in (download,
-        # extraction, import, index write …) before it went silent.
-        # Without this, `--show-output` only captures pacquet's
-        # empty stream since the default filter is off.
-        env:
-          TRACE: pacquet=info
-        # `--show-output` pipes each binary's stderr through hyperfine
-        # so the step log captures traces / profile output / panics
-        # inline with each run. Essential for diagnosing a hang on CI
-        # where we can't attach a debugger.
         run: |
-          just integrated-benchmark --show-output --scenario=frozen-lockfile --verdaccio --with-pnpm HEAD main
+          just integrated-benchmark --scenario=frozen-lockfile --verdaccio --with-pnpm HEAD main
           cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_FROZEN_LOCKFILE.md
           cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_FROZEN_LOCKFILE.json
 
       - name: 'Benchmark: Frozen Lockfile (Hot Cache)'
         shell: bash
-        # Same timeout / tracing rationale as the cold-cache step above.
+        # Same timeout rationale as the cold-cache step above.
         # Mirrors pnpm's "Headless install (frozen lockfile, warm
         # store+cache)" benchmark: each timed run wipes only
         # `node_modules`, the per-revision store survives, and
         # hyperfine's warmup run is what populates it on the first
         # iteration so timed runs all see a hot store.
         timeout-minutes: 10
-        env:
-          TRACE: pacquet=info
         run: |
-          just integrated-benchmark --show-output --scenario=frozen-lockfile-hot-cache --verdaccio --with-pnpm HEAD main
+          just integrated-benchmark --scenario=frozen-lockfile-hot-cache --verdaccio --with-pnpm HEAD main
           cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_FROZEN_LOCKFILE_HOT_CACHE.md
           cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_FROZEN_LOCKFILE_HOT_CACHE.json
 


### PR DESCRIPTION
Hyperfine's --show-output piped each install's stdout/stderr (with TRACE=pacquet=info enabled) into the workflow log, drowning the PR summary in noise. Suppress per-run output and remove the now-pointless TRACE env var; the markdown report still captures the timing summary.