### PR TITLE
ci(release): attest provenance

### DIFF
--- a/.github/workflows/release-to-npm.yml
+++ b/.github/workflows/release-to-npm.yml
@@ -40,6 +40,10 @@ jobs:
   build:
     needs: check
     if: needs.check.outputs.version_changed == 'true'
+    permissions:
+      contents: read
+      id-token: write # needed for actions/attest-build-provenance
+      attestations: write
     env:
       version: ${{ needs.check.outputs.version }}
     outputs:
@@ -106,6 +110,12 @@ jobs:
           BIN_NAME=pacquet-${{ matrix.code-target }}
           mv target/${{ matrix.target }}/release/pacquet $BIN_NAME
           tar czf $BIN_NAME.tar.gz $BIN_NAME
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: |
+            pacquet-${{ matrix.code-target }}*
 
       - name: Upload Binary
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Resolves <https://github.com/pnpm/pacquet/issues/376>.

Generate Sigstore-backed build provenance for the per-platform binary and its archive in the release matrix via actions/attest-build-provenance. This lets users verify with `gh attestation verify` that the artifacts attached to a GitHub Release came from this repository's release workflow rather than from a manual upload.

The publish job already uses --provenance for the npm tarballs, so GitHub-hosted attestations cover the binaries while npm provenance covers the published packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added build provenance attestations to release artifacts to enhance supply chain security and enable verification of artifact authenticity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->