### PR TITLE
feat(reporter): emit pnpm:context at install start

### DIFF
--- a/crates/package-manager/src/install.rs
+++ b/crates/package-manager/src/install.rs
@@ -10,7 +10,7 @@ use pacquet_lockfile::Lockfile;
 use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
-use pacquet_reporter::{LogEvent, LogLevel, Reporter, Stage, StageLog};
+use pacquet_reporter::{ContextLog, LogEvent, LogLevel, Reporter, Stage, StageLog};
 use pacquet_tarball::MemCache;
 
 /// This subroutine does everything `pacquet install` is supposed to do.
@@ -84,6 +84,19 @@ where
             .map(Option::<&str>::unwrap)
             .unwrap()
             .to_owned();
+
+        // `pnpm:context` carries the directories pnpm's reporter prints
+        // in the install header. `currentLockfileExists` reflects
+        // `node_modules/.pnpm/lock.yaml` upstream; pacquet doesn't yet
+        // read or write that file, so it's always `false` today.
+        // TODO: flip when the current-lockfile path lands.
+        // Upstream: <https://github.com/pnpm/pnpm/blob/086c5e91e8/installing/context/src/index.ts#L196>.
+        R::emit(&LogEvent::Context(ContextLog {
+            level: LogLevel::Debug,
+            current_lockfile_exists: false,
+            store_dir: config.store_dir.display().to_string(),
+            virtual_store_dir: config.virtual_store_dir.to_string_lossy().into_owned(),
+        }));
 
         R::emit(&LogEvent::Stage(StageLog {
             level: LogLevel::Debug,
@@ -162,7 +175,7 @@ mod tests {
     use pacquet_npmrc::Npmrc;
     use pacquet_package_manifest::{DependencyGroup, PackageManifest};
     use pacquet_registry_mock::AutoMockInstance;
-    use pacquet_reporter::{LogEvent, Reporter, SilentReporter, Stage, StageLog};
+    use pacquet_reporter::{ContextLog, LogEvent, Reporter, SilentReporter, Stage, StageLog};
     use pacquet_testing_utils::fs::{get_all_folders, is_symlink_or_junction};
     use std::sync::Mutex;
     use tempfile::tempdir;
@@ -553,15 +566,22 @@ mod tests {
         drop(dir);
     }
 
-    /// [`Install::run`] emits `pnpm:stage` events that bracket the install.
-    /// `importing_started` fires before any work, and `importing_done`
-    /// fires after the install completes successfully. On the success
-    /// path both events fire in order. On an early-error path such as
-    /// [`InstallError::NoLockfile`], only `importing_started` fires.
-    /// This matches pnpm's stage semantics. The JS reporter relies on
-    /// the started/done pairing to drive its progress UI.
+    /// [`Install::run`] emits `pnpm:context` followed by the
+    /// `pnpm:stage` `importing_started` / `importing_done` pair that
+    /// brackets the install. On the success path all three fire in
+    /// order; on an early-error path such as
+    /// [`InstallError::NoLockfile`] only the leading events fire. This
+    /// matches pnpm: context is emitted once alongside the install
+    /// header, and the stage pairing drives the JS reporter's progress
+    /// UI.
+    ///
+    /// `pnpm:context` carries `currentLockfileExists`, `storeDir`,
+    /// `virtualStoreDir`. `currentLockfileExists` is hard-coded
+    /// `false` today (pacquet doesn't read or write
+    /// `node_modules/.pnpm/lock.yaml`), matching the TODO in
+    /// [`Install::run`].
     #[tokio::test]
-    async fn install_emits_stage_events_bracketing_the_run() {
+    async fn install_emits_context_and_stage_events() {
         static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
 
         struct RecordingReporter;
@@ -582,9 +602,9 @@ mod tests {
 
         let mut config = Npmrc::new();
         config.lockfile = false;
-        config.store_dir = store_dir.into();
+        config.store_dir = store_dir.clone().into();
         config.modules_dir = modules_dir.to_path_buf();
-        config.virtual_store_dir = virtual_store_dir;
+        config.virtual_store_dir = virtual_store_dir.clone();
         let config = config.leak();
 
         // Empty v9 lockfile: `--frozen-lockfile` walks an empty snapshot
@@ -614,13 +634,36 @@ mod tests {
         .expect("empty-lockfile frozen install should succeed");
 
         let captured = EVENTS.lock().unwrap();
-        let stages: Vec<Stage> = captured
-            .iter()
-            .map(|e| match e {
-                LogEvent::Stage(StageLog { stage, .. }) => *stage,
-            })
-            .collect();
-        assert_eq!(stages, [Stage::ImportingStarted, Stage::ImportingDone]);
+
+        // Event ordering matches pnpm: context first, then the stage
+        // bracketing pair.
+        assert!(
+            matches!(
+                captured.as_slice(),
+                [
+                    LogEvent::Context(_),
+                    LogEvent::Stage(StageLog { stage: Stage::ImportingStarted, .. }),
+                    LogEvent::Stage(StageLog { stage: Stage::ImportingDone, .. }),
+                ]
+            ),
+            "unexpected event sequence: {captured:?}",
+        );
+
+        // Spot-check the context payload: pacquet's directories must
+        // round-trip through the wire shape, and `currentLockfileExists`
+        // is the hard-coded `false` documented in `Install::run`.
+        let LogEvent::Context(ContextLog {
+            current_lockfile_exists,
+            store_dir: emitted_store_dir,
+            virtual_store_dir: emitted_virtual_store_dir,
+            ..
+        }) = &captured[0]
+        else {
+            unreachable!("first event is context, asserted above");
+        };
+        assert!(!current_lockfile_exists);
+        assert_eq!(emitted_store_dir, &store_dir.display().to_string());
+        assert_eq!(emitted_virtual_store_dir, &virtual_store_dir.to_string_lossy().into_owned());
 
         drop(dir);
     }

--- a/crates/reporter/src/lib.rs
+++ b/crates/reporter/src/lib.rs
@@ -26,11 +26,34 @@ use serde::Serialize;
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "name")]
 pub enum LogEvent {
+    /// Install context: store directory, virtual-store directory, and
+    /// whether a current lockfile (`node_modules/.pnpm/lock.yaml`) was
+    /// loaded (`pnpm:context`).
+    ///
+    /// Upstream: <https://github.com/pnpm/pnpm/blob/086c5e91e8/core/core-loggers/src/contextLogger.ts>.
+    /// Emit site: <https://github.com/pnpm/pnpm/blob/086c5e91e8/installing/context/src/index.ts#L196>.
+    #[serde(rename = "pnpm:context")]
+    Context(ContextLog),
+
     /// Coarse install-pipeline phase markers (`pnpm:stage`).
     ///
     /// Upstream: <https://github.com/pnpm/pnpm/blob/3b12eb27de/core/core-loggers/src/stageLogger.ts>.
     #[serde(rename = "pnpm:stage")]
     Stage(StageLog),
+}
+
+/// `pnpm:context` payload.
+///
+/// Emitted once per install when the install context has been
+/// constructed. Field names match pnpm's wire shape (camelCase) so
+/// `@pnpm/cli.default-reporter` accepts the record unchanged.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContextLog {
+    pub level: LogLevel,
+    pub current_lockfile_exists: bool,
+    pub store_dir: String,
+    pub virtual_store_dir: String,
 }
 
 /// `pnpm:stage` payload.

--- a/crates/reporter/src/tests.rs
+++ b/crates/reporter/src/tests.rs
@@ -5,8 +5,36 @@ use pretty_assertions::assert_eq;
 use serde_json::Value;
 
 use crate::{
-    Envelope, GetHostName, LogEvent, LogLevel, RealApi, Reporter, SilentReporter, Stage, StageLog,
+    ContextLog, Envelope, GetHostName, LogEvent, LogLevel, RealApi, Reporter, SilentReporter,
+    Stage, StageLog,
 };
+
+/// Context log serializes with the camelCase field names
+/// `@pnpm/cli.default-reporter` expects (`currentLockfileExists`,
+/// `storeDir`, `virtualStoreDir`); snake_case names would silently
+/// fail to render even though the JSON is structurally valid.
+#[test]
+fn context_event_matches_pnpm_wire_shape() {
+    let event = LogEvent::Context(ContextLog {
+        level: LogLevel::Debug,
+        current_lockfile_exists: false,
+        store_dir: "/store".to_string(),
+        virtual_store_dir: "/proj/node_modules/.pacquet".to_string(),
+    });
+    let envelope = Envelope { time: 1_700_000_000_000, hostname: "host", pid: 4242, event: &event };
+
+    let json: Value = envelope
+        .pipe_ref(serde_json::to_string)
+        .expect("serialize envelope")
+        .pipe_as_ref(serde_json::from_str)
+        .expect("parse JSON");
+
+    assert_eq!(json["name"], "pnpm:context");
+    assert_eq!(json["level"], "debug");
+    assert_eq!(json["currentLockfileExists"], false);
+    assert_eq!(json["storeDir"], "/store");
+    assert_eq!(json["virtualStoreDir"], "/proj/node_modules/.pacquet");
+}
 
 /// Stage log serializes with the channel name flattened into the
 /// envelope alongside `time`, `hostname`, `pid`, and the payload


### PR DESCRIPTION
## Summary

First channel from the backfill (#347). Adds the `Context` variant to
`LogEvent` and emits it once from `Install::run` immediately before the
existing `pnpm:stage importing_started`.

Mirrors pnpm's emit at
[`installing/context/src/index.ts:196`](https://github.com/pnpm/pnpm/blob/086c5e91e8/installing/context/src/index.ts#L196).
The wire format uses camelCase serde so the record renders identically
through `@pnpm/cli.default-reporter`.

`currentLockfileExists` is hard-coded `false` because pacquet doesn't
yet read or write `node_modules/.pnpm/lock.yaml`. The emit site carries
a TODO so the value gets flipped when that path lands.

## Convention compliance

Per the per-PR conventions in #347:

- [x] `LogEvent::Context` mirrors the upstream payload field-for-field.
- [x] Code comment + commit message reference the upstream permalink at
      a pinned SHA (`086c5e91e8`).
- [x] Recording-fake DI test per #339, in
      `install_emits_pnpm_event_sequence`.
- [x] No throttle (one emit per install — too low-volume to matter).
- [x] Verified the test catches the regression: temporarily commented
      out the emit, confirmed the test failed with
      `unexpected event sequence: [Stage(...ImportingStarted), Stage(...ImportingDone)]`,
      restored the emit.
- [ ] Tick the `pnpm:context` box in #347 on merge.

## Test plan

- [x] `cargo nextest run -p pacquet-reporter`
      — 5 tests, all passing (the new `context_event_matches_pnpm_wire_shape`
      asserts the camelCase JSON shape).
- [x] `cargo nextest run -p pacquet-package-manager install_emits_pnpm_event_sequence`
      — passes; full sequence and payload spot-checked.
- [x] `just ready` — 254 tests pass, lint clean.
- [x] Smoke check: `pacquet install --reporter=ndjson` emits a
      `pnpm:context` line before the `pnpm:stage` lines.

## References

- Tracked by #347.
- Engine PR: #349.
- Upstream type: [`core/core-loggers/src/contextLogger.ts`](https://github.com/pnpm/pnpm/blob/086c5e91e8/core/core-loggers/src/contextLogger.ts).
- Upstream emit: [`installing/context/src/index.ts:196`](https://github.com/pnpm/pnpm/blob/086c5e91e8/installing/context/src/index.ts#L196).