### PR TITLE
chore(deny): ignore hickory-proto 0.25 advisories with rationale

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,7 @@ jobs:
           filters: |
             src:
               - 'Cargo.lock'
+              - 'deny.toml'
 
       - name: Install cargo-deny
         if: steps.filter.outputs.src == 'true'

--- a/deny.toml
+++ b/deny.toml
@@ -21,7 +21,30 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 unmaintained = "workspace"
 # yanked-crates check: "deny" | "warn" | "allow"
 yanked = "warn"
-ignore = []
+ignore = [
+  # hickory-proto 0.25.2 is pulled in transitively through reqwest 0.13.x ->
+  # hickory-resolver 0.25.x. The reqwest 0.13 line has not migrated to
+  # hickory-proto 0.26, so `cargo update` cannot resolve either advisory; the
+  # only paths forward are an upstream reqwest release on hickory 0.26 or
+  # dropping the `hickory-dns` reqwest feature, which would regress the macOS
+  # `mDNSResponder` / `EAI_NONAME` workaround landed in #302. Revisit when
+  # reqwest moves to hickory 0.26.
+  #
+  # NSEC3 closest-encloser proof unbounded loop in `DnssecDnsHandle`. The
+  # vulnerable path is only linked when hickory-proto is built with the
+  # `dnssec-ring` or `dnssec-aws-lc-rs` Cargo feature; reqwest's `hickory-dns`
+  # feature does not enable either, so the affected code is unreachable in
+  # pacquet. The advisory itself notes "No safe upgrade is available" for the
+  # 0.25 line.
+  { id = "RUSTSEC-2026-0118", reason = "DNSSEC validation path is not linked: reqwest's `hickory-dns` feature does not enable hickory-proto's `dnssec-ring`/`dnssec-aws-lc-rs` features, and no fix exists on the 0.25 line." },
+  # O(n²) name compression in `BinEncoder` during DNS message encoding. The
+  # encoder is only exercised against the registry hostnames pacquet resolves
+  # (npm registry / mirrors configured via `.npmrc`), which are not
+  # attacker-controlled, so the CPU-exhaustion vector is not reachable in
+  # practice. Fixed in hickory-proto 0.26.1, which reqwest 0.13.x does not yet
+  # consume.
+  { id = "RUSTSEC-2026-0119", reason = "DoS vector requires attacker-controlled DNS message encoding; pacquet only encodes trusted registry hostnames, and reqwest 0.13.x has no release on hickory-proto 0.26.1 yet." },
+]
 
 # --- Licenses ------------------------------------------------------------
 # https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html

--- a/deny.toml
+++ b/deny.toml
@@ -37,13 +37,16 @@ ignore = [
   # pacquet. The advisory itself notes "No safe upgrade is available" for the
   # 0.25 line.
   { id = "RUSTSEC-2026-0118", reason = "DNSSEC validation path is not linked: reqwest's `hickory-dns` feature does not enable hickory-proto's `dnssec-ring`/`dnssec-aws-lc-rs` features, and no fix exists on the 0.25 line." },
-  # O(n²) name compression in `BinEncoder` during DNS message encoding. The
-  # encoder is only exercised against the registry hostnames pacquet resolves
-  # (npm registry / mirrors configured via `.npmrc`), which are not
-  # attacker-controlled, so the CPU-exhaustion vector is not reachable in
-  # practice. Fixed in hickory-proto 0.26.1, which reqwest 0.13.x does not yet
-  # consume.
-  { id = "RUSTSEC-2026-0119", reason = "DoS vector requires attacker-controlled DNS message encoding; pacquet only encodes trusted registry hostnames, and reqwest 0.13.x has no release on hickory-proto 0.26.1 yet." },
+  # O(n²) name compression in `BinEncoder` during DNS message encoding.
+  # Reachability is bounded: the BinEncoder is only invoked when reqwest's
+  # `hickory-dns` resolver builds outbound DNS queries for the registry
+  # hostnames pacquet resolves, which originate from `.npmrc` and so can be
+  # attacker-influenced in an untrusted-checkout / untrusted-CI scenario. We
+  # accept this temporary DoS risk because no upgrade is reachable: reqwest
+  # 0.13.x (latest 0.13.3) is locked to `hickory-resolver` 0.25, and the fix
+  # ships only in `hickory-proto` 0.26.1+. Revisit when reqwest moves to
+  # hickory 0.26.
+  { id = "RUSTSEC-2026-0119", reason = "Temporary risk acceptance: reqwest 0.13.x (latest 0.13.3) is locked to hickory-resolver 0.25 and no release consumes hickory-proto 0.26.1+ yet; revisit on reqwest upgrade." },
 ]
 
 # --- Licenses ------------------------------------------------------------


### PR DESCRIPTION
`cargo deny check` flagged RUSTSEC-2026-0118 and RUSTSEC-2026-0119 against the transitive `hickory-proto v0.25.2` brought in via `reqwest 0.13.x` -> `hickory-resolver 0.25.x`. Neither has a reachable upgrade path: reqwest 0.13.x has not yet released against hickory-proto 0.26, and the upstream 0.25 line states "No safe upgrade is available" for 0118.

Both advisories are unreachable or impractical for pacquet:

- 0118 only fires inside `DnssecDnsHandle`, which is gated behind `dnssec-ring`/`dnssec-aws-lc-rs` Cargo features that reqwest's `hickory-dns` feature does not enable.
- 0119 needs an attacker-controlled DNS message during encoding, but pacquet only encodes registry hostnames configured by the user.

Dropping the `hickory-dns` reqwest feature would dodge the warnings but would regress the macOS `mDNSResponder`/`EAI_NONAME` workaround landed in #302, so the ignore is the right knob until reqwest moves to hickory 0.26.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated security advisory configuration to acknowledge two specific advisories, including per-advisory rationale and guidance for revisiting on upstream upgrades.
* **Tests / CI**
  * CI now enforces security advisory configuration updates by running the security check whenever the advisory config changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->