### PR TITLE
fix(ci/integrated-benchmark): cache key

### DIFF
--- a/.github/workflows/integrated-benchmark.yml
+++ b/.github/workflows/integrated-benchmark.yml
@@ -64,7 +64,10 @@ jobs:
       - name: Cache verdaccio
         uses: actions/cache@v5
         with:
-          key: integrated-benchmark-verdaccio
+          # actions/cache skips saving on an exact-key hit, so a static key would freeze the cache after the first run.
+          key: integrated-benchmark-verdaccio-${{ hashFiles('tasks/integrated-benchmark/src/fixtures/pnpm-lock.yaml') }}
+          restore-keys: |
+            integrated-benchmark-verdaccio-
           path: |
             ~/.local/share/verdaccio/storage
         timeout-minutes: 1
@@ -73,7 +76,11 @@ jobs:
       - name: Cache Rust builds
         uses: actions/cache@v5
         with:
-          key: integrated-benchmark-builds-${{ matrix.os }}
+          # github.sha forces a save every run so the incrementally-built target dirs keep accumulating; restore-keys widen progressively from exact-deps to any-prior-cache.
+          key: integrated-benchmark-builds-${{ matrix.os }}-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}-${{ github.sha }}
+          restore-keys: |
+            integrated-benchmark-builds-${{ matrix.os }}-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}-
+            integrated-benchmark-builds-${{ matrix.os }}-
           path: |
             ~/.cargo/registry
             ~/.cargo/git
@@ -101,7 +108,10 @@ jobs:
       - name: Cache pnpm
         uses: actions/cache@v5
         with:
-          key: integrated-benchmark-pnpm-v11
+          # Store contents follow tasks/registry-mock/pnpm-lock.yaml, which `just install` consumes via --frozen-lockfile.
+          key: integrated-benchmark-pnpm-v11-${{ hashFiles('tasks/registry-mock/pnpm-lock.yaml') }}
+          restore-keys: |
+            integrated-benchmark-pnpm-v11-
           path: |
             ${{ env.PNPM_HOME }}/store/v11
         timeout-minutes: 1

--- a/.github/workflows/integrated-benchmark.yml
+++ b/.github/workflows/integrated-benchmark.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Cache Rust builds
         uses: actions/cache@v5
         with:
-          key: integrated-benchmark-builds-${{ matrix.os }}-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}-${{ github.sha }}
+          key: integrated-benchmark-builds-${{ matrix.os }}-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}-${{ github.run_id }}
           restore-keys: |
             integrated-benchmark-builds-${{ matrix.os }}-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}-
             integrated-benchmark-builds-${{ matrix.os }}-

--- a/.github/workflows/integrated-benchmark.yml
+++ b/.github/workflows/integrated-benchmark.yml
@@ -64,7 +64,6 @@ jobs:
       - name: Cache verdaccio
         uses: actions/cache@v5
         with:
-          # actions/cache skips saving on an exact-key hit, so a static key would freeze the cache after the first run.
           key: integrated-benchmark-verdaccio-${{ hashFiles('tasks/integrated-benchmark/src/fixtures/pnpm-lock.yaml') }}
           restore-keys: |
             integrated-benchmark-verdaccio-
@@ -76,7 +75,6 @@ jobs:
       - name: Cache Rust builds
         uses: actions/cache@v5
         with:
-          # github.sha forces a save every run so the incrementally-built target dirs keep accumulating; restore-keys widen progressively from exact-deps to any-prior-cache.
           key: integrated-benchmark-builds-${{ matrix.os }}-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}-${{ github.sha }}
           restore-keys: |
             integrated-benchmark-builds-${{ matrix.os }}-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}-
@@ -108,7 +106,6 @@ jobs:
       - name: Cache pnpm
         uses: actions/cache@v5
         with:
-          # Store contents follow tasks/registry-mock/pnpm-lock.yaml, which `just install` consumes via --frozen-lockfile.
           key: integrated-benchmark-pnpm-v11-${{ hashFiles('tasks/registry-mock/pnpm-lock.yaml') }}
           restore-keys: |
             integrated-benchmark-pnpm-v11-


### PR DESCRIPTION
Closes <https://github.com/pnpm/pacquet/pull/387>.
Closes <https://github.com/pnpm/pacquet/pull/386>.

The three `actions/cache@v5` steps used static primary keys (`integrated-benchmark-verdaccio`, `integrated-benchmark-builds-<os>`, `integrated-benchmark-pnpm-v11`). `actions/cache` skips the post-job save whenever the primary key already exists in the cache, so a static key means the cache is written exactly once -- on the first successful run -- and then never refreshed. As Cargo.lock, the registry-mock pnpm-lock, or the benchmark fixtures evolve, the cached contents drift out of sync with what the job actually needs and stay drifted.

Hash the inputs that determine each cache's contents into the primary key, with restore-keys fallbacks so warm runs still pick up the most recent compatible cache:

* verdaccio: hash `tasks/integrated-benchmark/src/fixtures/pnpm-lock.yaml` (the lockfile that decides which tarballs verdaccio serves).
* Rust builds: hash `**/Cargo.lock` + `rust-toolchain.toml`, and append `${{ github.sha }}` so a fresh save happens on every run -- the `target/` and `bench-work-env/*/pacquet/target` dirs grow incrementally from source edits, which the lockfile hash alone doesn't capture. Restore-keys widen progressively to the latest same-deps cache and then to any prior cache for the OS.
* pnpm: hash `tasks/registry-mock/pnpm-lock.yaml`, which `just install` consumes with `--frozen-lockfile`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI caching to reduce stale artifacts and increase variability across runs.
  * Cache keys now vary more granularly and include per-run uniqueness to avoid accidental reuse.
  * Expanded restore fallbacks for more reliable cache retrieval.
  * No changes to benchmark execution or runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->