### PR TITLE
ci(integrated-benchmark): extract compilation step

### DIFF
--- a/.github/workflows/integrated-benchmark.yml
+++ b/.github/workflows/integrated-benchmark.yml
@@ -138,7 +138,7 @@ jobs:
         # minutes, which is exactly why it lives outside the timed steps —
         # 15 min covers a cold-cache double build with headroom.
         timeout-minutes: 15
-        run: just integrated-benchmark --scenario=frozen-lockfile --build-only HEAD main
+        run: just integrated-benchmark --build-only HEAD main
 
       - name: 'Benchmark: Frozen Lockfile'
         shell: bash

--- a/.github/workflows/integrated-benchmark.yml
+++ b/.github/workflows/integrated-benchmark.yml
@@ -130,13 +130,6 @@ jobs:
 
       - name: Precompile benchmark revisions
         shell: bash
-        # Clone HEAD and main and run `cargo build --release --bin=pacquet`
-        # for each, in a step of its own. Both timed benchmark steps below
-        # consume the same per-revision targets, so doing the compile here
-        # leaves them as near-no-op incremental builds. With the Rust build
-        # cache in place this is fast; on a cold cache it can take several
-        # minutes, which is exactly why it lives outside the timed steps —
-        # 15 min covers a cold-cache double build with headroom.
         timeout-minutes: 15
         run: just integrated-benchmark --build-only HEAD main
 
@@ -146,9 +139,6 @@ jobs:
         # install takes the whole step down with the GHA default job
         # timeout (6 h). A normal run is ~2 min — 10 min is generous
         # headroom, and a failure surfaces fast enough to iterate on.
-        # The preceding "Precompile benchmark revisions" step has already
-        # built each revision's pacquet binary, so the build phase here
-        # is an incremental near-no-op.
         timeout-minutes: 10
         run: |
           just integrated-benchmark --scenario=frozen-lockfile --verdaccio --with-pnpm HEAD main

--- a/.github/workflows/integrated-benchmark.yml
+++ b/.github/workflows/integrated-benchmark.yml
@@ -128,12 +128,27 @@ jobs:
       - name: Build the benchmark executor
         run: cargo build --bin=integrated-benchmark
 
+      - name: Precompile benchmark revisions
+        shell: bash
+        # Clone HEAD and main and run `cargo build --release --bin=pacquet`
+        # for each, in a step of its own. Both timed benchmark steps below
+        # consume the same per-revision targets, so doing the compile here
+        # leaves them as near-no-op incremental builds. With the Rust build
+        # cache in place this is fast; on a cold cache it can take several
+        # minutes, which is exactly why it lives outside the timed steps —
+        # 15 min covers a cold-cache double build with headroom.
+        timeout-minutes: 15
+        run: just integrated-benchmark --scenario=frozen-lockfile --build-only HEAD main
+
       - name: 'Benchmark: Frozen Lockfile'
         shell: bash
         # Hyperfine has no per-command timeout, so a single hanging
         # install takes the whole step down with the GHA default job
         # timeout (6 h). A normal run is ~2 min — 10 min is generous
         # headroom, and a failure surfaces fast enough to iterate on.
+        # The preceding "Precompile benchmark revisions" step has already
+        # built each revision's pacquet binary, so the build phase here
+        # is an incremental near-no-op.
         timeout-minutes: 10
         run: |
           just integrated-benchmark --scenario=frozen-lockfile --verdaccio --with-pnpm HEAD main

--- a/tasks/integrated-benchmark/src/cli_args.rs
+++ b/tasks/integrated-benchmark/src/cli_args.rs
@@ -36,6 +36,13 @@ pub struct CliArgs {
     #[clap(long)]
     pub with_pnpm: bool,
 
+    /// Clone and build each revision but skip the proxy-cache priming and
+    /// the hyperfine run. Intended for CI to precompile every revision in
+    /// a step of its own so the timed benchmark steps don't race their
+    /// timeout against `cargo build`.
+    #[clap(long)]
+    pub build_only: bool,
+
     /// Branch name, tag name, or commit id of the pacquet repo.
     #[clap(required = true)]
     pub revisions: Vec<String>,

--- a/tasks/integrated-benchmark/src/cli_args.rs
+++ b/tasks/integrated-benchmark/src/cli_args.rs
@@ -4,9 +4,9 @@ use std::{path::PathBuf, process::Command};
 
 #[derive(Debug, Parser)]
 pub struct CliArgs {
-    /// Task to benchmark.
-    #[clap(long, short)]
-    pub scenario: BenchmarkScenario,
+    /// Task to benchmark. Required unless `--build-only` is given.
+    #[clap(long, short, required_unless_present = "build_only", conflicts_with = "build_only")]
+    pub scenario: Option<BenchmarkScenario>,
 
     /// Port of the local virtual registry.
     #[clap(long, short = 'p', default_value_t = 4873)]

--- a/tasks/integrated-benchmark/src/cli_args.rs
+++ b/tasks/integrated-benchmark/src/cli_args.rs
@@ -4,7 +4,7 @@ use std::{path::PathBuf, process::Command};
 
 #[derive(Debug, Parser)]
 pub struct CliArgs {
-    /// Task to benchmark. Required unless `--build-only` is given.
+    /// Task to benchmark.
     #[clap(long, short, required_unless_present = "build_only", conflicts_with = "build_only")]
     pub scenario: Option<BenchmarkScenario>,
 
@@ -36,10 +36,7 @@ pub struct CliArgs {
     #[clap(long)]
     pub with_pnpm: bool,
 
-    /// Clone and build each revision but skip the proxy-cache priming and
-    /// the hyperfine run. Intended for CI to precompile every revision in
-    /// a step of its own so the timed benchmark steps don't race their
-    /// timeout against `cargo build`.
+    /// Build each revision without running the benchmark.
     #[clap(long)]
     pub build_only: bool,
 

--- a/tasks/integrated-benchmark/src/main.rs
+++ b/tasks/integrated-benchmark/src/main.rs
@@ -16,6 +16,7 @@ async fn main() {
         hyperfine_options,
         work_env,
         with_pnpm,
+        build_only,
         revisions,
     } = clap::Parser::parse();
     let repository = std::fs::canonicalize(repository).expect("get absolute path to repository");
@@ -24,7 +25,11 @@ async fn main() {
     }
     let work_env = std::fs::canonicalize(work_env).expect("get absolute path to work env");
     let registry = format!("http://localhost:{registry_port}/");
-    let verdaccio = if verdaccio {
+    // `--build-only` only clones and compiles each revision, so it doesn't
+    // need verdaccio, hyperfine, or pnpm.
+    let verdaccio = if build_only {
+        None
+    } else if verdaccio {
         verify::ensure_program("just").arg("install").pipe(verify::executor("just install"));
         pacquet_registry_mock::MockInstanceOptions {
             client: &Default::default(),
@@ -42,12 +47,14 @@ async fn main() {
     };
     verify::ensure_git_repo(&repository);
     verify::validate_revision_list(&revisions);
-    verify::ensure_program("bash");
     verify::ensure_program("cargo");
     verify::ensure_program("git");
-    verify::ensure_program("hyperfine");
-    verify::ensure_program("pnpm");
-    work_env::WorkEnv {
+    if !build_only {
+        verify::ensure_program("bash");
+        verify::ensure_program("hyperfine");
+        verify::ensure_program("pnpm");
+    }
+    let env = work_env::WorkEnv {
         root: work_env,
         with_pnpm,
         revisions,
@@ -56,7 +63,11 @@ async fn main() {
         scenario,
         hyperfine_options,
         fixture_dir,
+    };
+    if build_only {
+        env.build_only();
+    } else {
+        env.run();
     }
-    .run();
     drop(verdaccio); // terminate verdaccio if exists
 }

--- a/tasks/integrated-benchmark/src/main.rs
+++ b/tasks/integrated-benchmark/src/main.rs
@@ -45,13 +45,11 @@ async fn main() {
     };
     verify::ensure_git_repo(&repository);
     verify::validate_revision_list(&revisions);
+    verify::ensure_program("bash");
     verify::ensure_program("cargo");
     verify::ensure_program("git");
-    if !build_only {
-        verify::ensure_program("bash");
-        verify::ensure_program("hyperfine");
-        verify::ensure_program("pnpm");
-    }
+    verify::ensure_program("hyperfine");
+    verify::ensure_program("pnpm");
     let env = work_env::WorkEnv {
         root: work_env,
         with_pnpm,

--- a/tasks/integrated-benchmark/src/main.rs
+++ b/tasks/integrated-benchmark/src/main.rs
@@ -25,8 +25,6 @@ async fn main() {
     }
     let work_env = std::fs::canonicalize(work_env).expect("get absolute path to work env");
     let registry = format!("http://localhost:{registry_port}/");
-    // `--build-only` only clones and compiles each revision, so it doesn't
-    // need verdaccio, hyperfine, or pnpm.
     let verdaccio = if build_only {
         None
     } else if verdaccio {
@@ -65,7 +63,7 @@ async fn main() {
         fixture_dir,
     };
     if build_only {
-        env.build_only();
+        env.build();
     } else {
         env.run();
     }

--- a/tasks/integrated-benchmark/src/work_env.rs
+++ b/tasks/integrated-benchmark/src/work_env.rs
@@ -24,7 +24,11 @@ pub struct WorkEnv {
     pub revisions: Vec<String>,
     pub registry: String,
     pub repository: PathBuf,
-    pub scenario: BenchmarkScenario,
+    /// `None` only when we're in `--build-only` mode (clap enforces that
+    /// `--scenario` is otherwise required). Methods that read it —
+    /// `init()` and `benchmark()` — are only called from `run()`, which
+    /// the `build_only` branch in `main.rs` skips.
+    pub scenario: Option<BenchmarkScenario>,
     pub hyperfine_options: HyperfineOptions,
     pub fixture_dir: Option<PathBuf>,
 }
@@ -91,6 +95,7 @@ impl WorkEnv {
     }
 
     fn init(&self) {
+        let scenario = self.scenario.expect("scenario set when init() is reached");
         eprintln!("Initializing...");
         let id_list = self
             .revision_ids()
@@ -103,9 +108,9 @@ impl WorkEnv {
             fs::create_dir_all(&dir).expect("create directory for the revision");
             create_package_json(&dir, self.fixture_dir.as_deref());
             create_pnpm_workspace(&dir, self.fixture_dir.as_deref());
-            create_install_script(&dir, self.scenario, for_pnpm);
-            create_npmrc(&dir, self.registry(), self.scenario);
-            may_create_lockfile(&dir, self.scenario, self.fixture_dir.as_deref());
+            create_install_script(&dir, scenario, for_pnpm);
+            create_npmrc(&dir, self.registry(), scenario);
+            may_create_lockfile(&dir, scenario, self.fixture_dir.as_deref());
         }
 
         eprintln!("Populating proxy registry cache...");
@@ -221,7 +226,8 @@ impl WorkEnv {
         // scenarios wipe `node_modules` and `store-dir`, hot-cache wipes
         // only `node_modules` so the warmup-populated store survives
         // into the timed runs.
-        let cleanup_paths = self.scenario.cleanup_paths();
+        let cleanup_paths =
+            self.scenario.expect("scenario set when benchmark() is reached").cleanup_paths();
         let cleanup_targets = self
             .revision_ids()
             .chain(self.with_pnpm.then_some(WorkEnv::PNPM))

--- a/tasks/integrated-benchmark/src/work_env.rs
+++ b/tasks/integrated-benchmark/src/work_env.rs
@@ -254,6 +254,15 @@ impl WorkEnv {
         self.build();
         self.benchmark();
     }
+
+    /// Clone and build each revision without setting up the per-revision
+    /// install scripts, priming the proxy cache, or running hyperfine.
+    /// Used by CI to precompile every revision in a step of its own so
+    /// the timed benchmark steps don't race their timeout against
+    /// `cargo build`.
+    pub fn build_only(&self) {
+        self.build();
+    }
 }
 
 fn create_package_json(dst_dir: &Path, src_dir: Option<&Path>) {

--- a/tasks/integrated-benchmark/src/work_env.rs
+++ b/tasks/integrated-benchmark/src/work_env.rs
@@ -24,10 +24,6 @@ pub struct WorkEnv {
     pub revisions: Vec<String>,
     pub registry: String,
     pub repository: PathBuf,
-    /// `None` only when we're in `--build-only` mode (clap enforces that
-    /// `--scenario` is otherwise required). Methods that read it —
-    /// `init()` and `benchmark()` — are only called from `run()`, which
-    /// the `build_only` branch in `main.rs` skips.
     pub scenario: Option<BenchmarkScenario>,
     pub hyperfine_options: HyperfineOptions,
     pub fixture_dir: Option<PathBuf>,
@@ -119,7 +115,7 @@ impl WorkEnv {
             .pipe_mut(executor("install.bash"))
     }
 
-    fn build(&self) {
+    pub fn build(&self) {
         eprintln!("Building...");
         for revision in self.revision_names() {
             eprintln!("Revision: {revision:?}");
@@ -259,15 +255,6 @@ impl WorkEnv {
         self.init();
         self.build();
         self.benchmark();
-    }
-
-    /// Clone and build each revision without setting up the per-revision
-    /// install scripts, priming the proxy cache, or running hyperfine.
-    /// Used by CI to precompile every revision in a step of its own so
-    /// the timed benchmark steps don't race their timeout against
-    /// `cargo build`.
-    pub fn build_only(&self) {
-        self.build();
     }
 }
 


### PR DESCRIPTION
## Motivation

The "Benchmark: Frozen Lockfile" CI step has been responsible for compiling both revisions (HEAD and `main`) for **both** timed benchmark steps. With the Rust build cache hit it takes ~5 min — half its 10-min timeout. On a cache miss it climbs toward 10 min and edges close to the hard timeout.

## Change

### CI

Add a new **"Precompile benchmark revisions"** step that runs before both
timed benchmark steps, with its own 15-min timeout:

```yaml
- name: Precompile benchmark revisions
  shell: bash
  timeout-minutes: 15
  run: just integrated-benchmark --build-only HEAD main
```

The two timed steps now fall through to a near-no-op incremental build, so
their timeouts only need to cover hyperfine itself.

### `integrated-benchmark` binary

Add a `--build-only` flag that runs `WorkEnv::build()` (clone → fetch →
checkout → `cargo build --release --bin=pacquet` for each revision) and
exits — no `init()`, no proxy-cache priming, no hyperfine.

In this mode the binary also skips spawning verdaccio / connecting to a
running registry — the precompile step doesn't have one up yet, and
`cargo build` doesn't need a registry. The `ensure_program` checks for
`bash` / `hyperfine` / `pnpm` stay unconditional: CI installs them all
before the precompile step runs, so the checks are sub-second no-ops in
practice and keep fail-fast behavior if the environment is misconfigured.

`WorkEnv::build` is `pub` and called directly from `main.rs`.

### CLI ergonomics

`--scenario` and `--build-only` are mutually exclusive: exactly one must
be given. Expressed purely through clap field-level attributes — no
runtime validation:

```rust
#[clap(long, short, required_unless_present = "build_only", conflicts_with = "build_only")]
pub scenario: Option<BenchmarkScenario>,
```

| Invocation | Result |
| --- | --- |
| neither flag | clap error: `--scenario` required |
| both flags | clap error: `--scenario` cannot be used with `--build-only` |
| `--scenario=…` only | OK (full benchmark run) |
| `--build-only` only | OK (precompile only) |

`WorkEnv.scenario` becomes `Option<BenchmarkScenario>`; `init()` and
`benchmark()` unwrap it (only reached on the non-`--build-only` path,
where clap guarantees `--scenario` is set).

## Files touched

- `tasks/integrated-benchmark/src/cli_args.rs` — new `--build-only` flag; `--scenario` becomes `Option<…>` with `required_unless_present` + `conflicts_with`.
- `tasks/integrated-benchmark/src/main.rs` — gate verdaccio / virtual-registry setup on `!build_only`; dispatch to `env.build()` or `env.run()`.
- `tasks/integrated-benchmark/src/work_env.rs` — `build()` made public; `scenario` field becomes optional; `init()` and `benchmark()` unwrap it at the boundary.
- `.github/workflows/integrated-benchmark.yml` — new `Precompile benchmark revisions` step before the two timed steps.

## Out of scope / not done

- The total CI wall-clock for the job is roughly unchanged on a warm cache; this PR isolates the compile cost into its own step rather than shortening it.
- Timeouts on the two timed steps stay at 10 min — they could be tightened later now that they no longer include compile time, but that's a follow-up.