### PR TITLE
fix(package-manager): re-import reporter and lockfile types in tests

### DIFF
--- a/crates/package-manager/src/install.rs
+++ b/crates/package-manager/src/install.rs
@@ -158,10 +158,11 @@ where
 #[cfg(test)]
 mod tests {
     use super::{Install, InstallError};
+    use pacquet_lockfile::Lockfile;
     use pacquet_npmrc::Npmrc;
     use pacquet_package_manifest::{DependencyGroup, PackageManifest};
     use pacquet_registry_mock::AutoMockInstance;
-    use pacquet_reporter::SilentReporter;
+    use pacquet_reporter::{LogEvent, Reporter, SilentReporter, Stage, StageLog};
     use pacquet_testing_utils::fs::{get_all_folders, is_symlink_or_junction};
     use std::sync::Mutex;
     use tempfile::tempdir;
@@ -313,8 +314,6 @@ mod tests {
     /// integrity surfaces as `FrozenLockfile(...)`.
     #[tokio::test]
     async fn frozen_lockfile_flag_overrides_config_lockfile_false() {
-        use pacquet_lockfile::Lockfile;
-
         let dir = tempdir().unwrap();
         let store_dir = dir.path().join("pacquet-store");
         let project_root = dir.path().join("project");


### PR DESCRIPTION
## Summary

#364's `use super::*;` removal in `crates/package-manager/src/install.rs` stripped the test module's view of `LogEvent`, `Reporter`, `Stage`, `StageLog`, and `Lockfile`, but the test bodies still reference them. As a result `cargo nextest run -p pacquet-package-manager` (and `cargo check --tests`) fails to compile on current `main`.

Promotes the inline `use pacquet_lockfile::Lockfile` from `frozen_lockfile_flag_overrides_config_lockfile_false` to the module-level `use` block (it's now needed by two tests), and adds the missing reporter symbols alongside the existing `SilentReporter` import.

## Test plan

- [x] `cargo check --workspace --tests` — clean before this PR fails on the `install.rs` test module.
- [x] `cargo nextest run -p pacquet-package-manager install_emits_stage_events_bracketing_the_run` — passes (was a build error on `main`).
- [x] `just ready` — all checks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal reorganization of test module imports for improved code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->