### PR TITLE
ci(doc): check intra-doc links inside private items

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,12 @@ jobs:
         # --no-deps skips rendering HTML for every transitive crate. Only
         # workspace crates are documented; broken intra-doc links and bad
         # rustdoc markup in pacquet's own code are still caught.
-        run: cargo doc --no-deps --workspace
+        # --document-private-items extends those checks to private items
+        # too. The `rustdoc::private_intra_doc_links` lint (warn-by-default,
+        # promoted to error by `-D warnings`) still flags public items
+        # that link to private items, so a single pass covers both
+        # directions without doubling the build time.
+        run: cargo doc --no-deps --workspace --document-private-items
 
   typos:
     name: Spell Check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,11 +98,6 @@ jobs:
         # --no-deps skips rendering HTML for every transitive crate. Only
         # workspace crates are documented; broken intra-doc links and bad
         # rustdoc markup in pacquet's own code are still caught.
-        # --document-private-items extends those checks to private items
-        # too. The `rustdoc::private_intra_doc_links` lint (warn-by-default,
-        # promoted to error by `-D warnings`) still flags public items
-        # that link to private items, so a single pass covers both
-        # directions without doubling the build time.
         run: cargo doc --no-deps --workspace --document-private-items
 
   typos:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,9 +95,6 @@ jobs:
       - name: Doc
         env:
           RUSTDOCFLAGS: '-D warnings'
-        # --no-deps skips rendering HTML for every transitive crate. Only
-        # workspace crates are documented; broken intra-doc links and bad
-        # rustdoc markup in pacquet's own code are still caught.
         run: cargo doc --no-deps --workspace --document-private-items
 
   typos:

--- a/crates/package-manager/src/link_file.rs
+++ b/crates/package-manager/src/link_file.rs
@@ -110,7 +110,7 @@ fn log_method_once<R: Reporter>(logged: &AtomicU8, flag: u8, method: WireImportM
 ///   `importFile` (see `fs/indexed-pkg-importer/src/importIndexedDir.ts`,
 ///   `tryImportIndexedDir`), which mkdirs the unique parent set
 ///   sequentially up-front and then calls into the import primitive
-///   per file. [`create_cas_files`](crate::create_cas_files) is the
+///   per file. [`create_cas_files`](crate::create_cas_files()) is the
 ///   production caller and handles that pre-pass.
 pub fn link_file<R: Reporter>(
     logged: &AtomicU8,


### PR DESCRIPTION
`cargo doc --no-deps --workspace` only renders the docs of public items, so broken intra-doc links and bad rustdoc markup *inside* private items slipped past the doc job.

Adding `--document-private-items` extends the existing checks (with `RUSTDOCFLAGS=-D warnings`) to private items as well. The `rustdoc::private_intra_doc_links` lint is warn-by-default and gets promoted to a hard error by `-D warnings`, so public items linking to more-private items are still rejected — no second `cargo doc` pass is needed to cover that direction.

Also fix one such link surfaced by the stricter check: `link_file`'s doc referenced `crate::create_cas_files`, which is ambiguous because both a private module and a re-exported public function share that name. Disambiguate to the function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation generation to include comprehensive implementation details.
  * Corrected documentation references for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->