### PR TITLE
feat(reporter): emit pnpm:summary at install end

### DIFF
--- a/crates/package-manager/src/install.rs
+++ b/crates/package-manager/src/install.rs
@@ -10,7 +10,7 @@ use pacquet_lockfile::Lockfile;
 use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
-use pacquet_reporter::{ContextLog, LogEvent, LogLevel, Reporter, Stage, StageLog};
+use pacquet_reporter::{ContextLog, LogEvent, LogLevel, Reporter, Stage, StageLog, SummaryLog};
 use pacquet_tarball::MemCache;
 
 /// This subroutine does everything `pacquet install` is supposed to do.
@@ -160,9 +160,15 @@ where
 
         R::emit(&LogEvent::Stage(StageLog {
             level: LogLevel::Debug,
-            prefix,
+            prefix: prefix.clone(),
             stage: Stage::ImportingDone,
         }));
+
+        // `pnpm:summary` closes the install and lets the reporter render
+        // the accumulated `pnpm:root` events as a "+N -M" block. Must
+        // come after `importing_done`, matching pnpm's ordering at
+        // <https://github.com/pnpm/pnpm/blob/086c5e91e8/installing/deps-installer/src/install/index.ts#L1663>.
+        R::emit(&LogEvent::Summary(SummaryLog { level: LogLevel::Debug, prefix }));
 
         Ok(())
     }
@@ -175,7 +181,9 @@ mod tests {
     use pacquet_npmrc::Npmrc;
     use pacquet_package_manifest::{DependencyGroup, PackageManifest};
     use pacquet_registry_mock::AutoMockInstance;
-    use pacquet_reporter::{ContextLog, LogEvent, Reporter, SilentReporter, Stage, StageLog};
+    use pacquet_reporter::{
+        ContextLog, LogEvent, Reporter, SilentReporter, Stage, StageLog, SummaryLog,
+    };
     use pacquet_testing_utils::fs::{get_all_folders, is_symlink_or_junction};
     use std::sync::Mutex;
     use tempfile::tempdir;
@@ -566,14 +574,14 @@ mod tests {
         drop(dir);
     }
 
-    /// [`Install::run`] emits `pnpm:context` followed by the
-    /// `pnpm:stage` `importing_started` / `importing_done` pair that
-    /// brackets the install. On the success path all three fire in
-    /// order; on an early-error path such as
+    /// [`Install::run`] emits `pnpm:context`, then `pnpm:stage`
+    /// `importing_started`, then on the success path `importing_done`
+    /// followed by `pnpm:summary`. On an early-error path such as
     /// [`InstallError::NoLockfile`] only the leading events fire. This
     /// matches pnpm: context is emitted once alongside the install
-    /// header, and the stage pairing drives the JS reporter's progress
-    /// UI.
+    /// header, the stage pairing drives the JS reporter's progress
+    /// UI, and summary closes the run so the reporter can render its
+    /// "+N -M" block.
     ///
     /// `pnpm:context` carries `currentLockfileExists`, `storeDir`,
     /// `virtualStoreDir`. `currentLockfileExists` is hard-coded
@@ -581,7 +589,7 @@ mod tests {
     /// `node_modules/.pnpm/lock.yaml`), matching the TODO in
     /// [`Install::run`].
     #[tokio::test]
-    async fn install_emits_context_and_stage_events() {
+    async fn install_emits_pnpm_event_sequence() {
         static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
 
         struct RecordingReporter;
@@ -635,8 +643,8 @@ mod tests {
 
         let captured = EVENTS.lock().unwrap();
 
-        // Event ordering matches pnpm: context first, then the stage
-        // bracketing pair.
+        // Event ordering matches pnpm: context, then the stage
+        // bracketing pair, then summary closing the run.
         assert!(
             matches!(
                 captured.as_slice(),
@@ -644,6 +652,7 @@ mod tests {
                     LogEvent::Context(_),
                     LogEvent::Stage(StageLog { stage: Stage::ImportingStarted, .. }),
                     LogEvent::Stage(StageLog { stage: Stage::ImportingDone, .. }),
+                    LogEvent::Summary(_),
                 ]
             ),
             "unexpected event sequence: {captured:?}",
@@ -664,6 +673,17 @@ mod tests {
         assert!(!current_lockfile_exists);
         assert_eq!(emitted_store_dir, &store_dir.display().to_string());
         assert_eq!(emitted_virtual_store_dir, &virtual_store_dir.to_string_lossy().into_owned());
+
+        // Summary's `prefix` must equal the manifest-parent value
+        // `Install::run` derives, since pnpm's reporter keys its
+        // accumulated root-events by prefix to render the diff.
+        let LogEvent::Summary(SummaryLog { prefix: summary_prefix, .. }) = &captured[3] else {
+            unreachable!("fourth event is summary, asserted above");
+        };
+        assert_eq!(
+            summary_prefix,
+            &manifest.path().parent().unwrap().to_string_lossy().into_owned(),
+        );
 
         drop(dir);
     }

--- a/crates/reporter/src/lib.rs
+++ b/crates/reporter/src/lib.rs
@@ -86,8 +86,12 @@ pub enum Stage {
     ImportingDone,
 }
 
-/// `pnpm:summary` payload. pnpm carries only the importer prefix and
-/// uses the surrounding `pnpm:root` history to render the diff.
+/// `pnpm:summary` payload. `prefix` identifies the importer; pnpm's
+/// reporter uses it to look up the matching `pnpm:root` history and
+/// render its "+N -M" diff. `level` is the [bunyan]-envelope severity,
+/// common to every channel.
+///
+/// [bunyan]: https://github.com/trentm/node-bunyan
 #[derive(Debug, Clone, Serialize)]
 pub struct SummaryLog {
     pub level: LogLevel,

--- a/crates/reporter/src/lib.rs
+++ b/crates/reporter/src/lib.rs
@@ -40,6 +40,15 @@ pub enum LogEvent {
     /// Upstream: <https://github.com/pnpm/pnpm/blob/3b12eb27de/core/core-loggers/src/stageLogger.ts>.
     #[serde(rename = "pnpm:stage")]
     Stage(StageLog),
+
+    /// End-of-install marker (`pnpm:summary`). pnpm's reporter combines
+    /// this with the accumulated `pnpm:root` events to render the final
+    /// "+N -M" block.
+    ///
+    /// Upstream: <https://github.com/pnpm/pnpm/blob/086c5e91e8/core/core-loggers/src/summaryLogger.ts>.
+    /// Emit site: <https://github.com/pnpm/pnpm/blob/086c5e91e8/installing/deps-installer/src/install/index.ts#L1663>.
+    #[serde(rename = "pnpm:summary")]
+    Summary(SummaryLog),
 }
 
 /// `pnpm:context` payload.
@@ -75,6 +84,14 @@ pub enum Stage {
     ResolutionDone,
     ImportingStarted,
     ImportingDone,
+}
+
+/// `pnpm:summary` payload. pnpm carries only the importer prefix and
+/// uses the surrounding `pnpm:root` history to render the diff.
+#[derive(Debug, Clone, Serialize)]
+pub struct SummaryLog {
+    pub level: LogLevel,
+    pub prefix: String,
 }
 
 /// Severity level on the [bunyan]-shaped envelope.

--- a/crates/reporter/src/tests.rs
+++ b/crates/reporter/src/tests.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 
 use crate::{
     ContextLog, Envelope, GetHostName, LogEvent, LogLevel, RealApi, Reporter, SilentReporter,
-    Stage, StageLog,
+    Stage, StageLog, SummaryLog,
 };
 
 /// Context log serializes with the camelCase field names
@@ -62,6 +62,29 @@ fn stage_event_matches_pnpm_wire_shape() {
     assert_eq!(json["time"], 1_700_000_000_000_u64);
     assert_eq!(json["hostname"], "host");
     assert_eq!(json["pid"], 4242);
+}
+
+/// Summary log serializes with the channel name flattened into the
+/// envelope; the payload is just `prefix`, since pnpm's reporter
+/// combines this event with the accumulated `pnpm:root` history to
+/// render its "+N -M" block.
+#[test]
+fn summary_event_matches_pnpm_wire_shape() {
+    let event = LogEvent::Summary(SummaryLog {
+        level: LogLevel::Debug,
+        prefix: "/some/project".to_string(),
+    });
+    let envelope = Envelope { time: 1_700_000_000_000, hostname: "host", pid: 4242, event: &event };
+
+    let json: Value = envelope
+        .pipe_ref(serde_json::to_string)
+        .expect("serialize envelope")
+        .pipe_as_ref(serde_json::from_str)
+        .expect("parse JSON");
+
+    assert_eq!(json["name"], "pnpm:summary");
+    assert_eq!(json["level"], "debug");
+    assert_eq!(json["prefix"], "/some/project");
 }
 
 /// Phase markers serialize as the snake_case strings pnpm uses.

--- a/crates/reporter/src/tests.rs
+++ b/crates/reporter/src/tests.rs
@@ -65,9 +65,11 @@ fn stage_event_matches_pnpm_wire_shape() {
 }
 
 /// Summary log serializes with the channel name flattened into the
-/// envelope; the payload is just `prefix`, since pnpm's reporter
-/// combines this event with the accumulated `pnpm:root` history to
-/// render its "+N -M" block.
+/// envelope alongside `prefix` and the [bunyan]-envelope `level`.
+/// `prefix` is what pnpm's reporter uses to find the matching
+/// `pnpm:root` history and render its "+N -M" block.
+///
+/// [bunyan]: https://github.com/trentm/node-bunyan
 #[test]
 fn summary_event_matches_pnpm_wire_shape() {
     let event = LogEvent::Summary(SummaryLog {


### PR DESCRIPTION
## Summary

Second channel from the backfill (#347). Adds the `Summary` variant to
`LogEvent` and emits it from `Install::run` after the existing
`pnpm:stage importing_done`.

Mirrors pnpm's emit at
[`installing/deps-installer/src/install/index.ts:1663`](https://github.com/pnpm/pnpm/blob/086c5e91e8/installing/deps-installer/src/install/index.ts#L1663).
The payload carries only `prefix`; pnpm's reporter combines this with
the accumulated `pnpm:root` events to render the final "+N -M" diff
block. `pnpm:root` is its own backfill item (still unchecked in #347),
so today the summary is emitted but the diff block stays empty — same
as pnpm's behavior on a no-op install.

Stacked on #354 (`pnpm:context`).

## Convention compliance

Per the per-PR conventions in #347:

- [x] `LogEvent::Summary` mirrors the upstream payload field-for-field.
- [x] Code comment + commit message reference the upstream permalink at
      the pinned SHA (`086c5e91e8`).
- [x] Recording-fake DI test extended to cover the new event.
- [x] No throttle (one emit per install).
- [x] Verified the test catches the regression: commented out the
      emit, confirmed
      `unexpected event sequence: [Context, ImportingStarted, ImportingDone]`,
      restored.
- [ ] Tick the `pnpm:summary` box in #347 on merge.

## Drive-by rename

Renamed the install integration test from
`install_emits_context_and_stage_events` to
`install_emits_pnpm_event_sequence`. The test now asserts four events
(context, importing_started, importing_done, summary) and will keep
growing as more channels land at the install boundary
(`pnpm:package-manifest`, `pnpm:stats`, etc.). A stable name avoids
churn in subsequent PRs.

## Test plan

- [x] `cargo nextest run -p pacquet-reporter` — 6 tests, including the
      new `summary_event_matches_pnpm_wire_shape`.
- [x] `cargo nextest run -p pacquet-package-manager install_emits_pnpm_event_sequence`
      — passes; full sequence and summary's prefix spot-checked.
- [x] `just ready` — 255 tests pass, lint clean.
- [x] Smoke check: `pacquet install --reporter=ndjson` emits a
      `pnpm:summary` line after the closing `pnpm:stage` line.

## References

- Tracked by #347.
- Engine PR: #349.
- Previous channel PR (`pnpm:context`): #354.
- Upstream type: [`core/core-loggers/src/summaryLogger.ts`](https://github.com/pnpm/pnpm/blob/086c5e91e8/core/core-loggers/src/summaryLogger.ts).
- Upstream emit: [`installing/deps-installer/src/install/index.ts:1663`](https://github.com/pnpm/pnpm/blob/086c5e91e8/installing/deps-installer/src/install/index.ts#L1663).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pnpm summary logging to display package management summaries ("+N -M" blocks) in correct order.

* **Tests**
  * Updated test coverage for summary event serialization and event ordering verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->