### PR TITLE
fix(cli): ensure node.js file exists if no start script exists

### DIFF
--- a/crates/cli/src/cli_args.rs
+++ b/crates/cli/src/cli_args.rs
@@ -91,7 +91,7 @@ impl CliArgs {
                 // The intended usage of the property is to specify a command that starts your program.
                 let manifest = PackageManifest::from_path(manifest_path())
                     .wrap_err("getting the package.json in current directory")?;
-                let command = manifest.script("start", true)?.unwrap_or("node server.js");
+                let command = manifest.start_script()?;
                 execute_shell(command).wrap_err(format!("executing command: \"{0}\"", command))?;
             }
             CliCommand::Store(command) => command.run(|| npmrc())?,

--- a/crates/cli/tests/snapshots/start__should_fail_if_no_script_and_no_server_dot_js.snap
+++ b/crates/cli/tests/snapshots/start__should_fail_if_no_script_and_no_server_dot_js.snap
@@ -1,0 +1,7 @@
+---
+source: crates/cli/tests/start.rs
+expression: "String::from_utf8_lossy(&output.stderr).trim_end()"
+---
+Error: pacquet_package_manifest::no_script_or_server
+
+  × Missing script start or file server.js

--- a/crates/cli/tests/start.rs
+++ b/crates/cli/tests/start.rs
@@ -1,0 +1,33 @@
+pub mod _utils;
+use std::fs;
+
+pub use _utils::*;
+
+use command_extra::CommandExtra;
+use pacquet_testing_utils::bin::CommandTempCwd;
+
+#[test]
+fn should_fail_if_no_script_and_no_server_dot_js() {
+    let CommandTempCwd { pacquet, root, workspace, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+
+    eprintln!("Creating package.json...");
+    let manifest_path = workspace.join("package.json");
+    let package_json_content = serde_json::json!({});
+    fs::write(&manifest_path, package_json_content.to_string()).expect("write to package.json");
+
+    eprintln!("Executing pnpm start...");
+    let output = pacquet.with_arg("start").output().expect("could not start");
+
+    dbg!(&output);
+
+    eprintln!("Exit status code");
+    assert!(!output.status.success());
+
+    eprintln!("Stderr");
+    insta::assert_snapshot!(String::from_utf8_lossy(&output.stderr).trim_end());
+
+    assert!(!output.status.success());
+
+    drop(root)
+}

--- a/crates/package-manifest/src/lib.rs
+++ b/crates/package-manifest/src/lib.rs
@@ -40,6 +40,11 @@ pub enum PackageManifestError {
     #[display("Missing script: {_0:?}")]
     #[diagnostic(code(pacquet_package_manifest::no_script_error))]
     NoScript(#[error(not(source))] String),
+
+    #[from(ignore)] // TODO: remove this after derive(From) has been removed
+    #[display("Missing script start or file server.js")]
+    #[diagnostic(code(pacquet_package_manifest::no_script_or_server))]
+    NoStartScriptOrServerJs,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, IntoStaticStr)]
@@ -204,6 +209,18 @@ impl PackageManifest {
         }
 
         if if_present { Ok(None) } else { Err(PackageManifestError::NoScript(command.to_string())) }
+    }
+
+    pub fn start_script(&self) -> Result<&str, PackageManifestError> {
+        return self.script("start", true).and_then(|x| match x {
+            Some(x) => Ok(x),
+            None => {
+                if Path::new("server.js").exists() {
+                    return Ok("node server.js");
+                }
+                return Err(PackageManifestError::NoStartScriptOrServerJs);
+            }
+        });
     }
 }
 


### PR DESCRIPTION
## Scope

This PR fixes pnpm/pacquet#154 by ensuring no discrepancy between pnpm behavior and pacquet-pnpm behavior when one runs `pnpm start`

The documentation of `pnpm start` states that

> If no start property is specified on the scripts object, it will attempt to run node server.js as a default, failing if neither are present.

And the error as of now is: 

` ERR_PNPM_NO_SCRIPT_OR_SERVER  Missing script start or file server.js`

## Details

- This PR adds a new kind of error  `NoStartScriptOrServerJs`
- And a test file for start to assert this behavior. I could complete the file if necessary