### PR TITLE
feat(reporter): add NDJSON reporting engine with pnpm:stage smoke test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,6 +1755,7 @@ dependencies = [
  "pacquet-package-manager",
  "pacquet-package-manifest",
  "pacquet-registry",
+ "pacquet-reporter",
  "pacquet-store-dir",
  "pacquet-tarball",
  "pacquet-testing-utils",
@@ -1900,6 +1901,7 @@ dependencies = [
  "pacquet-package-manifest",
  "pacquet-registry",
  "pacquet-registry-mock",
+ "pacquet-reporter",
  "pacquet-store-dir",
  "pacquet-tarball",
  "pacquet-testing-utils",
@@ -1963,6 +1965,16 @@ dependencies = [
  "sysinfo",
  "tokio",
  "which",
+]
+
+[[package]]
+name = "pacquet-reporter"
+version = "0.0.1"
+dependencies = [
+ "insta",
+ "pretty_assertions",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1912,6 +1912,7 @@ dependencies = [
  "serde-saphyr",
  "ssri",
  "tempfile",
+ "text-block-macros",
  "tokio",
  "tracing",
  "walkdir",
@@ -1972,6 +1973,7 @@ name = "pacquet-reporter"
 version = "0.0.1"
 dependencies = [
  "insta",
+ "pipe-trait",
  "pretty_assertions",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -801,6 +801,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1972,6 +1982,7 @@ dependencies = [
 name = "pacquet-reporter"
 version = "0.0.1"
 dependencies = [
+ "gethostname",
  "insta",
  "pipe-trait",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ pacquet-npmrc            = { path = "crates/npmrc" }
 pacquet-executor         = { path = "crates/executor" }
 pacquet-diagnostics      = { path = "crates/diagnostics" }
 pacquet-store-dir        = { path = "crates/store-dir" }
+pacquet-reporter         = { path = "crates/reporter" }
 
 # Tasks
 pacquet-registry-mock = { path = "tasks/registry-mock" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ home = { version = "0.5.12" }
 insta = { version = "1.47.2", features = ["yaml", "glob", "walkdir"] }
 itertools = { version = "0.14.0" }
 futures-util = { version = "0.3.32" }
+gethostname = { version = "1" }
 miette = { version = "7.6.0", features = ["fancy"] }
 num_cpus = { version = "1.17.0" }
 os_display = { version = "0.1.4" }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -23,6 +23,7 @@ pacquet-npmrc            = { workspace = true }
 pacquet-package-manifest = { workspace = true }
 pacquet-package-manager  = { workspace = true }
 pacquet-registry         = { workspace = true }
+pacquet-reporter         = { workspace = true }
 pacquet-tarball          = { workspace = true }
 pacquet-diagnostics      = { workspace = true }
 

--- a/crates/cli/src/cli_args.rs
+++ b/crates/cli/src/cli_args.rs
@@ -37,7 +37,11 @@ pub struct CliArgs {
     /// `silent` drops every event. The default is `silent` until the
     /// in-process default renderer lands; the spawn-and-pipe wiring is
     /// tracked separately (see #344).
-    #[clap(long, value_enum, default_value_t = ReporterType::Silent)]
+    ///
+    /// `global = true` makes the flag accepted on either side of the
+    /// subcommand (`pacquet --reporter=ndjson install` and
+    /// `pacquet install --reporter=ndjson` both work), matching pnpm.
+    #[clap(long, value_enum, default_value_t = ReporterType::Silent, global = true)]
     pub reporter: ReporterType,
 }
 

--- a/crates/cli/src/cli_args.rs
+++ b/crates/cli/src/cli_args.rs
@@ -5,12 +5,13 @@ pub mod store;
 
 use crate::State;
 use add::AddArgs;
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use install::InstallArgs;
 use miette::Context;
 use pacquet_executor::execute_shell;
 use pacquet_npmrc::Npmrc;
 use pacquet_package_manifest::PackageManifest;
+use pacquet_reporter::{NdjsonReporter, SilentReporter};
 use run::RunArgs;
 use std::{env, path::PathBuf};
 use store::StoreCommand;
@@ -28,6 +29,30 @@ pub struct CliArgs {
     /// Set working directory.
     #[clap(short = 'C', long, default_value = ".")]
     pub dir: PathBuf,
+
+    /// How install progress is rendered.
+    ///
+    /// `ndjson` writes pnpm-shaped log records as newline-delimited JSON
+    /// to stderr, suitable for piping into `@pnpm/cli.default-reporter`.
+    /// `silent` drops every event. The default is `silent` until the
+    /// in-process default renderer lands; the spawn-and-pipe wiring is
+    /// tracked separately (see #344).
+    #[clap(long, value_enum, default_value_t = ReporterType::Silent)]
+    pub reporter: ReporterType,
+}
+
+/// Selectable rendering strategy for log events.
+///
+/// Mirrors the names pnpm uses for `--reporter` (`default`, `ndjson`,
+/// `silent`, `append-only`). Only the variants pacquet currently supports
+/// are listed; the others land alongside the default-reporter spawn-and-
+/// pipe (tracked under #344).
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum ReporterType {
+    /// Newline-delimited JSON in pnpm's wire format on stderr.
+    Ndjson,
+    /// No progress output.
+    Silent,
 }
 
 #[derive(Subcommand, Debug)]
@@ -52,7 +77,7 @@ pub enum CliCommand {
 impl CliArgs {
     /// Execute the command
     pub async fn run(self) -> miette::Result<()> {
-        let CliArgs { command, dir } = self;
+        let CliArgs { command, dir, reporter } = self;
         let manifest_path = || dir.join("package.json");
         let npmrc = || Npmrc::current(env::current_dir, home::home_dir, Default::default).leak();
         // `require_lockfile` is the "this subcommand cannot run without a
@@ -70,10 +95,17 @@ impl CliArgs {
             CliCommand::Init => {
                 PackageManifest::init(&manifest_path()).wrap_err("initialize package.json")?;
             }
-            CliCommand::Add(args) => args.run(state(false)?).await?,
+            CliCommand::Add(args) => match reporter {
+                ReporterType::Ndjson => args.run::<NdjsonReporter>(state(false)?).await?,
+                ReporterType::Silent => args.run::<SilentReporter>(state(false)?).await?,
+            },
             CliCommand::Install(args) => {
                 let require_lockfile = args.frozen_lockfile;
-                args.run(state(require_lockfile)?).await?
+                let state = state(require_lockfile)?;
+                match reporter {
+                    ReporterType::Ndjson => args.run::<NdjsonReporter>(state).await?,
+                    ReporterType::Silent => args.run::<SilentReporter>(state).await?,
+                }
             }
             CliCommand::Test => {
                 let manifest = PackageManifest::from_path(manifest_path())

--- a/crates/cli/src/cli_args/add.rs
+++ b/crates/cli/src/cli_args/add.rs
@@ -3,6 +3,7 @@ use clap::Args;
 use miette::Context;
 use pacquet_package_manager::Add;
 use pacquet_package_manifest::DependencyGroup;
+use pacquet_reporter::Reporter;
 use std::path::PathBuf;
 
 #[derive(Debug, Args)]
@@ -82,7 +83,7 @@ pub struct AddArgs {
 
 impl AddArgs {
     /// Execute the subcommand.
-    pub async fn run(self, mut state: State) -> miette::Result<()> {
+    pub async fn run<R: Reporter>(self, mut state: State) -> miette::Result<()> {
         // TODO: if a package already exists in another dependency group, don't remove the existing entry.
 
         let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
@@ -99,7 +100,7 @@ impl AddArgs {
             save_exact: self.save_exact,
             resolved_packages,
         }
-        .run()
+        .run::<R>()
         .await
         .wrap_err("adding a new package")
     }

--- a/crates/cli/src/cli_args/install.rs
+++ b/crates/cli/src/cli_args/install.rs
@@ -3,6 +3,7 @@ use clap::Args;
 use miette::Context;
 use pacquet_package_manager::Install;
 use pacquet_package_manifest::DependencyGroup;
+use pacquet_reporter::Reporter;
 
 #[derive(Debug, Args)]
 pub struct InstallDependencyOptions {
@@ -49,7 +50,7 @@ pub struct InstallArgs {
 }
 
 impl InstallArgs {
-    pub async fn run(self, state: State) -> miette::Result<()> {
+    pub async fn run<R: Reporter>(self, state: State) -> miette::Result<()> {
         let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
             &state;
         let InstallArgs { dependency_options, frozen_lockfile } = self;
@@ -64,7 +65,7 @@ impl InstallArgs {
             frozen_lockfile,
             resolved_packages,
         }
-        .run()
+        .run::<R>()
         .await
         .wrap_err("installing dependencies")?;
 

--- a/crates/package-manager/Cargo.toml
+++ b/crates/package-manager/Cargo.toml
@@ -17,6 +17,7 @@ pacquet-network          = { workspace = true }
 pacquet-npmrc            = { workspace = true }
 pacquet-package-manifest = { workspace = true }
 pacquet-registry         = { workspace = true }
+pacquet-reporter         = { workspace = true }
 pacquet-store-dir        = { workspace = true }
 pacquet-tarball          = { workspace = true }
 

--- a/crates/package-manager/Cargo.toml
+++ b/crates/package-manager/Cargo.toml
@@ -43,4 +43,5 @@ pretty_assertions = { workspace = true }
 serde-saphyr      = { workspace = true }
 ssri              = { workspace = true }
 tempfile          = { workspace = true }
+text-block-macros = { workspace = true }
 walkdir           = { workspace = true }

--- a/crates/package-manager/src/add.rs
+++ b/crates/package-manager/src/add.rs
@@ -7,6 +7,7 @@ use pacquet_npmrc::Npmrc;
 use pacquet_package_manifest::PackageManifestError;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_registry::{PackageTag, PackageVersion};
+use pacquet_reporter::Reporter;
 use pacquet_tarball::MemCache;
 
 /// This subroutine does everything `pacquet add` is supposed to do.
@@ -44,7 +45,7 @@ where
     ListDependencyGroups: Fn() -> DependencyGroupList,
     DependencyGroupList: IntoIterator<Item = DependencyGroup>,
 {
-    pub async fn run(self) -> Result<(), AddError> {
+    pub async fn run<R: Reporter>(self) -> Result<(), AddError> {
         let Add {
             tarball_mem_cache,
             http_client,
@@ -83,7 +84,7 @@ where
             frozen_lockfile: false,
             resolved_packages,
         }
-        .run()
+        .run::<R>()
         .await
         .map_err(AddError::Install)?;
 

--- a/crates/package-manager/src/install.rs
+++ b/crates/package-manager/src/install.rs
@@ -68,13 +68,15 @@ where
             frozen_lockfile,
         } = self;
 
-        // Project root for the bunyan-envelope `prefix`. Upstream pnpm
-        // emits this as `lockfileDir` — the directory containing
-        // `pnpm-lock.yaml`, which equals the workspace root when one is
-        // present. Pacquet has no workspace support yet, so the manifest's
-        // parent directory is the correct value today; tracked as
-        // pnpm/pacquet#357 (resolve via a `findWorkspaceDir`-equivalent
-        // once workspaces land).
+        // Project root for the [bunyan]-envelope `prefix`. Upstream pnpm
+        // emits this as `lockfileDir`, the directory containing
+        // `pnpm-lock.yaml`. With workspace support that equals the
+        // workspace root. Pacquet has no workspace support yet, so the
+        // manifest's parent directory is the correct value today.
+        // pnpm/pacquet#357 tracks resolving this via a
+        // `findWorkspaceDir`-equivalent once workspaces land.
+        //
+        // [bunyan]: https://github.com/trentm/node-bunyan
         let prefix = manifest
             .path()
             .parent()
@@ -159,6 +161,7 @@ mod tests {
     use pacquet_npmrc::Npmrc;
     use pacquet_package_manifest::{DependencyGroup, PackageManifest};
     use pacquet_registry_mock::AutoMockInstance;
+    use pacquet_reporter::SilentReporter;
     use pacquet_testing_utils::fs::{get_all_folders, is_symlink_or_junction};
     use std::sync::Mutex;
     use tempfile::tempdir;
@@ -205,7 +208,7 @@ mod tests {
             frozen_lockfile: false,
             resolved_packages: &Default::default(),
         }
-        .run::<pacquet_reporter::SilentReporter>()
+        .run::<SilentReporter>()
         .await
         .expect("install should succeed");
 
@@ -253,7 +256,7 @@ mod tests {
             frozen_lockfile: true,
             resolved_packages: &Default::default(),
         }
-        .run::<pacquet_reporter::SilentReporter>()
+        .run::<SilentReporter>()
         .await;
 
         assert!(matches!(result, Err(InstallError::NoLockfile)));
@@ -288,7 +291,7 @@ mod tests {
             frozen_lockfile: false,
             resolved_packages: &Default::default(),
         }
-        .run::<pacquet_reporter::SilentReporter>()
+        .run::<SilentReporter>()
         .await;
 
         assert!(matches!(result, Err(InstallError::UnsupportedLockfileMode)));
@@ -354,7 +357,7 @@ mod tests {
             frozen_lockfile: true,
             resolved_packages: &Default::default(),
         }
-        .run::<pacquet_reporter::SilentReporter>()
+        .run::<SilentReporter>()
         .await
         .expect("--frozen-lockfile + empty lockfile should succeed via InstallFrozenLockfile");
 
@@ -411,7 +414,7 @@ mod tests {
             frozen_lockfile: false,
             resolved_packages: &Default::default(),
         }
-        .run::<pacquet_reporter::SilentReporter>()
+        .run::<SilentReporter>()
         .await
         .expect("npm-alias install should succeed");
 
@@ -485,7 +488,7 @@ mod tests {
             frozen_lockfile: false,
             resolved_packages: &Default::default(),
         }
-        .run::<pacquet_reporter::SilentReporter>()
+        .run::<SilentReporter>()
         .await
         .expect("unversioned npm-alias install should succeed (defaults to latest)");
 
@@ -544,20 +547,20 @@ mod tests {
             frozen_lockfile: true,
             resolved_packages: &Default::default(),
         }
-        .run::<pacquet_reporter::SilentReporter>()
+        .run::<SilentReporter>()
         .await;
 
         assert!(matches!(result, Err(InstallError::NoLockfile)));
         drop(dir);
     }
 
-    /// [`Install::run`] emits `pnpm:stage` events bracketing the install:
-    /// `importing_started` before any work, `importing_done` after the
-    /// install completes successfully. On the success path, both fire in
-    /// order; on an early-error path (e.g. [`InstallError::NoLockfile`]),
-    /// only `importing_started` fires. This matches pnpm's stage
-    /// semantics — the JS reporter relies on the started/done pairing to
-    /// drive its progress UI.
+    /// [`Install::run`] emits `pnpm:stage` events that bracket the install.
+    /// `importing_started` fires before any work, and `importing_done`
+    /// fires after the install completes successfully. On the success
+    /// path both events fire in order. On an early-error path such as
+    /// [`InstallError::NoLockfile`], only `importing_started` fires.
+    /// This matches pnpm's stage semantics. The JS reporter relies on
+    /// the started/done pairing to drive its progress UI.
     #[tokio::test]
     async fn install_emits_stage_events_bracketing_the_run() {
         static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());

--- a/crates/package-manager/src/install.rs
+++ b/crates/package-manager/src/install.rs
@@ -66,9 +66,18 @@ where
             frozen_lockfile,
         } = self;
 
-        // Project root for the bunyan-envelope `prefix`. pnpm uses the
-        // workspace path; the closest pacquet equivalent is the directory
-        // holding `package.json`.
+        // Project root for the bunyan-envelope `prefix`. Upstream pnpm
+        // emits this as `lockfileDir` — the directory containing
+        // `pnpm-lock.yaml`, which equals the workspace root when one is
+        // present. Pacquet has no workspace support yet, so the manifest's
+        // parent directory is the correct value today.
+        //
+        // TODO: once workspace support lands, replace this with the
+        // resolved workspace dir so per-importer stage events carry the
+        // right prefix. The upstream helper to mirror is
+        // `findWorkspaceDir`, which walks up from the cwd looking for
+        // `pnpm-workspace.yaml`:
+        // <https://github.com/pnpm/pnpm/blob/3b12eb27de/workspace/root-finder/src/index.ts>.
         let prefix =
             manifest.path().parent().map(|p| p.to_string_lossy().into_owned()).unwrap_or_default();
 

--- a/crates/package-manager/src/install.rs
+++ b/crates/package-manager/src/install.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use crate::{
     InstallFrozenLockfile, InstallFrozenLockfileError, InstallWithoutLockfile,
     InstallWithoutLockfileError, ResolvedPackages,
@@ -70,16 +72,16 @@ where
         // emits this as `lockfileDir` — the directory containing
         // `pnpm-lock.yaml`, which equals the workspace root when one is
         // present. Pacquet has no workspace support yet, so the manifest's
-        // parent directory is the correct value today.
-        //
-        // TODO: once workspace support lands, replace this with the
-        // resolved workspace dir so per-importer stage events carry the
-        // right prefix. The upstream helper to mirror is
-        // `findWorkspaceDir`, which walks up from the cwd looking for
-        // `pnpm-workspace.yaml`:
-        // <https://github.com/pnpm/pnpm/blob/3b12eb27de/workspace/root-finder/src/index.ts>.
-        let prefix =
-            manifest.path().parent().map(|p| p.to_string_lossy().into_owned()).unwrap_or_default();
+        // parent directory is the correct value today; tracked as
+        // pnpm/pacquet#357 (resolve via a `findWorkspaceDir`-equivalent
+        // once workspaces land).
+        let prefix = manifest
+            .path()
+            .parent()
+            .map(Path::to_str)
+            .map(Option::<&str>::unwrap)
+            .unwrap()
+            .to_owned();
 
         R::emit(&LogEvent::Stage(StageLog {
             level: LogLevel::Debug,
@@ -160,6 +162,7 @@ mod tests {
     use pacquet_testing_utils::fs::{get_all_folders, is_symlink_or_junction};
     use std::sync::Mutex;
     use tempfile::tempdir;
+    use text_block_macros::text_block;
 
     #[tokio::test]
     async fn should_install_dependencies() {
@@ -331,14 +334,14 @@ mod tests {
         // run through `CreateVirtualStore` with an empty snapshot set,
         // which is a successful no-op. That's enough to prove we took
         // the frozen branch.
-        let lockfile: Lockfile = serde_saphyr::from_str(concat!(
-            "lockfileVersion: '9.0'\n",
-            "importers:\n",
-            "  .:\n",
-            "    dependencies: {}\n",
-            "packages: {}\n",
-            "snapshots: {}\n",
-        ))
+        let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+            "lockfileVersion: '9.0'"
+            "importers:"
+            "  .:"
+            "    dependencies: {}"
+            "packages: {}"
+            "snapshots: {}"
+        })
         .expect("parse minimal v9 lockfile");
 
         Install {
@@ -548,19 +551,13 @@ mod tests {
         drop(dir);
     }
 
-    /// `Install::run` emits `pnpm:stage` events bracketing the install:
+    /// [`Install::run`] emits `pnpm:stage` events bracketing the install:
     /// `importing_started` before any work, `importing_done` after the
     /// install completes successfully. On the success path, both fire in
-    /// order; on an early-error path (e.g. `NoLockfile`), only
-    /// `importing_started` fires. This matches pnpm's stage semantics —
-    /// the JS reporter relies on the started/done pairing to drive its
-    /// progress UI.
-    ///
-    /// Uses the recording-fake DI pattern from
-    /// <https://github.com/pnpm/pacquet/issues/339>: a unit-struct
-    /// reporter declared inside the test body, recording into a `static`
-    /// mutex declared in the same body. The mutex is per-test-fn, so
-    /// concurrent tests don't race on it.
+    /// order; on an early-error path (e.g. [`InstallError::NoLockfile`]),
+    /// only `importing_started` fires. This matches pnpm's stage
+    /// semantics — the JS reporter relies on the started/done pairing to
+    /// drive its progress UI.
     #[tokio::test]
     async fn install_emits_stage_events_bracketing_the_run() {
         static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
@@ -590,14 +587,14 @@ mod tests {
 
         // Empty v9 lockfile: `--frozen-lockfile` walks an empty snapshot
         // set successfully, which is the cheapest "real" install path.
-        let lockfile: Lockfile = serde_saphyr::from_str(concat!(
-            "lockfileVersion: '9.0'\n",
-            "importers:\n",
-            "  .:\n",
-            "    dependencies: {}\n",
-            "packages: {}\n",
-            "snapshots: {}\n",
-        ))
+        let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+            "lockfileVersion: '9.0'"
+            "importers:"
+            "  .:"
+            "    dependencies: {}"
+            "packages: {}"
+            "snapshots: {}"
+        })
         .expect("parse minimal v9 lockfile");
 
         Install {

--- a/crates/package-manager/src/install.rs
+++ b/crates/package-manager/src/install.rs
@@ -8,6 +8,7 @@ use pacquet_lockfile::Lockfile;
 use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
+use pacquet_reporter::{LogEvent, LogLevel, Reporter, Stage, StageLog};
 use pacquet_tarball::MemCache;
 
 /// This subroutine does everything `pacquet install` is supposed to do.
@@ -53,7 +54,7 @@ where
     DependencyGroupList: IntoIterator<Item = DependencyGroup>,
 {
     /// Execute the subroutine.
-    pub async fn run(self) -> Result<(), InstallError> {
+    pub async fn run<R: Reporter>(self) -> Result<(), InstallError> {
         let Install {
             tarball_mem_cache,
             resolved_packages,
@@ -64,6 +65,18 @@ where
             dependency_groups,
             frozen_lockfile,
         } = self;
+
+        // Project root for the bunyan-envelope `prefix`. pnpm uses the
+        // workspace path; the closest pacquet equivalent is the directory
+        // holding `package.json`.
+        let prefix =
+            manifest.path().parent().map(|p| p.to_string_lossy().into_owned()).unwrap_or_default();
+
+        R::emit(&LogEvent::Stage(StageLog {
+            level: LogLevel::Debug,
+            prefix: prefix.clone(),
+            stage: Stage::ImportingStarted,
+        }));
 
         tracing::info!(target: "pacquet::install", "Start all");
 
@@ -118,6 +131,13 @@ where
         }
 
         tracing::info!(target: "pacquet::install", "Complete all");
+
+        R::emit(&LogEvent::Stage(StageLog {
+            level: LogLevel::Debug,
+            prefix,
+            stage: Stage::ImportingDone,
+        }));
+
         Ok(())
     }
 }
@@ -129,6 +149,7 @@ mod tests {
     use pacquet_package_manifest::{DependencyGroup, PackageManifest};
     use pacquet_registry_mock::AutoMockInstance;
     use pacquet_testing_utils::fs::{get_all_folders, is_symlink_or_junction};
+    use std::sync::Mutex;
     use tempfile::tempdir;
 
     #[tokio::test]
@@ -172,7 +193,7 @@ mod tests {
             frozen_lockfile: false,
             resolved_packages: &Default::default(),
         }
-        .run()
+        .run::<pacquet_reporter::SilentReporter>()
         .await
         .expect("install should succeed");
 
@@ -220,7 +241,7 @@ mod tests {
             frozen_lockfile: true,
             resolved_packages: &Default::default(),
         }
-        .run()
+        .run::<pacquet_reporter::SilentReporter>()
         .await;
 
         assert!(matches!(result, Err(InstallError::NoLockfile)));
@@ -255,7 +276,7 @@ mod tests {
             frozen_lockfile: false,
             resolved_packages: &Default::default(),
         }
-        .run()
+        .run::<pacquet_reporter::SilentReporter>()
         .await;
 
         assert!(matches!(result, Err(InstallError::UnsupportedLockfileMode)));
@@ -321,7 +342,7 @@ mod tests {
             frozen_lockfile: true,
             resolved_packages: &Default::default(),
         }
-        .run()
+        .run::<pacquet_reporter::SilentReporter>()
         .await
         .expect("--frozen-lockfile + empty lockfile should succeed via InstallFrozenLockfile");
 
@@ -378,7 +399,7 @@ mod tests {
             frozen_lockfile: false,
             resolved_packages: &Default::default(),
         }
-        .run()
+        .run::<pacquet_reporter::SilentReporter>()
         .await
         .expect("npm-alias install should succeed");
 
@@ -452,7 +473,7 @@ mod tests {
             frozen_lockfile: false,
             resolved_packages: &Default::default(),
         }
-        .run()
+        .run::<pacquet_reporter::SilentReporter>()
         .await
         .expect("unversioned npm-alias install should succeed (defaults to latest)");
 
@@ -511,10 +532,88 @@ mod tests {
             frozen_lockfile: true,
             resolved_packages: &Default::default(),
         }
-        .run()
+        .run::<pacquet_reporter::SilentReporter>()
         .await;
 
         assert!(matches!(result, Err(InstallError::NoLockfile)));
+        drop(dir);
+    }
+
+    /// `Install::run` emits `pnpm:stage` events bracketing the install:
+    /// `importing_started` before any work, `importing_done` after the
+    /// install completes successfully. On the success path, both fire in
+    /// order; on an early-error path (e.g. `NoLockfile`), only
+    /// `importing_started` fires. This matches pnpm's stage semantics —
+    /// the JS reporter relies on the started/done pairing to drive its
+    /// progress UI.
+    ///
+    /// Uses the recording-fake DI pattern from
+    /// <https://github.com/pnpm/pacquet/issues/339>: a unit-struct
+    /// reporter declared inside the test body, recording into a `static`
+    /// mutex declared in the same body. The mutex is per-test-fn, so
+    /// concurrent tests don't race on it.
+    #[tokio::test]
+    async fn install_emits_stage_events_bracketing_the_run() {
+        static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
+
+        struct RecordingReporter;
+        impl Reporter for RecordingReporter {
+            fn emit(event: &LogEvent) {
+                EVENTS.lock().unwrap().push(event.clone());
+            }
+        }
+
+        let dir = tempdir().unwrap();
+        let store_dir = dir.path().join("pacquet-store");
+        let project_root = dir.path().join("project");
+        let modules_dir = project_root.join("node_modules");
+        let virtual_store_dir = modules_dir.join(".pacquet");
+
+        let manifest_path = dir.path().join("package.json");
+        let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
+
+        let mut config = Npmrc::new();
+        config.lockfile = false;
+        config.store_dir = store_dir.into();
+        config.modules_dir = modules_dir.to_path_buf();
+        config.virtual_store_dir = virtual_store_dir;
+        let config = config.leak();
+
+        // Empty v9 lockfile: `--frozen-lockfile` walks an empty snapshot
+        // set successfully, which is the cheapest "real" install path.
+        let lockfile: Lockfile = serde_saphyr::from_str(concat!(
+            "lockfileVersion: '9.0'\n",
+            "importers:\n",
+            "  .:\n",
+            "    dependencies: {}\n",
+            "packages: {}\n",
+            "snapshots: {}\n",
+        ))
+        .expect("parse minimal v9 lockfile");
+
+        Install {
+            tarball_mem_cache: &Default::default(),
+            http_client: &Default::default(),
+            config,
+            manifest: &manifest,
+            lockfile: Some(&lockfile),
+            dependency_groups: [DependencyGroup::Prod],
+            frozen_lockfile: true,
+            resolved_packages: &Default::default(),
+        }
+        .run::<RecordingReporter>()
+        .await
+        .expect("empty-lockfile frozen install should succeed");
+
+        let captured = EVENTS.lock().unwrap();
+        let stages: Vec<Stage> = captured
+            .iter()
+            .map(|e| match e {
+                LogEvent::Stage(StageLog { stage, .. }) => *stage,
+            })
+            .collect();
+        assert_eq!(stages, [Stage::ImportingStarted, Stage::ImportingDone]);
+
         drop(dir);
     }
 }

--- a/crates/reporter/Cargo.toml
+++ b/crates/reporter/Cargo.toml
@@ -11,8 +11,9 @@ license.workspace     = true
 repository.workspace  = true
 
 [dependencies]
-serde      = { workspace = true }
-serde_json = { workspace = true }
+gethostname = { workspace = true }
+serde       = { workspace = true }
+serde_json  = { workspace = true }
 
 [dev-dependencies]
 insta             = { workspace = true }

--- a/crates/reporter/Cargo.toml
+++ b/crates/reporter/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name                  = "pacquet-reporter"
+version               = "0.0.1"
+publish               = false
+authors.workspace     = true
+description.workspace = true
+edition.workspace     = true
+homepage.workspace    = true
+keywords.workspace    = true
+license.workspace     = true
+repository.workspace  = true
+
+[dependencies]
+serde      = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+insta             = { workspace = true }
+pretty_assertions = { workspace = true }

--- a/crates/reporter/Cargo.toml
+++ b/crates/reporter/Cargo.toml
@@ -16,4 +16,5 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 insta             = { workspace = true }
+pipe-trait        = { workspace = true }
 pretty_assertions = { workspace = true }

--- a/crates/reporter/src/lib.rs
+++ b/crates/reporter/src/lib.rs
@@ -3,7 +3,7 @@
 //! Pacquet's progress, lifecycle, summary, and similar output is shaped to
 //! match pnpm's so that emitted NDJSON is consumable by
 //! `@pnpm/cli.default-reporter`. The wire format mirrors what
-//! [`@pnpm/core-loggers`](https://github.com/pnpm/pnpm/tree/3b12eb27de/core/core-loggers/src)
+//! [`@pnpm/core-loggers`](https://github.com/pnpm/pnpm/tree/3b12eb27de/core/core-loggers/)
 //! defines for each channel.
 //!
 //! # Adding a channel
@@ -13,6 +13,7 @@
 //! them.
 
 use std::io::Write;
+use std::sync::LazyLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::Serialize;
@@ -35,7 +36,7 @@ pub enum LogEvent {
 /// `pnpm:stage` payload.
 ///
 /// `prefix` is the project root path the stage applies to, matching pnpm's
-/// usage. `stage` is the phase marker — see [`Stage`].
+/// usage. `stage` is the phase marker; see [`Stage`].
 #[derive(Debug, Clone, Serialize)]
 pub struct StageLog {
     pub level: LogLevel,
@@ -115,7 +116,7 @@ impl Reporter for NdjsonReporter {
 
 fn write_record(buf: &mut Vec<u8>, event: &LogEvent) -> serde_json::Result<()> {
     let envelope =
-        Envelope { time: now_millis(), hostname: hostname(), pid: std::process::id(), event };
+        Envelope { time: now_millis(), hostname: &HOSTNAME, pid: std::process::id(), event };
     serde_json::to_writer(buf, &envelope)
 }
 
@@ -136,219 +137,34 @@ fn now_millis() -> u128 {
     SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_millis()).unwrap_or(0)
 }
 
-/// Capability for reading process environment variables.
+/// Capability for obtaining the host name written into the [bunyan]-shaped
+/// envelope.
 ///
-/// Lets env-dependent helpers in this crate be exercised without touching
-/// the real process environment. The production implementation is
-/// [`RealEnvVar`].
-pub trait EnvVar {
-    fn var(name: &str) -> Option<String>;
-}
-
-/// Production [`EnvVar`] backed by [`std::env::var`].
-pub struct RealEnvVar;
-
-impl EnvVar for RealEnvVar {
-    fn var(name: &str) -> Option<String> {
-        std::env::var(name).ok()
-    }
-}
-
-/// Resolve the hostname for the [bunyan]-shaped envelope from `E`.
-///
-/// pnpm's logger (via [bole]) populates this from `os.hostname()`. Pacquet
-/// reads it from the standard environment variables instead so we don't
-/// pay for a syscall on every reporter init: `HOSTNAME` on Unix shells,
-/// `COMPUTERNAME` on Windows. Empty string when neither is set —
-/// downstream consumers (notably `@pnpm/cli.default-reporter`) only
-/// dispatch on `name`, so this field is informational.
+/// Backed by a real syscall in production via [`RealApi`]. Tests can supply
+/// their own implementation when behavior depends on the value.
 ///
 /// [bunyan]: https://github.com/trentm/node-bunyan
-/// [bole]: https://github.com/rvagg/bole
-fn resolve_hostname<E: EnvVar>() -> String {
-    E::var("HOSTNAME").or_else(|| E::var("COMPUTERNAME")).unwrap_or_default()
+pub trait GetHostName {
+    fn get_host_name() -> String;
 }
 
-// Cached hostname for production use. Kept non-generic because `static`
-// items inside generic functions are *not* monomorphised per type
-// parameter, so a generic `OnceLock` cache would leak the first
-// instantiation's value across every `E`.
-fn hostname() -> &'static str {
-    use std::sync::OnceLock;
-    static HOSTNAME: OnceLock<String> = OnceLock::new();
-    HOSTNAME.get_or_init(resolve_hostname::<RealEnvVar>).as_str()
+/// Production implementation of the capability traits in this crate.
+///
+/// Each trait method calls into the real underlying system facility (for
+/// [`GetHostName`], the `gethostname` syscall via the [`gethostname`] crate).
+pub struct RealApi;
+
+impl GetHostName for RealApi {
+    fn get_host_name() -> String {
+        gethostname::gethostname().to_string_lossy().into_owned()
+    }
 }
+
+// Process-wide cache of the host name. The value cannot change at runtime,
+// and `gethostname` is one syscall we'd otherwise repeat on every emit.
+// Initialized lazily through `RealApi::get_host_name` so tests that exercise
+// the capability trait directly can do so without paying for the syscall.
+static HOSTNAME: LazyLock<String> = LazyLock::new(RealApi::get_host_name);
 
 #[cfg(test)]
-mod tests {
-    use std::cell::RefCell;
-    use std::collections::HashMap;
-    use std::sync::Mutex;
-
-    use pipe_trait::Pipe;
-    use pretty_assertions::assert_eq;
-    use serde_json::Value;
-
-    use super::*;
-
-    /// Stage log serializes with the channel name flattened into the
-    /// envelope alongside `time`, `hostname`, `pid`, and the payload
-    /// fields. This is the wire shape `@pnpm/cli.default-reporter`
-    /// consumes — adding a wrapper object would break it.
-    #[test]
-    fn stage_event_matches_pnpm_wire_shape() {
-        let event = LogEvent::Stage(StageLog {
-            level: LogLevel::Debug,
-            prefix: "/some/project".to_string(),
-            stage: Stage::ImportingStarted,
-        });
-        let envelope =
-            Envelope { time: 1_700_000_000_000, hostname: "host", pid: 4242, event: &event };
-
-        let json: Value = envelope
-            .pipe_ref(serde_json::to_string)
-            .expect("serialize envelope")
-            .pipe_as_ref(serde_json::from_str)
-            .expect("parse JSON");
-
-        assert_eq!(json["name"], "pnpm:stage");
-        assert_eq!(json["stage"], "importing_started");
-        assert_eq!(json["level"], "debug");
-        assert_eq!(json["prefix"], "/some/project");
-        assert_eq!(json["time"], 1_700_000_000_000_u64);
-        assert_eq!(json["hostname"], "host");
-        assert_eq!(json["pid"], 4242);
-    }
-
-    /// Phase markers serialize as the snake_case strings pnpm uses.
-    #[test]
-    fn stage_phases_serialize_in_pnpm_form() {
-        let cases = [
-            (Stage::ResolutionStarted, "resolution_started"),
-            (Stage::ResolutionDone, "resolution_done"),
-            (Stage::ImportingStarted, "importing_started"),
-            (Stage::ImportingDone, "importing_done"),
-        ];
-        for (stage, expected) in cases {
-            let json = serde_json::to_string(&stage).expect("serialize stage");
-            assert_eq!(json, format!("\"{expected}\""), "phase {expected}");
-        }
-    }
-
-    /// [`SilentReporter`] is observably a no-op: any test fake is harder to
-    /// write than just calling it.
-    #[test]
-    fn silent_reporter_drops_events() {
-        // The point is that no panic, no I/O, and no observable side
-        // effect happens. The test passes by virtue of the call returning.
-        SilentReporter::emit(&LogEvent::Stage(StageLog {
-            level: LogLevel::Debug,
-            prefix: String::new(),
-            stage: Stage::ImportingStarted,
-        }));
-    }
-
-    #[test]
-    fn recording_fake_captures_emitted_events() {
-        static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
-
-        struct RecordingReporter;
-        impl Reporter for RecordingReporter {
-            fn emit(event: &LogEvent) {
-                EVENTS.lock().unwrap().push(event.clone());
-            }
-        }
-
-        fn install_step<R: Reporter>() {
-            R::emit(&LogEvent::Stage(StageLog {
-                level: LogLevel::Debug,
-                prefix: "/proj".to_string(),
-                stage: Stage::ImportingStarted,
-            }));
-            R::emit(&LogEvent::Stage(StageLog {
-                level: LogLevel::Debug,
-                prefix: "/proj".to_string(),
-                stage: Stage::ImportingDone,
-            }));
-        }
-
-        install_step::<RecordingReporter>();
-
-        let captured = EVENTS.lock().unwrap();
-        assert_eq!(captured.len(), 2);
-        assert!(matches!(
-            &captured[0],
-            LogEvent::Stage(StageLog { stage: Stage::ImportingStarted, .. })
-        ));
-        assert!(matches!(
-            &captured[1],
-            LogEvent::Stage(StageLog { stage: Stage::ImportingDone, .. })
-        ));
-    }
-
-    // Per-thread mock environment used by the [`resolve_hostname`] tests.
-    // `cargo nextest` runs each test in its own process, and the std test
-    // runner runs each test on its own thread, so a `thread_local!` is
-    // enough isolation either way.
-    struct MockEnv;
-
-    thread_local! {
-        static MOCK_ENV: RefCell<HashMap<&'static str, &'static str>> =
-            RefCell::new(HashMap::new());
-    }
-
-    impl EnvVar for MockEnv {
-        fn var(name: &str) -> Option<String> {
-            MOCK_ENV.with(|m| m.borrow().get(name).map(|s| (*s).to_string()))
-        }
-    }
-
-    fn with_mock_env<R>(entries: &[(&'static str, &'static str)], f: impl FnOnce() -> R) -> R {
-        MOCK_ENV.with(|m| {
-            let mut map = m.borrow_mut();
-            map.clear();
-            for (k, v) in entries {
-                map.insert(k, v);
-            }
-        });
-        let result = f();
-        MOCK_ENV.with(|m| m.borrow_mut().clear());
-        result
-    }
-
-    /// `HOSTNAME` is the preferred source — Unix shells set it.
-    #[test]
-    fn resolve_hostname_prefers_hostname_env() {
-        let got = with_mock_env(&[("HOSTNAME", "unix-host")], resolve_hostname::<MockEnv>);
-        assert_eq!(got, "unix-host");
-    }
-
-    /// On Windows, `COMPUTERNAME` is the standard variable; pacquet falls
-    /// back to it when `HOSTNAME` is unset.
-    #[test]
-    fn resolve_hostname_falls_back_to_computername() {
-        let got = with_mock_env(&[("COMPUTERNAME", "WIN-PC")], resolve_hostname::<MockEnv>);
-        assert_eq!(got, "WIN-PC");
-    }
-
-    /// When both are set, `HOSTNAME` wins. Some Windows shells (e.g. Git
-    /// Bash, WSL bridges) populate both; the Unix-style variable is the
-    /// one pnpm itself observes via `os.hostname()` indirection on
-    /// MINGW/MSYS hosts.
-    #[test]
-    fn resolve_hostname_hostname_wins_over_computername() {
-        let got = with_mock_env(
-            &[("HOSTNAME", "primary"), ("COMPUTERNAME", "secondary")],
-            resolve_hostname::<MockEnv>,
-        );
-        assert_eq!(got, "primary");
-    }
-
-    /// Neither set → empty string. The bunyan envelope's `hostname` field
-    /// is informational, so this is acceptable rather than an error.
-    #[test]
-    fn resolve_hostname_empty_when_unset() {
-        let got = with_mock_env(&[], resolve_hostname::<MockEnv>);
-        assert_eq!(got, "");
-    }
-}
+mod tests;

--- a/crates/reporter/src/lib.rs
+++ b/crates/reporter/src/lib.rs
@@ -138,9 +138,9 @@ fn now_millis() -> u128 {
 
 /// Capability for reading process environment variables.
 ///
-/// Lets [`resolve_hostname`] (and any future env-dependent helper in this
-/// crate) be exercised without touching the real process environment. The
-/// production implementation is [`RealEnvVar`].
+/// Lets env-dependent helpers in this crate be exercised without touching
+/// the real process environment. The production implementation is
+/// [`RealEnvVar`].
 pub trait EnvVar {
     fn var(name: &str) -> Option<String>;
 }

--- a/crates/reporter/src/lib.rs
+++ b/crates/reporter/src/lib.rs
@@ -6,14 +6,11 @@
 //! [`@pnpm/core-loggers`](https://github.com/pnpm/pnpm/tree/3b12eb27de/core/core-loggers/src)
 //! defines for each channel.
 //!
-//! Design background: <https://github.com/pnpm/pacquet/issues/344>.
-//!
 //! # Adding a channel
 //!
 //! Only the variants pacquet currently emits live in [`LogEvent`]. New
 //! channels are added incrementally as the surrounding code starts using
-//! them; the sweep across already-ported code is tracked in
-//! <https://github.com/pnpm/pacquet/issues/347>.
+//! them.
 
 use std::io::Write;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -38,7 +35,7 @@ pub enum LogEvent {
 /// `pnpm:stage` payload.
 ///
 /// `prefix` is the project root path the stage applies to, matching pnpm's
-/// usage. `stage` is the phase marker.
+/// usage. `stage` is the phase marker — see [`Stage`].
 #[derive(Debug, Clone, Serialize)]
 pub struct StageLog {
     pub level: LogLevel,
@@ -56,11 +53,14 @@ pub enum Stage {
     ImportingDone,
 }
 
-/// Severity level on the bunyan envelope.
+/// Severity level on the [bunyan]-shaped envelope.
 ///
-/// pnpm's logger uses the bole library, which writes one of these strings
+/// pnpm's logger uses the [bole] library, which writes one of these strings
 /// for every record. Each channel pins the level pnpm itself uses (e.g.
 /// `pnpm:stage` is always emitted at `debug`).
+///
+/// [bunyan]: https://github.com/trentm/node-bunyan
+/// [bole]: https://github.com/rvagg/bole
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum LogLevel {
@@ -72,15 +72,13 @@ pub enum LogLevel {
 
 /// Capability for emitting log events.
 ///
-/// Follows the dependency-injection pattern documented in
-/// <https://github.com/pnpm/pacquet/issues/339>: methods are associated
-/// functions (no `&self`), implementations are unit structs, and any
-/// implementation-internal state lives in module-level `static`s. Functions
-/// that emit take a generic `R: Reporter` and call `R::emit(...)`; the
-/// production entry point monomorphises with the chosen sink.
+/// Implementations are unit structs; any implementation-internal state
+/// lives in module-level `static`s. Emitting code is generic over
+/// `R: Reporter` and calls `R::emit(...)`; the production entry point
+/// monomorphises with the chosen sink.
 ///
-/// `emit` must not panic. A serialization or I/O failure is swallowed so a
-/// reporter problem can never crash an install.
+/// [`Reporter::emit`] must not panic. A serialization or I/O failure is
+/// swallowed so a reporter problem can never crash an install.
 pub trait Reporter {
     fn emit(event: &LogEvent);
 }
@@ -92,14 +90,16 @@ impl Reporter for SilentReporter {
     fn emit(_event: &LogEvent) {}
 }
 
-/// `--reporter=ndjson`: writes one bunyan-shaped JSON record per event to
+/// `--reporter=ndjson`: writes one [bunyan]-shaped JSON record per event to
 /// stderr, terminated by `\n`. The wire format matches what pnpm itself
 /// produces under `--reporter=ndjson`, so the same consumers work
 /// unmodified.
 ///
 /// Today this writes synchronously under the stderr lock. When the volume
 /// of emit sites grows past coarse start/end markers, the writer should
-/// move behind an MPSC channel (see #344's Implementation notes).
+/// move behind an MPSC channel.
+///
+/// [bunyan]: https://github.com/trentm/node-bunyan
 pub struct NdjsonReporter;
 
 impl Reporter for NdjsonReporter {
@@ -119,11 +119,10 @@ fn write_record(buf: &mut Vec<u8>, event: &LogEvent) -> serde_json::Result<()> {
     serde_json::to_writer(buf, &envelope)
 }
 
-/// Wraps a [`LogEvent`] with the bunyan envelope fields pnpm's logger adds.
-///
-/// `#[serde(flatten)]` merges the channel-specific tag (`"name": "pnpm:..."`)
-/// and payload fields up to the top level of the JSON object so the wire
-/// format is one flat record per line.
+// Wraps a [`LogEvent`] with the bunyan envelope fields pnpm's logger adds.
+// `#[serde(flatten)]` merges the channel-specific tag and payload fields up
+// to the top level of the JSON object so the wire format is one flat record
+// per line.
 #[derive(Serialize)]
 struct Envelope<'a> {
     time: u128,
@@ -137,28 +136,56 @@ fn now_millis() -> u128 {
     SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_millis()).unwrap_or(0)
 }
 
-/// Best-effort hostname for the bunyan envelope.
+/// Capability for reading process environment variables.
 ///
-/// pnpm's logger (via `bole`) populates this from `os.hostname()`. Pacquet
+/// Lets [`resolve_hostname`] (and any future env-dependent helper in this
+/// crate) be exercised without touching the real process environment. The
+/// production implementation is [`RealEnvVar`].
+pub trait EnvVar {
+    fn var(name: &str) -> Option<String>;
+}
+
+/// Production [`EnvVar`] backed by [`std::env::var`].
+pub struct RealEnvVar;
+
+impl EnvVar for RealEnvVar {
+    fn var(name: &str) -> Option<String> {
+        std::env::var(name).ok()
+    }
+}
+
+/// Resolve the hostname for the [bunyan]-shaped envelope from `E`.
+///
+/// pnpm's logger (via [bole]) populates this from `os.hostname()`. Pacquet
 /// reads it from the standard environment variables instead so we don't
 /// pay for a syscall on every reporter init: `HOSTNAME` on Unix shells,
 /// `COMPUTERNAME` on Windows. Empty string when neither is set —
 /// downstream consumers (notably `@pnpm/cli.default-reporter`) only
 /// dispatch on `name`, so this field is informational.
+///
+/// [bunyan]: https://github.com/trentm/node-bunyan
+/// [bole]: https://github.com/rvagg/bole
+fn resolve_hostname<E: EnvVar>() -> String {
+    E::var("HOSTNAME").or_else(|| E::var("COMPUTERNAME")).unwrap_or_default()
+}
+
+// Cached hostname for production use. Kept non-generic because `static`
+// items inside generic functions are *not* monomorphised per type
+// parameter, so a generic `OnceLock` cache would leak the first
+// instantiation's value across every `E`.
 fn hostname() -> &'static str {
     use std::sync::OnceLock;
     static HOSTNAME: OnceLock<String> = OnceLock::new();
-    HOSTNAME
-        .get_or_init(|| {
-            std::env::var("HOSTNAME").or_else(|_| std::env::var("COMPUTERNAME")).unwrap_or_default()
-        })
-        .as_str()
+    HOSTNAME.get_or_init(resolve_hostname::<RealEnvVar>).as_str()
 }
 
 #[cfg(test)]
 mod tests {
+    use std::cell::RefCell;
+    use std::collections::HashMap;
     use std::sync::Mutex;
 
+    use pipe_trait::Pipe;
     use pretty_assertions::assert_eq;
     use serde_json::Value;
 
@@ -178,9 +205,11 @@ mod tests {
         let envelope =
             Envelope { time: 1_700_000_000_000, hostname: "host", pid: 4242, event: &event };
 
-        let json: Value =
-            serde_json::from_str(&serde_json::to_string(&envelope).expect("serialize envelope"))
-                .expect("parse JSON");
+        let json: Value = envelope
+            .pipe_ref(serde_json::to_string)
+            .expect("serialize envelope")
+            .pipe_as_ref(serde_json::from_str)
+            .expect("parse JSON");
 
         assert_eq!(json["name"], "pnpm:stage");
         assert_eq!(json["stage"], "importing_started");
@@ -206,7 +235,7 @@ mod tests {
         }
     }
 
-    /// `SilentReporter` is observably a no-op: any test fake is harder to
+    /// [`SilentReporter`] is observably a no-op: any test fake is harder to
     /// write than just calling it.
     #[test]
     fn silent_reporter_drops_events() {
@@ -219,12 +248,6 @@ mod tests {
         }));
     }
 
-    /// Recording fake per the DI pattern in
-    /// <https://github.com/pnpm/pacquet/issues/339>: a unit struct declared
-    /// inside the `#[test]` body, recording into a `static` mutex declared
-    /// in the same body so the per-test isolation `#339` calls for stays
-    /// intact. This is the shape every consumer test in the workspace
-    /// should follow when asserting against emitted events.
     #[test]
     fn recording_fake_captures_emitted_events() {
         static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
@@ -261,5 +284,71 @@ mod tests {
             &captured[1],
             LogEvent::Stage(StageLog { stage: Stage::ImportingDone, .. })
         ));
+    }
+
+    // Per-thread mock environment used by the [`resolve_hostname`] tests.
+    // `cargo nextest` runs each test in its own process, and the std test
+    // runner runs each test on its own thread, so a `thread_local!` is
+    // enough isolation either way.
+    struct MockEnv;
+
+    thread_local! {
+        static MOCK_ENV: RefCell<HashMap<&'static str, &'static str>> =
+            RefCell::new(HashMap::new());
+    }
+
+    impl EnvVar for MockEnv {
+        fn var(name: &str) -> Option<String> {
+            MOCK_ENV.with(|m| m.borrow().get(name).map(|s| (*s).to_string()))
+        }
+    }
+
+    fn with_mock_env<R>(entries: &[(&'static str, &'static str)], f: impl FnOnce() -> R) -> R {
+        MOCK_ENV.with(|m| {
+            let mut map = m.borrow_mut();
+            map.clear();
+            for (k, v) in entries {
+                map.insert(k, v);
+            }
+        });
+        let result = f();
+        MOCK_ENV.with(|m| m.borrow_mut().clear());
+        result
+    }
+
+    /// `HOSTNAME` is the preferred source — Unix shells set it.
+    #[test]
+    fn resolve_hostname_prefers_hostname_env() {
+        let got = with_mock_env(&[("HOSTNAME", "unix-host")], resolve_hostname::<MockEnv>);
+        assert_eq!(got, "unix-host");
+    }
+
+    /// On Windows, `COMPUTERNAME` is the standard variable; pacquet falls
+    /// back to it when `HOSTNAME` is unset.
+    #[test]
+    fn resolve_hostname_falls_back_to_computername() {
+        let got = with_mock_env(&[("COMPUTERNAME", "WIN-PC")], resolve_hostname::<MockEnv>);
+        assert_eq!(got, "WIN-PC");
+    }
+
+    /// When both are set, `HOSTNAME` wins. Some Windows shells (e.g. Git
+    /// Bash, WSL bridges) populate both; the Unix-style variable is the
+    /// one pnpm itself observes via `os.hostname()` indirection on
+    /// MINGW/MSYS hosts.
+    #[test]
+    fn resolve_hostname_hostname_wins_over_computername() {
+        let got = with_mock_env(
+            &[("HOSTNAME", "primary"), ("COMPUTERNAME", "secondary")],
+            resolve_hostname::<MockEnv>,
+        );
+        assert_eq!(got, "primary");
+    }
+
+    /// Neither set → empty string. The bunyan envelope's `hostname` field
+    /// is informational, so this is acceptable rather than an error.
+    #[test]
+    fn resolve_hostname_empty_when_unset() {
+        let got = with_mock_env(&[], resolve_hostname::<MockEnv>);
+        assert_eq!(got, "");
     }
 }

--- a/crates/reporter/src/lib.rs
+++ b/crates/reporter/src/lib.rs
@@ -1,0 +1,265 @@
+//! User-facing log channels for pacquet.
+//!
+//! Pacquet's progress, lifecycle, summary, and similar output is shaped to
+//! match pnpm's so that emitted NDJSON is consumable by
+//! `@pnpm/cli.default-reporter`. The wire format mirrors what
+//! [`@pnpm/core-loggers`](https://github.com/pnpm/pnpm/tree/3b12eb27de/core/core-loggers/src)
+//! defines for each channel.
+//!
+//! Design background: <https://github.com/pnpm/pacquet/issues/344>.
+//!
+//! # Adding a channel
+//!
+//! Only the variants pacquet currently emits live in [`LogEvent`]. New
+//! channels are added incrementally as the surrounding code starts using
+//! them; the sweep across already-ported code is tracked in
+//! <https://github.com/pnpm/pacquet/issues/347>.
+
+use std::io::Write;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::Serialize;
+
+/// One log channel from `@pnpm/core-loggers`.
+///
+/// Variants are added as pacquet starts emitting them. The `name` tag in
+/// the serialized JSON identifies the channel; consumers (notably
+/// `@pnpm/cli.default-reporter`) dispatch on this value.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "name")]
+pub enum LogEvent {
+    /// Coarse install-pipeline phase markers (`pnpm:stage`).
+    ///
+    /// Upstream: <https://github.com/pnpm/pnpm/blob/3b12eb27de/core/core-loggers/src/stageLogger.ts>.
+    #[serde(rename = "pnpm:stage")]
+    Stage(StageLog),
+}
+
+/// `pnpm:stage` payload.
+///
+/// `prefix` is the project root path the stage applies to, matching pnpm's
+/// usage. `stage` is the phase marker.
+#[derive(Debug, Clone, Serialize)]
+pub struct StageLog {
+    pub level: LogLevel,
+    pub prefix: String,
+    pub stage: Stage,
+}
+
+/// `pnpm:stage` phase marker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Stage {
+    ResolutionStarted,
+    ResolutionDone,
+    ImportingStarted,
+    ImportingDone,
+}
+
+/// Severity level on the bunyan envelope.
+///
+/// pnpm's logger uses the bole library, which writes one of these strings
+/// for every record. Each channel pins the level pnpm itself uses (e.g.
+/// `pnpm:stage` is always emitted at `debug`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LogLevel {
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+/// Capability for emitting log events.
+///
+/// Follows the dependency-injection pattern documented in
+/// <https://github.com/pnpm/pacquet/issues/339>: methods are associated
+/// functions (no `&self`), implementations are unit structs, and any
+/// implementation-internal state lives in module-level `static`s. Functions
+/// that emit take a generic `R: Reporter` and call `R::emit(...)`; the
+/// production entry point monomorphises with the chosen sink.
+///
+/// `emit` must not panic. A serialization or I/O failure is swallowed so a
+/// reporter problem can never crash an install.
+pub trait Reporter {
+    fn emit(event: &LogEvent);
+}
+
+/// `--reporter=silent`: every event is dropped.
+pub struct SilentReporter;
+
+impl Reporter for SilentReporter {
+    fn emit(_event: &LogEvent) {}
+}
+
+/// `--reporter=ndjson`: writes one bunyan-shaped JSON record per event to
+/// stderr, terminated by `\n`. The wire format matches what pnpm itself
+/// produces under `--reporter=ndjson`, so the same consumers work
+/// unmodified.
+///
+/// Today this writes synchronously under the stderr lock. When the volume
+/// of emit sites grows past coarse start/end markers, the writer should
+/// move behind an MPSC channel (see #344's Implementation notes).
+pub struct NdjsonReporter;
+
+impl Reporter for NdjsonReporter {
+    fn emit(event: &LogEvent) {
+        let mut buf = Vec::with_capacity(256);
+        if write_record(&mut buf, event).is_err() {
+            return;
+        }
+        buf.push(b'\n');
+        let _ = std::io::stderr().lock().write_all(&buf);
+    }
+}
+
+fn write_record(buf: &mut Vec<u8>, event: &LogEvent) -> serde_json::Result<()> {
+    let envelope =
+        Envelope { time: now_millis(), hostname: hostname(), pid: std::process::id(), event };
+    serde_json::to_writer(buf, &envelope)
+}
+
+/// Wraps a [`LogEvent`] with the bunyan envelope fields pnpm's logger adds.
+///
+/// `#[serde(flatten)]` merges the channel-specific tag (`"name": "pnpm:..."`)
+/// and payload fields up to the top level of the JSON object so the wire
+/// format is one flat record per line.
+#[derive(Serialize)]
+struct Envelope<'a> {
+    time: u128,
+    hostname: &'a str,
+    pid: u32,
+    #[serde(flatten)]
+    event: &'a LogEvent,
+}
+
+fn now_millis() -> u128 {
+    SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_millis()).unwrap_or(0)
+}
+
+/// Best-effort hostname for the bunyan envelope.
+///
+/// pnpm's logger (via `bole`) populates this from `os.hostname()`. Pacquet
+/// reads it from the standard environment variables instead so we don't
+/// pay for a syscall on every reporter init: `HOSTNAME` on Unix shells,
+/// `COMPUTERNAME` on Windows. Empty string when neither is set —
+/// downstream consumers (notably `@pnpm/cli.default-reporter`) only
+/// dispatch on `name`, so this field is informational.
+fn hostname() -> &'static str {
+    use std::sync::OnceLock;
+    static HOSTNAME: OnceLock<String> = OnceLock::new();
+    HOSTNAME
+        .get_or_init(|| {
+            std::env::var("HOSTNAME").or_else(|_| std::env::var("COMPUTERNAME")).unwrap_or_default()
+        })
+        .as_str()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use pretty_assertions::assert_eq;
+    use serde_json::Value;
+
+    use super::*;
+
+    /// Stage log serializes with the channel name flattened into the
+    /// envelope alongside `time`, `hostname`, `pid`, and the payload
+    /// fields. This is the wire shape `@pnpm/cli.default-reporter`
+    /// consumes — adding a wrapper object would break it.
+    #[test]
+    fn stage_event_matches_pnpm_wire_shape() {
+        let event = LogEvent::Stage(StageLog {
+            level: LogLevel::Debug,
+            prefix: "/some/project".to_string(),
+            stage: Stage::ImportingStarted,
+        });
+        let envelope =
+            Envelope { time: 1_700_000_000_000, hostname: "host", pid: 4242, event: &event };
+
+        let json: Value =
+            serde_json::from_str(&serde_json::to_string(&envelope).expect("serialize envelope"))
+                .expect("parse JSON");
+
+        assert_eq!(json["name"], "pnpm:stage");
+        assert_eq!(json["stage"], "importing_started");
+        assert_eq!(json["level"], "debug");
+        assert_eq!(json["prefix"], "/some/project");
+        assert_eq!(json["time"], 1_700_000_000_000_u64);
+        assert_eq!(json["hostname"], "host");
+        assert_eq!(json["pid"], 4242);
+    }
+
+    /// Phase markers serialize as the snake_case strings pnpm uses.
+    #[test]
+    fn stage_phases_serialize_in_pnpm_form() {
+        let cases = [
+            (Stage::ResolutionStarted, "resolution_started"),
+            (Stage::ResolutionDone, "resolution_done"),
+            (Stage::ImportingStarted, "importing_started"),
+            (Stage::ImportingDone, "importing_done"),
+        ];
+        for (stage, expected) in cases {
+            let json = serde_json::to_string(&stage).expect("serialize stage");
+            assert_eq!(json, format!("\"{expected}\""), "phase {expected}");
+        }
+    }
+
+    /// `SilentReporter` is observably a no-op: any test fake is harder to
+    /// write than just calling it.
+    #[test]
+    fn silent_reporter_drops_events() {
+        // The point is that no panic, no I/O, and no observable side
+        // effect happens. The test passes by virtue of the call returning.
+        SilentReporter::emit(&LogEvent::Stage(StageLog {
+            level: LogLevel::Debug,
+            prefix: String::new(),
+            stage: Stage::ImportingStarted,
+        }));
+    }
+
+    /// Recording fake per the DI pattern in
+    /// <https://github.com/pnpm/pacquet/issues/339>: a unit struct declared
+    /// inside the `#[test]` body, recording into a `static` mutex declared
+    /// in the same body so the per-test isolation `#339` calls for stays
+    /// intact. This is the shape every consumer test in the workspace
+    /// should follow when asserting against emitted events.
+    #[test]
+    fn recording_fake_captures_emitted_events() {
+        static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
+
+        struct RecordingReporter;
+        impl Reporter for RecordingReporter {
+            fn emit(event: &LogEvent) {
+                EVENTS.lock().unwrap().push(event.clone());
+            }
+        }
+
+        fn install_step<R: Reporter>() {
+            R::emit(&LogEvent::Stage(StageLog {
+                level: LogLevel::Debug,
+                prefix: "/proj".to_string(),
+                stage: Stage::ImportingStarted,
+            }));
+            R::emit(&LogEvent::Stage(StageLog {
+                level: LogLevel::Debug,
+                prefix: "/proj".to_string(),
+                stage: Stage::ImportingDone,
+            }));
+        }
+
+        install_step::<RecordingReporter>();
+
+        let captured = EVENTS.lock().unwrap();
+        assert_eq!(captured.len(), 2);
+        assert!(matches!(
+            &captured[0],
+            LogEvent::Stage(StageLog { stage: Stage::ImportingStarted, .. })
+        ));
+        assert!(matches!(
+            &captured[1],
+            LogEvent::Stage(StageLog { stage: Stage::ImportingDone, .. })
+        ));
+    }
+}

--- a/crates/reporter/src/tests.rs
+++ b/crates/reporter/src/tests.rs
@@ -1,0 +1,123 @@
+use std::sync::Mutex;
+
+use pipe_trait::Pipe;
+use pretty_assertions::assert_eq;
+use serde_json::Value;
+
+use crate::{
+    Envelope, GetHostName, LogEvent, LogLevel, RealApi, Reporter, SilentReporter, Stage, StageLog,
+};
+
+/// Stage log serializes with the channel name flattened into the
+/// envelope alongside `time`, `hostname`, `pid`, and the payload
+/// fields. This is the wire shape `@pnpm/cli.default-reporter`
+/// consumes; adding a wrapper object would break it.
+#[test]
+fn stage_event_matches_pnpm_wire_shape() {
+    let event = LogEvent::Stage(StageLog {
+        level: LogLevel::Debug,
+        prefix: "/some/project".to_string(),
+        stage: Stage::ImportingStarted,
+    });
+    let envelope = Envelope { time: 1_700_000_000_000, hostname: "host", pid: 4242, event: &event };
+
+    let json: Value = envelope
+        .pipe_ref(serde_json::to_string)
+        .expect("serialize envelope")
+        .pipe_as_ref(serde_json::from_str)
+        .expect("parse JSON");
+
+    assert_eq!(json["name"], "pnpm:stage");
+    assert_eq!(json["stage"], "importing_started");
+    assert_eq!(json["level"], "debug");
+    assert_eq!(json["prefix"], "/some/project");
+    assert_eq!(json["time"], 1_700_000_000_000_u64);
+    assert_eq!(json["hostname"], "host");
+    assert_eq!(json["pid"], 4242);
+}
+
+/// Phase markers serialize as the snake_case strings pnpm uses.
+#[test]
+fn stage_phases_serialize_in_pnpm_form() {
+    let cases = [
+        (Stage::ResolutionStarted, "resolution_started"),
+        (Stage::ResolutionDone, "resolution_done"),
+        (Stage::ImportingStarted, "importing_started"),
+        (Stage::ImportingDone, "importing_done"),
+    ];
+    for (stage, expected) in cases {
+        let json = serde_json::to_string(&stage).expect("serialize stage");
+        assert_eq!(json, format!("\"{expected}\""), "phase {expected}");
+    }
+}
+
+/// [`SilentReporter`] is observably a no-op. Any test fake is harder
+/// to write than just calling it.
+#[test]
+fn silent_reporter_drops_events() {
+    // The point is that no panic, no I/O, and no observable side
+    // effect happens. The test passes by virtue of the call returning.
+    SilentReporter::emit(&LogEvent::Stage(StageLog {
+        level: LogLevel::Debug,
+        prefix: String::new(),
+        stage: Stage::ImportingStarted,
+    }));
+}
+
+#[test]
+fn recording_fake_captures_emitted_events() {
+    static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
+
+    struct RecordingReporter;
+    impl Reporter for RecordingReporter {
+        fn emit(event: &LogEvent) {
+            EVENTS.lock().unwrap().push(event.clone());
+        }
+    }
+
+    fn install_step<R: Reporter>() {
+        R::emit(&LogEvent::Stage(StageLog {
+            level: LogLevel::Debug,
+            prefix: "/proj".to_string(),
+            stage: Stage::ImportingStarted,
+        }));
+        R::emit(&LogEvent::Stage(StageLog {
+            level: LogLevel::Debug,
+            prefix: "/proj".to_string(),
+            stage: Stage::ImportingDone,
+        }));
+    }
+
+    install_step::<RecordingReporter>();
+
+    let captured = EVENTS.lock().unwrap();
+    assert_eq!(captured.len(), 2);
+    assert!(matches!(
+        &captured[0],
+        LogEvent::Stage(StageLog { stage: Stage::ImportingStarted, .. })
+    ));
+    assert!(matches!(&captured[1], LogEvent::Stage(StageLog { stage: Stage::ImportingDone, .. })));
+}
+
+/// A test fake of [`GetHostName`] returns whatever value its impl
+/// declares. This proves the capability trait is dispatchable from a
+/// test, which is what consumers of the trait need to know.
+#[test]
+fn get_host_name_capability_is_mockable() {
+    struct FakeApi;
+    impl GetHostName for FakeApi {
+        fn get_host_name() -> String {
+            "fixture-host".to_owned()
+        }
+    }
+    assert_eq!(FakeApi::get_host_name(), "fixture-host");
+}
+
+/// [`RealApi::get_host_name`] returns the value of `gethostname(2)`,
+/// which any real environment populates with at least one byte.
+#[test]
+fn real_api_returns_a_non_empty_host_name() {
+    let host = RealApi::get_host_name();
+    eprintln!("RealApi::get_host_name() = {host:?}");
+    assert!(!host.is_empty());
+}


### PR DESCRIPTION
## Summary

Lands the reporting engine from #344's design as the first step toward
#345. Establishes:

- A typed `LogEvent` enum mirroring `@pnpm/core-loggers`, starting with
  the `pnpm:stage` channel.
- The `Reporter` capability trait per the DI pattern in #339 — no `&self`,
  associated function, generic threading at call sites, unit-struct
  implementations.
- `NdjsonReporter` (writes pnpm-wire-format records to stderr, one per
  line) and `SilentReporter` (no-op).
- A `--reporter=ndjson|silent` CLI flag dispatched at the entry point via
  turbofish into the install pipeline.
- Smoke test: `Install::run` emits `pnpm:stage` `importing_started` /
  `importing_done` bracketing the install, validated by a recording-fake
  test using the per-test-`static`-mutex pattern from #339.

The default reporter is `silent` until the spawn-and-pipe wiring exists,
so user-facing output is unchanged on this PR.

## What's deferred

These were in the original #345 scope but split into follow-ups so this PR
stays reviewable:

- **`--reporter=default` and the JS-reporter spawn-and-pipe.** Picking the
  delivery vehicle (system Node + bundled wrapper script vs. an `npx`
  bridge package vs. waiting for the Integration Milestone N-API path) is
  its own discussion and shouldn't be tangled with the engine PR.
- **MPSC writer task and emit-side throttle.** Earn their complexity once
  there are multiple concurrent emit points and a high-volume channel
  (`pnpm:fetching-progress`). Today there's one stage emit at start/end
  of install — `stderr().lock()` is the right level of complexity.
- **Identifier interning (`Arc<str>`).** Earns its complexity once channels
  fire per-package; not yet.
- **Schema-version pinning + CI check.** Needs a separate decision on
  which pnpm version pacquet targets and whether the check runs against a
  TS schema, a JSON Schema, or a Rust-side round-trip.
- **All the other `LogEvent` variants.** Added under #347 as each crate's
  emissions are wired.

## Tests

- `cargo nextest run -p pacquet-reporter`: 4 tests, all passing.
  - `stage_event_matches_pnpm_wire_shape` — JSON shape assertion against
    `name`, `stage`, `level`, `prefix`, `time`, `hostname`, `pid`.
  - `stage_phases_serialize_in_pnpm_form` — snake_case phase names match
    pnpm's.
  - `silent_reporter_drops_events` — no panic, no I/O.
  - `recording_fake_captures_emitted_events` — exercises the #339
    per-test-`static`-mutex DI pattern.
- `cargo nextest run -p pacquet-package-manager
  install_emits_stage_events_bracketing_the_run`: integration test using
  an empty v9 lockfile fixture (cheapest "real" install path), asserting
  exactly `[ImportingStarted, ImportingDone]`.
- `just ready` is green: 253 tests pass, 2 skipped, lint clean.

## Test plan

- [x] `cargo nextest run -p pacquet-reporter`
- [x] `cargo nextest run -p pacquet-package-manager`
- [x] `just ready`
- [x] `pacquet --help` lists `--reporter` with `ndjson` / `silent` values
      and `silent` as default.

## References

- Design issue: #344
- Issue closed by full work tracked in #345 — this PR delivers the
  engine slice; spawn-and-pipe + extra channels follow.
- Pattern reference: #339 (no-`self` capability + per-test `static`
  mutex DI).
- Upstream `@pnpm/core-loggers` (pinned): https://github.com/pnpm/pnpm/tree/3b12eb27de/core/core-loggers/src
- Upstream `stageLogger`: https://github.com/pnpm/pnpm/blob/3b12eb27de/core/core-loggers/src/stageLogger.ts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global --reporter flag (ndjson, silent); defaults to silent.
  * Introduced NDJSON structured event logging (stage start/done events) for install/add operations to enable machine-readable progress output.

* **Chores**
  * Added a packaged reporter component available to the workspace.

* **Tests**
  * Added tests validating reporter output, event ordering, and hostname handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->