### PR TITLE
docs(dev/guide): reference test porting guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,15 @@ Warnings are errors (`--deny warnings` in lint). Do not silence them with
 - When porting behavior from pnpm, port the relevant pnpm tests too (as Rust
   tests) whenever they translate. Matching test coverage is the easiest way
   to prove behavioral parity.
+- The active test-porting plan lives in
+  [`plans/TEST_PORTING.md`](./plans/TEST_PORTING.md). It enumerates the
+  upstream TypeScript tests scheduled to be ported (with file paths and line
+  numbers) and the conventions expected of the ports — `known_failures`
+  modules, `pacquet_testing_utils::allow_known_failure!` at the
+  not-yet-implemented boundary, and the practice of temporarily breaking the
+  subject under test to verify the ported test actually catches the
+  regression. Consult it before adding ported tests, and update its
+  checkboxes as items land.
 
 ### Running tests narrowly
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,14 @@ just registry-mock launch # start a mocked registry server (optional)
 just test                 # run tests
 ```
 
+When porting tests from the upstream `pnpm/pnpm` TypeScript repository, see
+[`plans/TEST_PORTING.md`](./plans/TEST_PORTING.md). It tracks the tests
+scheduled for porting (with upstream file paths and line numbers), the
+expected layout for not-yet-implemented behavior (`known_failures` modules
+guarded by `pacquet_testing_utils::allow_known_failure!`), and the
+verification step of temporarily breaking the implementation to confirm a
+ported test actually fails for the right reason before committing.
+
 ## Benchmarking
 
 First, start a local registry server, such as [verdaccio](https://verdaccio.org/):


### PR DESCRIPTION
The test-porting plan in plans/TEST_PORTING.md tracks the upstream pnpm tests scheduled for porting and the conventions expected of the ports, but neither AGENTS.md nor CONTRIBUTING.md pointed at it. Add references from both so contributors find the plan when working on ported tests.

https://claude.ai/code/session_01TESBtd59bbwcaNu6jsCaiU