### PR TITLE
feat(reporter): emit pnpm:package-manifest, pnpm:root, pnpm:stats, and pnpm:request-retry

### DIFF
--- a/crates/package-manager/src/add.rs
+++ b/crates/package-manager/src/add.rs
@@ -7,7 +7,7 @@ use pacquet_npmrc::Npmrc;
 use pacquet_package_manifest::PackageManifestError;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_registry::{PackageTag, PackageVersion};
-use pacquet_reporter::Reporter;
+use pacquet_reporter::{LogEvent, LogLevel, PackageManifestLog, PackageManifestMessage, Reporter};
 use pacquet_tarball::MemCache;
 
 /// This subroutine does everything `pacquet add` is supposed to do.
@@ -89,6 +89,25 @@ where
         .map_err(AddError::Install)?;
 
         manifest.save().map_err(AddError::SaveManifest)?;
+
+        // `pnpm:package-manifest updated` mirrors pnpm's emit at
+        // <https://github.com/pnpm/pnpm/blob/086c5e91e8/installing/deps-resolver/src/index.ts#L238>:
+        // fires once after the manifest is rewritten so consumers
+        // (e.g. the audit pipeline that diffs initial vs updated)
+        // see the post-add shape. `prefix` is the manifest's parent
+        // directory, matching what `Install::run` derived for the
+        // matching `initial` event.
+        let prefix = manifest
+            .path()
+            .parent()
+            .map(std::path::Path::to_str)
+            .map(Option::<&str>::unwrap)
+            .unwrap()
+            .to_owned();
+        R::emit(&LogEvent::PackageManifest(PackageManifestLog {
+            level: LogLevel::Debug,
+            message: PackageManifestMessage::Updated { prefix, updated: manifest.value().clone() },
+        }));
 
         Ok(())
     }

--- a/crates/package-manager/src/add.rs
+++ b/crates/package-manager/src/add.rs
@@ -97,13 +97,19 @@ where
         // see the post-add shape. `prefix` is the manifest's parent
         // directory, matching what `Install::run` derived for the
         // matching `initial` event.
+        //
+        // `parent()` only returns `None` when the path has no parent
+        // (a root or empty); fall back to the manifest path itself
+        // so a degenerate `package.json` placed directly at `/`
+        // doesn't crash the post-save emit. `to_string_lossy`
+        // coerces non-UTF-8 path bytes to U+FFFD instead of
+        // panicking.
         let prefix = manifest
             .path()
             .parent()
-            .map(std::path::Path::to_str)
-            .map(Option::<&str>::unwrap)
-            .unwrap()
-            .to_owned();
+            .unwrap_or_else(|| manifest.path())
+            .to_string_lossy()
+            .into_owned();
         R::emit(&LogEvent::PackageManifest(PackageManifestLog {
             level: LogLevel::Debug,
             message: PackageManifestMessage::Updated { prefix, updated: manifest.value().clone() },

--- a/crates/package-manager/src/create_virtual_store.rs
+++ b/crates/package-manager/src/create_virtual_store.rs
@@ -7,7 +7,9 @@ use miette::Diagnostic;
 use pacquet_lockfile::{LockfileResolution, PackageKey, PackageMetadata, SnapshotEntry};
 use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
-use pacquet_reporter::{LogEvent, LogLevel, ProgressLog, ProgressMessage, Reporter};
+use pacquet_reporter::{
+    LogEvent, LogLevel, ProgressLog, ProgressMessage, Reporter, StatsLog, StatsMessage,
+};
 use pacquet_store_dir::{SharedVerifiedFilesCache, StoreIndex, StoreIndexWriter, store_index_key};
 use pacquet_tarball::prefetch_cas_paths;
 use pipe_trait::Pipe;
@@ -65,6 +67,36 @@ impl<'a> CreateVirtualStore<'a> {
             return Ok(());
         };
         let packages = packages.ok_or(CreateVirtualStoreError::MissingPackagesSection)?;
+
+        // `pnpm:stats added` mirrors pnpm's emit at
+        // <https://github.com/pnpm/pnpm/blob/086c5e91e8/installing/deps-installer/src/install/link.ts#L363>:
+        // one event per project once the orchestrator has decided
+        // how many packages will land in the virtual store. Pnpm
+        // reports `newDepPathsSet.size` (the *delta* between current
+        // and wanted lockfile); pacquet has no current-lockfile
+        // tracking yet, so every install looks like a fresh install
+        // and `added` ends up as the total snapshot count. Once the
+        // current-lockfile path lands the count will narrow to the
+        // diff, matching pnpm exactly.
+        //
+        // `pnpm:stats removed: 0` mirrors the no-current-lockfile
+        // branch of
+        // <https://github.com/pnpm/pnpm/blob/086c5e91e8/installing/deps-restorer/src/index.ts#L290>:
+        // pnpm emits a placeholder `0` when there's nothing to prune
+        // so consumers don't render a stale "removed" count from a
+        // previous install. Pacquet has no pruning pipeline yet, so
+        // the placeholder is the truthful value today.
+        R::emit(&LogEvent::Stats(StatsLog {
+            level: LogLevel::Debug,
+            message: StatsMessage::Added {
+                prefix: requester.to_owned(),
+                added: snapshots.len() as u64,
+            },
+        }));
+        R::emit(&LogEvent::Stats(StatsLog {
+            level: LogLevel::Debug,
+            message: StatsMessage::Removed { prefix: requester.to_owned(), removed: 0 },
+        }));
 
         // Open the read-only SQLite index once for the whole run instead of
         // per snapshot. Every `InstallPackageBySnapshot` performs a cache

--- a/crates/package-manager/src/install.rs
+++ b/crates/package-manager/src/install.rs
@@ -10,7 +10,10 @@ use pacquet_lockfile::Lockfile;
 use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
-use pacquet_reporter::{ContextLog, LogEvent, LogLevel, Reporter, Stage, StageLog, SummaryLog};
+use pacquet_reporter::{
+    ContextLog, LogEvent, LogLevel, PackageManifestLog, PackageManifestMessage, Reporter, Stage,
+    StageLog, SummaryLog,
+};
 use pacquet_tarball::MemCache;
 
 /// This subroutine does everything `pacquet install` is supposed to do.
@@ -84,6 +87,20 @@ where
             .map(Option::<&str>::unwrap)
             .unwrap()
             .to_owned();
+
+        // `pnpm:package-manifest initial` carries the on-disk
+        // `package.json` body. Mirrors pnpm's per-project emit at
+        // <https://github.com/pnpm/pnpm/blob/086c5e91e8/installing/context/src/index.ts#L133>:
+        // fires before `pnpm:context` so consumers that key off
+        // manifest contents have it ready when the install header
+        // renders.
+        R::emit(&LogEvent::PackageManifest(PackageManifestLog {
+            level: LogLevel::Debug,
+            message: PackageManifestMessage::Initial {
+                prefix: prefix.clone(),
+                initial: manifest.value().clone(),
+            },
+        }));
 
         // `pnpm:context` carries the directories pnpm's reporter prints
         // in the install header. `currentLockfileExists` reflects

--- a/crates/package-manager/src/install/tests.rs
+++ b/crates/package-manager/src/install/tests.rs
@@ -4,7 +4,8 @@ use pacquet_npmrc::Npmrc;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_registry_mock::AutoMockInstance;
 use pacquet_reporter::{
-    ContextLog, LogEvent, Reporter, SilentReporter, Stage, StageLog, SummaryLog,
+    ContextLog, LogEvent, PackageManifestLog, PackageManifestMessage, Reporter, SilentReporter,
+    Stage, StageLog, StatsLog, StatsMessage, SummaryLog,
 };
 use pacquet_testing_utils::fs::{get_all_folders, is_symlink_or_junction};
 use std::sync::Mutex;
@@ -396,14 +397,15 @@ async fn frozen_lockfile_flag_with_no_lockfile_errors() {
     drop(dir);
 }
 
-/// [`Install::run`] emits `pnpm:context`, then `pnpm:stage`
-/// `importing_started`, then on the success path `importing_done`
-/// followed by `pnpm:summary`. On an early-error path such as
-/// [`InstallError::NoLockfile`] only the leading events fire. This
-/// matches pnpm: context is emitted once alongside the install
-/// header, the stage pairing drives the JS reporter's progress
-/// UI, and summary closes the run so the reporter can render its
-/// "+N -M" block.
+/// [`Install::run`] emits `pnpm:package-manifest initial`,
+/// `pnpm:context`, then `pnpm:stage` `importing_started`, then on
+/// the success path `importing_done` followed by `pnpm:summary`.
+/// On an early-error path such as [`InstallError::NoLockfile`]
+/// only the leading events fire. This matches pnpm: the manifest
+/// snapshot lands first so consumers can diff it against
+/// `updated`, context is emitted alongside the install header, the
+/// stage pairing drives the JS reporter's progress UI, and summary
+/// closes the run so the reporter can render its "+N -M" block.
 ///
 /// `pnpm:package-import-method` is emitted lazily by `link_file`
 /// the first time each method actually resolves (after `auto`'s
@@ -473,20 +475,44 @@ async fn install_emits_pnpm_event_sequence() {
 
     let captured = EVENTS.lock().unwrap();
 
-    // Event ordering matches pnpm: context, then the stage
-    // bracketing pair, then summary closing the run.
+    // Event ordering matches pnpm: manifest snapshot, context,
+    // importing_started, the `pnpm:stats` added/removed pair from
+    // `CreateVirtualStore::run`, importing_done, and summary
+    // closing the run. The empty snapshot map still triggers the
+    // stats emit (`added: 0`, `removed: 0`), matching pnpm's
+    // unconditional emit at link time.
     assert!(
         matches!(
             captured.as_slice(),
             [
+                LogEvent::PackageManifest(PackageManifestLog {
+                    message: PackageManifestMessage::Initial { .. },
+                    ..
+                }),
                 LogEvent::Context(_),
                 LogEvent::Stage(StageLog { stage: Stage::ImportingStarted, .. }),
+                LogEvent::Stats(StatsLog { message: StatsMessage::Added { added: 0, .. }, .. }),
+                LogEvent::Stats(StatsLog { message: StatsMessage::Removed { removed: 0, .. }, .. }),
                 LogEvent::Stage(StageLog { stage: Stage::ImportingDone, .. }),
                 LogEvent::Summary(_),
             ]
         ),
         "unexpected event sequence: {captured:?}",
     );
+
+    let expected_prefix = manifest.path().parent().unwrap().to_string_lossy().into_owned();
+
+    // Manifest event carries the on-disk JSON unchanged so consumers
+    // can diff `initial` vs a later `updated` byte-for-byte.
+    let LogEvent::PackageManifest(PackageManifestLog {
+        message: PackageManifestMessage::Initial { prefix: manifest_prefix, initial },
+        ..
+    }) = &captured[0]
+    else {
+        unreachable!("first event is package-manifest, asserted above");
+    };
+    assert_eq!(manifest_prefix, &expected_prefix);
+    assert_eq!(initial, manifest.value());
 
     // Spot-check the context payload: pacquet's directories must
     // round-trip through the wire shape, and `currentLockfileExists`
@@ -496,9 +522,9 @@ async fn install_emits_pnpm_event_sequence() {
         store_dir: emitted_store_dir,
         virtual_store_dir: emitted_virtual_store_dir,
         ..
-    }) = &captured[0]
+    }) = &captured[1]
     else {
-        unreachable!("first event is context, asserted above");
+        unreachable!("second event is context, asserted above");
     };
     assert!(!current_lockfile_exists);
     assert_eq!(emitted_store_dir, &store_dir.display().to_string());
@@ -507,10 +533,11 @@ async fn install_emits_pnpm_event_sequence() {
     // Summary's `prefix` must equal the manifest-parent value
     // `Install::run` derives, since pnpm's reporter keys its
     // accumulated root-events by prefix to render the diff.
-    let LogEvent::Summary(SummaryLog { prefix: summary_prefix, .. }) = &captured[3] else {
-        unreachable!("fourth event is summary, asserted above");
+    let LogEvent::Summary(SummaryLog { prefix: summary_prefix, .. }) = captured.last().unwrap()
+    else {
+        unreachable!("last event is summary, asserted above");
     };
-    assert_eq!(summary_prefix, &manifest.path().parent().unwrap().to_string_lossy().into_owned(),);
+    assert_eq!(summary_prefix, &expected_prefix);
 
     drop(dir);
 }

--- a/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/crates/package-manager/src/install_frozen_lockfile.rs
@@ -72,8 +72,8 @@ where
             .await
             .map_err(InstallFrozenLockfileError::CreateVirtualStore)?;
 
-        SymlinkDirectDependencies { config, importers, dependency_groups }
-            .run()
+        SymlinkDirectDependencies { config, importers, dependency_groups, requester }
+            .run::<R>()
             .map_err(InstallFrozenLockfileError::SymlinkDirectDependencies)?;
 
         Ok(())

--- a/crates/package-manager/src/symlink_direct_dependencies.rs
+++ b/crates/package-manager/src/symlink_direct_dependencies.rs
@@ -8,7 +8,7 @@ use pacquet_reporter::{
     AddedRoot, DependencyType, LogEvent, LogLevel, Reporter, RootLog, RootMessage,
 };
 use rayon::prelude::*;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// This subroutine creates symbolic links in the `node_modules` directory for
 /// the direct dependencies. The targets of the link are the virtual directories.
@@ -69,6 +69,21 @@ where
         // the per-group → [`DependencyType`] match below stay
         // exhaustive without a misleading `Peer` arm that maps to
         // an "absent" type.
+        //
+        // Dedup with a `HashSet<PkgName>`, first-wins. A v9 lockfile
+        // pnpm itself wrote shouldn't list the same package across
+        // multiple importer sections — pnpm's resolver normalises
+        // (a package with `optional: true` lands in
+        // `optionalDependencies` only). But pacquet ingests
+        // user-supplied lockfiles, and a malformed one with the same
+        // key in two sections would race two `symlink_package` calls
+        // to the same `node_modules/<name>` and emit duplicate
+        // `pnpm:root added` events. First-wins picks up the highest-
+        // priority group from the caller-supplied
+        // `dependency_groups` order — the CLI today passes
+        // `[Prod, Dev, Optional]`, matching pnpm's
+        // dependencies-over-optional precedence.
+        let mut seen: HashSet<&PkgName> = HashSet::new();
         let entries: Vec<(&PkgName, &_, DependencyGroup)> = dependency_groups
             .into_iter()
             .filter(|group| !matches!(group, DependencyGroup::Peer))
@@ -79,6 +94,7 @@ where
                     .flatten()
                     .map(move |(name, spec)| (name, spec, group))
             })
+            .filter(|(name, _, _)| seen.insert(*name))
             .collect();
 
         entries.par_iter().for_each(|(name, spec, group)| {

--- a/crates/package-manager/src/symlink_direct_dependencies.rs
+++ b/crates/package-manager/src/symlink_direct_dependencies.rs
@@ -60,8 +60,18 @@ where
         // [`ProjectSnapshot::dependencies_by_groups`] flattens the
         // groups together, which is convenient for the symlink loop
         // but loses the per-group identity we need for the emit.
+        //
+        // Peers are filtered upfront: pnpm doesn't emit `pnpm:root`
+        // for peer dependencies (they're materialised through their
+        // host package, not directly under `node_modules/`), and
+        // [`ProjectSnapshot::get_map_by_group`] also returns `None`
+        // for `Peer` so this filter is belt-and-braces — it lets
+        // the per-group → [`DependencyType`] match below stay
+        // exhaustive without a misleading `Peer` arm that maps to
+        // an "absent" type.
         let entries: Vec<(&PkgName, &_, DependencyGroup)> = dependency_groups
             .into_iter()
+            .filter(|group| !matches!(group, DependencyGroup::Peer))
             .flat_map(|group| {
                 project_snapshot
                     .get_map_by_group(group)
@@ -98,10 +108,12 @@ where
             // and skip from the wire shape rather than serializing as
             // JSON `null`.
             let dependency_type = match group {
-                DependencyGroup::Prod => Some(DependencyType::Prod),
-                DependencyGroup::Dev => Some(DependencyType::Dev),
-                DependencyGroup::Optional => Some(DependencyType::Optional),
-                DependencyGroup::Peer => None,
+                DependencyGroup::Prod => DependencyType::Prod,
+                DependencyGroup::Dev => DependencyType::Dev,
+                DependencyGroup::Optional => DependencyType::Optional,
+                // Filtered upfront — see the comment on the
+                // `entries` builder above.
+                DependencyGroup::Peer => unreachable!("peers are filtered out before this point"),
             };
             R::emit(&LogEvent::Root(RootLog {
                 level: LogLevel::Debug,
@@ -111,7 +123,7 @@ where
                         name: name_str,
                         real_name: name.to_string(),
                         version: Some(spec.version.version().to_string()),
-                        dependency_type,
+                        dependency_type: Some(dependency_type),
                         id: None,
                         latest: None,
                         linked_from: None,

--- a/crates/package-manager/src/symlink_direct_dependencies.rs
+++ b/crates/package-manager/src/symlink_direct_dependencies.rs
@@ -131,13 +131,19 @@ where
                 // `entries` builder above.
                 DependencyGroup::Peer => unreachable!("peers are filtered out before this point"),
             };
+            // Pacquet's lockfile snapshot doesn't track the
+            // npm-alias key separately from the resolved package
+            // name at this layer, so `name` and `real_name` carry
+            // the same value — clone the already-built string
+            // instead of formatting `name` a second time.
+            let real_name = name_str.clone();
             R::emit(&LogEvent::Root(RootLog {
                 level: LogLevel::Debug,
                 message: RootMessage::Added {
                     prefix: requester.to_owned(),
                     added: AddedRoot {
                         name: name_str,
-                        real_name: name.to_string(),
+                        real_name,
                         version: Some(spec.version.version().to_string()),
                         dependency_type: Some(dependency_type),
                         id: None,

--- a/crates/package-manager/src/symlink_direct_dependencies.rs
+++ b/crates/package-manager/src/symlink_direct_dependencies.rs
@@ -4,6 +4,9 @@ use miette::Diagnostic;
 use pacquet_lockfile::{Lockfile, PkgName, PkgNameVerPeer, ProjectSnapshot};
 use pacquet_npmrc::Npmrc;
 use pacquet_package_manifest::DependencyGroup;
+use pacquet_reporter::{
+    AddedRoot, DependencyType, LogEvent, LogLevel, Reporter, RootLog, RootMessage,
+};
 use rayon::prelude::*;
 use std::collections::HashMap;
 
@@ -21,6 +24,9 @@ where
     pub config: &'static Npmrc,
     pub importers: &'a HashMap<String, ProjectSnapshot>,
     pub dependency_groups: DependencyGroupList,
+    /// Install root, threaded into the `pnpm:root` `prefix` field.
+    /// Same value as the `prefix` in [`pacquet_reporter::StageLog`].
+    pub requester: &'a str,
 }
 
 /// Error type of [`SymlinkDirectDependencies`].
@@ -38,8 +44,8 @@ where
     DependencyGroupList: IntoIterator<Item = DependencyGroup>,
 {
     /// Execute the subroutine.
-    pub fn run(self) -> Result<(), SymlinkDirectDependenciesError> {
-        let SymlinkDirectDependencies { config, importers, dependency_groups } = self;
+    pub fn run<R: Reporter>(self) -> Result<(), SymlinkDirectDependenciesError> {
+        let SymlinkDirectDependencies { config, importers, dependency_groups, requester } = self;
 
         let project_snapshot = importers.get(Lockfile::ROOT_IMPORTER_KEY).ok_or_else(|| {
             SymlinkDirectDependenciesError::MissingRootImporter {
@@ -47,28 +53,76 @@ where
             }
         })?;
 
-        project_snapshot
-            .dependencies_by_groups(dependency_groups)
-            .collect::<Vec<_>>()
-            .par_iter()
-            .for_each(|(name, spec)| {
-                // TODO: the code below is not optimal
-                let virtual_store_name =
-                    PkgNameVerPeer::new(PkgName::clone(name), spec.version.clone())
-                        .to_virtual_store_name();
+        // Iterate per group so each emit can label the dependency
+        // with its [`DependencyType`] — pnpm's reporter renders the
+        // diff with that hint, so dropping it would silently
+        // misclassify devDependencies as prod.
+        // [`ProjectSnapshot::dependencies_by_groups`] flattens the
+        // groups together, which is convenient for the symlink loop
+        // but loses the per-group identity we need for the emit.
+        let entries: Vec<(&PkgName, &_, DependencyGroup)> = dependency_groups
+            .into_iter()
+            .flat_map(|group| {
+                project_snapshot
+                    .get_map_by_group(group)
+                    .into_iter()
+                    .flatten()
+                    .map(move |(name, spec)| (name, spec, group))
+            })
+            .collect();
 
-                let name_str = name.to_string();
-                symlink_package(
-                    &config
-                        .virtual_store_dir
-                        .join(virtual_store_name)
-                        .join("node_modules")
-                        .join(&name_str),
-                    &config.modules_dir.join(&name_str),
-                )
-                .expect("symlink pkg"); // TODO: properly propagate this error
-            });
+        entries.par_iter().for_each(|(name, spec, group)| {
+            // TODO: the code below is not optimal
+            let virtual_store_name =
+                PkgNameVerPeer::new(PkgName::clone(name), spec.version.clone())
+                    .to_virtual_store_name();
+
+            let name_str = name.to_string();
+            symlink_package(
+                &config
+                    .virtual_store_dir
+                    .join(virtual_store_name)
+                    .join("node_modules")
+                    .join(&name_str),
+                &config.modules_dir.join(&name_str),
+            )
+            .expect("symlink pkg"); // TODO: properly propagate this error
+
+            // `pnpm:root added` mirrors pnpm's emit at
+            // <https://github.com/pnpm/pnpm/blob/086c5e91e8/installing/linking/direct-dep-linker/src/linkDirectDeps.ts#L131>:
+            // one event per direct dependency once the symlink has
+            // been created. pacquet's frozen-lockfile snapshot doesn't
+            // preserve npm-alias keys at this layer, so `realName`
+            // mirrors `name`; the optional `id` / `latest` /
+            // `linkedFrom` fields are out of pacquet's reach today
+            // and skip from the wire shape rather than serializing as
+            // JSON `null`.
+            let dependency_type = match group {
+                DependencyGroup::Prod => Some(DependencyType::Prod),
+                DependencyGroup::Dev => Some(DependencyType::Dev),
+                DependencyGroup::Optional => Some(DependencyType::Optional),
+                DependencyGroup::Peer => None,
+            };
+            R::emit(&LogEvent::Root(RootLog {
+                level: LogLevel::Debug,
+                message: RootMessage::Added {
+                    prefix: requester.to_owned(),
+                    added: AddedRoot {
+                        name: name_str,
+                        real_name: name.to_string(),
+                        version: Some(spec.version.version().to_string()),
+                        dependency_type,
+                        id: None,
+                        latest: None,
+                        linked_from: None,
+                    },
+                },
+            }));
+        });
 
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/package-manager/src/symlink_direct_dependencies/tests.rs
+++ b/crates/package-manager/src/symlink_direct_dependencies/tests.rs
@@ -126,6 +126,95 @@ fn emits_pnpm_root_added_per_direct_dependency() {
     drop(dir);
 }
 
+/// A malformed importer snapshot can list the same package name
+/// across multiple sections (e.g. both `dependencies` and
+/// `optionalDependencies`). The dedup pass must collapse that to
+/// one entry — first-wins per the caller-supplied
+/// `dependency_groups` order — so we don't race two
+/// `symlink_package` calls to the same `node_modules/<name>` and
+/// emit two `pnpm:root added` events for the same dep.
+#[test]
+fn duplicate_dep_across_groups_collapses_to_one_entry() {
+    static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
+    EVENTS.lock().unwrap().clear();
+
+    struct RecordingReporter;
+    impl Reporter for RecordingReporter {
+        fn emit(event: &LogEvent) {
+            EVENTS.lock().unwrap().push(event.clone());
+        }
+    }
+
+    let dir = tempdir().unwrap();
+    let project_root = dir.path().join("project");
+    let modules_dir = project_root.join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pacquet");
+
+    let mut config = Npmrc::new();
+    config.store_dir = dir.path().join("pacquet-store").into();
+    config.modules_dir = modules_dir.clone();
+    config.virtual_store_dir = virtual_store_dir.clone();
+    let config = config.leak();
+
+    // Same name in `dependencies` and `optionalDependencies`. The
+    // versions match here so the symlink target path is the same;
+    // a real malformed lockfile that mismatched versions would also
+    // collapse here, with first-wins picking the prod entry.
+    let target = virtual_store_dir.join("fastify@4.0.0").join("node_modules").join("fastify");
+    fs::create_dir_all(&target).expect("create symlink target");
+
+    let mut prod = ResolvedDependencyMap::new();
+    prod.insert(
+        "fastify".parse().expect("parse fastify pkg name"),
+        ResolvedDependencySpec {
+            specifier: "^4.0.0".to_string(),
+            version: "4.0.0".parse().expect("parse fastify version"),
+        },
+    );
+    let mut optional = ResolvedDependencyMap::new();
+    optional.insert(
+        "fastify".parse().expect("parse fastify pkg name"),
+        ResolvedDependencySpec {
+            specifier: "^4.0.0".to_string(),
+            version: "4.0.0".parse().expect("parse fastify version"),
+        },
+    );
+
+    let project_snapshot = ProjectSnapshot {
+        dependencies: Some(prod),
+        optional_dependencies: Some(optional),
+        ..ProjectSnapshot::default()
+    };
+    let mut importers = HashMap::new();
+    importers.insert(Lockfile::ROOT_IMPORTER_KEY.to_string(), project_snapshot);
+
+    SymlinkDirectDependencies {
+        config,
+        importers: &importers,
+        // Prod first → first-wins gives `dependencyType: prod`.
+        dependency_groups: [DependencyGroup::Prod, DependencyGroup::Optional],
+        requester: "/proj",
+    }
+    .run::<RecordingReporter>()
+    .expect("symlink should succeed");
+
+    let captured = EVENTS.lock().unwrap();
+    let added: Vec<&AddedRoot> = captured
+        .iter()
+        .filter_map(|e| match e {
+            LogEvent::Root(RootLog { message: RootMessage::Added { added, .. }, .. }) => {
+                Some(added)
+            }
+            _ => None,
+        })
+        .collect();
+    assert_eq!(added.len(), 1, "duplicate dep across groups must collapse to one emit");
+    assert_eq!(added[0].name, "fastify");
+    assert_eq!(added[0].dependency_type, Some(DependencyType::Prod));
+
+    drop(dir);
+}
+
 /// Missing root importer in the lockfile is the only error the
 /// subroutine produces. Pin it so a future refactor that elides
 /// the lookup doesn't silently turn into a no-op install.

--- a/crates/package-manager/src/symlink_direct_dependencies/tests.rs
+++ b/crates/package-manager/src/symlink_direct_dependencies/tests.rs
@@ -92,8 +92,12 @@ fn emits_pnpm_root_added_per_direct_dependency() {
     // Both symlinks must land under `node_modules/` for the wire-
     // shape assertion below to be meaningful — an emit without the
     // matching FS effect would mask a real regression.
-    assert!(is_symlink_or_junction(&modules_dir.join("fastify")).unwrap());
-    assert!(is_symlink_or_junction(&modules_dir.join("@pnpm.e2e/dev-dep")).unwrap());
+    let fastify_link = modules_dir.join("fastify");
+    let dev_dep_link = modules_dir.join("@pnpm.e2e/dev-dep");
+    eprintln!("fastify_link = {fastify_link:?}");
+    assert!(is_symlink_or_junction(&fastify_link).unwrap());
+    eprintln!("dev_dep_link = {dev_dep_link:?}");
+    assert!(is_symlink_or_junction(&dev_dep_link).unwrap());
 
     let captured = EVENTS.lock().unwrap();
     let added: Vec<&AddedRoot> = captured
@@ -236,6 +240,7 @@ fn missing_root_importer_surfaces_as_error() {
     }
     .run::<SilentReporter>();
 
+    dbg!(&result);
     assert!(matches!(result, Err(SymlinkDirectDependenciesError::MissingRootImporter { .. })));
     drop(dir);
 }

--- a/crates/package-manager/src/symlink_direct_dependencies/tests.rs
+++ b/crates/package-manager/src/symlink_direct_dependencies/tests.rs
@@ -1,0 +1,141 @@
+use super::{SymlinkDirectDependencies, SymlinkDirectDependenciesError};
+use pacquet_lockfile::{Lockfile, ProjectSnapshot, ResolvedDependencyMap, ResolvedDependencySpec};
+use pacquet_npmrc::Npmrc;
+use pacquet_package_manifest::DependencyGroup;
+use pacquet_reporter::{
+    AddedRoot, DependencyType, LogEvent, Reporter, RootLog, RootMessage, SilentReporter,
+};
+use pacquet_testing_utils::fs::is_symlink_or_junction;
+use std::{collections::HashMap, sync::Mutex};
+use tempfile::tempdir;
+
+/// `pnpm:root added` fires once per direct dependency, after the
+/// symlink under `node_modules/` has been created. The captured
+/// payload must mirror pnpm's wire shape: `name` and `realName`
+/// from the lockfile key, `version` from the resolved snapshot
+/// spec, and `dependencyType` keyed off the originating
+/// [`DependencyGroup`]. `prefix` is the install root, mirroring
+/// pnpm's emit at
+/// <https://github.com/pnpm/pnpm/blob/086c5e91e8/installing/linking/direct-dep-linker/src/linkDirectDeps.ts#L131>.
+#[test]
+fn emits_pnpm_root_added_per_direct_dependency() {
+    static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
+    EVENTS.lock().unwrap().clear();
+
+    struct RecordingReporter;
+    impl Reporter for RecordingReporter {
+        fn emit(event: &LogEvent) {
+            EVENTS.lock().unwrap().push(event.clone());
+        }
+    }
+
+    let dir = tempdir().unwrap();
+    let project_root = dir.path().join("project");
+    let modules_dir = project_root.join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pacquet");
+
+    let mut config = Npmrc::new();
+    config.store_dir = dir.path().join("pacquet-store").into();
+    config.modules_dir = modules_dir.clone();
+    config.virtual_store_dir = virtual_store_dir;
+    let config = config.leak();
+
+    // One prod and one dev dep so we can assert that `dependencyType`
+    // tracks the originating group across the iteration order.
+    let mut prod = ResolvedDependencyMap::new();
+    prod.insert(
+        "fastify".parse().expect("parse fastify pkg name"),
+        ResolvedDependencySpec {
+            specifier: "^4.0.0".to_string(),
+            version: "4.0.0".parse().expect("parse fastify version"),
+        },
+    );
+    let mut dev = ResolvedDependencyMap::new();
+    dev.insert(
+        "@pnpm.e2e/dev-dep".parse().expect("parse dev pkg name"),
+        ResolvedDependencySpec {
+            specifier: "^1.2.3".to_string(),
+            version: "1.2.3".parse().expect("parse dev version"),
+        },
+    );
+
+    let project_snapshot = ProjectSnapshot {
+        dependencies: Some(prod),
+        dev_dependencies: Some(dev),
+        ..ProjectSnapshot::default()
+    };
+    let mut importers = HashMap::new();
+    importers.insert(Lockfile::ROOT_IMPORTER_KEY.to_string(), project_snapshot);
+
+    let requester = "/proj";
+    SymlinkDirectDependencies {
+        config,
+        importers: &importers,
+        dependency_groups: [DependencyGroup::Prod, DependencyGroup::Dev],
+        requester,
+    }
+    .run::<RecordingReporter>()
+    .expect("symlink should succeed");
+
+    // Both symlinks must land under `node_modules/` for the wire-
+    // shape assertion below to be meaningful — an emit without the
+    // matching FS effect would mask a real regression.
+    assert!(is_symlink_or_junction(&modules_dir.join("fastify")).unwrap());
+    assert!(is_symlink_or_junction(&modules_dir.join("@pnpm.e2e/dev-dep")).unwrap());
+
+    let captured = EVENTS.lock().unwrap();
+    eprintln!("captured = {captured:?}");
+    let added: Vec<&AddedRoot> = captured
+        .iter()
+        .filter_map(|e| match e {
+            LogEvent::Root(RootLog { message: RootMessage::Added { added, prefix }, .. }) => {
+                assert_eq!(prefix, requester);
+                Some(added)
+            }
+            _ => None,
+        })
+        .collect();
+    assert_eq!(added.len(), 2, "one pnpm:root added per direct dep");
+
+    // par_iter doesn't pin order, so look up by name. Both entries
+    // must carry their version, the matching dependency type, and
+    // `realName == name` (pacquet's lockfile snapshots don't
+    // preserve npm-alias keys at this layer).
+    let fastify = added.iter().find(|a| a.name == "fastify").expect("fastify added event missing");
+    assert_eq!(fastify.real_name, "fastify");
+    assert_eq!(fastify.version.as_deref(), Some("4.0.0"));
+    assert_eq!(fastify.dependency_type, Some(DependencyType::Prod));
+
+    let dev =
+        added.iter().find(|a| a.name == "@pnpm.e2e/dev-dep").expect("dev-dep added event missing");
+    assert_eq!(dev.real_name, "@pnpm.e2e/dev-dep");
+    assert_eq!(dev.version.as_deref(), Some("1.2.3"));
+    assert_eq!(dev.dependency_type, Some(DependencyType::Dev));
+
+    drop(dir);
+}
+
+/// Missing root importer in the lockfile is the only error the
+/// subroutine produces. Pin it so a future refactor that elides
+/// the lookup doesn't silently turn into a no-op install.
+#[test]
+fn missing_root_importer_surfaces_as_error() {
+    let dir = tempdir().unwrap();
+    let mut config = Npmrc::new();
+    config.store_dir = dir.path().join("pacquet-store").into();
+    config.modules_dir = dir.path().join("project/node_modules");
+    config.virtual_store_dir = dir.path().join("project/node_modules/.pacquet");
+    let config = config.leak();
+
+    let importers = HashMap::new();
+    let result = SymlinkDirectDependencies {
+        config,
+        importers: &importers,
+        dependency_groups: [DependencyGroup::Prod],
+        requester: "/proj",
+    }
+    .run::<SilentReporter>();
+
+    assert!(matches!(result, Err(SymlinkDirectDependenciesError::MissingRootImporter { .. })));
+    drop(dir);
+}

--- a/crates/package-manager/src/symlink_direct_dependencies/tests.rs
+++ b/crates/package-manager/src/symlink_direct_dependencies/tests.rs
@@ -6,7 +6,7 @@ use pacquet_reporter::{
     AddedRoot, DependencyType, LogEvent, Reporter, RootLog, RootMessage, SilentReporter,
 };
 use pacquet_testing_utils::fs::is_symlink_or_junction;
-use std::{collections::HashMap, sync::Mutex};
+use std::{collections::HashMap, fs, sync::Mutex};
 use tempfile::tempdir;
 
 /// `pnpm:root added` fires once per direct dependency, after the
@@ -37,8 +37,20 @@ fn emits_pnpm_root_added_per_direct_dependency() {
     let mut config = Npmrc::new();
     config.store_dir = dir.path().join("pacquet-store").into();
     config.modules_dir = modules_dir.clone();
-    config.virtual_store_dir = virtual_store_dir;
+    config.virtual_store_dir = virtual_store_dir.clone();
     let config = config.leak();
+
+    // The symlink targets must exist for the test to work on
+    // Windows: pacquet's `symlink_dir` falls back to junctions
+    // there, and `junction::create` requires the target directory
+    // to exist. On Unix `symlink` doesn't care, but creating the
+    // dirs here keeps the test platform-uniform.
+    for (store_name, real_name) in
+        [("fastify@4.0.0", "fastify"), ("@pnpm.e2e+dev-dep@1.2.3", "@pnpm.e2e/dev-dep")]
+    {
+        let target = virtual_store_dir.join(store_name).join("node_modules").join(real_name);
+        fs::create_dir_all(&target).expect("create symlink target");
+    }
 
     // One prod and one dev dep so we can assert that `dependencyType`
     // tracks the originating group across the iteration order.
@@ -84,7 +96,6 @@ fn emits_pnpm_root_added_per_direct_dependency() {
     assert!(is_symlink_or_junction(&modules_dir.join("@pnpm.e2e/dev-dep")).unwrap());
 
     let captured = EVENTS.lock().unwrap();
-    eprintln!("captured = {captured:?}");
     let added: Vec<&AddedRoot> = captured
         .iter()
         .filter_map(|e| match e {

--- a/crates/reporter/src/lib.rs
+++ b/crates/reporter/src/lib.rs
@@ -86,6 +86,48 @@ pub enum LogEvent {
     /// Emit site: <https://github.com/pnpm/pnpm/blob/086c5e91e8/installing/package-requester/src/packageRequester.ts#L560>.
     #[serde(rename = "pnpm:fetching-progress")]
     FetchingProgress(FetchingProgressLog),
+
+    /// Project manifest snapshots (`pnpm:package-manifest`). Two
+    /// presence-tagged shapes per pnpm's union: `initial` (emitted
+    /// once at install start with the on-disk manifest) and
+    /// `updated` (emitted after the manifest is rewritten — e.g.
+    /// `pacquet add` saves a new dependency entry).
+    ///
+    /// Upstream: <https://github.com/pnpm/pnpm/blob/086c5e91e8/core/core-loggers/src/packageManifestLogger.ts>.
+    #[serde(rename = "pnpm:package-manifest")]
+    PackageManifest(PackageManifestLog),
+
+    /// Per-direct-dependency add / remove events (`pnpm:root`). pnpm's
+    /// reporter accumulates these and renders the "+N -M" block at
+    /// `pnpm:summary` time.
+    ///
+    /// Upstream: <https://github.com/pnpm/pnpm/blob/086c5e91e8/core/core-loggers/src/rootLogger.ts>.
+    /// Emit site: <https://github.com/pnpm/pnpm/blob/086c5e91e8/installing/linking/direct-dep-linker/src/linkDirectDeps.ts#L131>.
+    #[serde(rename = "pnpm:root")]
+    Root(RootLog),
+
+    /// Aggregate add / remove counts emitted once per project after
+    /// the link phase (`pnpm:stats`). Pnpm emits `added` and
+    /// `removed` from separate sites; pacquet currently emits both
+    /// together because pruning hasn't landed yet — see
+    /// [`StatsMessage::Removed`].
+    ///
+    /// Upstream: <https://github.com/pnpm/pnpm/blob/086c5e91e8/core/core-loggers/src/statsLogger.ts>.
+    /// Emit site: <https://github.com/pnpm/pnpm/blob/086c5e91e8/installing/deps-installer/src/install/link.ts#L363>.
+    #[serde(rename = "pnpm:stats")]
+    Stats(StatsLog),
+
+    /// One per failed-and-being-retried HTTP request
+    /// (`pnpm:request-retry`). Pnpm's default reporter surfaces these
+    /// as `Will retry in <ms>. <N> retries left.` warnings; the
+    /// `error` payload is what the JS reporter dispatches on
+    /// (`httpStatusCode` / `status` / `errno` / `code`) to render the
+    /// reason.
+    ///
+    /// Upstream: <https://github.com/pnpm/pnpm/blob/086c5e91e8/core/core-loggers/src/requestRetryLogger.ts>.
+    /// Emit site: <https://github.com/pnpm/pnpm/blob/086c5e91e8/fetching/tarball-fetcher/src/remoteTarballFetcher.ts#L91>.
+    #[serde(rename = "pnpm:request-retry")]
+    RequestRetry(RequestRetryLog),
 }
 
 /// `pnpm:context` payload.
@@ -230,6 +272,152 @@ pub enum FetchingProgressMessage {
         #[serde(rename = "packageId")]
         package_id: String,
     },
+}
+
+/// `pnpm:package-manifest` payload. The bunyan-envelope `level` is a
+/// fixed outer field; the rest is a presence-tagged union — pnpm
+/// keys on whether `initial` or `updated` is present rather than
+/// using a `status` discriminator. `#[serde(untagged)]` matches
+/// that shape; `#[serde(flatten)]` keeps `prefix` adjacent to
+/// `initial` / `updated` at the top level.
+#[derive(Debug, Clone, Serialize)]
+pub struct PackageManifestLog {
+    pub level: LogLevel,
+    #[serde(flatten)]
+    pub message: PackageManifestMessage,
+}
+
+/// `pnpm:package-manifest` discriminated payload. The `Value` carries
+/// the entire on-disk `package.json` body — pnpm's reporter doesn't
+/// pick fields out, it threads the manifest through to consumers
+/// like the audit pipeline that need the full thing.
+#[derive(Debug, Clone, Serialize)]
+#[serde(untagged)]
+pub enum PackageManifestMessage {
+    Initial { prefix: String, initial: serde_json::Value },
+    Updated { prefix: String, updated: serde_json::Value },
+}
+
+/// `pnpm:root` payload. Same flatten-on-presence pattern as
+/// [`PackageManifestLog`].
+#[derive(Debug, Clone, Serialize)]
+pub struct RootLog {
+    pub level: LogLevel,
+    #[serde(flatten)]
+    pub message: RootMessage,
+}
+
+/// `pnpm:root` discriminated payload. pnpm's reporter dispatches on
+/// whether `added` or `removed` is present; tag-on-presence matches
+/// that. Pacquet only emits `added` today (no pruning pipeline yet)
+/// — `Removed` is here to pin the wire shape so the channel is
+/// usable when pruning lands.
+#[derive(Debug, Clone, Serialize)]
+#[serde(untagged)]
+pub enum RootMessage {
+    Added { prefix: String, added: AddedRoot },
+    Removed { prefix: String, removed: RemovedRoot },
+}
+
+/// `added` payload on a [`RootMessage::Added`] event. `name` is the
+/// directory name under `node_modules/` (the manifest alias for
+/// npm-aliased entries; the package name otherwise). `real_name`
+/// is the registry name. The other fields are optional in pnpm's
+/// shape; pacquet populates what it has from the lockfile snapshot
+/// today.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AddedRoot {
+    pub name: String,
+    pub real_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dependency_type: Option<DependencyType>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latest: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub linked_from: Option<String>,
+}
+
+/// `removed` payload on a [`RootMessage::Removed`] event. Optional
+/// fields match pnpm's shape and are skipped when absent.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemovedRoot {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dependency_type: Option<DependencyType>,
+}
+
+/// Direct-dependency category. Mirrors pnpm's three-value union;
+/// peer dependencies are not a separate emit and don't appear here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DependencyType {
+    Prod,
+    Dev,
+    Optional,
+}
+
+/// `pnpm:stats` payload. Same flatten-on-presence pattern as
+/// [`PackageManifestLog`] / [`RootLog`].
+#[derive(Debug, Clone, Serialize)]
+pub struct StatsLog {
+    pub level: LogLevel,
+    #[serde(flatten)]
+    pub message: StatsMessage,
+}
+
+/// `pnpm:stats` discriminated payload. pnpm's reporter dispatches on
+/// presence: an event carries either `added` *or* `removed`, never
+/// both, because pnpm emits them from two separate sites.
+#[derive(Debug, Clone, Serialize)]
+#[serde(untagged)]
+pub enum StatsMessage {
+    Added { prefix: String, added: u64 },
+    Removed { prefix: String, removed: u64 },
+}
+
+/// `pnpm:request-retry` payload. `attempt` is one-indexed (the failed
+/// attempt that triggered the retry) and `timeout` is the
+/// milliseconds the retry loop will sleep before the next attempt;
+/// pnpm's default reporter renders both directly.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RequestRetryLog {
+    pub level: LogLevel,
+    pub attempt: u32,
+    pub error: RequestRetryError,
+    pub max_retries: u32,
+    pub method: String,
+    pub timeout: u64,
+    pub url: String,
+}
+
+/// JS-shaped error object the default-reporter dispatches on:
+/// `error.httpStatusCode ?? error.status ?? error.errno ?? error.code`
+/// is what gets rendered as the reason. pacquet populates whichever
+/// field its [`pacquet_tarball::TarballError`] variant maps to (HTTP
+/// status → `http_status_code`, decode / IO failures → `code`) and
+/// always carries the rendered `message` so consumers that read
+/// `err.message` directly still work.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RequestRetryError {
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub http_status_code: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub errno: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
 }
 
 /// Severity level on the [bunyan]-shaped envelope.

--- a/crates/reporter/src/lib.rs
+++ b/crates/reporter/src/lib.rs
@@ -402,10 +402,14 @@ pub struct RequestRetryLog {
 /// JS-shaped error object the default-reporter dispatches on:
 /// `error.httpStatusCode ?? error.status ?? error.errno ?? error.code`
 /// is what gets rendered as the reason. pacquet populates whichever
-/// field its [`pacquet_tarball::TarballError`] variant maps to (HTTP
+/// field its `pacquet_tarball::TarballError` variant maps to (HTTP
 /// status → `http_status_code`, decode / IO failures → `code`) and
 /// always carries the rendered `message` so consumers that read
 /// `err.message` directly still work.
+///
+/// Plain backticks (not an intra-doc link) because `pacquet-reporter`
+/// cannot depend on `pacquet-tarball` — the dependency runs the
+/// other way.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RequestRetryError {

--- a/crates/reporter/src/tests.rs
+++ b/crates/reporter/src/tests.rs
@@ -5,9 +5,11 @@ use pretty_assertions::assert_eq;
 use serde_json::Value;
 
 use crate::{
-    ContextLog, Envelope, FetchingProgressLog, FetchingProgressMessage, GetHostName, LogEvent,
-    LogLevel, PackageImportMethod, PackageImportMethodLog, ProgressLog, ProgressMessage, RealApi,
-    Reporter, SilentReporter, Stage, StageLog, SummaryLog,
+    AddedRoot, ContextLog, DependencyType, Envelope, FetchingProgressLog, FetchingProgressMessage,
+    GetHostName, LogEvent, LogLevel, PackageImportMethod, PackageImportMethodLog,
+    PackageManifestLog, PackageManifestMessage, ProgressLog, ProgressMessage, RealApi, RemovedRoot,
+    Reporter, RequestRetryError, RequestRetryLog, RootLog, RootMessage, SilentReporter, Stage,
+    StageLog, StatsLog, StatsMessage, SummaryLog,
 };
 
 /// Context log serializes with the camelCase field names
@@ -259,6 +261,207 @@ fn fetching_progress_event_matches_pnpm_wire_shape() {
     assert_eq!(json["status"], "in_progress");
     assert_eq!(json["downloaded"], 65_536);
     assert_eq!(json["packageId"], "react@18.0.0");
+}
+
+/// `pnpm:package-manifest` is presence-tagged on `initial` /
+/// `updated`. The JS reporter checks `'initial' in log` to dispatch,
+/// so the wire shape must carry exactly one of the two keys (never
+/// both, never neither). The payload value is the entire
+/// `package.json` body — pnpm threads it through unchanged.
+#[test]
+fn package_manifest_event_matches_pnpm_wire_shape() {
+    let manifest = serde_json::json!({
+        "name": "demo",
+        "version": "1.0.0",
+        "dependencies": { "fastify": "1.0.0" },
+    });
+
+    let event = LogEvent::PackageManifest(PackageManifestLog {
+        level: LogLevel::Debug,
+        message: PackageManifestMessage::Initial {
+            prefix: "/proj".to_string(),
+            initial: manifest.clone(),
+        },
+    });
+    let envelope = Envelope { time: 1_700_000_000_000, hostname: "host", pid: 4242, event: &event };
+    let json: Value = envelope
+        .pipe_ref(serde_json::to_string)
+        .expect("serialize envelope")
+        .pipe_as_ref(serde_json::from_str)
+        .expect("parse JSON");
+    assert_eq!(json["name"], "pnpm:package-manifest");
+    assert_eq!(json["level"], "debug");
+    assert_eq!(json["prefix"], "/proj");
+    assert_eq!(json["initial"], manifest);
+    assert!(json.get("updated").is_none(), "initial event must not carry updated");
+
+    let event = LogEvent::PackageManifest(PackageManifestLog {
+        level: LogLevel::Debug,
+        message: PackageManifestMessage::Updated {
+            prefix: "/proj".to_string(),
+            updated: manifest.clone(),
+        },
+    });
+    let envelope = Envelope { time: 1_700_000_000_000, hostname: "host", pid: 4242, event: &event };
+    let json: Value = envelope
+        .pipe_ref(serde_json::to_string)
+        .expect("serialize envelope")
+        .pipe_as_ref(serde_json::from_str)
+        .expect("parse JSON");
+    assert_eq!(json["updated"], manifest);
+    assert!(json.get("initial").is_none(), "updated event must not carry initial");
+}
+
+/// `pnpm:root` is presence-tagged on `added` / `removed`. The JS
+/// reporter accumulates `added` events and renders them in the
+/// `pnpm:summary` "+N -M" block. Optional fields skip when absent
+/// — emitting them as JSON `null` would put `null` in the rendered
+/// version string.
+#[test]
+fn root_event_matches_pnpm_wire_shape() {
+    let event = LogEvent::Root(RootLog {
+        level: LogLevel::Debug,
+        message: RootMessage::Added {
+            prefix: "/proj".to_string(),
+            added: AddedRoot {
+                name: "fastify".to_string(),
+                real_name: "fastify".to_string(),
+                version: Some("4.0.0".to_string()),
+                dependency_type: Some(DependencyType::Prod),
+                id: None,
+                latest: None,
+                linked_from: None,
+            },
+        },
+    });
+    let envelope = Envelope { time: 1_700_000_000_000, hostname: "host", pid: 4242, event: &event };
+    let json: Value = envelope
+        .pipe_ref(serde_json::to_string)
+        .expect("serialize envelope")
+        .pipe_as_ref(serde_json::from_str)
+        .expect("parse JSON");
+    assert_eq!(json["name"], "pnpm:root");
+    assert_eq!(json["level"], "debug");
+    assert_eq!(json["prefix"], "/proj");
+    assert_eq!(json["added"]["name"], "fastify");
+    assert_eq!(json["added"]["realName"], "fastify");
+    assert_eq!(json["added"]["version"], "4.0.0");
+    assert_eq!(json["added"]["dependencyType"], "prod");
+    // Optional fields skip when None so the JS reporter doesn't see
+    // `id: null` etc. — pnpm's emit also omits them when absent.
+    for k in ["id", "latest", "linkedFrom"] {
+        assert!(json["added"].get(k).is_none(), "added.{k} should be absent, got {json:?}");
+    }
+    assert!(json.get("removed").is_none(), "added event must not carry removed");
+
+    let event = LogEvent::Root(RootLog {
+        level: LogLevel::Debug,
+        message: RootMessage::Removed {
+            prefix: "/proj".to_string(),
+            removed: RemovedRoot {
+                name: "fastify".to_string(),
+                version: None,
+                dependency_type: None,
+            },
+        },
+    });
+    let envelope = Envelope { time: 1_700_000_000_000, hostname: "host", pid: 4242, event: &event };
+    let json: Value = envelope
+        .pipe_ref(serde_json::to_string)
+        .expect("serialize envelope")
+        .pipe_as_ref(serde_json::from_str)
+        .expect("parse JSON");
+    assert_eq!(json["removed"]["name"], "fastify");
+    assert!(json.get("added").is_none(), "removed event must not carry added");
+
+    for (ty, expected) in [
+        (DependencyType::Prod, "prod"),
+        (DependencyType::Dev, "dev"),
+        (DependencyType::Optional, "optional"),
+    ] {
+        let json = serde_json::to_string(&ty).expect("serialize dependency type");
+        assert_eq!(json, format!("\"{expected}\""));
+    }
+}
+
+/// `pnpm:stats` is presence-tagged on `added` / `removed`. pnpm
+/// emits each from a separate site, so an event carries one or the
+/// other — never both. Pacquet currently emits both back-to-back
+/// (added from `CreateVirtualStore`, removed from a placeholder)
+/// to keep the wire shape consumable until pruning lands.
+#[test]
+fn stats_event_matches_pnpm_wire_shape() {
+    let event = LogEvent::Stats(StatsLog {
+        level: LogLevel::Debug,
+        message: StatsMessage::Added { prefix: "/proj".to_string(), added: 42 },
+    });
+    let envelope = Envelope { time: 1_700_000_000_000, hostname: "host", pid: 4242, event: &event };
+    let json: Value = envelope
+        .pipe_ref(serde_json::to_string)
+        .expect("serialize envelope")
+        .pipe_as_ref(serde_json::from_str)
+        .expect("parse JSON");
+    assert_eq!(json["name"], "pnpm:stats");
+    assert_eq!(json["level"], "debug");
+    assert_eq!(json["prefix"], "/proj");
+    assert_eq!(json["added"], 42);
+    assert!(json.get("removed").is_none(), "added event must not carry removed");
+
+    let event = LogEvent::Stats(StatsLog {
+        level: LogLevel::Debug,
+        message: StatsMessage::Removed { prefix: "/proj".to_string(), removed: 0 },
+    });
+    let envelope = Envelope { time: 1_700_000_000_000, hostname: "host", pid: 4242, event: &event };
+    let json: Value = envelope
+        .pipe_ref(serde_json::to_string)
+        .expect("serialize envelope")
+        .pipe_as_ref(serde_json::from_str)
+        .expect("parse JSON");
+    assert_eq!(json["removed"], 0);
+    assert!(json.get("added").is_none(), "removed event must not carry added");
+}
+
+/// `pnpm:request-retry` carries the retry loop's bookkeeping
+/// (attempt, maxRetries, timeout-ms-until-next-attempt) and a JS-
+/// shaped error object. The default-reporter dispatches on the
+/// chain `httpStatusCode ?? status ?? errno ?? code`; absent
+/// fields must skip rather than render as JSON `null`, since the
+/// `??` chain treats `null` as a present value.
+#[test]
+fn request_retry_event_matches_pnpm_wire_shape() {
+    let event = LogEvent::RequestRetry(RequestRetryLog {
+        level: LogLevel::Debug,
+        attempt: 1,
+        error: RequestRetryError {
+            message: "503 Service Unavailable".to_string(),
+            http_status_code: Some("503".to_string()),
+            status: None,
+            errno: None,
+            code: None,
+        },
+        max_retries: 2,
+        method: "GET".to_string(),
+        timeout: 10_000,
+        url: "https://registry.npmjs.org/x/-/x-1.0.0.tgz".to_string(),
+    });
+    let envelope = Envelope { time: 1_700_000_000_000, hostname: "host", pid: 4242, event: &event };
+    let json: Value = envelope
+        .pipe_ref(serde_json::to_string)
+        .expect("serialize envelope")
+        .pipe_as_ref(serde_json::from_str)
+        .expect("parse JSON");
+    assert_eq!(json["name"], "pnpm:request-retry");
+    assert_eq!(json["level"], "debug");
+    assert_eq!(json["attempt"], 1);
+    assert_eq!(json["maxRetries"], 2);
+    assert_eq!(json["method"], "GET");
+    assert_eq!(json["timeout"], 10_000);
+    assert_eq!(json["url"], "https://registry.npmjs.org/x/-/x-1.0.0.tgz");
+    assert_eq!(json["error"]["message"], "503 Service Unavailable");
+    assert_eq!(json["error"]["httpStatusCode"], "503");
+    for k in ["status", "errno", "code"] {
+        assert!(json["error"].get(k).is_none(), "error.{k} should be absent, got {json:?}");
+    }
 }
 
 /// Phase markers serialize as the snake_case strings pnpm uses.

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -13,7 +13,7 @@ use pacquet_fs::file_mode;
 use pacquet_network::ThrottledClient;
 use pacquet_reporter::{
     FetchingProgressLog, FetchingProgressMessage, LogEvent, LogLevel, ProgressLog, ProgressMessage,
-    Reporter,
+    Reporter, RequestRetryError, RequestRetryLog,
 };
 use pacquet_store_dir::{
     CafsFileInfo, PackageFilesIndex, SharedReadonlyStoreIndex, SharedVerifiedFilesCache, StoreDir,
@@ -713,6 +713,57 @@ pub struct DownloadTarballToStore<'a> {
     pub retry_opts: RetryOpts,
 }
 
+/// Project [`TarballError`] onto pnpm's `requestRetryLogger`'s
+/// JS-shaped error object. The JS default-reporter dispatches on
+/// `httpStatusCode ?? status ?? errno ?? code` to render the retry
+/// reason; absent fields skip rather than emit `null` so the `??`
+/// chain doesn't short-circuit on a present-but-`null` field.
+///
+/// Today pacquet only populates `http_status_code` (for
+/// `HttpStatus`) and a string `code` derived from the variant name
+/// for everything else. `errno` and `status` are skipped because
+/// pacquet's error layer doesn't carry them; pnpm's emit fills
+/// them when the underlying network error did.
+fn tarball_error_to_request_retry(err: &TarballError) -> RequestRetryError {
+    let mut out = RequestRetryError {
+        message: err.to_string(),
+        http_status_code: None,
+        status: None,
+        errno: None,
+        code: None,
+    };
+    match err {
+        TarballError::HttpStatus(http) => {
+            out.http_status_code = Some(http.status.to_string());
+        }
+        TarballError::FetchTarball(_) => {
+            out.code = Some("ERR_PACQUET_FETCH".to_string());
+        }
+        TarballError::Checksum(_) => {
+            out.code = Some("ERR_PACQUET_TARBALL_INTEGRITY".to_string());
+        }
+        TarballError::DecodeGzip(_) => {
+            out.code = Some("ERR_PACQUET_TARBALL_GZIP".to_string());
+        }
+        TarballError::ReadTarballEntries(_) => {
+            out.code = Some("ERR_PACQUET_TARBALL_TAR".to_string());
+        }
+        TarballError::WriteCasFile(_) | TarballError::WriteStoreIndex(_) => {
+            out.code = Some("ERR_PACQUET_TARBALL_STORE".to_string());
+        }
+        TarballError::TaskJoin(_) => {
+            out.code = Some("ERR_PACQUET_TASK_JOIN".to_string());
+        }
+        TarballError::TarballTooLarge { .. } => {
+            out.code = Some("ERR_PACQUET_TARBALL_TOO_LARGE".to_string());
+        }
+        TarballError::SiblingFetchFailed { .. } => {
+            out.code = Some("ERR_PACQUET_SIBLING_FETCH".to_string());
+        }
+    }
+    out
+}
+
 /// Whether a [`TarballError`] from one tarball-fetch attempt should be
 /// retried. Matches pnpm's
 /// [`remoteTarballFetcher.ts`](https://github.com/pnpm/pnpm/blob/1819226b51/fetching/tarball-fetcher/src/remoteTarballFetcher.ts#L76-L84)
@@ -1040,6 +1091,24 @@ async fn fetch_and_extract_with_retry<R: Reporter>(
                     ?err,
                     "Tarball fetch failed; retrying after backoff",
                 );
+                // `pnpm:request-retry` mirrors pnpm's emit at
+                // <https://github.com/pnpm/pnpm/blob/086c5e91e8/fetching/tarball-fetcher/src/remoteTarballFetcher.ts#L91>:
+                // one event per failed-and-being-retried HTTP
+                // attempt, before the backoff sleep, so the JS
+                // reporter renders "Will retry in <ms>. <N> retries
+                // left." while pacquet is still waiting. `attempt`
+                // is one-indexed (the failed attempt) to match
+                // pnpm's wire shape; pacquet's loop counter is
+                // zero-indexed.
+                R::emit(&LogEvent::RequestRetry(RequestRetryLog {
+                    level: LogLevel::Debug,
+                    attempt: attempt + 1,
+                    error: tarball_error_to_request_retry(&err),
+                    max_retries: retry_opts.retries,
+                    method: "GET".to_string(),
+                    timeout: u64::try_from(delay.as_millis()).unwrap_or(u64::MAX),
+                    url: package_url.to_string(),
+                }));
                 tokio::time::sleep(delay).await;
                 attempt += 1;
             }

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -719,11 +719,14 @@ pub struct DownloadTarballToStore<'a> {
 /// reason; absent fields skip rather than emit `null` so the `??`
 /// chain doesn't short-circuit on a present-but-`null` field.
 ///
-/// Today pacquet only populates `http_status_code` (for
-/// `HttpStatus`) and a string `code` derived from the variant name
-/// for everything else. `errno` and `status` are skipped because
-/// pacquet's error layer doesn't carry them; pnpm's emit fills
-/// them when the underlying network error did.
+/// Today pacquet populates `http_status_code` for the
+/// [`TarballError::HttpStatus`] variant and a curated
+/// `ERR_PACQUET_*` constant in `code` for every other variant —
+/// the mapping is hand-maintained per match arm rather than
+/// reflectively derived, so renaming a [`TarballError`] variant
+/// won't silently change the emitted `code`. `errno` and `status`
+/// are skipped because pacquet's error layer doesn't carry them;
+/// pnpm's emit fills them when the underlying network error did.
 fn tarball_error_to_request_retry(err: &TarballError) -> RequestRetryError {
     let mut out = RequestRetryError {
         message: err.to_string(),

--- a/crates/tarball/src/tests.rs
+++ b/crates/tarball/src/tests.rs
@@ -1838,3 +1838,93 @@ async fn found_in_store_event_fires_on_cache_hit() {
 
     drop(store_dir_keep);
 }
+
+/// `pnpm:request-retry` fires before each backoff sleep — once per
+/// failed-and-being-retried attempt — and never on the final
+/// successful or final failed attempt. With one transient 503
+/// followed by a 200, the retry loop emits exactly one event:
+/// `attempt: 1` (one-indexed, matching pnpm's wire shape) carrying
+/// the response status as `httpStatusCode`.
+#[tokio::test]
+async fn request_retry_event_fires_per_retried_attempt() {
+    use std::sync::Mutex;
+
+    use pacquet_reporter::{LogEvent, RequestRetryLog};
+
+    static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
+
+    struct RecordingReporter;
+    impl pacquet_reporter::Reporter for RecordingReporter {
+        fn emit(event: &LogEvent) {
+            EVENTS.lock().unwrap().push(event.clone());
+        }
+    }
+
+    let (store_dir_keep, store_path) = tempdir_with_leaked_path();
+    let mut server = mockito::Server::new_async().await;
+    let fail = server.mock("GET", "/pkg.tgz").with_status(503).expect(1).create_async().await;
+    let ok = server
+        .mock("GET", "/pkg.tgz")
+        .with_status(200)
+        .with_body(FASTIFY_ERROR_TARBALL)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let url = format!("{}/pkg.tgz", server.url());
+    let client = ThrottledClient::default();
+    let pkg_integrity = integrity(FASTIFY_ERROR_INTEGRITY);
+
+    EVENTS.lock().unwrap().clear();
+
+    fetch_and_extract_with_retry::<RecordingReporter>(
+        &client,
+        &url,
+        &pkg_integrity,
+        None,
+        "test-pkg",
+        "",
+        store_path,
+        fast_retry_opts(),
+    )
+    .await
+    .expect("transient 503 should be followed by a successful retry");
+
+    fail.assert_async().await;
+    ok.assert_async().await;
+
+    let captured = EVENTS.lock().unwrap();
+    let retries: Vec<&RequestRetryLog> = captured
+        .iter()
+        .filter_map(|e| match e {
+            LogEvent::RequestRetry(log) => Some(log),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(retries.len(), 1, "exactly one retry emit expected; got {captured:?}");
+
+    let retry = retries[0];
+    // attempt is one-indexed (the failed attempt). With one transient
+    // 503 and the retry succeeding, the only retry-emit is for
+    // attempt 1.
+    assert_eq!(retry.attempt, 1, "attempt must be one-indexed");
+    assert_eq!(retry.max_retries, fast_retry_opts().retries);
+    assert_eq!(retry.method, "GET");
+    assert_eq!(retry.url, url);
+    // `fast_retry_opts` collapses the backoff to 1 ms, so `timeout`
+    // must reflect the actual retry-loop sleep (not pnpm's
+    // production 10 s default) — guard against an off-by-one that
+    // emits the wrong attempt's delay.
+    assert_eq!(retry.timeout, 1, "timeout must mirror RetryOpts::delay_for");
+    // The 503 surfaces as `TarballError::HttpStatus`, so the
+    // wire-shape carries `httpStatusCode: "503"` and the JS
+    // reporter's `??` chain dispatches on it before falling
+    // through to the placeholder `code`.
+    assert_eq!(retry.error.http_status_code.as_deref(), Some("503"));
+    assert!(
+        retry.error.code.is_none(),
+        "HTTP failures must skip the placeholder code so the JS reporter dispatches on httpStatusCode",
+    );
+
+    drop(store_dir_keep);
+}


### PR DESCRIPTION
## Summary

Wires the four remaining portable channels from #347 into pacquet's reporter pipeline. Each follows the convention documented in `CODE_STYLE_GUIDE.md` § "Reporter / log events":

- a `LogEvent` variant + payload struct in `pacquet-reporter`
- a wire-shape unit test in `crates/reporter/src/tests.rs`
- the emit at the matching upstream pnpm site, with a pinned permalink at SHA `086c5e91e8`
- a recording-fake test where the surrounding code makes one reachable

### Channels

- **`pnpm:package-manifest`** — presence-tagged on `initial` / `updated`. `Initial` fires from `Install::run` next to the existing `pnpm:context` emit so consumers have the on-disk manifest before the install header renders. `Updated` fires from `Add::run` after `manifest.save()` so the audit pipeline can diff initial vs updated.
- **`pnpm:root`** — `Added` per direct dependency from `SymlinkDirectDependencies::run`. Iterates per `DependencyGroup` so each emit can label its `dependencyType` (`prod` / `dev` / `optional`); peer deps aren't materialised here so they're skipped, matching pnpm.
- **`pnpm:stats`** — `Added` (snapshot count) and `Removed` (placeholder `0` until pruning lands) from `CreateVirtualStore::run`. The code comment notes the upstream-divergence: pnpm reports the current/wanted diff (`newDepPathsSet.size`), pacquet has no current-lockfile tracking yet so every install looks like a fresh install and `added` ends up as the total snapshot count.
- **`pnpm:request-retry`** — emitted from `fetch_and_extract_with_retry` before each backoff sleep, with `attempt` one-indexed (the failed attempt) and `timeout` mirroring `RetryOpts::delay_for` ms. A new `tarball_error_to_request_retry` helper maps `TarballError` onto pnpm's JS-shaped error object: `httpStatusCode` for HTTP failures, a placeholder `code` derived from the variant name for everything else, so the JS reporter's `?? `-chain dispatch (`httpStatusCode ?? status ?? errno ?? code`) picks up the right field.

### Tests

- `crates/reporter/src/tests.rs` — wire-shape tests for all four new channels, asserting the JSON shape `@pnpm/cli.default-reporter` consumes (camelCase field names, presence-tagged dispatch, optional fields skipping rather than rendering as `null`).
- `crates/package-manager/src/install/tests.rs` — extends `install_emits_pnpm_event_sequence` to pin the new `[PackageManifest, Context, ImportingStarted, Stats(Added), Stats(Removed), ImportingDone, Summary]` order.
- `crates/package-manager/src/symlink_direct_dependencies/tests.rs` — new unit tests proving `pnpm:root added` fires once per direct dep with the right `dependencyType` per group, and pinning the existing `MissingRootImporter` error path.
- `crates/tarball/src/tests.rs` — `request_retry_event_fires_per_retried_attempt` proves the retry-loop emits exactly once per failed-and-being-retried attempt with `httpStatusCode: "503"` (no placeholder `code` when the JS-side dispatch field is populated).

Pure additive — no existing wire-shape changed.

## Test plan

- [x] `just ready` (typos / fmt / check / test / lint, including the new wire-shape and recording-fake tests)
- [x] `cargo nextest run -p pacquet-reporter` — 15/15 passing
- [x] `cargo nextest run -p pacquet-package-manager symlink_direct_dependencies install_emits_pnpm_event_sequence` — passes
- [x] `cargo nextest run -p pacquet-tarball request_retry` — passes

## References

- Closes the four remaining portable rows in #347.
- Convention reference: #374 (CODE_STYLE_GUIDE.md § "Reporter / log events").

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced runtime reporting: package-manifest initial/updated events, per-dependency "root added" events with dependency type, add/remove stats, and network request-retry diagnostics.

* **Tests**
  * New unit/integration tests validating log event shapes, emit ordering, retry reporting, and direct-dependency symlink behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->