### PR TITLE
feat(reporter): emit pnpm:package-import-method from link_file

### DIFF
--- a/crates/package-manager/src/create_cas_files.rs
+++ b/crates/package-manager/src/create_cas_files.rs
@@ -2,6 +2,7 @@ use crate::{LinkFileError, link_file};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_npmrc::PackageImportMethod;
+use pacquet_reporter::Reporter;
 use rayon::prelude::*;
 use std::{
     collections::{HashMap, HashSet},
@@ -25,7 +26,7 @@ pub enum CreateCasFilesError {
 /// If `dir_path` doesn't exist, create and populate it with files from `cas_paths`.
 ///
 /// If `dir_path` already exists, do nothing.
-pub fn create_cas_files(
+pub fn create_cas_files<R: Reporter>(
     import_method: PackageImportMethod,
     dir_path: &Path,
     cas_paths: &HashMap<String, PathBuf>,
@@ -73,7 +74,7 @@ pub fn create_cas_files(
     cas_paths
         .par_iter()
         .try_for_each(|(cleaned_entry, store_path)| {
-            link_file(import_method, store_path, &dir_path.join(cleaned_entry))
+            link_file::<R>(import_method, store_path, &dir_path.join(cleaned_entry))
         })
         .map_err(CreateCasFilesError::LinkFile)
 }

--- a/crates/package-manager/src/create_cas_files.rs
+++ b/crates/package-manager/src/create_cas_files.rs
@@ -8,6 +8,7 @@ use std::{
     collections::{HashMap, HashSet},
     fs, io,
     path::{Path, PathBuf},
+    sync::atomic::AtomicU8,
 };
 
 /// Error type for [`create_cas_files`].
@@ -27,6 +28,7 @@ pub enum CreateCasFilesError {
 ///
 /// If `dir_path` already exists, do nothing.
 pub fn create_cas_files<R: Reporter>(
+    logged_methods: &AtomicU8,
     import_method: PackageImportMethod,
     dir_path: &Path,
     cas_paths: &HashMap<String, PathBuf>,
@@ -74,7 +76,7 @@ pub fn create_cas_files<R: Reporter>(
     cas_paths
         .par_iter()
         .try_for_each(|(cleaned_entry, store_path)| {
-            link_file::<R>(import_method, store_path, &dir_path.join(cleaned_entry))
+            link_file::<R>(logged_methods, import_method, store_path, &dir_path.join(cleaned_entry))
         })
         .map_err(CreateCasFilesError::LinkFile)
 }

--- a/crates/package-manager/src/create_virtual_dir_by_snapshot.rs
+++ b/crates/package-manager/src/create_virtual_dir_by_snapshot.rs
@@ -3,6 +3,7 @@ use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_lockfile::{PackageKey, SnapshotEntry};
 use pacquet_npmrc::PackageImportMethod;
+use pacquet_reporter::Reporter;
 use std::{
     collections::HashMap,
     fs, io,
@@ -46,7 +47,7 @@ pub enum CreateVirtualDirError {
 
 impl<'a> CreateVirtualDirBySnapshot<'a> {
     /// Execute the subroutine.
-    pub fn run(self) -> Result<(), CreateVirtualDirError> {
+    pub fn run<R: Reporter>(self) -> Result<(), CreateVirtualDirError> {
         let CreateVirtualDirBySnapshot {
             virtual_store_dir,
             cas_paths,
@@ -75,7 +76,7 @@ impl<'a> CreateVirtualDirBySnapshot<'a> {
         // current stack frame.
         let (cas_result, symlink_result) = rayon::join(
             || {
-                create_cas_files(import_method, &save_path, cas_paths)
+                create_cas_files::<R>(import_method, &save_path, cas_paths)
                     .map_err(CreateVirtualDirError::CreateCasFiles)
             },
             || match snapshot.dependencies.as_ref() {

--- a/crates/package-manager/src/create_virtual_dir_by_snapshot.rs
+++ b/crates/package-manager/src/create_virtual_dir_by_snapshot.rs
@@ -8,6 +8,7 @@ use std::{
     collections::HashMap,
     fs, io,
     path::{Path, PathBuf},
+    sync::atomic::AtomicU8,
 };
 
 /// This subroutine creates the virtual-store slot for one package and then
@@ -23,6 +24,10 @@ pub struct CreateVirtualDirBySnapshot<'a> {
     pub virtual_store_dir: &'a Path,
     pub cas_paths: &'a HashMap<String, PathBuf>,
     pub import_method: PackageImportMethod,
+    /// Install-scoped dedupe state for `pnpm:package-import-method`.
+    /// See the comment on `link_file::log_method_once` for why this
+    /// is install-scoped rather than module-static.
+    pub logged_methods: &'a AtomicU8,
     pub package_key: &'a PackageKey,
     pub snapshot: &'a SnapshotEntry,
 }
@@ -52,6 +57,7 @@ impl<'a> CreateVirtualDirBySnapshot<'a> {
             virtual_store_dir,
             cas_paths,
             import_method,
+            logged_methods,
             package_key,
             snapshot,
         } = self;
@@ -76,7 +82,7 @@ impl<'a> CreateVirtualDirBySnapshot<'a> {
         // current stack frame.
         let (cas_result, symlink_result) = rayon::join(
             || {
-                create_cas_files::<R>(import_method, &save_path, cas_paths)
+                create_cas_files::<R>(logged_methods, import_method, &save_path, cas_paths)
                     .map_err(CreateVirtualDirError::CreateCasFiles)
             },
             || match snapshot.dependencies.as_ref() {

--- a/crates/package-manager/src/create_virtual_store.rs
+++ b/crates/package-manager/src/create_virtual_store.rs
@@ -11,7 +11,7 @@ use pacquet_reporter::Reporter;
 use pacquet_store_dir::{SharedVerifiedFilesCache, StoreIndex, StoreIndexWriter, store_index_key};
 use pacquet_tarball::prefetch_cas_paths;
 use pipe_trait::Pipe;
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::atomic::AtomicU8};
 
 /// This subroutine generates filesystem layout for the virtual store at `node_modules/.pacquet`.
 #[must_use]
@@ -20,6 +20,9 @@ pub struct CreateVirtualStore<'a> {
     pub config: &'static Npmrc,
     pub packages: Option<&'a HashMap<PackageKey, PackageMetadata>>,
     pub snapshots: Option<&'a HashMap<PackageKey, SnapshotEntry>>,
+    /// Install-scoped dedupe state for `pnpm:package-import-method`.
+    /// See `link_file::log_method_once`.
+    pub logged_methods: &'a AtomicU8,
 }
 
 /// Error type of [`CreateVirtualStore`].
@@ -44,7 +47,7 @@ pub enum CreateVirtualStoreError {
 impl<'a> CreateVirtualStore<'a> {
     /// Execute the subroutine.
     pub async fn run<R: Reporter>(self) -> Result<(), CreateVirtualStoreError> {
-        let CreateVirtualStore { http_client, config, packages, snapshots } = self;
+        let CreateVirtualStore { http_client, config, packages, snapshots, logged_methods } = self;
 
         let Some(snapshots) = snapshots else {
             // No snapshots to install. If the lockfile also has no project deps
@@ -252,6 +255,7 @@ impl<'a> CreateVirtualStore<'a> {
                         virtual_store_dir,
                         cas_paths: cas_paths.as_ref(),
                         import_method,
+                        logged_methods,
                         package_key: snapshot_key,
                         snapshot,
                     }
@@ -293,6 +297,7 @@ impl<'a> CreateVirtualStore<'a> {
                         store_index_writer: store_index_writer_ref,
                         prefetched_cas_paths: prefetched_ref,
                         verified_files_cache: verified_files_cache_ref,
+                        logged_methods,
                         package_key: snapshot_key,
                         metadata,
                         snapshot,

--- a/crates/package-manager/src/create_virtual_store.rs
+++ b/crates/package-manager/src/create_virtual_store.rs
@@ -7,6 +7,7 @@ use miette::Diagnostic;
 use pacquet_lockfile::{LockfileResolution, PackageKey, PackageMetadata, SnapshotEntry};
 use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
+use pacquet_reporter::Reporter;
 use pacquet_store_dir::{SharedVerifiedFilesCache, StoreIndex, StoreIndexWriter, store_index_key};
 use pacquet_tarball::prefetch_cas_paths;
 use pipe_trait::Pipe;
@@ -42,7 +43,7 @@ pub enum CreateVirtualStoreError {
 
 impl<'a> CreateVirtualStore<'a> {
     /// Execute the subroutine.
-    pub async fn run(self) -> Result<(), CreateVirtualStoreError> {
+    pub async fn run<R: Reporter>(self) -> Result<(), CreateVirtualStoreError> {
         let CreateVirtualStore { http_client, config, packages, snapshots } = self;
 
         let Some(snapshots) = snapshots else {
@@ -254,7 +255,7 @@ impl<'a> CreateVirtualStore<'a> {
                         package_key: snapshot_key,
                         snapshot,
                     }
-                    .run()
+                    .run::<R>()
                     .map_err(|e| {
                         CreateVirtualStoreError::InstallPackageBySnapshot(
                             InstallPackageBySnapshotError::CreateVirtualDir(e),
@@ -296,7 +297,7 @@ impl<'a> CreateVirtualStore<'a> {
                         metadata,
                         snapshot,
                     }
-                    .run()
+                    .run::<R>()
                     .await
                     .map_err(CreateVirtualStoreError::InstallPackageBySnapshot)
                 })

--- a/crates/package-manager/src/install.rs
+++ b/crates/package-manager/src/install.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::{path::Path, sync::atomic::AtomicU8};
 
 use crate::{
     InstallFrozenLockfile, InstallFrozenLockfileError, InstallWithoutLockfile,
@@ -104,6 +104,12 @@ where
             stage: Stage::ImportingStarted,
         }));
 
+        // Install-scoped dedupe state for `pnpm:package-import-method`.
+        // Threaded down to `link_file::log_method_once` so each install
+        // emits the channel afresh — mirroring upstream pnpm's per-
+        // importer closure capture rather than a process-static.
+        let logged_methods = AtomicU8::new(0);
+
         tracing::info!(target: "pacquet::install", "Start all");
 
         // Dispatch priority, matching pnpm's CLI semantics:
@@ -136,6 +142,7 @@ where
                 packages: packages.as_ref(),
                 snapshots: snapshots.as_ref(),
                 dependency_groups,
+                logged_methods: &logged_methods,
             }
             .run::<R>()
             .await
@@ -150,6 +157,7 @@ where
                 config,
                 manifest,
                 dependency_groups,
+                logged_methods: &logged_methods,
             }
             .run::<R>()
             .await

--- a/crates/package-manager/src/install.rs
+++ b/crates/package-manager/src/install.rs
@@ -9,12 +9,8 @@ use miette::Diagnostic;
 use pacquet_lockfile::Lockfile;
 use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
-use pacquet_npmrc::PackageImportMethod as ConfigImportMethod;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
-use pacquet_reporter::{
-    ContextLog, LogEvent, LogLevel, PackageImportMethod, PackageImportMethodLog, Reporter, Stage,
-    StageLog, SummaryLog,
-};
+use pacquet_reporter::{ContextLog, LogEvent, LogLevel, Reporter, Stage, StageLog, SummaryLog};
 use pacquet_tarball::MemCache;
 
 /// This subroutine does everything `pacquet install` is supposed to do.
@@ -53,21 +49,6 @@ pub enum InstallError {
 
     #[diagnostic(transparent)]
     FrozenLockfile(#[error(source)] InstallFrozenLockfileError),
-}
-
-/// Map pacquet's configured [`ConfigImportMethod`] to the three values
-/// pnpm's wire format accepts. `Auto` and `CloneOrCopy` collapse to
-/// `Clone` because that's the optimistic path both attempt first; if
-/// the import falls back to hardlink/copy the wire value is then a
-/// best-effort approximation. See the TODO at the emit site.
-fn import_method_for_wire(method: ConfigImportMethod) -> PackageImportMethod {
-    match method {
-        ConfigImportMethod::Auto | ConfigImportMethod::Clone | ConfigImportMethod::CloneOrCopy => {
-            PackageImportMethod::Clone
-        }
-        ConfigImportMethod::Hardlink => PackageImportMethod::Hardlink,
-        ConfigImportMethod::Copy => PackageImportMethod::Copy,
-    }
 }
 
 impl<'a, DependencyGroupList> Install<'a, DependencyGroupList>
@@ -117,22 +98,6 @@ where
             virtual_store_dir: config.virtual_store_dir.to_string_lossy().into_owned(),
         }));
 
-        // `pnpm:package-import-method` reports the strategy used to
-        // materialise files from the store (clone / hardlink / copy).
-        // Upstream emits the *resolved* method after fallback (e.g.
-        // `auto` may try clone, fall back to hardlink). Pacquet emits
-        // the configured method optimistically because the fallback
-        // signal isn't surfaced past the per-package import path yet.
-        // For the explicit settings (`Hardlink`, `Copy`, `Clone`) the
-        // optimistic value is also the actual one.
-        // TODO: emit after the first successful import so the value
-        // reflects the real fallback path for `Auto` and `CloneOrCopy`.
-        // Upstream: <https://github.com/pnpm/pnpm/blob/086c5e91e8/fs/indexed-pkg-importer/src/index.ts#L32>.
-        R::emit(&LogEvent::PackageImportMethod(PackageImportMethodLog {
-            level: LogLevel::Debug,
-            method: import_method_for_wire(config.package_import_method),
-        }));
-
         R::emit(&LogEvent::Stage(StageLog {
             level: LogLevel::Debug,
             prefix: prefix.clone(),
@@ -172,7 +137,7 @@ where
                 snapshots: snapshots.as_ref(),
                 dependency_groups,
             }
-            .run()
+            .run::<R>()
             .await
             .map_err(InstallError::FrozenLockfile)?;
         } else if config.lockfile {
@@ -186,7 +151,7 @@ where
                 manifest,
                 dependency_groups,
             }
-            .run()
+            .run::<R>()
             .await
             .map_err(InstallError::WithoutLockfile)?;
         }
@@ -217,8 +182,7 @@ mod tests {
     use pacquet_package_manifest::{DependencyGroup, PackageManifest};
     use pacquet_registry_mock::AutoMockInstance;
     use pacquet_reporter::{
-        ContextLog, LogEvent, PackageImportMethod, PackageImportMethodLog, Reporter,
-        SilentReporter, Stage, StageLog, SummaryLog,
+        ContextLog, LogEvent, Reporter, SilentReporter, Stage, StageLog, SummaryLog,
     };
     use pacquet_testing_utils::fs::{get_all_folders, is_symlink_or_junction};
     use std::sync::Mutex;
@@ -610,15 +574,20 @@ mod tests {
         drop(dir);
     }
 
-    /// [`Install::run`] emits `pnpm:context`,
-    /// `pnpm:package-import-method`, `pnpm:stage importing_started`,
-    /// then on the success path `pnpm:stage importing_done` followed
-    /// by `pnpm:summary`. On an early-error path such as
+    /// [`Install::run`] emits `pnpm:context`, then `pnpm:stage`
+    /// `importing_started`, then on the success path `importing_done`
+    /// followed by `pnpm:summary`. On an early-error path such as
     /// [`InstallError::NoLockfile`] only the leading events fire. This
-    /// matches pnpm: context and the chosen import strategy go in the
-    /// install header, the stage pairing drives the JS reporter's
-    /// progress UI, and summary closes the run so the reporter can
-    /// render its "+N -M" block.
+    /// matches pnpm: context is emitted once alongside the install
+    /// header, the stage pairing drives the JS reporter's progress
+    /// UI, and summary closes the run so the reporter can render its
+    /// "+N -M" block.
+    ///
+    /// `pnpm:package-import-method` is emitted lazily by `link_file`
+    /// the first time each method actually resolves (after `auto`'s
+    /// fallback chain finishes), so an empty-lockfile install like this
+    /// one has no link_file calls and no such event in the captured
+    /// sequence. See `link_file::tests` for that channel's coverage.
     ///
     /// `pnpm:context` carries `currentLockfileExists`, `storeDir`,
     /// `virtualStoreDir`. `currentLockfileExists` is hard-coded
@@ -680,15 +649,13 @@ mod tests {
 
         let captured = EVENTS.lock().unwrap();
 
-        // Event ordering matches pnpm: install-header events
-        // (context, package-import-method), then the stage bracketing
-        // pair, then summary closing the run.
+        // Event ordering matches pnpm: context, then the stage
+        // bracketing pair, then summary closing the run.
         assert!(
             matches!(
                 captured.as_slice(),
                 [
                     LogEvent::Context(_),
-                    LogEvent::PackageImportMethod(_),
                     LogEvent::Stage(StageLog { stage: Stage::ImportingStarted, .. }),
                     LogEvent::Stage(StageLog { stage: Stage::ImportingDone, .. }),
                     LogEvent::Summary(_),
@@ -713,19 +680,11 @@ mod tests {
         assert_eq!(emitted_store_dir, &store_dir.display().to_string());
         assert_eq!(emitted_virtual_store_dir, &virtual_store_dir.to_string_lossy().into_owned());
 
-        // Default `Npmrc` uses `Auto`, which collapses to `Clone` on
-        // the wire per `import_method_for_wire`.
-        let LogEvent::PackageImportMethod(PackageImportMethodLog { method, .. }) = &captured[1]
-        else {
-            unreachable!("second event is package-import-method, asserted above");
-        };
-        assert_eq!(*method, PackageImportMethod::Clone);
-
         // Summary's `prefix` must equal the manifest-parent value
         // `Install::run` derives, since pnpm's reporter keys its
         // accumulated root-events by prefix to render the diff.
-        let LogEvent::Summary(SummaryLog { prefix: summary_prefix, .. }) = &captured[4] else {
-            unreachable!("fifth event is summary, asserted above");
+        let LogEvent::Summary(SummaryLog { prefix: summary_prefix, .. }) = &captured[3] else {
+            unreachable!("fourth event is summary, asserted above");
         };
         assert_eq!(
             summary_prefix,

--- a/crates/package-manager/src/install.rs
+++ b/crates/package-manager/src/install.rs
@@ -9,8 +9,12 @@ use miette::Diagnostic;
 use pacquet_lockfile::Lockfile;
 use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
+use pacquet_npmrc::PackageImportMethod as ConfigImportMethod;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
-use pacquet_reporter::{ContextLog, LogEvent, LogLevel, Reporter, Stage, StageLog, SummaryLog};
+use pacquet_reporter::{
+    ContextLog, LogEvent, LogLevel, PackageImportMethod, PackageImportMethodLog, Reporter, Stage,
+    StageLog, SummaryLog,
+};
 use pacquet_tarball::MemCache;
 
 /// This subroutine does everything `pacquet install` is supposed to do.
@@ -49,6 +53,21 @@ pub enum InstallError {
 
     #[diagnostic(transparent)]
     FrozenLockfile(#[error(source)] InstallFrozenLockfileError),
+}
+
+/// Map pacquet's configured [`ConfigImportMethod`] to the three values
+/// pnpm's wire format accepts. `Auto` and `CloneOrCopy` collapse to
+/// `Clone` because that's the optimistic path both attempt first; if
+/// the import falls back to hardlink/copy the wire value is then a
+/// best-effort approximation. See the TODO at the emit site.
+fn import_method_for_wire(method: ConfigImportMethod) -> PackageImportMethod {
+    match method {
+        ConfigImportMethod::Auto | ConfigImportMethod::Clone | ConfigImportMethod::CloneOrCopy => {
+            PackageImportMethod::Clone
+        }
+        ConfigImportMethod::Hardlink => PackageImportMethod::Hardlink,
+        ConfigImportMethod::Copy => PackageImportMethod::Copy,
+    }
 }
 
 impl<'a, DependencyGroupList> Install<'a, DependencyGroupList>
@@ -96,6 +115,22 @@ where
             current_lockfile_exists: false,
             store_dir: config.store_dir.display().to_string(),
             virtual_store_dir: config.virtual_store_dir.to_string_lossy().into_owned(),
+        }));
+
+        // `pnpm:package-import-method` reports the strategy used to
+        // materialise files from the store (clone / hardlink / copy).
+        // Upstream emits the *resolved* method after fallback (e.g.
+        // `auto` may try clone, fall back to hardlink). Pacquet emits
+        // the configured method optimistically because the fallback
+        // signal isn't surfaced past the per-package import path yet.
+        // For the explicit settings (`Hardlink`, `Copy`, `Clone`) the
+        // optimistic value is also the actual one.
+        // TODO: emit after the first successful import so the value
+        // reflects the real fallback path for `Auto` and `CloneOrCopy`.
+        // Upstream: <https://github.com/pnpm/pnpm/blob/086c5e91e8/fs/indexed-pkg-importer/src/index.ts#L32>.
+        R::emit(&LogEvent::PackageImportMethod(PackageImportMethodLog {
+            level: LogLevel::Debug,
+            method: import_method_for_wire(config.package_import_method),
         }));
 
         R::emit(&LogEvent::Stage(StageLog {
@@ -182,7 +217,8 @@ mod tests {
     use pacquet_package_manifest::{DependencyGroup, PackageManifest};
     use pacquet_registry_mock::AutoMockInstance;
     use pacquet_reporter::{
-        ContextLog, LogEvent, Reporter, SilentReporter, Stage, StageLog, SummaryLog,
+        ContextLog, LogEvent, PackageImportMethod, PackageImportMethodLog, Reporter,
+        SilentReporter, Stage, StageLog, SummaryLog,
     };
     use pacquet_testing_utils::fs::{get_all_folders, is_symlink_or_junction};
     use std::sync::Mutex;
@@ -574,14 +610,15 @@ mod tests {
         drop(dir);
     }
 
-    /// [`Install::run`] emits `pnpm:context`, then `pnpm:stage`
-    /// `importing_started`, then on the success path `importing_done`
-    /// followed by `pnpm:summary`. On an early-error path such as
+    /// [`Install::run`] emits `pnpm:context`,
+    /// `pnpm:package-import-method`, `pnpm:stage importing_started`,
+    /// then on the success path `pnpm:stage importing_done` followed
+    /// by `pnpm:summary`. On an early-error path such as
     /// [`InstallError::NoLockfile`] only the leading events fire. This
-    /// matches pnpm: context is emitted once alongside the install
-    /// header, the stage pairing drives the JS reporter's progress
-    /// UI, and summary closes the run so the reporter can render its
-    /// "+N -M" block.
+    /// matches pnpm: context and the chosen import strategy go in the
+    /// install header, the stage pairing drives the JS reporter's
+    /// progress UI, and summary closes the run so the reporter can
+    /// render its "+N -M" block.
     ///
     /// `pnpm:context` carries `currentLockfileExists`, `storeDir`,
     /// `virtualStoreDir`. `currentLockfileExists` is hard-coded
@@ -643,13 +680,15 @@ mod tests {
 
         let captured = EVENTS.lock().unwrap();
 
-        // Event ordering matches pnpm: context, then the stage
-        // bracketing pair, then summary closing the run.
+        // Event ordering matches pnpm: install-header events
+        // (context, package-import-method), then the stage bracketing
+        // pair, then summary closing the run.
         assert!(
             matches!(
                 captured.as_slice(),
                 [
                     LogEvent::Context(_),
+                    LogEvent::PackageImportMethod(_),
                     LogEvent::Stage(StageLog { stage: Stage::ImportingStarted, .. }),
                     LogEvent::Stage(StageLog { stage: Stage::ImportingDone, .. }),
                     LogEvent::Summary(_),
@@ -674,11 +713,19 @@ mod tests {
         assert_eq!(emitted_store_dir, &store_dir.display().to_string());
         assert_eq!(emitted_virtual_store_dir, &virtual_store_dir.to_string_lossy().into_owned());
 
+        // Default `Npmrc` uses `Auto`, which collapses to `Clone` on
+        // the wire per `import_method_for_wire`.
+        let LogEvent::PackageImportMethod(PackageImportMethodLog { method, .. }) = &captured[1]
+        else {
+            unreachable!("second event is package-import-method, asserted above");
+        };
+        assert_eq!(*method, PackageImportMethod::Clone);
+
         // Summary's `prefix` must equal the manifest-parent value
         // `Install::run` derives, since pnpm's reporter keys its
         // accumulated root-events by prefix to render the diff.
-        let LogEvent::Summary(SummaryLog { prefix: summary_prefix, .. }) = &captured[3] else {
-            unreachable!("fourth event is summary, asserted above");
+        let LogEvent::Summary(SummaryLog { prefix: summary_prefix, .. }) = &captured[4] else {
+            unreachable!("fifth event is summary, asserted above");
         };
         assert_eq!(
             summary_prefix,

--- a/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/crates/package-manager/src/install_frozen_lockfile.rs
@@ -9,7 +9,7 @@ use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
 use pacquet_package_manifest::DependencyGroup;
 use pacquet_reporter::Reporter;
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::atomic::AtomicU8};
 
 /// This subroutine installs dependencies from a frozen lockfile.
 ///
@@ -31,6 +31,9 @@ where
     pub packages: Option<&'a HashMap<PackageKey, PackageMetadata>>,
     pub snapshots: Option<&'a HashMap<PackageKey, SnapshotEntry>>,
     pub dependency_groups: DependencyGroupList,
+    /// Install-scoped dedupe state for `pnpm:package-import-method`.
+    /// See `link_file::log_method_once`.
+    pub logged_methods: &'a AtomicU8,
 }
 
 /// Error type of [`InstallFrozenLockfile`].
@@ -56,11 +59,12 @@ where
             packages,
             snapshots,
             dependency_groups,
+            logged_methods,
         } = self;
 
         // TODO: check if the lockfile is out-of-date
 
-        CreateVirtualStore { http_client, config, packages, snapshots }
+        CreateVirtualStore { http_client, config, packages, snapshots, logged_methods }
             .run::<R>()
             .await
             .map_err(InstallFrozenLockfileError::CreateVirtualStore)?;

--- a/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/crates/package-manager/src/install_frozen_lockfile.rs
@@ -8,6 +8,7 @@ use pacquet_lockfile::{PackageKey, PackageMetadata, ProjectSnapshot, SnapshotEnt
 use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
 use pacquet_package_manifest::DependencyGroup;
+use pacquet_reporter::Reporter;
 use std::collections::HashMap;
 
 /// This subroutine installs dependencies from a frozen lockfile.
@@ -47,7 +48,7 @@ where
     DependencyGroupList: IntoIterator<Item = DependencyGroup>,
 {
     /// Execute the subroutine.
-    pub async fn run(self) -> Result<(), InstallFrozenLockfileError> {
+    pub async fn run<R: Reporter>(self) -> Result<(), InstallFrozenLockfileError> {
         let InstallFrozenLockfile {
             http_client,
             config,
@@ -60,7 +61,7 @@ where
         // TODO: check if the lockfile is out-of-date
 
         CreateVirtualStore { http_client, config, packages, snapshots }
-            .run()
+            .run::<R>()
             .await
             .map_err(InstallFrozenLockfileError::CreateVirtualStore)?;
 

--- a/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/crates/package-manager/src/install_package_by_snapshot.rs
@@ -6,6 +6,7 @@ use miette::Diagnostic;
 use pacquet_lockfile::{LockfileResolution, PackageKey, PackageMetadata, SnapshotEntry};
 use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
+use pacquet_reporter::Reporter;
 use pacquet_store_dir::{SharedReadonlyStoreIndex, SharedVerifiedFilesCache, StoreIndexWriter};
 use pacquet_tarball::{DownloadTarballToStore, PrefetchedCasPaths, TarballError};
 use pipe_trait::Pipe;
@@ -57,7 +58,7 @@ pub enum InstallPackageBySnapshotError {
 
 impl<'a> InstallPackageBySnapshot<'a> {
     /// Execute the subroutine.
-    pub async fn run(self) -> Result<(), InstallPackageBySnapshotError> {
+    pub async fn run<R: Reporter>(self) -> Result<(), InstallPackageBySnapshotError> {
         let InstallPackageBySnapshot {
             http_client,
             config,
@@ -129,7 +130,7 @@ impl<'a> InstallPackageBySnapshot<'a> {
             package_key,
             snapshot,
         }
-        .run()
+        .run::<R>()
         .map_err(InstallPackageBySnapshotError::CreateVirtualDir)?;
 
         Ok(())

--- a/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/crates/package-manager/src/install_package_by_snapshot.rs
@@ -10,7 +10,10 @@ use pacquet_reporter::Reporter;
 use pacquet_store_dir::{SharedReadonlyStoreIndex, SharedVerifiedFilesCache, StoreIndexWriter};
 use pacquet_tarball::{DownloadTarballToStore, PrefetchedCasPaths, TarballError};
 use pipe_trait::Pipe;
-use std::{borrow::Cow, sync::Arc};
+use std::{
+    borrow::Cow,
+    sync::{Arc, atomic::AtomicU8},
+};
 
 /// This subroutine downloads a package tarball, extracts it, installs it to a
 /// virtual dir, then creates the symlink layout for the package. CAS file
@@ -29,6 +32,9 @@ pub struct InstallPackageBySnapshot<'a> {
     /// per-snapshot fetch. See `DownloadTarballToStore::verified_files_cache`
     /// for the rationale.
     pub verified_files_cache: &'a SharedVerifiedFilesCache,
+    /// Install-scoped dedupe state for `pnpm:package-import-method`.
+    /// See `link_file::log_method_once`.
+    pub logged_methods: &'a AtomicU8,
     pub package_key: &'a PackageKey,
     pub metadata: &'a PackageMetadata,
     pub snapshot: &'a SnapshotEntry,
@@ -66,6 +72,7 @@ impl<'a> InstallPackageBySnapshot<'a> {
             store_index_writer,
             prefetched_cas_paths,
             verified_files_cache,
+            logged_methods,
             package_key,
             metadata,
             snapshot,
@@ -127,6 +134,7 @@ impl<'a> InstallPackageBySnapshot<'a> {
             virtual_store_dir: &config.virtual_store_dir,
             cas_paths: &cas_paths,
             import_method: config.package_import_method,
+            logged_methods,
             package_key,
             snapshot,
         }

--- a/crates/package-manager/src/install_package_from_registry.rs
+++ b/crates/package-manager/src/install_package_from_registry.rs
@@ -8,6 +8,7 @@ use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
 use pacquet_package_manifest::PackageManifest;
 use pacquet_registry::{Package, PackageTag, PackageVersion, RegistryError};
+use pacquet_reporter::Reporter;
 use pacquet_store_dir::{SharedReadonlyStoreIndex, SharedVerifiedFilesCache, StoreIndexWriter};
 use pacquet_tarball::{DownloadTarballToStore, MemCache, TarballError};
 use std::{path::Path, sync::Arc};
@@ -53,7 +54,7 @@ pub enum InstallPackageFromRegistryError {
 
 impl<'a> InstallPackageFromRegistry<'a> {
     /// Execute the subroutine.
-    pub async fn run(self) -> Result<PackageVersion, InstallPackageFromRegistryError> {
+    pub async fn run<R: Reporter>(self) -> Result<PackageVersion, InstallPackageFromRegistryError> {
         let &InstallPackageFromRegistry { http_client, config, name, version_range, .. } = &self;
 
         // Strip any `npm:<name>@<range>` alias prefix before talking to
@@ -77,7 +78,7 @@ impl<'a> InstallPackageFromRegistry<'a> {
             )
             .await
             .map_err(InstallPackageFromRegistryError::FetchFromRegistry)?;
-            self.install_package_version(&package_version).await?;
+            self.install_package_version::<R>(&package_version).await?;
             package_version
         } else {
             let package =
@@ -85,12 +86,12 @@ impl<'a> InstallPackageFromRegistry<'a> {
                     .await
                     .map_err(InstallPackageFromRegistryError::FetchFromRegistry)?;
             let package_version = package.pinned_version(version_range).unwrap(); // TODO: propagate error for when no version satisfies range
-            self.install_package_version(package_version).await?;
+            self.install_package_version::<R>(package_version).await?;
             package_version.clone()
         })
     }
 
-    async fn install_package_version(
+    async fn install_package_version<R: Reporter>(
         self,
         package_version: &PackageVersion,
     ) -> Result<(), InstallPackageFromRegistryError> {
@@ -147,7 +148,7 @@ impl<'a> InstallPackageFromRegistry<'a> {
 
         tracing::info!(target: "pacquet::import", ?save_path, ?symlink_path, "Import package");
 
-        create_cas_files(config.package_import_method, &save_path, &cas_paths)
+        create_cas_files::<R>(config.package_import_method, &save_path, &cas_paths)
             .map_err(InstallPackageFromRegistryError::CreateCasFiles)?;
 
         symlink_package(&save_path, &symlink_path)
@@ -163,6 +164,7 @@ mod tests {
     use node_semver::Version;
     use pacquet_network::ThrottledClient;
     use pacquet_npmrc::Npmrc;
+    use pacquet_reporter::SilentReporter;
     use pacquet_store_dir::{SharedVerifiedFilesCache, StoreDir};
     use pipe_trait::Pipe;
     use pretty_assertions::assert_eq;
@@ -220,7 +222,7 @@ mod tests {
             version_range: "1.0.0",
             node_modules_dir: modules_dir.path(),
         }
-        .run()
+        .run::<SilentReporter>()
         .await
         .unwrap();
 

--- a/crates/package-manager/src/install_package_from_registry.rs
+++ b/crates/package-manager/src/install_package_from_registry.rs
@@ -11,7 +11,10 @@ use pacquet_registry::{Package, PackageTag, PackageVersion, RegistryError};
 use pacquet_reporter::Reporter;
 use pacquet_store_dir::{SharedReadonlyStoreIndex, SharedVerifiedFilesCache, StoreIndexWriter};
 use pacquet_tarball::{DownloadTarballToStore, MemCache, TarballError};
-use std::{path::Path, sync::Arc};
+use std::{
+    path::Path,
+    sync::{Arc, atomic::AtomicU8},
+};
 
 /// This subroutine executes the following and returns the package
 /// * Retrieves the package from the registry
@@ -38,6 +41,9 @@ pub struct InstallPackageFromRegistry<'a> {
     /// per-package fetch. See `DownloadTarballToStore::verified_files_cache`
     /// for the rationale.
     pub verified_files_cache: &'a SharedVerifiedFilesCache,
+    /// Install-scoped dedupe state for `pnpm:package-import-method`.
+    /// See `link_file::log_method_once`.
+    pub logged_methods: &'a AtomicU8,
     pub node_modules_dir: &'a Path,
     pub name: &'a str,
     pub version_range: &'a str,
@@ -102,6 +108,7 @@ impl<'a> InstallPackageFromRegistry<'a> {
             store_index,
             store_index_writer,
             verified_files_cache,
+            logged_methods,
             node_modules_dir,
             name,
             ..
@@ -148,7 +155,7 @@ impl<'a> InstallPackageFromRegistry<'a> {
 
         tracing::info!(target: "pacquet::import", ?save_path, ?symlink_path, "Import package");
 
-        create_cas_files::<R>(config.package_import_method, &save_path, &cas_paths)
+        create_cas_files::<R>(logged_methods, config.package_import_method, &save_path, &cas_paths)
             .map_err(InstallPackageFromRegistryError::CreateCasFiles)?;
 
         symlink_package(&save_path, &symlink_path)
@@ -168,7 +175,7 @@ mod tests {
     use pacquet_store_dir::{SharedVerifiedFilesCache, StoreDir};
     use pipe_trait::Pipe;
     use pretty_assertions::assert_eq;
-    use std::{fs, path::Path};
+    use std::{fs, path::Path, sync::atomic::AtomicU8};
     use tempfile::tempdir;
 
     fn create_config(store_dir: &Path, modules_dir: &Path, virtual_store_dir: &Path) -> Npmrc {
@@ -211,6 +218,7 @@ mod tests {
                 .pipe(Box::leak);
         let http_client = ThrottledClient::new_for_installs();
         let verified_files_cache = SharedVerifiedFilesCache::default();
+        let logged_methods = AtomicU8::new(0);
         let package = InstallPackageFromRegistry {
             tarball_mem_cache: &Default::default(),
             config,
@@ -218,6 +226,7 @@ mod tests {
             store_index: None,
             store_index_writer: None,
             verified_files_cache: &verified_files_cache,
+            logged_methods: &logged_methods,
             name: "fast-querystring",
             version_range: "1.0.0",
             node_modules_dir: modules_dir.path(),

--- a/crates/package-manager/src/install_without_lockfile.rs
+++ b/crates/package-manager/src/install_without_lockfile.rs
@@ -11,6 +11,7 @@ use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_registry::PackageVersion;
+use pacquet_reporter::Reporter;
 use pacquet_store_dir::{SharedVerifiedFilesCache, StoreIndex, StoreIndexWriter};
 use pacquet_tarball::MemCache;
 use pipe_trait::Pipe;
@@ -49,7 +50,7 @@ pub enum InstallWithoutLockfileError {
 
 impl<'a, DependencyGroupList> InstallWithoutLockfile<'a, DependencyGroupList> {
     /// Execute the subroutine.
-    pub async fn run(self) -> Result<(), InstallWithoutLockfileError>
+    pub async fn run<R: Reporter>(self) -> Result<(), InstallWithoutLockfileError>
     where
         DependencyGroupList: IntoIterator<Item = DependencyGroup>,
     {
@@ -125,7 +126,7 @@ impl<'a, DependencyGroupList> InstallWithoutLockfile<'a, DependencyGroupList> {
                         name,
                         version_range,
                     }
-                    .run()
+                    .run::<R>()
                     .await
                     .map_err(InstallWithoutLockfileError::InstallPackageFromRegistry)?;
 
@@ -137,7 +138,7 @@ impl<'a, DependencyGroupList> InstallWithoutLockfile<'a, DependencyGroupList> {
                         dependency_groups: (),
                         resolved_packages,
                     }
-                    .install_dependencies_from_registry(
+                    .install_dependencies_from_registry::<R>(
                         &dependency,
                         store_index_ref,
                         store_index_writer_ref,
@@ -176,7 +177,7 @@ impl<'a, DependencyGroupList> InstallWithoutLockfile<'a, DependencyGroupList> {
 impl<'a> InstallWithoutLockfile<'a, ()> {
     /// Install dependencies of a dependency.
     #[async_recursion]
-    async fn install_dependencies_from_registry(
+    async fn install_dependencies_from_registry<R>(
         &self,
         package: &PackageVersion,
         store_index: Option<&'async_recursion pacquet_store_dir::SharedReadonlyStoreIndex>,
@@ -184,7 +185,10 @@ impl<'a> InstallWithoutLockfile<'a, ()> {
             &'async_recursion std::sync::Arc<pacquet_store_dir::StoreIndexWriter>,
         >,
         verified_files_cache: &'async_recursion SharedVerifiedFilesCache,
-    ) -> Result<(), InstallWithoutLockfileError> {
+    ) -> Result<(), InstallWithoutLockfileError>
+    where
+        R: Reporter,
+    {
         let InstallWithoutLockfile {
             tarball_mem_cache,
             http_client,
@@ -222,10 +226,10 @@ impl<'a> InstallWithoutLockfile<'a, ()> {
                     name,
                     version_range,
                 }
-                .run()
+                .run::<R>()
                 .await
                 .map_err(InstallWithoutLockfileError::InstallPackageFromRegistry)?;
-                self.install_dependencies_from_registry(
+                self.install_dependencies_from_registry::<R>(
                     &dependency,
                     store_index,
                     store_index_writer,

--- a/crates/package-manager/src/install_without_lockfile.rs
+++ b/crates/package-manager/src/install_without_lockfile.rs
@@ -15,6 +15,7 @@ use pacquet_reporter::Reporter;
 use pacquet_store_dir::{SharedVerifiedFilesCache, StoreIndex, StoreIndexWriter};
 use pacquet_tarball::MemCache;
 use pipe_trait::Pipe;
+use std::sync::atomic::AtomicU8;
 
 /// In-memory cache for packages that have started resolving dependencies.
 ///
@@ -39,6 +40,9 @@ pub struct InstallWithoutLockfile<'a, DependencyGroupList> {
     pub config: &'static Npmrc,
     pub manifest: &'a PackageManifest,
     pub dependency_groups: DependencyGroupList,
+    /// Install-scoped dedupe state for `pnpm:package-import-method`.
+    /// See `link_file::log_method_once`.
+    pub logged_methods: &'a AtomicU8,
 }
 
 /// Error type of [`InstallWithoutLockfile`].
@@ -61,6 +65,7 @@ impl<'a, DependencyGroupList> InstallWithoutLockfile<'a, DependencyGroupList> {
             manifest,
             dependency_groups,
             resolved_packages,
+            logged_methods,
         } = self;
 
         let store_dir: &'static _ = &config.store_dir;
@@ -122,6 +127,7 @@ impl<'a, DependencyGroupList> InstallWithoutLockfile<'a, DependencyGroupList> {
                         store_index: store_index_ref,
                         store_index_writer: store_index_writer_ref,
                         verified_files_cache: &verified_files_cache,
+                        logged_methods,
                         node_modules_dir: &config.modules_dir,
                         name,
                         version_range,
@@ -137,6 +143,7 @@ impl<'a, DependencyGroupList> InstallWithoutLockfile<'a, DependencyGroupList> {
                         manifest,
                         dependency_groups: (),
                         resolved_packages,
+                        logged_methods,
                     }
                     .install_dependencies_from_registry::<R>(
                         &dependency,
@@ -222,6 +229,7 @@ impl<'a> InstallWithoutLockfile<'a, ()> {
                     store_index,
                     store_index_writer,
                     verified_files_cache,
+                    logged_methods: self.logged_methods,
                     node_modules_dir: node_modules_path_ref,
                     name,
                     version_range,

--- a/crates/package-manager/src/link_file.rs
+++ b/crates/package-manager/src/link_file.rs
@@ -83,9 +83,9 @@ const LINK_STATE_COPY: u8 = 2;
 // (`@pnpm/cli.default-reporter` and friends). `fetch_or` returns the
 // previous bitfield, so the first caller to set a given bit is the one
 // that emits.
-pub(crate) const LOG_FLAG_CLONE: u8 = 1 << 0;
-pub(crate) const LOG_FLAG_HARDLINK: u8 = 1 << 1;
-pub(crate) const LOG_FLAG_COPY: u8 = 1 << 2;
+const LOG_FLAG_CLONE: u8 = 1 << 0;
+const LOG_FLAG_HARDLINK: u8 = 1 << 1;
+const LOG_FLAG_COPY: u8 = 1 << 2;
 
 fn log_method_once<R: Reporter>(logged: &AtomicU8, flag: u8, method: WireImportMethod) {
     if logged.fetch_or(flag, Ordering::Relaxed) & flag == 0 {

--- a/crates/package-manager/src/link_file.rs
+++ b/crates/package-manager/src/link_file.rs
@@ -1,6 +1,9 @@
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_npmrc::PackageImportMethod;
+use pacquet_reporter::{
+    LogEvent, LogLevel, PackageImportMethod as WireImportMethod, PackageImportMethodLog, Reporter,
+};
 use std::{
     fs, io,
     path::{Path, PathBuf},
@@ -66,18 +69,28 @@ const LINK_STATE_COPY: u8 = 2;
 // crucial for verifying hardlinks are kicking in on CI runners where
 // reflink isn't available.
 //
-// Pnpm logs at `debug`; pacquet uses `info` so the message surfaces
-// without verbose logging configured. `fetch_or` returns the previous
-// bitfield, so the first caller to set a given bit is the one that
-// emits.
+// Each method gets two emits the first time it's used: a `tracing::info!`
+// for human / diagnostic logs, and a `pnpm:package-import-method` reporter
+// event for structured consumers (`@pnpm/cli.default-reporter` and
+// friends). `fetch_or` returns the previous bitfield, so the first caller
+// to set a given bit is the one that emits.
 const LOG_FLAG_CLONE: u8 = 1 << 0;
 const LOG_FLAG_HARDLINK: u8 = 1 << 1;
 const LOG_FLAG_COPY: u8 = 1 << 2;
 static LOGGED_METHODS: AtomicU8 = AtomicU8::new(0);
 
-fn log_method_once(flag: u8, method: &'static str) {
-    if LOGGED_METHODS.fetch_or(flag, Ordering::Relaxed) & flag == 0 {
-        tracing::info!(target: "pacquet::package_import_method", method, "selected package import method");
+fn log_method_once<R: Reporter>(logged: &AtomicU8, flag: u8, method: WireImportMethod) {
+    if logged.fetch_or(flag, Ordering::Relaxed) & flag == 0 {
+        let method_name = match method {
+            WireImportMethod::Clone => "clone",
+            WireImportMethod::Hardlink => "hardlink",
+            WireImportMethod::Copy => "copy",
+        };
+        tracing::info!(target: "pacquet::package_import_method", method = method_name, "selected package import method");
+        R::emit(&LogEvent::PackageImportMethod(PackageImportMethodLog {
+            level: LogLevel::Debug,
+            method,
+        }));
     }
 }
 
@@ -91,7 +104,7 @@ fn log_method_once(flag: u8, method: &'static str) {
 ///   sequentially up-front and then calls into the import primitive
 ///   per file. [`create_cas_files`](crate::create_cas_files) is the
 ///   production caller and handles that pre-pass.
-pub fn link_file(
+pub fn link_file<R: Reporter>(
     method: PackageImportMethod,
     source_file: &Path,
     target_link: &Path,
@@ -138,7 +151,7 @@ pub fn link_file(
     let result = match method {
         PackageImportMethod::Auto => {
             static AUTO_STATE: AtomicU8 = AtomicU8::new(LINK_STATE_CLONE);
-            auto_link(&AUTO_STATE, source_file, target_link)
+            auto_link::<R>(&AUTO_STATE, source_file, target_link)
         }
         // pnpm's explicit `hardlink` method uses `hardlinkPkg(linkOrCopy)`
         // which falls back to copy on `EXDEV` (cross-device link not
@@ -150,26 +163,30 @@ pub fn link_file(
         // itself is already cheap; pnpm doesn't cache this path either.
         PackageImportMethod::Hardlink => match fs::hard_link(source_file, target_link) {
             Ok(()) => {
-                log_method_once(LOG_FLAG_HARDLINK, "hardlink");
+                log_method_once::<R>(
+                    &LOGGED_METHODS,
+                    LOG_FLAG_HARDLINK,
+                    WireImportMethod::Hardlink,
+                );
                 Ok(())
             }
             Err(error) if is_cross_device(&error) => {
-                log_method_once(LOG_FLAG_COPY, "copy");
+                log_method_once::<R>(&LOGGED_METHODS, LOG_FLAG_COPY, WireImportMethod::Copy);
                 fs::copy(source_file, target_link).map(drop)
             }
             Err(error) => Err(error),
         },
         PackageImportMethod::Clone => {
             reflink_copy::reflink(source_file, target_link).inspect(|_| {
-                log_method_once(LOG_FLAG_CLONE, "clone");
+                log_method_once::<R>(&LOGGED_METHODS, LOG_FLAG_CLONE, WireImportMethod::Clone);
             })
         }
         PackageImportMethod::CloneOrCopy => {
             static CLONE_OR_COPY_STATE: AtomicU8 = AtomicU8::new(LINK_STATE_CLONE);
-            clone_or_copy_link(&CLONE_OR_COPY_STATE, source_file, target_link)
+            clone_or_copy_link::<R>(&CLONE_OR_COPY_STATE, source_file, target_link)
         }
         PackageImportMethod::Copy => {
-            log_method_once(LOG_FLAG_COPY, "copy");
+            log_method_once::<R>(&LOGGED_METHODS, LOG_FLAG_COPY, WireImportMethod::Copy);
             fs::copy(source_file, target_link).map(drop)
         }
     };
@@ -250,12 +267,12 @@ fn is_call_error(err: &io::Error) -> bool {
 /// downgrade the cached state; other errors propagate immediately so a
 /// one-off `NotFound` on a single file doesn't permanently disable a
 /// tier for the rest of the process.
-fn auto_link(state: &AtomicU8, source: &Path, target: &Path) -> io::Result<()> {
+fn auto_link<R: Reporter>(state: &AtomicU8, source: &Path, target: &Path) -> io::Result<()> {
     loop {
         match state.load(Ordering::Relaxed) {
             LINK_STATE_CLONE => match reflink_copy::reflink(source, target) {
                 Ok(()) => {
-                    log_method_once(LOG_FLAG_CLONE, "clone");
+                    log_method_once::<R>(&LOGGED_METHODS, LOG_FLAG_CLONE, WireImportMethod::Clone);
                     return Ok(());
                 }
                 Err(err) if is_call_error(&err) => return Err(err),
@@ -265,7 +282,11 @@ fn auto_link(state: &AtomicU8, source: &Path, target: &Path) -> io::Result<()> {
             },
             LINK_STATE_HARDLINK => match fs::hard_link(source, target) {
                 Ok(()) => {
-                    log_method_once(LOG_FLAG_HARDLINK, "hardlink");
+                    log_method_once::<R>(
+                        &LOGGED_METHODS,
+                        LOG_FLAG_HARDLINK,
+                        WireImportMethod::Hardlink,
+                    );
                     return Ok(());
                 }
                 Err(err) if is_call_error(&err) => return Err(err),
@@ -274,7 +295,7 @@ fn auto_link(state: &AtomicU8, source: &Path, target: &Path) -> io::Result<()> {
                 }
             },
             _ => {
-                log_method_once(LOG_FLAG_COPY, "copy");
+                log_method_once::<R>(&LOGGED_METHODS, LOG_FLAG_COPY, WireImportMethod::Copy);
                 return fs::copy(source, target).map(drop);
             }
         }
@@ -287,12 +308,16 @@ fn auto_link(state: &AtomicU8, source: &Path, target: &Path) -> io::Result<()> {
 /// first reflink failure reassigns its closure directly to `copyPkg`.
 /// Same error-narrowing as `auto_link`: only capability failures
 /// downgrade; real errors propagate.
-fn clone_or_copy_link(state: &AtomicU8, source: &Path, target: &Path) -> io::Result<()> {
+fn clone_or_copy_link<R: Reporter>(
+    state: &AtomicU8,
+    source: &Path,
+    target: &Path,
+) -> io::Result<()> {
     loop {
         match state.load(Ordering::Relaxed) {
             LINK_STATE_CLONE => match reflink_copy::reflink(source, target) {
                 Ok(()) => {
-                    log_method_once(LOG_FLAG_CLONE, "clone");
+                    log_method_once::<R>(&LOGGED_METHODS, LOG_FLAG_CLONE, WireImportMethod::Clone);
                     return Ok(());
                 }
                 Err(err) if is_call_error(&err) => return Err(err),
@@ -301,7 +326,7 @@ fn clone_or_copy_link(state: &AtomicU8, source: &Path, target: &Path) -> io::Res
                 }
             },
             _ => {
-                log_method_once(LOG_FLAG_COPY, "copy");
+                log_method_once::<R>(&LOGGED_METHODS, LOG_FLAG_COPY, WireImportMethod::Copy);
                 return fs::copy(source, target).map(drop);
             }
         }
@@ -315,6 +340,7 @@ mod tests {
         clone_or_copy_link, is_call_error, is_cross_device, link_file,
     };
     use pacquet_npmrc::PackageImportMethod;
+    use pacquet_reporter::SilentReporter;
     use pretty_assertions::assert_eq;
     use std::{
         fs, io,
@@ -338,7 +364,8 @@ mod tests {
         let dst = tmp.path().join("nested/dst.txt");
         fs::create_dir_all(dst.parent().unwrap()).unwrap();
 
-        link_file(PackageImportMethod::Copy, &src, &dst).expect("link_file should succeed");
+        link_file::<SilentReporter>(PackageImportMethod::Copy, &src, &dst)
+            .expect("link_file should succeed");
 
         assert_eq!(fs::read(&dst).unwrap(), b"hello");
         // A plain copy leaves the two files as independent inodes.
@@ -363,7 +390,8 @@ mod tests {
         let dst = tmp.path().join("nested/dst.txt");
         fs::create_dir_all(dst.parent().unwrap()).unwrap();
 
-        link_file(PackageImportMethod::Hardlink, &src, &dst).expect("link_file should succeed");
+        link_file::<SilentReporter>(PackageImportMethod::Hardlink, &src, &dst)
+            .expect("link_file should succeed");
 
         assert_eq!(fs::read(&dst).unwrap(), b"shared");
         #[cfg(unix)]
@@ -386,7 +414,8 @@ mod tests {
         let dst = tmp.path().join("nested/dst.txt");
         fs::create_dir_all(dst.parent().unwrap()).unwrap();
 
-        link_file(PackageImportMethod::Auto, &src, &dst).expect("Auto should always succeed");
+        link_file::<SilentReporter>(PackageImportMethod::Auto, &src, &dst)
+            .expect("Auto should always succeed");
         assert_eq!(fs::read(&dst).unwrap(), b"auto");
     }
 
@@ -407,7 +436,8 @@ mod tests {
             PackageImportMethod::Clone,
             PackageImportMethod::CloneOrCopy,
         ] {
-            link_file(method, &src, &dst).expect("existing target should short-circuit");
+            link_file::<SilentReporter>(method, &src, &dst)
+                .expect("existing target should short-circuit");
             assert_eq!(fs::read(&dst).unwrap(), b"old", "method {method:?} must not overwrite");
         }
     }
@@ -424,8 +454,8 @@ mod tests {
         let src = tmp.path().join("does-not-exist");
         let dst = tmp.path().join("dst.txt");
 
-        let err =
-            link_file(PackageImportMethod::Hardlink, &src, &dst).expect_err("no source → error");
+        let err = link_file::<SilentReporter>(PackageImportMethod::Hardlink, &src, &dst)
+            .expect_err("no source → error");
         assert!(matches!(err, LinkFileError::Import { .. }), "got: {err:?}");
     }
 
@@ -442,7 +472,7 @@ mod tests {
         let dst = tmp.path().join("nested/dst.txt");
         fs::create_dir_all(dst.parent().unwrap()).unwrap();
 
-        link_file(PackageImportMethod::CloneOrCopy, &src, &dst)
+        link_file::<SilentReporter>(PackageImportMethod::CloneOrCopy, &src, &dst)
             .expect("CloneOrCopy should always succeed");
         assert_eq!(fs::read(&dst).unwrap(), b"clone-or-copy");
     }
@@ -457,7 +487,8 @@ mod tests {
         let src = tmp.path().join("does-not-exist");
         let dst = tmp.path().join("dst.txt");
 
-        let err = link_file(PackageImportMethod::Clone, &src, &dst).expect_err("no source → error");
+        let err = link_file::<SilentReporter>(PackageImportMethod::Clone, &src, &dst)
+            .expect_err("no source → error");
         assert!(matches!(err, LinkFileError::Import { .. }), "got: {err:?}");
     }
 
@@ -475,7 +506,7 @@ mod tests {
         let dst = tmp.path().join("dst.txt");
         std::os::unix::fs::symlink(tmp.path().join("never-created"), &dst).unwrap();
 
-        link_file(PackageImportMethod::Hardlink, &src, &dst)
+        link_file::<SilentReporter>(PackageImportMethod::Hardlink, &src, &dst)
             .expect("dangling symlink should be scrubbed, then hardlinked");
 
         let meta = fs::symlink_metadata(&dst).unwrap();
@@ -496,7 +527,7 @@ mod tests {
         let dst = tmp.path().join("dst.txt");
         std::os::unix::fs::symlink(&real_target, &dst).unwrap();
 
-        link_file(PackageImportMethod::Hardlink, &src, &dst)
+        link_file::<SilentReporter>(PackageImportMethod::Hardlink, &src, &dst)
             .expect("live symlink should short-circuit");
 
         assert!(fs::symlink_metadata(&dst).unwrap().file_type().is_symlink());
@@ -528,7 +559,8 @@ mod tests {
         let dst = tmp.path().join("dst");
         fs::write(&dst, b"pre-existing").unwrap();
 
-        let err = auto_link(&state, &src, &dst).expect_err("target exists → AlreadyExists");
+        let err = auto_link::<SilentReporter>(&state, &src, &dst)
+            .expect_err("target exists → AlreadyExists");
         assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
         assert_eq!(
             state.load(Ordering::Relaxed),
@@ -548,7 +580,8 @@ mod tests {
         let src = tmp.path().join("does-not-exist");
         let dst = tmp.path().join("dst");
 
-        let err = auto_link(&state, &src, &dst).expect_err("missing source → NotFound");
+        let err =
+            auto_link::<SilentReporter>(&state, &src, &dst).expect_err("missing source → NotFound");
         assert_eq!(err.kind(), io::ErrorKind::NotFound);
         assert_eq!(
             state.load(Ordering::Relaxed),
@@ -571,7 +604,7 @@ mod tests {
         let src = write_source(tmp.path(), "src.txt", b"cached-copy");
         let dst = tmp.path().join("dst.txt");
 
-        auto_link(&state, &src, &dst).expect("copy should succeed");
+        auto_link::<SilentReporter>(&state, &src, &dst).expect("copy should succeed");
 
         assert_eq!(fs::read(&dst).unwrap(), b"cached-copy");
         assert_ne!(
@@ -594,7 +627,8 @@ mod tests {
         let src = write_source(tmp.path(), "src.txt", b"cached-hardlink");
         let dst = tmp.path().join("dst.txt");
 
-        auto_link(&state, &src, &dst).expect("hardlink should succeed on same-FS tempdir");
+        auto_link::<SilentReporter>(&state, &src, &dst)
+            .expect("hardlink should succeed on same-FS tempdir");
 
         assert_eq!(
             fs::metadata(&src).unwrap().ino(),
@@ -618,8 +652,8 @@ mod tests {
         let dst = tmp.path().join("dst");
         fs::write(&dst, b"pre-existing").unwrap();
 
-        let err =
-            clone_or_copy_link(&state, &src, &dst).expect_err("target exists → AlreadyExists");
+        let err = clone_or_copy_link::<SilentReporter>(&state, &src, &dst)
+            .expect_err("target exists → AlreadyExists");
         assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
         assert_eq!(
             state.load(Ordering::Relaxed),
@@ -709,7 +743,7 @@ mod tests {
         let src = write_source(tmp.path(), "src.txt", b"cached");
         let dst = tmp.path().join("dst.txt");
 
-        clone_or_copy_link(&state, &src, &dst).expect("copy should succeed");
+        clone_or_copy_link::<SilentReporter>(&state, &src, &dst).expect("copy should succeed");
 
         assert_ne!(
             fs::metadata(&src).unwrap().ino(),
@@ -717,5 +751,55 @@ mod tests {
             "state=COPY must not hardlink",
         );
         assert_eq!(state.load(Ordering::Relaxed), LINK_STATE_COPY, "state must not drift");
+    }
+
+    /// `log_method_once` emits one `pnpm:package-import-method` event
+    /// per resolved method per `logged` atomic. Repeated calls with the
+    /// same flag are suppressed, distinct flags fire independently. The
+    /// production [`link_file`] passes the module-level
+    /// `LOGGED_METHODS` static; this test passes a fresh atomic so it
+    /// observes the single-emit-per-method contract without racing
+    /// other tests that touch the global.
+    #[test]
+    fn log_method_once_emits_first_call_per_method_only() {
+        use pacquet_reporter::{LogEvent, PackageImportMethod as WireImportMethod, Reporter};
+        use std::sync::Mutex;
+
+        static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
+
+        struct RecordingReporter;
+        impl Reporter for RecordingReporter {
+            fn emit(event: &LogEvent) {
+                EVENTS.lock().unwrap().push(event.clone());
+            }
+        }
+
+        let logged = AtomicU8::new(0);
+
+        super::log_method_once::<RecordingReporter>(
+            &logged,
+            super::LOG_FLAG_CLONE,
+            WireImportMethod::Clone,
+        );
+        super::log_method_once::<RecordingReporter>(
+            &logged,
+            super::LOG_FLAG_CLONE,
+            WireImportMethod::Clone,
+        );
+        super::log_method_once::<RecordingReporter>(
+            &logged,
+            super::LOG_FLAG_HARDLINK,
+            WireImportMethod::Hardlink,
+        );
+
+        let captured = EVENTS.lock().unwrap();
+        let kinds: Vec<WireImportMethod> = captured
+            .iter()
+            .map(|e| match e {
+                LogEvent::PackageImportMethod(log) => log.method,
+                other => panic!("unexpected event {other:?}"),
+            })
+            .collect();
+        assert_eq!(kinds, [WireImportMethod::Clone, WireImportMethod::Hardlink]);
     }
 }

--- a/crates/package-manager/src/link_file.rs
+++ b/crates/package-manager/src/link_file.rs
@@ -175,10 +175,11 @@ pub fn link_file<R: Reporter>(
                 log_method_once::<R>(logged, LOG_FLAG_HARDLINK, WireImportMethod::Hardlink);
                 Ok(())
             }
-            Err(error) if is_cross_device(&error) => {
-                log_method_once::<R>(logged, LOG_FLAG_COPY, WireImportMethod::Copy);
-                fs::copy(source_file, target_link).map(drop)
-            }
+            Err(error) if is_cross_device(&error) => fs::copy(source_file, target_link)
+                .inspect(|_| {
+                    log_method_once::<R>(logged, LOG_FLAG_COPY, WireImportMethod::Copy);
+                })
+                .map(drop),
             Err(error) => Err(error),
         },
         PackageImportMethod::Clone => {
@@ -190,10 +191,11 @@ pub fn link_file<R: Reporter>(
             static CLONE_OR_COPY_STATE: AtomicU8 = AtomicU8::new(LINK_STATE_CLONE);
             clone_or_copy_link::<R>(logged, &CLONE_OR_COPY_STATE, source_file, target_link)
         }
-        PackageImportMethod::Copy => {
-            log_method_once::<R>(logged, LOG_FLAG_COPY, WireImportMethod::Copy);
-            fs::copy(source_file, target_link).map(drop)
-        }
+        PackageImportMethod::Copy => fs::copy(source_file, target_link)
+            .inspect(|_| {
+                log_method_once::<R>(logged, LOG_FLAG_COPY, WireImportMethod::Copy);
+            })
+            .map(drop),
     };
 
     match result {
@@ -301,8 +303,11 @@ fn auto_link<R: Reporter>(
                 }
             },
             _ => {
-                log_method_once::<R>(logged, LOG_FLAG_COPY, WireImportMethod::Copy);
-                return fs::copy(source, target).map(drop);
+                return fs::copy(source, target)
+                    .inspect(|_| {
+                        log_method_once::<R>(logged, LOG_FLAG_COPY, WireImportMethod::Copy);
+                    })
+                    .map(drop);
             }
         }
     }
@@ -333,8 +338,11 @@ fn clone_or_copy_link<R: Reporter>(
                 }
             },
             _ => {
-                log_method_once::<R>(logged, LOG_FLAG_COPY, WireImportMethod::Copy);
-                return fs::copy(source, target).map(drop);
+                return fs::copy(source, target)
+                    .inspect(|_| {
+                        log_method_once::<R>(logged, LOG_FLAG_COPY, WireImportMethod::Copy);
+                    })
+                    .map(drop);
             }
         }
     }

--- a/crates/package-manager/src/link_file.rs
+++ b/crates/package-manager/src/link_file.rs
@@ -64,20 +64,28 @@ const LINK_STATE_COPY: u8 = 2;
 
 // One-shot "we picked this import method" log, matching pnpm's
 // `packageImportMethodLogger.debug({ method: 'clone' | 'hardlink' | 'copy' })`
-// in `fs/indexed-pkg-importer/src/index.ts`. Emits once per process per
+// in `fs/indexed-pkg-importer/src/index.ts`. Emits once per install per
 // method so a reader of the logs can tell which tier actually ran —
 // crucial for verifying hardlinks are kicking in on CI runners where
 // reflink isn't available.
 //
-// Each method gets two emits the first time it's used: a `tracing::info!`
-// for human / diagnostic logs, and a `pnpm:package-import-method` reporter
-// event for structured consumers (`@pnpm/cli.default-reporter` and
-// friends). `fetch_or` returns the previous bitfield, so the first caller
-// to set a given bit is the one that emits.
-const LOG_FLAG_CLONE: u8 = 1 << 0;
-const LOG_FLAG_HARDLINK: u8 = 1 << 1;
-const LOG_FLAG_COPY: u8 = 1 << 2;
-static LOGGED_METHODS: AtomicU8 = AtomicU8::new(0);
+// The bitfield atomic is install-scoped, threaded down from
+// `Install::run`, mirroring upstream's per-importer closure capture:
+// pnpm's `createIndexedPackageImporter` builds a fresh closure per
+// install, so a second install that wires up `pnpm:package-import-method`
+// emits afresh. A module-static here would suppress emits on every
+// install after the first in the same process — fine for the one-shot
+// CLI today but a footgun for tests and any future embedded use.
+//
+// Each method gets two emits the first time it's used in an install: a
+// `tracing::info!` for human / diagnostic logs, and a
+// `pnpm:package-import-method` reporter event for structured consumers
+// (`@pnpm/cli.default-reporter` and friends). `fetch_or` returns the
+// previous bitfield, so the first caller to set a given bit is the one
+// that emits.
+pub(crate) const LOG_FLAG_CLONE: u8 = 1 << 0;
+pub(crate) const LOG_FLAG_HARDLINK: u8 = 1 << 1;
+pub(crate) const LOG_FLAG_COPY: u8 = 1 << 2;
 
 fn log_method_once<R: Reporter>(logged: &AtomicU8, flag: u8, method: WireImportMethod) {
     if logged.fetch_or(flag, Ordering::Relaxed) & flag == 0 {
@@ -105,6 +113,7 @@ fn log_method_once<R: Reporter>(logged: &AtomicU8, flag: u8, method: WireImportM
 ///   per file. [`create_cas_files`](crate::create_cas_files) is the
 ///   production caller and handles that pre-pass.
 pub fn link_file<R: Reporter>(
+    logged: &AtomicU8,
     method: PackageImportMethod,
     source_file: &Path,
     target_link: &Path,
@@ -151,7 +160,7 @@ pub fn link_file<R: Reporter>(
     let result = match method {
         PackageImportMethod::Auto => {
             static AUTO_STATE: AtomicU8 = AtomicU8::new(LINK_STATE_CLONE);
-            auto_link::<R>(&AUTO_STATE, source_file, target_link)
+            auto_link::<R>(logged, &AUTO_STATE, source_file, target_link)
         }
         // pnpm's explicit `hardlink` method uses `hardlinkPkg(linkOrCopy)`
         // which falls back to copy on `EXDEV` (cross-device link not
@@ -163,30 +172,26 @@ pub fn link_file<R: Reporter>(
         // itself is already cheap; pnpm doesn't cache this path either.
         PackageImportMethod::Hardlink => match fs::hard_link(source_file, target_link) {
             Ok(()) => {
-                log_method_once::<R>(
-                    &LOGGED_METHODS,
-                    LOG_FLAG_HARDLINK,
-                    WireImportMethod::Hardlink,
-                );
+                log_method_once::<R>(logged, LOG_FLAG_HARDLINK, WireImportMethod::Hardlink);
                 Ok(())
             }
             Err(error) if is_cross_device(&error) => {
-                log_method_once::<R>(&LOGGED_METHODS, LOG_FLAG_COPY, WireImportMethod::Copy);
+                log_method_once::<R>(logged, LOG_FLAG_COPY, WireImportMethod::Copy);
                 fs::copy(source_file, target_link).map(drop)
             }
             Err(error) => Err(error),
         },
         PackageImportMethod::Clone => {
             reflink_copy::reflink(source_file, target_link).inspect(|_| {
-                log_method_once::<R>(&LOGGED_METHODS, LOG_FLAG_CLONE, WireImportMethod::Clone);
+                log_method_once::<R>(logged, LOG_FLAG_CLONE, WireImportMethod::Clone);
             })
         }
         PackageImportMethod::CloneOrCopy => {
             static CLONE_OR_COPY_STATE: AtomicU8 = AtomicU8::new(LINK_STATE_CLONE);
-            clone_or_copy_link::<R>(&CLONE_OR_COPY_STATE, source_file, target_link)
+            clone_or_copy_link::<R>(logged, &CLONE_OR_COPY_STATE, source_file, target_link)
         }
         PackageImportMethod::Copy => {
-            log_method_once::<R>(&LOGGED_METHODS, LOG_FLAG_COPY, WireImportMethod::Copy);
+            log_method_once::<R>(logged, LOG_FLAG_COPY, WireImportMethod::Copy);
             fs::copy(source_file, target_link).map(drop)
         }
     };
@@ -267,12 +272,17 @@ fn is_call_error(err: &io::Error) -> bool {
 /// downgrade the cached state; other errors propagate immediately so a
 /// one-off `NotFound` on a single file doesn't permanently disable a
 /// tier for the rest of the process.
-fn auto_link<R: Reporter>(state: &AtomicU8, source: &Path, target: &Path) -> io::Result<()> {
+fn auto_link<R: Reporter>(
+    logged: &AtomicU8,
+    state: &AtomicU8,
+    source: &Path,
+    target: &Path,
+) -> io::Result<()> {
     loop {
         match state.load(Ordering::Relaxed) {
             LINK_STATE_CLONE => match reflink_copy::reflink(source, target) {
                 Ok(()) => {
-                    log_method_once::<R>(&LOGGED_METHODS, LOG_FLAG_CLONE, WireImportMethod::Clone);
+                    log_method_once::<R>(logged, LOG_FLAG_CLONE, WireImportMethod::Clone);
                     return Ok(());
                 }
                 Err(err) if is_call_error(&err) => return Err(err),
@@ -282,11 +292,7 @@ fn auto_link<R: Reporter>(state: &AtomicU8, source: &Path, target: &Path) -> io:
             },
             LINK_STATE_HARDLINK => match fs::hard_link(source, target) {
                 Ok(()) => {
-                    log_method_once::<R>(
-                        &LOGGED_METHODS,
-                        LOG_FLAG_HARDLINK,
-                        WireImportMethod::Hardlink,
-                    );
+                    log_method_once::<R>(logged, LOG_FLAG_HARDLINK, WireImportMethod::Hardlink);
                     return Ok(());
                 }
                 Err(err) if is_call_error(&err) => return Err(err),
@@ -295,7 +301,7 @@ fn auto_link<R: Reporter>(state: &AtomicU8, source: &Path, target: &Path) -> io:
                 }
             },
             _ => {
-                log_method_once::<R>(&LOGGED_METHODS, LOG_FLAG_COPY, WireImportMethod::Copy);
+                log_method_once::<R>(logged, LOG_FLAG_COPY, WireImportMethod::Copy);
                 return fs::copy(source, target).map(drop);
             }
         }
@@ -309,6 +315,7 @@ fn auto_link<R: Reporter>(state: &AtomicU8, source: &Path, target: &Path) -> io:
 /// Same error-narrowing as `auto_link`: only capability failures
 /// downgrade; real errors propagate.
 fn clone_or_copy_link<R: Reporter>(
+    logged: &AtomicU8,
     state: &AtomicU8,
     source: &Path,
     target: &Path,
@@ -317,7 +324,7 @@ fn clone_or_copy_link<R: Reporter>(
         match state.load(Ordering::Relaxed) {
             LINK_STATE_CLONE => match reflink_copy::reflink(source, target) {
                 Ok(()) => {
-                    log_method_once::<R>(&LOGGED_METHODS, LOG_FLAG_CLONE, WireImportMethod::Clone);
+                    log_method_once::<R>(logged, LOG_FLAG_CLONE, WireImportMethod::Clone);
                     return Ok(());
                 }
                 Err(err) if is_call_error(&err) => return Err(err),
@@ -326,7 +333,7 @@ fn clone_or_copy_link<R: Reporter>(
                 }
             },
             _ => {
-                log_method_once::<R>(&LOGGED_METHODS, LOG_FLAG_COPY, WireImportMethod::Copy);
+                log_method_once::<R>(logged, LOG_FLAG_COPY, WireImportMethod::Copy);
                 return fs::copy(source, target).map(drop);
             }
         }
@@ -364,7 +371,7 @@ mod tests {
         let dst = tmp.path().join("nested/dst.txt");
         fs::create_dir_all(dst.parent().unwrap()).unwrap();
 
-        link_file::<SilentReporter>(PackageImportMethod::Copy, &src, &dst)
+        link_file::<SilentReporter>(&AtomicU8::new(0), PackageImportMethod::Copy, &src, &dst)
             .expect("link_file should succeed");
 
         assert_eq!(fs::read(&dst).unwrap(), b"hello");
@@ -390,7 +397,7 @@ mod tests {
         let dst = tmp.path().join("nested/dst.txt");
         fs::create_dir_all(dst.parent().unwrap()).unwrap();
 
-        link_file::<SilentReporter>(PackageImportMethod::Hardlink, &src, &dst)
+        link_file::<SilentReporter>(&AtomicU8::new(0), PackageImportMethod::Hardlink, &src, &dst)
             .expect("link_file should succeed");
 
         assert_eq!(fs::read(&dst).unwrap(), b"shared");
@@ -414,7 +421,7 @@ mod tests {
         let dst = tmp.path().join("nested/dst.txt");
         fs::create_dir_all(dst.parent().unwrap()).unwrap();
 
-        link_file::<SilentReporter>(PackageImportMethod::Auto, &src, &dst)
+        link_file::<SilentReporter>(&AtomicU8::new(0), PackageImportMethod::Auto, &src, &dst)
             .expect("Auto should always succeed");
         assert_eq!(fs::read(&dst).unwrap(), b"auto");
     }
@@ -436,7 +443,7 @@ mod tests {
             PackageImportMethod::Clone,
             PackageImportMethod::CloneOrCopy,
         ] {
-            link_file::<SilentReporter>(method, &src, &dst)
+            link_file::<SilentReporter>(&AtomicU8::new(0), method, &src, &dst)
                 .expect("existing target should short-circuit");
             assert_eq!(fs::read(&dst).unwrap(), b"old", "method {method:?} must not overwrite");
         }
@@ -454,8 +461,13 @@ mod tests {
         let src = tmp.path().join("does-not-exist");
         let dst = tmp.path().join("dst.txt");
 
-        let err = link_file::<SilentReporter>(PackageImportMethod::Hardlink, &src, &dst)
-            .expect_err("no source → error");
+        let err = link_file::<SilentReporter>(
+            &AtomicU8::new(0),
+            PackageImportMethod::Hardlink,
+            &src,
+            &dst,
+        )
+        .expect_err("no source → error");
         assert!(matches!(err, LinkFileError::Import { .. }), "got: {err:?}");
     }
 
@@ -472,8 +484,13 @@ mod tests {
         let dst = tmp.path().join("nested/dst.txt");
         fs::create_dir_all(dst.parent().unwrap()).unwrap();
 
-        link_file::<SilentReporter>(PackageImportMethod::CloneOrCopy, &src, &dst)
-            .expect("CloneOrCopy should always succeed");
+        link_file::<SilentReporter>(
+            &AtomicU8::new(0),
+            PackageImportMethod::CloneOrCopy,
+            &src,
+            &dst,
+        )
+        .expect("CloneOrCopy should always succeed");
         assert_eq!(fs::read(&dst).unwrap(), b"clone-or-copy");
     }
 
@@ -487,8 +504,9 @@ mod tests {
         let src = tmp.path().join("does-not-exist");
         let dst = tmp.path().join("dst.txt");
 
-        let err = link_file::<SilentReporter>(PackageImportMethod::Clone, &src, &dst)
-            .expect_err("no source → error");
+        let err =
+            link_file::<SilentReporter>(&AtomicU8::new(0), PackageImportMethod::Clone, &src, &dst)
+                .expect_err("no source → error");
         assert!(matches!(err, LinkFileError::Import { .. }), "got: {err:?}");
     }
 
@@ -506,7 +524,7 @@ mod tests {
         let dst = tmp.path().join("dst.txt");
         std::os::unix::fs::symlink(tmp.path().join("never-created"), &dst).unwrap();
 
-        link_file::<SilentReporter>(PackageImportMethod::Hardlink, &src, &dst)
+        link_file::<SilentReporter>(&AtomicU8::new(0), PackageImportMethod::Hardlink, &src, &dst)
             .expect("dangling symlink should be scrubbed, then hardlinked");
 
         let meta = fs::symlink_metadata(&dst).unwrap();
@@ -527,7 +545,7 @@ mod tests {
         let dst = tmp.path().join("dst.txt");
         std::os::unix::fs::symlink(&real_target, &dst).unwrap();
 
-        link_file::<SilentReporter>(PackageImportMethod::Hardlink, &src, &dst)
+        link_file::<SilentReporter>(&AtomicU8::new(0), PackageImportMethod::Hardlink, &src, &dst)
             .expect("live symlink should short-circuit");
 
         assert!(fs::symlink_metadata(&dst).unwrap().file_type().is_symlink());
@@ -559,7 +577,7 @@ mod tests {
         let dst = tmp.path().join("dst");
         fs::write(&dst, b"pre-existing").unwrap();
 
-        let err = auto_link::<SilentReporter>(&state, &src, &dst)
+        let err = auto_link::<SilentReporter>(&AtomicU8::new(0), &state, &src, &dst)
             .expect_err("target exists → AlreadyExists");
         assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
         assert_eq!(
@@ -580,8 +598,8 @@ mod tests {
         let src = tmp.path().join("does-not-exist");
         let dst = tmp.path().join("dst");
 
-        let err =
-            auto_link::<SilentReporter>(&state, &src, &dst).expect_err("missing source → NotFound");
+        let err = auto_link::<SilentReporter>(&AtomicU8::new(0), &state, &src, &dst)
+            .expect_err("missing source → NotFound");
         assert_eq!(err.kind(), io::ErrorKind::NotFound);
         assert_eq!(
             state.load(Ordering::Relaxed),
@@ -604,7 +622,8 @@ mod tests {
         let src = write_source(tmp.path(), "src.txt", b"cached-copy");
         let dst = tmp.path().join("dst.txt");
 
-        auto_link::<SilentReporter>(&state, &src, &dst).expect("copy should succeed");
+        auto_link::<SilentReporter>(&AtomicU8::new(0), &state, &src, &dst)
+            .expect("copy should succeed");
 
         assert_eq!(fs::read(&dst).unwrap(), b"cached-copy");
         assert_ne!(
@@ -627,7 +646,7 @@ mod tests {
         let src = write_source(tmp.path(), "src.txt", b"cached-hardlink");
         let dst = tmp.path().join("dst.txt");
 
-        auto_link::<SilentReporter>(&state, &src, &dst)
+        auto_link::<SilentReporter>(&AtomicU8::new(0), &state, &src, &dst)
             .expect("hardlink should succeed on same-FS tempdir");
 
         assert_eq!(
@@ -652,7 +671,7 @@ mod tests {
         let dst = tmp.path().join("dst");
         fs::write(&dst, b"pre-existing").unwrap();
 
-        let err = clone_or_copy_link::<SilentReporter>(&state, &src, &dst)
+        let err = clone_or_copy_link::<SilentReporter>(&AtomicU8::new(0), &state, &src, &dst)
             .expect_err("target exists → AlreadyExists");
         assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
         assert_eq!(
@@ -743,7 +762,8 @@ mod tests {
         let src = write_source(tmp.path(), "src.txt", b"cached");
         let dst = tmp.path().join("dst.txt");
 
-        clone_or_copy_link::<SilentReporter>(&state, &src, &dst).expect("copy should succeed");
+        clone_or_copy_link::<SilentReporter>(&AtomicU8::new(0), &state, &src, &dst)
+            .expect("copy should succeed");
 
         assert_ne!(
             fs::metadata(&src).unwrap().ino(),
@@ -755,11 +775,11 @@ mod tests {
 
     /// `log_method_once` emits one `pnpm:package-import-method` event
     /// per resolved method per `logged` atomic. Repeated calls with the
-    /// same flag are suppressed, distinct flags fire independently. The
-    /// production [`link_file`] passes the module-level
-    /// `LOGGED_METHODS` static; this test passes a fresh atomic so it
+    /// same flag are suppressed, distinct flags fire independently.
+    /// Production threads an install-scoped atomic from `Install::run`
+    /// down to [`link_file`]; this test passes a per-test atomic so it
     /// observes the single-emit-per-method contract without racing
-    /// other tests that touch the global.
+    /// other tests.
     #[test]
     fn log_method_once_emits_first_call_per_method_only() {
         use pacquet_reporter::{LogEvent, PackageImportMethod as WireImportMethod, Reporter};

--- a/crates/reporter/src/lib.rs
+++ b/crates/reporter/src/lib.rs
@@ -162,6 +162,16 @@ pub enum LogLevel {
 ///
 /// [`Reporter::emit`] must not panic. A serialization or I/O failure is
 /// swallowed so a reporter problem can never crash an install.
+///
+/// **Thread safety.** `emit` may be invoked concurrently from
+/// arbitrary threads — pacquet's import path runs `link_file` from a
+/// rayon `par_iter`, and tarball download / store-index work runs
+/// across tokio workers, all of which can fire reporter events at
+/// once. Implementations must therefore guard any shared state they
+/// touch (`Mutex`, atomic, or write-once initialization). Both
+/// production sinks satisfy this: `SilentReporter` is a no-op, and
+/// `NdjsonReporter` serializes per-event then writes under
+/// `std::io::stderr().lock()`.
 pub trait Reporter {
     fn emit(event: &LogEvent);
 }

--- a/crates/reporter/src/lib.rs
+++ b/crates/reporter/src/lib.rs
@@ -51,8 +51,13 @@ pub enum LogEvent {
     Summary(SummaryLog),
 
     /// The import method used to materialise files from the store
-    /// (`pnpm:package-import-method`). Fires once per install when the
-    /// importer is constructed.
+    /// (`pnpm:package-import-method`). Fires the first time each
+    /// resolved method (`clone` / `hardlink` / `copy`) actually
+    /// succeeds during an install — so for the `auto` and
+    /// `clone-or-copy` config values, the wire value reflects the
+    /// post-fallback method rather than the optimistic configured
+    /// one. Up to three events per install (one per resolved method)
+    /// gated by an install-scoped atomic in `pacquet-package-manager`.
     ///
     /// Upstream: <https://github.com/pnpm/pnpm/blob/086c5e91e8/core/core-loggers/src/packageImportMethodLogger.ts>.
     /// Emit site: <https://github.com/pnpm/pnpm/blob/086c5e91e8/fs/indexed-pkg-importer/src/index.ts#L32>.
@@ -117,10 +122,12 @@ pub struct PackageImportMethodLog {
 }
 
 /// Wire-format import method. pnpm only knows three values; pacquet's
-/// config enum has more (`Auto`, `CloneOrCopy`) which collapse to
-/// `clone` because that's the optimistic path both fall through to
-/// first. See `import_method_for_wire` in `pacquet-package-manager`
-/// for the mapping.
+/// config enum (`pacquet_npmrc::PackageImportMethod`) carries `Auto`
+/// and `CloneOrCopy` on top of those, but those are dispatched-on by
+/// the auto-importer's fallback chain, not emitted. The wire value is
+/// the resolved method `link_file` actually used — `Clone` /
+/// `Hardlink` / `Copy` — so an `auto` install that falls back to
+/// hardlink emits `hardlink`, not the optimistic `clone`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum PackageImportMethod {

--- a/crates/reporter/src/lib.rs
+++ b/crates/reporter/src/lib.rs
@@ -49,6 +49,15 @@ pub enum LogEvent {
     /// Emit site: <https://github.com/pnpm/pnpm/blob/086c5e91e8/installing/deps-installer/src/install/index.ts#L1663>.
     #[serde(rename = "pnpm:summary")]
     Summary(SummaryLog),
+
+    /// The import method used to materialise files from the store
+    /// (`pnpm:package-import-method`). Fires once per install when the
+    /// importer is constructed.
+    ///
+    /// Upstream: <https://github.com/pnpm/pnpm/blob/086c5e91e8/core/core-loggers/src/packageImportMethodLogger.ts>.
+    /// Emit site: <https://github.com/pnpm/pnpm/blob/086c5e91e8/fs/indexed-pkg-importer/src/index.ts#L32>.
+    #[serde(rename = "pnpm:package-import-method")]
+    PackageImportMethod(PackageImportMethodLog),
 }
 
 /// `pnpm:context` payload.
@@ -96,6 +105,28 @@ pub enum Stage {
 pub struct SummaryLog {
     pub level: LogLevel,
     pub prefix: String,
+}
+
+/// `pnpm:package-import-method` payload. The method names match pnpm's
+/// wire shape exactly — anything else would silently fail to render
+/// even though the JSON parses.
+#[derive(Debug, Clone, Serialize)]
+pub struct PackageImportMethodLog {
+    pub level: LogLevel,
+    pub method: PackageImportMethod,
+}
+
+/// Wire-format import method. pnpm only knows three values; pacquet's
+/// config enum has more (`Auto`, `CloneOrCopy`) which collapse to
+/// `clone` because that's the optimistic path both fall through to
+/// first. See `import_method_for_wire` in `pacquet-package-manager`
+/// for the mapping.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PackageImportMethod {
+    Clone,
+    Hardlink,
+    Copy,
 }
 
 /// Severity level on the [bunyan]-shaped envelope.

--- a/crates/reporter/src/tests.rs
+++ b/crates/reporter/src/tests.rs
@@ -5,8 +5,8 @@ use pretty_assertions::assert_eq;
 use serde_json::Value;
 
 use crate::{
-    ContextLog, Envelope, GetHostName, LogEvent, LogLevel, RealApi, Reporter, SilentReporter,
-    Stage, StageLog, SummaryLog,
+    ContextLog, Envelope, GetHostName, LogEvent, LogLevel, PackageImportMethod,
+    PackageImportMethodLog, RealApi, Reporter, SilentReporter, Stage, StageLog, SummaryLog,
 };
 
 /// Context log serializes with the camelCase field names
@@ -87,6 +87,38 @@ fn summary_event_matches_pnpm_wire_shape() {
     assert_eq!(json["name"], "pnpm:summary");
     assert_eq!(json["level"], "debug");
     assert_eq!(json["prefix"], "/some/project");
+}
+
+/// Package-import-method log carries the chosen method as one of
+/// pnpm's three lowercase strings; anything else (e.g. the camelCase
+/// `cloneOrCopy` from pacquet's config enum) would silently fail to
+/// render.
+#[test]
+fn package_import_method_event_matches_pnpm_wire_shape() {
+    let event = LogEvent::PackageImportMethod(PackageImportMethodLog {
+        level: LogLevel::Debug,
+        method: PackageImportMethod::Clone,
+    });
+    let envelope = Envelope { time: 1_700_000_000_000, hostname: "host", pid: 4242, event: &event };
+
+    let json: Value = envelope
+        .pipe_ref(serde_json::to_string)
+        .expect("serialize envelope")
+        .pipe_as_ref(serde_json::from_str)
+        .expect("parse JSON");
+
+    assert_eq!(json["name"], "pnpm:package-import-method");
+    assert_eq!(json["level"], "debug");
+    assert_eq!(json["method"], "clone");
+
+    for (method, expected) in [
+        (PackageImportMethod::Clone, "clone"),
+        (PackageImportMethod::Hardlink, "hardlink"),
+        (PackageImportMethod::Copy, "copy"),
+    ] {
+        let json = serde_json::to_string(&method).expect("serialize method");
+        assert_eq!(json, format!("\"{expected}\""), "method {expected}");
+    }
 }
 
 /// Phase markers serialize as the snake_case strings pnpm uses.

--- a/crates/reporter/src/tests.rs
+++ b/crates/reporter/src/tests.rs
@@ -90,9 +90,9 @@ fn summary_event_matches_pnpm_wire_shape() {
 }
 
 /// Package-import-method log carries the chosen method as one of
-/// pnpm's three lowercase strings; anything else (e.g. the camelCase
-/// `cloneOrCopy` from pacquet's config enum) would silently fail to
-/// render.
+/// pnpm's three lowercase strings; anything else (e.g. the
+/// kebab-case `clone-or-copy` that `pacquet_npmrc::PackageImportMethod`
+/// deserializes from) would silently fail to render.
 #[test]
 fn package_import_method_event_matches_pnpm_wire_shape() {
     let event = LogEvent::PackageImportMethod(PackageImportMethodLog {
@@ -117,7 +117,7 @@ fn package_import_method_event_matches_pnpm_wire_shape() {
         (PackageImportMethod::Copy, "copy"),
     ] {
         let json = serde_json::to_string(&method).expect("serialize method");
-        assert_eq!(json, format!("\"{expected}\""), "method {expected}");
+        assert_eq!(json, format!("\"{expected}\""));
     }
 }
 


### PR DESCRIPTION
## Summary

Third channel from the backfill (#347), and a course-correction on a
fourth.

**`pnpm:package-import-method`.** Adds the `PackageImportMethod`
variant to `LogEvent` and emits it from `link_file`'s
`log_method_once` helper, mirroring pnpm's emit at
[`fs/indexed-pkg-importer/src/index.ts:32`](https://github.com/pnpm/pnpm/blob/086c5e91e8/fs/indexed-pkg-importer/src/index.ts#L32).
The structured event fires alongside the existing `tracing::info!`
diagnostic the first time each resolved method (`clone` / `hardlink`
/ `copy`) actually *succeeds*, so for `Auto` and `CloneOrCopy` the
wire value is the post-fallback method rather than the optimistic
configured one.

The wire-format enum is `clone | hardlink | copy` exactly. Pacquet's
`Npmrc::package_import_method` carries `Auto` and `CloneOrCopy` on
top of those, but those are dispatched-on by the auto-importer's
fallback chain, not emitted, so the wire enum stays in lockstep with
pnpm's. Threading the reporter through the link path required adding
`<R: Reporter>` to `link_file`, `auto_link`, `clone_or_copy_link`,
and the call chain above (`create_cas_files`,
`create_virtual_dir_by_snapshot`, `install_package_by_snapshot`,
`create_virtual_store`, `install_package_from_registry`,
`install_frozen_lockfile`, `install_without_lockfile`). The reporter
type monomorphises away — zero runtime cost.

**Install-scoped dedupe.** The bitfield atomic that gates
once-per-method emission is install-scoped — created in `Install::run`
and threaded down as a `&'a AtomicU8` field on each install-layer
struct, matching the existing `verified_files_cache` pattern.
Mirroring upstream pnpm's per-importer closure capture (a process-
static would suppress emits on every install after the first in the
same process — fine for the one-shot CLI today but a footgun for
tests and any future embedded use).

**Emit-only-on-success.** All four `fs::copy`-bearing branches
(explicit `Copy`, explicit `Hardlink`'s EXDEV fallback to copy, and
the copy fallbacks in both `auto_link` and `clone_or_copy_link`)
emit *after* the copy returns `Ok`, so a copy failure can't record a
method that never succeeded.

**Deferral on `pnpm:stage resolution_started/done`.** Investigated
this channel before picking the current one and concluded it can't
land cleanly today: pacquet's no-lockfile flow interleaves resolution
and import per dependency, so emitting `resolution_done` after import
work has already happened would break the JS reporter's per-package
state. Frozen-lockfile installs (the primary path today) don't need
the events — pnpm itself skips them in `deps-restorer`. Recorded the
deferral on #347 alongside the dependency on a phase-separated
resolution pass.

## Convention compliance

- [x] `LogEvent::PackageImportMethod` mirrors the upstream payload
      field-for-field; the wire enum uses pnpm's exact lowercase
      strings.
- [x] Code comment + commit message + this PR all reference the
      upstream permalink at the pinned SHA (`086c5e91e8`).
- [x] Recording-fake DI test in
      `link_file::tests::log_method_once_emits_first_call_per_method_only`
      drives the helper directly with its own atomic and asserts the
      once-per-method emission contract — sidesteps cross-test
      interference on the production install-scoped atomic.
- [x] Wire-shape test in `pacquet-reporter`
      (`package_import_method_event_matches_pnpm_wire_shape`)
      asserts every wire value renders correctly under the bunyan
      envelope.
- [x] No throttle (one emit per resolved method per install,
      atomic-gated).
- [x] Verified the test catches the regression: commented out the
      `R::emit` call in `log_method_once`, confirmed
      `log_method_once_emits_first_call_per_method_only` failed,
      then restored.
- [ ] Tick the `pnpm:package-import-method` box in #347 on merge.

## Test plan

- [x] `cargo nextest run -p pacquet-reporter` — all wire-shape tests
      pass including the new
      `package_import_method_event_matches_pnpm_wire_shape`.
- [x] `cargo nextest run -p pacquet-package-manager log_method_once_emits_first_call_per_method_only`
      — passes; per-test atomic, asserts once-per-method contract.
- [x] `just ready` — 259 tests pass, lint clean.

## References

- Tracked by #347.
- Engine PR: #349.
- Previous channel PRs: #354 (`pnpm:context`), #355 (`pnpm:summary`).
- Upstream type: [`core/core-loggers/src/packageImportMethodLogger.ts`](https://github.com/pnpm/pnpm/blob/086c5e91e8/core/core-loggers/src/packageImportMethodLogger.ts).
- Upstream emit: [`fs/indexed-pkg-importer/src/index.ts:32`](https://github.com/pnpm/pnpm/blob/086c5e91e8/fs/indexed-pkg-importer/src/index.ts#L32).