### PR TITLE
feat: lifecycle script execution and allowBuilds policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1837,7 +1837,10 @@ version = "0.0.1"
 dependencies = [
  "derive_more",
  "miette 7.6.0",
+ "pacquet-reporter",
+ "pretty_assertions",
  "serde_json",
+ "tempfile",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1837,6 +1837,7 @@ version = "0.0.1"
 dependencies = [
  "derive_more",
  "miette 7.6.0",
+ "pacquet-package-manifest",
  "pacquet-reporter",
  "pretty_assertions",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1837,6 +1837,8 @@ version = "0.0.1"
 dependencies = [
  "derive_more",
  "miette 7.6.0",
+ "serde_json",
+ "tracing",
 ]
 
 [[package]]
@@ -1963,6 +1965,7 @@ dependencies = [
  "insta",
  "miette 7.6.0",
  "node-semver",
+ "pacquet-executor",
  "pacquet-fs",
  "pacquet-lockfile",
  "pacquet-modules-yaml",
@@ -1980,6 +1983,7 @@ dependencies = [
  "rayon",
  "reflink-copy",
  "serde-saphyr",
+ "serde_json",
  "ssri",
  "tempfile",
  "text-block-macros",

--- a/crates/cli/tests/lifecycle_scripts.rs
+++ b/crates/cli/tests/lifecycle_scripts.rs
@@ -1,3 +1,38 @@
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
+use std::fs;
+
+// Ported from https://github.com/pnpm/pnpm/blob/7e91e4b35f/installing/deps-installer/test/install/lifecycleScripts.ts#L121
+#[test]
+fn run_install_scripts() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    eprintln!("Creating package.json...");
+    let manifest_path = workspace.join("package.json");
+    let package_json = serde_json::json!({
+        "dependencies": {
+            "@pnpm.e2e/install-script-example": "1.0.0",
+        },
+    });
+    fs::write(&manifest_path, package_json.to_string()).expect("write package.json");
+
+    eprintln!("Running pacquet install...");
+    pacquet.with_arg("install").assert().success();
+
+    let pkg_dir = workspace.join(
+        "node_modules/.pnpm/@pnpm.e2e+install-script-example@1.0.0\
+         /node_modules/@pnpm.e2e/install-script-example",
+    );
+
+    eprintln!("Checking generated-by-install.js exists...");
+    assert!(pkg_dir.join("generated-by-install.js").exists());
+
+    drop((root, mock_instance));
+}
+
 mod known_failures {
     use assert_cmd::prelude::*;
     use command_extra::CommandExtra;
@@ -10,7 +45,9 @@ mod known_failures {
     use std::{fs, path::Path};
 
     fn build_deps_ran(_workspace: &Path) -> KnownResult<()> {
-        Err(KnownFailure::new("building dependencies is not implemented"))
+        Err(KnownFailure::new(
+            "bin linking (#330) is not implemented; lifecycle scripts that invoke dependency bins fail with exit 127",
+        ))
     }
 
     // Ported from https://github.com/pnpm/pnpm/blob/7e91e4b35f/installing/deps-installer/test/install/lifecycleScripts.ts#L26
@@ -50,38 +87,6 @@ mod known_failures {
 
         eprintln!("Checking generated-by-postinstall.js exists...");
         assert!(pkg_dir.join("generated-by-postinstall.js").exists());
-
-        drop((root, mock_instance));
-    }
-
-    // Ported from https://github.com/pnpm/pnpm/blob/7e91e4b35f/installing/deps-installer/test/install/lifecycleScripts.ts#L121
-    #[test]
-    fn run_install_scripts() {
-        let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
-            CommandTempCwd::init().add_mocked_registry();
-        let AddMockedRegistry { mock_instance, .. } = npmrc_info;
-
-        eprintln!("Creating package.json...");
-        let manifest_path = workspace.join("package.json");
-        let package_json = serde_json::json!({
-            "dependencies": {
-                "@pnpm.e2e/install-script-example": "1.0.0",
-            },
-        });
-        fs::write(&manifest_path, package_json.to_string()).expect("write package.json");
-
-        eprintln!("Running pacquet install...");
-        pacquet.with_arg("install").assert().success();
-
-        allow_known_failure!(build_deps_ran(&workspace));
-
-        let pkg_dir = workspace.join(
-            "node_modules/.pnpm/@pnpm.e2e+install-script-example@1.0.0\
-             /node_modules/@pnpm.e2e/install-script-example",
-        );
-
-        eprintln!("Checking generated-by-install.js exists...");
-        assert!(pkg_dir.join("generated-by-install.js").exists());
 
         drop((root, mock_instance));
     }

--- a/crates/cli/tests/lifecycle_scripts.rs
+++ b/crates/cli/tests/lifecycle_scripts.rs
@@ -295,7 +295,7 @@ mod known_failures {
         drop((root, mock_instance));
     }
 
-    // Ported from https://github.com/pnpm/pnpm/blob/7e91e4b35f/installing/deps-installer/test/install/lifecycleScripts.ts#L505
+    // Ported from https://github.com/pnpm/pnpm/blob/7e91e4b35f/installing/deps-installer/test/install/lifecycleScripts.ts#L466
     #[test]
     fn selectively_allow_scripts_by_allow_builds() {
         let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
@@ -323,6 +323,7 @@ mod known_failures {
         allow_known_failure!(build_deps_ran(&workspace));
 
         let virtual_store = workspace.join("node_modules/.pnpm");
+        let node_modules = workspace.join("node_modules");
 
         let denied_pkg = virtual_store.join(
             "@pnpm.e2e+pre-and-postinstall-scripts-example@1.0.0\
@@ -337,7 +338,45 @@ mod known_failures {
         );
         assert!(allowed_pkg.join("generated-by-install.js").exists());
 
-        drop((root, mock_instance));
+        // TODO: assert the `pnpm:ignored-scripts` reporter event lists
+        // `@pnpm.e2e/pre-and-postinstall-scripts-example@1.0.0` here. Pacquet
+        // does not emit that channel yet (see issue #397).
+
+        eprintln!(
+            "Re-running install with explicit denial of pre-and-postinstall-scripts-example..."
+        );
+        fs::remove_dir_all(&node_modules).expect("remove node_modules");
+        let updated_package_json = serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/pre-and-postinstall-scripts-example": "1.0.0",
+                "@pnpm.e2e/install-script-example": "1.0.0",
+            },
+            "pnpm": {
+                "allowBuilds": {
+                    "@pnpm.e2e/install-script-example": true,
+                    "@pnpm.e2e/pre-and-postinstall-scripts-example": false,
+                },
+            },
+        });
+        fs::write(&manifest_path, updated_package_json.to_string()).expect("update package.json");
+
+        let CommandTempCwd { pacquet: frozen_pacquet, root: frozen_root, .. } =
+            CommandTempCwd::init().add_mocked_registry();
+        frozen_pacquet
+            .with_current_dir(&workspace)
+            .with_args(["install", "--frozen-lockfile"])
+            .assert()
+            .success();
+
+        assert!(!denied_pkg.join("generated-by-preinstall.js").exists());
+        assert!(!denied_pkg.join("generated-by-postinstall.js").exists());
+        assert!(allowed_pkg.join("generated-by-install.js").exists());
+
+        // TODO: assert the `pnpm:ignored-scripts` reporter event lists no
+        // package names this time — explicit denial moves the package from
+        // "ignored" to "silently skipped".
+
+        drop((root, mock_instance, frozen_root));
     }
 
     // Ported from https://github.com/pnpm/pnpm/blob/7e91e4b35f/installing/deps-installer/test/install/lifecycleScripts.ts#L543

--- a/crates/cli/tests/lifecycle_scripts.rs
+++ b/crates/cli/tests/lifecycle_scripts.rs
@@ -329,6 +329,7 @@ mod known_failures {
             "@pnpm.e2e+pre-and-postinstall-scripts-example@1.0.0\
              /node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example",
         );
+        eprintln!("Checking denied package did NOT run scripts...");
         assert!(!denied_pkg.join("generated-by-preinstall.js").exists());
         assert!(!denied_pkg.join("generated-by-postinstall.js").exists());
 
@@ -336,6 +337,7 @@ mod known_failures {
             "@pnpm.e2e+install-script-example@1.0.0\
              /node_modules/@pnpm.e2e/install-script-example",
         );
+        eprintln!("Checking allowed package DID run scripts...");
         assert!(allowed_pkg.join("generated-by-install.js").exists());
 
         // TODO: assert the `pnpm:ignored-scripts` reporter event lists
@@ -412,6 +414,7 @@ mod known_failures {
             "@pnpm.e2e+pre-and-postinstall-scripts-example@1.0.0\
              /node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example",
         );
+        eprintln!("Checking denied package did NOT run scripts...");
         assert!(!denied_pkg.join("generated-by-preinstall.js").exists());
         assert!(!denied_pkg.join("generated-by-postinstall.js").exists());
 
@@ -419,6 +422,7 @@ mod known_failures {
             "@pnpm.e2e+install-script-example@1.0.0\
              /node_modules/@pnpm.e2e/install-script-example",
         );
+        eprintln!("Checking allowed package DID run scripts...");
         assert!(allowed_pkg.join("generated-by-install.js").exists());
 
         drop((root, mock_instance));
@@ -495,12 +499,14 @@ mod known_failures {
             "@pnpm.e2e+install-script-example@1.0.0\
              /node_modules/@pnpm.e2e/install-script-example",
         );
+        eprintln!("Checking allowed package ran scripts...");
         assert!(install_pkg.join("generated-by-install.js").exists());
 
         let scripts_pkg = virtual_store.join(
             "@pnpm.e2e+pre-and-postinstall-scripts-example@1.0.0\
              /node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example",
         );
+        eprintln!("Checking denied package did NOT run scripts...");
         assert!(!scripts_pkg.join("generated-by-preinstall.js").exists());
         assert!(!scripts_pkg.join("generated-by-postinstall.js").exists());
 
@@ -562,7 +568,9 @@ mod known_failures {
             "node_modules/.pnpm/@pnpm.e2e+pre-and-postinstall-scripts-example@1.0.0\
              /node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example",
         );
+        eprintln!("Checking generated-by-preinstall.js exists...");
         assert!(pkg_dir.join("generated-by-preinstall.js").exists());
+        eprintln!("Checking generated-by-postinstall.js exists...");
         assert!(pkg_dir.join("generated-by-postinstall.js").exists());
 
         drop((root, mock_instance));

--- a/crates/cli/tests/lifecycle_scripts.rs
+++ b/crates/cli/tests/lifecycle_scripts.rs
@@ -180,9 +180,9 @@ mod known_failures {
         fs::remove_dir_all(&node_modules).expect("remove node_modules");
 
         eprintln!("Running pacquet install --frozen-lockfile...");
-        CommandTempCwd::init()
-            .add_mocked_registry()
-            .pacquet
+        let CommandTempCwd { pacquet: frozen_pacquet, root: frozen_root, .. } =
+            CommandTempCwd::init().add_mocked_registry();
+        frozen_pacquet
             .with_current_dir(&workspace)
             .with_args(["install", "--frozen-lockfile"])
             .assert()
@@ -198,7 +198,7 @@ mod known_failures {
             assert!(is_path_executable(&node_modules.join(".bin/cmd2")));
         }
 
-        drop((root, mock_instance));
+        drop((root, mock_instance, frozen_root));
     }
 
     // Ported from https://github.com/pnpm/pnpm/blob/7e91e4b35f/installing/deps-installer/test/install/lifecycleScripts.ts#L372
@@ -412,15 +412,15 @@ mod known_failures {
         fs::remove_dir_all(&node_modules).expect("remove node_modules");
 
         eprintln!("Running pacquet install --frozen-lockfile...");
-        CommandTempCwd::init()
-            .add_mocked_registry()
-            .pacquet
+        let CommandTempCwd { pacquet: frozen_pacquet, root: frozen_root, .. } =
+            CommandTempCwd::init().add_mocked_registry();
+        frozen_pacquet
             .with_current_dir(&workspace)
             .with_args(["install", "--frozen-lockfile"])
             .assert()
             .success();
 
-        drop((root, mock_instance));
+        drop((root, mock_instance, frozen_root));
     }
 
     // Ported from https://github.com/pnpm/pnpm/blob/7e91e4b35f/installing/deps-installer/test/install/lifecycleScripts.ts#L724
@@ -480,9 +480,9 @@ mod known_failures {
         });
         fs::write(&manifest_path, updated_manifest.to_string()).expect("write package.json");
 
-        CommandTempCwd::init()
-            .add_mocked_registry()
-            .pacquet
+        let CommandTempCwd { pacquet: frozen_pacquet, root: frozen_root, .. } =
+            CommandTempCwd::init().add_mocked_registry();
+        frozen_pacquet
             .with_current_dir(&workspace)
             .with_args(["install", "--frozen-lockfile"])
             .assert()
@@ -495,7 +495,7 @@ mod known_failures {
         assert!(scripts_pkg.join("generated-by-preinstall.js").exists());
         assert!(scripts_pkg.join("generated-by-postinstall.js").exists());
 
-        drop((root, mock_instance));
+        drop((root, mock_instance, frozen_root));
     }
 
     // Ported from https://github.com/pnpm/pnpm/blob/7e91e4b35f/installing/deps-restorer/test/index.ts#L362

--- a/crates/cli/tests/lifecycle_scripts.rs
+++ b/crates/cli/tests/lifecycle_scripts.rs
@@ -1,0 +1,536 @@
+mod known_failures {
+    use assert_cmd::prelude::*;
+    use command_extra::CommandExtra;
+    use pacquet_testing_utils::{
+        allow_known_failure,
+        bin::{AddMockedRegistry, CommandTempCwd},
+        known_failure::{KnownFailure, KnownResult},
+    };
+    use pipe_trait::Pipe;
+    use std::{fs, path::Path};
+
+    fn build_deps_ran(_workspace: &Path) -> KnownResult<()> {
+        Err(KnownFailure::new("building dependencies is not implemented"))
+    }
+
+    // Ported from https://github.com/pnpm/pnpm/blob/7e91e4b35f/installing/deps-installer/test/install/lifecycleScripts.ts#L26
+    #[test]
+    fn run_pre_and_postinstall_scripts() {
+        let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+            CommandTempCwd::init().add_mocked_registry();
+        let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+        eprintln!("Creating package.json...");
+        let manifest_path = workspace.join("package.json");
+        let package_json = serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/pre-and-postinstall-scripts-example": "1.0.0",
+            },
+        });
+        fs::write(&manifest_path, package_json.to_string()).expect("write package.json");
+
+        eprintln!("Running pacquet install...");
+        pacquet.with_arg("install").assert().success();
+
+        allow_known_failure!(build_deps_ran(&workspace));
+
+        let pkg_dir = workspace.join(
+            "node_modules/.pnpm/@pnpm.e2e+pre-and-postinstall-scripts-example@1.0.0\
+             /node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example",
+        );
+
+        eprintln!("Checking generated-by-prepare.js does NOT exist...");
+        assert!(
+            !pkg_dir.join("generated-by-prepare.js").exists(),
+            "prepare should not run for registry packages"
+        );
+
+        eprintln!("Checking generated-by-preinstall.js exists...");
+        assert!(pkg_dir.join("generated-by-preinstall.js").exists());
+
+        eprintln!("Checking generated-by-postinstall.js exists...");
+        assert!(pkg_dir.join("generated-by-postinstall.js").exists());
+
+        drop((root, mock_instance));
+    }
+
+    // Ported from https://github.com/pnpm/pnpm/blob/7e91e4b35f/installing/deps-installer/test/install/lifecycleScripts.ts#L121
+    #[test]
+    fn run_install_scripts() {
+        let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+            CommandTempCwd::init().add_mocked_registry();
+        let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+        eprintln!("Creating package.json...");
+        let manifest_path = workspace.join("package.json");
+        let package_json = serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/install-script-example": "1.0.0",
+            },
+        });
+        fs::write(&manifest_path, package_json.to_string()).expect("write package.json");
+
+        eprintln!("Running pacquet install...");
+        pacquet.with_arg("install").assert().success();
+
+        allow_known_failure!(build_deps_ran(&workspace));
+
+        let pkg_dir = workspace.join(
+            "node_modules/.pnpm/@pnpm.e2e+install-script-example@1.0.0\
+             /node_modules/@pnpm.e2e/install-script-example",
+        );
+
+        eprintln!("Checking generated-by-install.js exists...");
+        assert!(pkg_dir.join("generated-by-install.js").exists());
+
+        drop((root, mock_instance));
+    }
+
+    // Ported from https://github.com/pnpm/pnpm/blob/7e91e4b35f/installing/deps-installer/test/install/lifecycleScripts.ts#L303
+    #[test]
+    fn lifecycle_scripts_run_in_dependency_order() {
+        let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+            CommandTempCwd::init().add_mocked_registry();
+        let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+        eprintln!("Creating package.json...");
+        let manifest_path = workspace.join("package.json");
+        let package_json = serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/with-postinstall-a": "1.0.0",
+            },
+        });
+        fs::write(&manifest_path, package_json.to_string()).expect("write package.json");
+
+        eprintln!("Running pacquet install...");
+        pacquet.with_arg("install").assert().success();
+
+        allow_known_failure!(build_deps_ran(&workspace));
+
+        let virtual_store = workspace.join("node_modules/.pnpm");
+        let output_a: serde_json::Value = virtual_store
+            .join(
+                "@pnpm.e2e+with-postinstall-a@1.0.0\
+                 /node_modules/@pnpm.e2e/with-postinstall-a/output.json",
+            )
+            .pipe_ref(fs::read_to_string)
+            .expect("read output A")
+            .pipe_ref(|s| serde_json::from_str(s))
+            .expect("parse output A");
+        let output_b: serde_json::Value = virtual_store
+            .join(
+                "@pnpm.e2e+with-postinstall-b@1.0.0\
+                 /node_modules/@pnpm.e2e/with-postinstall-b/output.json",
+            )
+            .pipe_ref(fs::read_to_string)
+            .expect("read output B")
+            .pipe_ref(|s| serde_json::from_str(s))
+            .expect("parse output B");
+
+        let ts_b = output_b[0].as_u64().expect("B timestamp");
+        let ts_a = output_a[0].as_u64().expect("A timestamp");
+        eprintln!("Checking B ran before A (B={ts_b}, A={ts_a})...");
+        assert!(ts_b < ts_a, "dependency B should run before dependent A");
+
+        drop((root, mock_instance));
+    }
+
+    // Ported from https://github.com/pnpm/pnpm/blob/7e91e4b35f/installing/deps-installer/test/install/lifecycleScripts.ts#L331
+    #[test]
+    fn lifecycle_scripts_run_before_linking_bins() {
+        let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+            CommandTempCwd::init().add_mocked_registry();
+        let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+        eprintln!("Creating package.json...");
+        let manifest_path = workspace.join("package.json");
+        let package_json = serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/generated-bins": "1.0.0",
+            },
+        });
+        fs::write(&manifest_path, package_json.to_string()).expect("write package.json");
+
+        eprintln!("Running pacquet install...");
+        pacquet.with_arg("install").assert().success();
+
+        allow_known_failure!(build_deps_ran(&workspace));
+
+        let node_modules = workspace.join("node_modules");
+
+        eprintln!("Checking generated bins are executable...");
+        #[cfg(unix)]
+        {
+            use pacquet_testing_utils::fs::is_path_executable;
+            assert!(is_path_executable(&node_modules.join(".bin/cmd1")));
+            assert!(is_path_executable(&node_modules.join(".bin/cmd2")));
+        }
+
+        eprintln!("Deleting node_modules for frozen reinstall...");
+        fs::remove_dir_all(&node_modules).expect("remove node_modules");
+
+        eprintln!("Running pacquet install --frozen-lockfile...");
+        CommandTempCwd::init()
+            .add_mocked_registry()
+            .pacquet
+            .with_current_dir(&workspace)
+            .with_args(["install", "--frozen-lockfile"])
+            .assert()
+            .success();
+
+        allow_known_failure!(build_deps_ran(&workspace));
+
+        eprintln!("Checking generated bins are executable after frozen reinstall...");
+        #[cfg(unix)]
+        {
+            use pacquet_testing_utils::fs::is_path_executable;
+            assert!(is_path_executable(&node_modules.join(".bin/cmd1")));
+            assert!(is_path_executable(&node_modules.join(".bin/cmd2")));
+        }
+
+        drop((root, mock_instance));
+    }
+
+    // Ported from https://github.com/pnpm/pnpm/blob/7e91e4b35f/installing/deps-installer/test/install/lifecycleScripts.ts#L372
+    #[test]
+    fn bins_linked_even_if_scripts_ignored() {
+        let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+            CommandTempCwd::init().add_mocked_registry();
+        let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+        eprintln!("Creating package.json...");
+        let manifest_path = workspace.join("package.json");
+        let package_json = serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/pre-and-postinstall-scripts-example": "1.0.0",
+                "@pnpm.e2e/peer-with-bin": "1.0.0",
+                "@pnpm.e2e/pkg-with-peer-having-bin": "1.0.0",
+            },
+        });
+        fs::write(&manifest_path, package_json.to_string()).expect("write package.json");
+
+        eprintln!("Running pacquet install...");
+        pacquet.with_arg("install").assert().success();
+
+        allow_known_failure!(build_deps_ran(&workspace));
+
+        let node_modules = workspace.join("node_modules");
+
+        eprintln!("Checking bins are linked...");
+        #[cfg(unix)]
+        {
+            use pacquet_testing_utils::fs::is_path_executable;
+            assert!(is_path_executable(&node_modules.join(".bin/peer-with-bin")));
+        }
+
+        let scripts_pkg_dir = node_modules.join(
+            ".pnpm/@pnpm.e2e+pre-and-postinstall-scripts-example@1.0.0\
+             /node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example",
+        );
+
+        eprintln!("Checking package.json exists but generated files do not...");
+        assert!(scripts_pkg_dir.join("package.json").exists());
+        assert!(
+            !scripts_pkg_dir.join("generated-by-preinstall.js").exists(),
+            "scripts should not have run with ignoreScripts"
+        );
+
+        drop((root, mock_instance));
+    }
+
+    // Ported from https://github.com/pnpm/pnpm/blob/7e91e4b35f/installing/deps-installer/test/install/lifecycleScripts.ts#L445
+    #[test]
+    fn selectively_ignore_scripts_by_allow_builds() {
+        let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+            CommandTempCwd::init().add_mocked_registry();
+        let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+        eprintln!("Creating package.json with allowBuilds...");
+        let manifest_path = workspace.join("package.json");
+        let package_json = serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/pre-and-postinstall-scripts-example": "1.0.0",
+                "@pnpm.e2e/install-script-example": "1.0.0",
+            },
+            "pnpm": {
+                "allowBuilds": {
+                    "@pnpm.e2e/install-script-example": true,
+                },
+            },
+        });
+        fs::write(&manifest_path, package_json.to_string()).expect("write package.json");
+
+        eprintln!("Running pacquet install...");
+        pacquet.with_arg("install").assert().success();
+
+        allow_known_failure!(build_deps_ran(&workspace));
+
+        let virtual_store = workspace.join("node_modules/.pnpm");
+
+        let denied_pkg = virtual_store.join(
+            "@pnpm.e2e+pre-and-postinstall-scripts-example@1.0.0\
+             /node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example",
+        );
+        eprintln!("Checking denied package did NOT run scripts...");
+        assert!(!denied_pkg.join("generated-by-preinstall.js").exists());
+        assert!(!denied_pkg.join("generated-by-postinstall.js").exists());
+
+        let allowed_pkg = virtual_store.join(
+            "@pnpm.e2e+install-script-example@1.0.0\
+             /node_modules/@pnpm.e2e/install-script-example",
+        );
+        eprintln!("Checking allowed package DID run scripts...");
+        assert!(allowed_pkg.join("generated-by-install.js").exists());
+
+        drop((root, mock_instance));
+    }
+
+    // Ported from https://github.com/pnpm/pnpm/blob/7e91e4b35f/installing/deps-installer/test/install/lifecycleScripts.ts#L505
+    #[test]
+    fn selectively_allow_scripts_by_allow_builds() {
+        let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+            CommandTempCwd::init().add_mocked_registry();
+        let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+        eprintln!("Creating package.json with allowBuilds...");
+        let manifest_path = workspace.join("package.json");
+        let package_json = serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/pre-and-postinstall-scripts-example": "1.0.0",
+                "@pnpm.e2e/install-script-example": "1.0.0",
+            },
+            "pnpm": {
+                "allowBuilds": {
+                    "@pnpm.e2e/install-script-example": true,
+                },
+            },
+        });
+        fs::write(&manifest_path, package_json.to_string()).expect("write package.json");
+
+        eprintln!("Running pacquet install...");
+        pacquet.with_arg("install").assert().success();
+
+        allow_known_failure!(build_deps_ran(&workspace));
+
+        let virtual_store = workspace.join("node_modules/.pnpm");
+
+        let denied_pkg = virtual_store.join(
+            "@pnpm.e2e+pre-and-postinstall-scripts-example@1.0.0\
+             /node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example",
+        );
+        assert!(!denied_pkg.join("generated-by-preinstall.js").exists());
+        assert!(!denied_pkg.join("generated-by-postinstall.js").exists());
+
+        let allowed_pkg = virtual_store.join(
+            "@pnpm.e2e+install-script-example@1.0.0\
+             /node_modules/@pnpm.e2e/install-script-example",
+        );
+        assert!(allowed_pkg.join("generated-by-install.js").exists());
+
+        eprintln!("Reinstalling with explicit deny...");
+        let manifest_with_deny = serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/pre-and-postinstall-scripts-example": "1.0.0",
+                "@pnpm.e2e/install-script-example": "1.0.0",
+            },
+            "pnpm": {
+                "allowBuilds": {
+                    "@pnpm.e2e/install-script-example": true,
+                    "@pnpm.e2e/pre-and-postinstall-scripts-example": false,
+                },
+            },
+        });
+        fs::write(&manifest_path, manifest_with_deny.to_string()).expect("write package.json");
+
+        drop((root, mock_instance));
+    }
+
+    // Ported from https://github.com/pnpm/pnpm/blob/7e91e4b35f/installing/deps-installer/test/install/lifecycleScripts.ts#L543
+    #[test]
+    fn selectively_allow_scripts_by_allow_builds_exact_versions() {
+        let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+            CommandTempCwd::init().add_mocked_registry();
+        let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+        eprintln!("Creating package.json with exact-version allowBuilds...");
+        let manifest_path = workspace.join("package.json");
+        let package_json = serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/pre-and-postinstall-scripts-example": "1.0.0",
+                "@pnpm.e2e/install-script-example": "1.0.0",
+            },
+            "pnpm": {
+                "allowBuilds": {
+                    "@pnpm.e2e/install-script-example@1.0.0": true,
+                },
+            },
+        });
+        fs::write(&manifest_path, package_json.to_string()).expect("write package.json");
+
+        eprintln!("Running pacquet install...");
+        pacquet.with_arg("install").assert().success();
+
+        allow_known_failure!(build_deps_ran(&workspace));
+
+        let virtual_store = workspace.join("node_modules/.pnpm");
+
+        let denied_pkg = virtual_store.join(
+            "@pnpm.e2e+pre-and-postinstall-scripts-example@1.0.0\
+             /node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example",
+        );
+        assert!(!denied_pkg.join("generated-by-preinstall.js").exists());
+        assert!(!denied_pkg.join("generated-by-postinstall.js").exists());
+
+        let allowed_pkg = virtual_store.join(
+            "@pnpm.e2e+install-script-example@1.0.0\
+             /node_modules/@pnpm.e2e/install-script-example",
+        );
+        assert!(allowed_pkg.join("generated-by-install.js").exists());
+
+        drop((root, mock_instance));
+    }
+
+    // Ported from https://github.com/pnpm/pnpm/blob/7e91e4b35f/installing/deps-installer/test/install/lifecycleScripts.ts#L552
+    #[test]
+    fn lifecycle_scripts_run_after_linking_root_deps() {
+        let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+            CommandTempCwd::init().add_mocked_registry();
+        let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+        eprintln!("Creating package.json...");
+        let manifest_path = workspace.join("package.json");
+        let package_json = serde_json::json!({
+            "dependencies": {
+                "is-positive": "1.0.0",
+                "@pnpm.e2e/postinstall-requires-is-positive": "1.0.0",
+            },
+        });
+        fs::write(&manifest_path, package_json.to_string()).expect("write package.json");
+
+        eprintln!("Running pacquet install...");
+        pacquet.with_arg("install").assert().success();
+
+        allow_known_failure!(build_deps_ran(&workspace));
+
+        eprintln!("Deleting node_modules for frozen reinstall...");
+        let node_modules = workspace.join("node_modules");
+        fs::remove_dir_all(&node_modules).expect("remove node_modules");
+
+        eprintln!("Running pacquet install --frozen-lockfile...");
+        CommandTempCwd::init()
+            .add_mocked_registry()
+            .pacquet
+            .with_current_dir(&workspace)
+            .with_args(["install", "--frozen-lockfile"])
+            .assert()
+            .success();
+
+        drop((root, mock_instance));
+    }
+
+    // Ported from https://github.com/pnpm/pnpm/blob/7e91e4b35f/installing/deps-installer/test/install/lifecycleScripts.ts#L724
+    #[test]
+    fn rebuild_after_allow_builds_changes() {
+        let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+            CommandTempCwd::init().add_mocked_registry();
+        let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+        eprintln!("Creating package.json with partial allowBuilds...");
+        let manifest_path = workspace.join("package.json");
+        let package_json = serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/pre-and-postinstall-scripts-example": "1.0.0",
+                "@pnpm.e2e/install-script-example": "1.0.0",
+            },
+            "pnpm": {
+                "allowBuilds": {
+                    "@pnpm.e2e/install-script-example": true,
+                },
+            },
+        });
+        fs::write(&manifest_path, package_json.to_string()).expect("write package.json");
+
+        eprintln!("Running pacquet install...");
+        pacquet.with_arg("install").assert().success();
+
+        allow_known_failure!(build_deps_ran(&workspace));
+
+        let virtual_store = workspace.join("node_modules/.pnpm");
+
+        let install_pkg = virtual_store.join(
+            "@pnpm.e2e+install-script-example@1.0.0\
+             /node_modules/@pnpm.e2e/install-script-example",
+        );
+        assert!(install_pkg.join("generated-by-install.js").exists());
+
+        let scripts_pkg = virtual_store.join(
+            "@pnpm.e2e+pre-and-postinstall-scripts-example@1.0.0\
+             /node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example",
+        );
+        assert!(!scripts_pkg.join("generated-by-preinstall.js").exists());
+        assert!(!scripts_pkg.join("generated-by-postinstall.js").exists());
+
+        eprintln!("Updating allowBuilds and running frozen reinstall...");
+        let updated_manifest = serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/pre-and-postinstall-scripts-example": "1.0.0",
+                "@pnpm.e2e/install-script-example": "1.0.0",
+            },
+            "pnpm": {
+                "allowBuilds": {
+                    "@pnpm.e2e/install-script-example": true,
+                    "@pnpm.e2e/pre-and-postinstall-scripts-example": true,
+                },
+            },
+        });
+        fs::write(&manifest_path, updated_manifest.to_string()).expect("write package.json");
+
+        CommandTempCwd::init()
+            .add_mocked_registry()
+            .pacquet
+            .with_current_dir(&workspace)
+            .with_args(["install", "--frozen-lockfile"])
+            .assert()
+            .success();
+
+        allow_known_failure!(build_deps_ran(&workspace));
+
+        eprintln!("Checking all scripts ran after allowBuilds change...");
+        assert!(install_pkg.join("generated-by-install.js").exists());
+        assert!(scripts_pkg.join("generated-by-preinstall.js").exists());
+        assert!(scripts_pkg.join("generated-by-postinstall.js").exists());
+
+        drop((root, mock_instance));
+    }
+
+    // Ported from https://github.com/pnpm/pnpm/blob/7e91e4b35f/installing/deps-restorer/test/index.ts#L362
+    #[test]
+    fn headless_run_pre_postinstall_scripts() {
+        let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+            CommandTempCwd::init().add_mocked_registry();
+        let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+        eprintln!("Creating package.json...");
+        let manifest_path = workspace.join("package.json");
+        let package_json = serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/pre-and-postinstall-scripts-example": "1.0.0",
+            },
+        });
+        fs::write(&manifest_path, package_json.to_string()).expect("write package.json");
+
+        eprintln!("Running pacquet install...");
+        pacquet.with_arg("install").assert().success();
+
+        allow_known_failure!(build_deps_ran(&workspace));
+
+        let pkg_dir = workspace.join(
+            "node_modules/.pnpm/@pnpm.e2e+pre-and-postinstall-scripts-example@1.0.0\
+             /node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example",
+        );
+        assert!(pkg_dir.join("generated-by-preinstall.js").exists());
+        assert!(pkg_dir.join("generated-by-postinstall.js").exists());
+
+        drop((root, mock_instance));
+    }
+}

--- a/crates/cli/tests/lifecycle_scripts.rs
+++ b/crates/cli/tests/lifecycle_scripts.rs
@@ -33,6 +33,137 @@ fn run_install_scripts() {
     drop((root, mock_instance));
 }
 
+// Ported from https://github.com/pnpm/pnpm/blob/7e91e4b35f/installing/deps-installer/test/install/lifecycleScripts.ts#L445
+#[test]
+fn selectively_ignore_scripts_by_allow_builds() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    eprintln!("Creating package.json with allowBuilds...");
+    let manifest_path = workspace.join("package.json");
+    let package_json = serde_json::json!({
+        "dependencies": {
+            "@pnpm.e2e/pre-and-postinstall-scripts-example": "1.0.0",
+            "@pnpm.e2e/install-script-example": "1.0.0",
+        },
+        "pnpm": {
+            "allowBuilds": {
+                "@pnpm.e2e/install-script-example": true,
+            },
+        },
+    });
+    fs::write(&manifest_path, package_json.to_string()).expect("write package.json");
+
+    eprintln!("Running pacquet install...");
+    pacquet.with_arg("install").assert().success();
+
+    let virtual_store = workspace.join("node_modules/.pnpm");
+
+    let denied_pkg = virtual_store.join(
+        "@pnpm.e2e+pre-and-postinstall-scripts-example@1.0.0\
+         /node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example",
+    );
+    eprintln!("Checking denied package did NOT run scripts...");
+    assert!(!denied_pkg.join("generated-by-preinstall.js").exists());
+    assert!(!denied_pkg.join("generated-by-postinstall.js").exists());
+
+    let allowed_pkg = virtual_store.join(
+        "@pnpm.e2e+install-script-example@1.0.0\
+         /node_modules/@pnpm.e2e/install-script-example",
+    );
+    eprintln!("Checking allowed package DID run scripts...");
+    assert!(allowed_pkg.join("generated-by-install.js").exists());
+
+    drop((root, mock_instance));
+}
+
+// Ported from https://github.com/pnpm/pnpm/blob/7e91e4b35f/installing/deps-installer/test/install/lifecycleScripts.ts#L505
+#[test]
+fn selectively_allow_scripts_by_allow_builds() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    eprintln!("Creating package.json with allowBuilds...");
+    let manifest_path = workspace.join("package.json");
+    let package_json = serde_json::json!({
+        "dependencies": {
+            "@pnpm.e2e/pre-and-postinstall-scripts-example": "1.0.0",
+            "@pnpm.e2e/install-script-example": "1.0.0",
+        },
+        "pnpm": {
+            "allowBuilds": {
+                "@pnpm.e2e/install-script-example": true,
+            },
+        },
+    });
+    fs::write(&manifest_path, package_json.to_string()).expect("write package.json");
+
+    eprintln!("Running pacquet install...");
+    pacquet.with_arg("install").assert().success();
+
+    let virtual_store = workspace.join("node_modules/.pnpm");
+
+    let denied_pkg = virtual_store.join(
+        "@pnpm.e2e+pre-and-postinstall-scripts-example@1.0.0\
+         /node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example",
+    );
+    assert!(!denied_pkg.join("generated-by-preinstall.js").exists());
+    assert!(!denied_pkg.join("generated-by-postinstall.js").exists());
+
+    let allowed_pkg = virtual_store.join(
+        "@pnpm.e2e+install-script-example@1.0.0\
+         /node_modules/@pnpm.e2e/install-script-example",
+    );
+    assert!(allowed_pkg.join("generated-by-install.js").exists());
+
+    drop((root, mock_instance));
+}
+
+// Ported from https://github.com/pnpm/pnpm/blob/7e91e4b35f/installing/deps-installer/test/install/lifecycleScripts.ts#L543
+#[test]
+fn selectively_allow_scripts_by_allow_builds_exact_versions() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    eprintln!("Creating package.json with exact-version allowBuilds...");
+    let manifest_path = workspace.join("package.json");
+    let package_json = serde_json::json!({
+        "dependencies": {
+            "@pnpm.e2e/pre-and-postinstall-scripts-example": "1.0.0",
+            "@pnpm.e2e/install-script-example": "1.0.0",
+        },
+        "pnpm": {
+            "allowBuilds": {
+                "@pnpm.e2e/install-script-example@1.0.0": true,
+            },
+        },
+    });
+    fs::write(&manifest_path, package_json.to_string()).expect("write package.json");
+
+    eprintln!("Running pacquet install...");
+    pacquet.with_arg("install").assert().success();
+
+    let virtual_store = workspace.join("node_modules/.pnpm");
+
+    let denied_pkg = virtual_store.join(
+        "@pnpm.e2e+pre-and-postinstall-scripts-example@1.0.0\
+         /node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example",
+    );
+    assert!(!denied_pkg.join("generated-by-preinstall.js").exists());
+    assert!(!denied_pkg.join("generated-by-postinstall.js").exists());
+
+    let allowed_pkg = virtual_store.join(
+        "@pnpm.e2e+install-script-example@1.0.0\
+         /node_modules/@pnpm.e2e/install-script-example",
+    );
+    assert!(allowed_pkg.join("generated-by-install.js").exists());
+
+    drop((root, mock_instance));
+}
+
 mod known_failures {
     use assert_cmd::prelude::*;
     use command_extra::CommandExtra;
@@ -239,158 +370,6 @@ mod known_failures {
             !scripts_pkg_dir.join("generated-by-preinstall.js").exists(),
             "scripts should not have run with ignoreScripts"
         );
-
-        drop((root, mock_instance));
-    }
-
-    // Ported from https://github.com/pnpm/pnpm/blob/7e91e4b35f/installing/deps-installer/test/install/lifecycleScripts.ts#L445
-    #[test]
-    fn selectively_ignore_scripts_by_allow_builds() {
-        let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
-            CommandTempCwd::init().add_mocked_registry();
-        let AddMockedRegistry { mock_instance, .. } = npmrc_info;
-
-        eprintln!("Creating package.json with allowBuilds...");
-        let manifest_path = workspace.join("package.json");
-        let package_json = serde_json::json!({
-            "dependencies": {
-                "@pnpm.e2e/pre-and-postinstall-scripts-example": "1.0.0",
-                "@pnpm.e2e/install-script-example": "1.0.0",
-            },
-            "pnpm": {
-                "allowBuilds": {
-                    "@pnpm.e2e/install-script-example": true,
-                },
-            },
-        });
-        fs::write(&manifest_path, package_json.to_string()).expect("write package.json");
-
-        eprintln!("Running pacquet install...");
-        pacquet.with_arg("install").assert().success();
-
-        allow_known_failure!(build_deps_ran(&workspace));
-
-        let virtual_store = workspace.join("node_modules/.pnpm");
-
-        let denied_pkg = virtual_store.join(
-            "@pnpm.e2e+pre-and-postinstall-scripts-example@1.0.0\
-             /node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example",
-        );
-        eprintln!("Checking denied package did NOT run scripts...");
-        assert!(!denied_pkg.join("generated-by-preinstall.js").exists());
-        assert!(!denied_pkg.join("generated-by-postinstall.js").exists());
-
-        let allowed_pkg = virtual_store.join(
-            "@pnpm.e2e+install-script-example@1.0.0\
-             /node_modules/@pnpm.e2e/install-script-example",
-        );
-        eprintln!("Checking allowed package DID run scripts...");
-        assert!(allowed_pkg.join("generated-by-install.js").exists());
-
-        drop((root, mock_instance));
-    }
-
-    // Ported from https://github.com/pnpm/pnpm/blob/7e91e4b35f/installing/deps-installer/test/install/lifecycleScripts.ts#L505
-    #[test]
-    fn selectively_allow_scripts_by_allow_builds() {
-        let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
-            CommandTempCwd::init().add_mocked_registry();
-        let AddMockedRegistry { mock_instance, .. } = npmrc_info;
-
-        eprintln!("Creating package.json with allowBuilds...");
-        let manifest_path = workspace.join("package.json");
-        let package_json = serde_json::json!({
-            "dependencies": {
-                "@pnpm.e2e/pre-and-postinstall-scripts-example": "1.0.0",
-                "@pnpm.e2e/install-script-example": "1.0.0",
-            },
-            "pnpm": {
-                "allowBuilds": {
-                    "@pnpm.e2e/install-script-example": true,
-                },
-            },
-        });
-        fs::write(&manifest_path, package_json.to_string()).expect("write package.json");
-
-        eprintln!("Running pacquet install...");
-        pacquet.with_arg("install").assert().success();
-
-        allow_known_failure!(build_deps_ran(&workspace));
-
-        let virtual_store = workspace.join("node_modules/.pnpm");
-
-        let denied_pkg = virtual_store.join(
-            "@pnpm.e2e+pre-and-postinstall-scripts-example@1.0.0\
-             /node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example",
-        );
-        assert!(!denied_pkg.join("generated-by-preinstall.js").exists());
-        assert!(!denied_pkg.join("generated-by-postinstall.js").exists());
-
-        let allowed_pkg = virtual_store.join(
-            "@pnpm.e2e+install-script-example@1.0.0\
-             /node_modules/@pnpm.e2e/install-script-example",
-        );
-        assert!(allowed_pkg.join("generated-by-install.js").exists());
-
-        eprintln!("Reinstalling with explicit deny...");
-        let manifest_with_deny = serde_json::json!({
-            "dependencies": {
-                "@pnpm.e2e/pre-and-postinstall-scripts-example": "1.0.0",
-                "@pnpm.e2e/install-script-example": "1.0.0",
-            },
-            "pnpm": {
-                "allowBuilds": {
-                    "@pnpm.e2e/install-script-example": true,
-                    "@pnpm.e2e/pre-and-postinstall-scripts-example": false,
-                },
-            },
-        });
-        fs::write(&manifest_path, manifest_with_deny.to_string()).expect("write package.json");
-
-        drop((root, mock_instance));
-    }
-
-    // Ported from https://github.com/pnpm/pnpm/blob/7e91e4b35f/installing/deps-installer/test/install/lifecycleScripts.ts#L543
-    #[test]
-    fn selectively_allow_scripts_by_allow_builds_exact_versions() {
-        let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
-            CommandTempCwd::init().add_mocked_registry();
-        let AddMockedRegistry { mock_instance, .. } = npmrc_info;
-
-        eprintln!("Creating package.json with exact-version allowBuilds...");
-        let manifest_path = workspace.join("package.json");
-        let package_json = serde_json::json!({
-            "dependencies": {
-                "@pnpm.e2e/pre-and-postinstall-scripts-example": "1.0.0",
-                "@pnpm.e2e/install-script-example": "1.0.0",
-            },
-            "pnpm": {
-                "allowBuilds": {
-                    "@pnpm.e2e/install-script-example@1.0.0": true,
-                },
-            },
-        });
-        fs::write(&manifest_path, package_json.to_string()).expect("write package.json");
-
-        eprintln!("Running pacquet install...");
-        pacquet.with_arg("install").assert().success();
-
-        allow_known_failure!(build_deps_ran(&workspace));
-
-        let virtual_store = workspace.join("node_modules/.pnpm");
-
-        let denied_pkg = virtual_store.join(
-            "@pnpm.e2e+pre-and-postinstall-scripts-example@1.0.0\
-             /node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example",
-        );
-        assert!(!denied_pkg.join("generated-by-preinstall.js").exists());
-        assert!(!denied_pkg.join("generated-by-postinstall.js").exists());
-
-        let allowed_pkg = virtual_store.join(
-            "@pnpm.e2e+install-script-example@1.0.0\
-             /node_modules/@pnpm.e2e/install-script-example",
-        );
-        assert!(allowed_pkg.join("generated-by-install.js").exists());
 
         drop((root, mock_instance));
     }

--- a/crates/cli/tests/lifecycle_scripts.rs
+++ b/crates/cli/tests/lifecycle_scripts.rs
@@ -16,6 +16,11 @@ fn run_install_scripts() {
         "dependencies": {
             "@pnpm.e2e/install-script-example": "1.0.0",
         },
+        "pnpm": {
+            "allowBuilds": {
+                "@pnpm.e2e/install-script-example": true,
+            },
+        },
     });
     fs::write(&manifest_path, package_json.to_string()).expect("write package.json");
 

--- a/crates/cli/tests/lifecycle_scripts.rs
+++ b/crates/cli/tests/lifecycle_scripts.rs
@@ -1,174 +1,3 @@
-use assert_cmd::prelude::*;
-use command_extra::CommandExtra;
-use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
-use std::fs;
-
-// Ported from https://github.com/pnpm/pnpm/blob/7e91e4b35f/installing/deps-installer/test/install/lifecycleScripts.ts#L121
-#[test]
-fn run_install_scripts() {
-    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
-        CommandTempCwd::init().add_mocked_registry();
-    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
-
-    eprintln!("Creating package.json...");
-    let manifest_path = workspace.join("package.json");
-    let package_json = serde_json::json!({
-        "dependencies": {
-            "@pnpm.e2e/install-script-example": "1.0.0",
-        },
-        "pnpm": {
-            "allowBuilds": {
-                "@pnpm.e2e/install-script-example": true,
-            },
-        },
-    });
-    fs::write(&manifest_path, package_json.to_string()).expect("write package.json");
-
-    eprintln!("Running pacquet install...");
-    pacquet.with_arg("install").assert().success();
-
-    let pkg_dir = workspace.join(
-        "node_modules/.pnpm/@pnpm.e2e+install-script-example@1.0.0\
-         /node_modules/@pnpm.e2e/install-script-example",
-    );
-
-    eprintln!("Checking generated-by-install.js exists...");
-    assert!(pkg_dir.join("generated-by-install.js").exists());
-
-    drop((root, mock_instance));
-}
-
-// Ported from https://github.com/pnpm/pnpm/blob/7e91e4b35f/installing/deps-installer/test/install/lifecycleScripts.ts#L445
-#[test]
-fn selectively_ignore_scripts_by_allow_builds() {
-    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
-        CommandTempCwd::init().add_mocked_registry();
-    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
-
-    eprintln!("Creating package.json with allowBuilds...");
-    let manifest_path = workspace.join("package.json");
-    let package_json = serde_json::json!({
-        "dependencies": {
-            "@pnpm.e2e/pre-and-postinstall-scripts-example": "1.0.0",
-            "@pnpm.e2e/install-script-example": "1.0.0",
-        },
-        "pnpm": {
-            "allowBuilds": {
-                "@pnpm.e2e/install-script-example": true,
-            },
-        },
-    });
-    fs::write(&manifest_path, package_json.to_string()).expect("write package.json");
-
-    eprintln!("Running pacquet install...");
-    pacquet.with_arg("install").assert().success();
-
-    let virtual_store = workspace.join("node_modules/.pnpm");
-
-    let denied_pkg = virtual_store.join(
-        "@pnpm.e2e+pre-and-postinstall-scripts-example@1.0.0\
-         /node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example",
-    );
-    eprintln!("Checking denied package did NOT run scripts...");
-    assert!(!denied_pkg.join("generated-by-preinstall.js").exists());
-    assert!(!denied_pkg.join("generated-by-postinstall.js").exists());
-
-    let allowed_pkg = virtual_store.join(
-        "@pnpm.e2e+install-script-example@1.0.0\
-         /node_modules/@pnpm.e2e/install-script-example",
-    );
-    eprintln!("Checking allowed package DID run scripts...");
-    assert!(allowed_pkg.join("generated-by-install.js").exists());
-
-    drop((root, mock_instance));
-}
-
-// Ported from https://github.com/pnpm/pnpm/blob/7e91e4b35f/installing/deps-installer/test/install/lifecycleScripts.ts#L505
-#[test]
-fn selectively_allow_scripts_by_allow_builds() {
-    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
-        CommandTempCwd::init().add_mocked_registry();
-    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
-
-    eprintln!("Creating package.json with allowBuilds...");
-    let manifest_path = workspace.join("package.json");
-    let package_json = serde_json::json!({
-        "dependencies": {
-            "@pnpm.e2e/pre-and-postinstall-scripts-example": "1.0.0",
-            "@pnpm.e2e/install-script-example": "1.0.0",
-        },
-        "pnpm": {
-            "allowBuilds": {
-                "@pnpm.e2e/install-script-example": true,
-            },
-        },
-    });
-    fs::write(&manifest_path, package_json.to_string()).expect("write package.json");
-
-    eprintln!("Running pacquet install...");
-    pacquet.with_arg("install").assert().success();
-
-    let virtual_store = workspace.join("node_modules/.pnpm");
-
-    let denied_pkg = virtual_store.join(
-        "@pnpm.e2e+pre-and-postinstall-scripts-example@1.0.0\
-         /node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example",
-    );
-    assert!(!denied_pkg.join("generated-by-preinstall.js").exists());
-    assert!(!denied_pkg.join("generated-by-postinstall.js").exists());
-
-    let allowed_pkg = virtual_store.join(
-        "@pnpm.e2e+install-script-example@1.0.0\
-         /node_modules/@pnpm.e2e/install-script-example",
-    );
-    assert!(allowed_pkg.join("generated-by-install.js").exists());
-
-    drop((root, mock_instance));
-}
-
-// Ported from https://github.com/pnpm/pnpm/blob/7e91e4b35f/installing/deps-installer/test/install/lifecycleScripts.ts#L543
-#[test]
-fn selectively_allow_scripts_by_allow_builds_exact_versions() {
-    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
-        CommandTempCwd::init().add_mocked_registry();
-    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
-
-    eprintln!("Creating package.json with exact-version allowBuilds...");
-    let manifest_path = workspace.join("package.json");
-    let package_json = serde_json::json!({
-        "dependencies": {
-            "@pnpm.e2e/pre-and-postinstall-scripts-example": "1.0.0",
-            "@pnpm.e2e/install-script-example": "1.0.0",
-        },
-        "pnpm": {
-            "allowBuilds": {
-                "@pnpm.e2e/install-script-example@1.0.0": true,
-            },
-        },
-    });
-    fs::write(&manifest_path, package_json.to_string()).expect("write package.json");
-
-    eprintln!("Running pacquet install...");
-    pacquet.with_arg("install").assert().success();
-
-    let virtual_store = workspace.join("node_modules/.pnpm");
-
-    let denied_pkg = virtual_store.join(
-        "@pnpm.e2e+pre-and-postinstall-scripts-example@1.0.0\
-         /node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example",
-    );
-    assert!(!denied_pkg.join("generated-by-preinstall.js").exists());
-    assert!(!denied_pkg.join("generated-by-postinstall.js").exists());
-
-    let allowed_pkg = virtual_store.join(
-        "@pnpm.e2e+install-script-example@1.0.0\
-         /node_modules/@pnpm.e2e/install-script-example",
-    );
-    assert!(allowed_pkg.join("generated-by-install.js").exists());
-
-    drop((root, mock_instance));
-}
-
 mod known_failures {
     use assert_cmd::prelude::*;
     use command_extra::CommandExtra;
@@ -182,7 +11,10 @@ mod known_failures {
 
     fn build_deps_ran(_workspace: &Path) -> KnownResult<()> {
         Err(KnownFailure::new(
-            "bin linking (#330) is not implemented; lifecycle scripts that invoke dependency bins fail with exit 127",
+            "lifecycle scripts only run in the frozen-lockfile path; \
+             the non-frozen path does not write a lockfile so these \
+             tests cannot exercise --frozen-lockfile yet. \
+             Additionally, bin linking (#330) is not implemented.",
         ))
     }
 
@@ -223,6 +55,43 @@ mod known_failures {
 
         eprintln!("Checking generated-by-postinstall.js exists...");
         assert!(pkg_dir.join("generated-by-postinstall.js").exists());
+
+        drop((root, mock_instance));
+    }
+
+    // Ported from https://github.com/pnpm/pnpm/blob/7e91e4b35f/installing/deps-installer/test/install/lifecycleScripts.ts#L121
+    #[test]
+    fn run_install_scripts() {
+        let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+            CommandTempCwd::init().add_mocked_registry();
+        let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+        eprintln!("Creating package.json...");
+        let manifest_path = workspace.join("package.json");
+        let package_json = serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/install-script-example": "1.0.0",
+            },
+            "pnpm": {
+                "allowBuilds": {
+                    "@pnpm.e2e/install-script-example": true,
+                },
+            },
+        });
+        fs::write(&manifest_path, package_json.to_string()).expect("write package.json");
+
+        eprintln!("Running pacquet install...");
+        pacquet.with_arg("install").assert().success();
+
+        allow_known_failure!(build_deps_ran(&workspace));
+
+        let pkg_dir = workspace.join(
+            "node_modules/.pnpm/@pnpm.e2e+install-script-example@1.0.0\
+             /node_modules/@pnpm.e2e/install-script-example",
+        );
+
+        eprintln!("Checking generated-by-install.js exists...");
+        assert!(pkg_dir.join("generated-by-install.js").exists());
 
         drop((root, mock_instance));
     }
@@ -375,6 +244,143 @@ mod known_failures {
             !scripts_pkg_dir.join("generated-by-preinstall.js").exists(),
             "scripts should not have run with ignoreScripts"
         );
+
+        drop((root, mock_instance));
+    }
+
+    // Ported from https://github.com/pnpm/pnpm/blob/7e91e4b35f/installing/deps-installer/test/install/lifecycleScripts.ts#L445
+    #[test]
+    fn selectively_ignore_scripts_by_allow_builds() {
+        let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+            CommandTempCwd::init().add_mocked_registry();
+        let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+        eprintln!("Creating package.json with allowBuilds...");
+        let manifest_path = workspace.join("package.json");
+        let package_json = serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/pre-and-postinstall-scripts-example": "1.0.0",
+                "@pnpm.e2e/install-script-example": "1.0.0",
+            },
+            "pnpm": {
+                "allowBuilds": {
+                    "@pnpm.e2e/install-script-example": true,
+                },
+            },
+        });
+        fs::write(&manifest_path, package_json.to_string()).expect("write package.json");
+
+        eprintln!("Running pacquet install...");
+        pacquet.with_arg("install").assert().success();
+
+        allow_known_failure!(build_deps_ran(&workspace));
+
+        let virtual_store = workspace.join("node_modules/.pnpm");
+
+        let denied_pkg = virtual_store.join(
+            "@pnpm.e2e+pre-and-postinstall-scripts-example@1.0.0\
+             /node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example",
+        );
+        eprintln!("Checking denied package did NOT run scripts...");
+        assert!(!denied_pkg.join("generated-by-preinstall.js").exists());
+        assert!(!denied_pkg.join("generated-by-postinstall.js").exists());
+
+        let allowed_pkg = virtual_store.join(
+            "@pnpm.e2e+install-script-example@1.0.0\
+             /node_modules/@pnpm.e2e/install-script-example",
+        );
+        eprintln!("Checking allowed package DID run scripts...");
+        assert!(allowed_pkg.join("generated-by-install.js").exists());
+
+        drop((root, mock_instance));
+    }
+
+    // Ported from https://github.com/pnpm/pnpm/blob/7e91e4b35f/installing/deps-installer/test/install/lifecycleScripts.ts#L505
+    #[test]
+    fn selectively_allow_scripts_by_allow_builds() {
+        let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+            CommandTempCwd::init().add_mocked_registry();
+        let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+        eprintln!("Creating package.json with allowBuilds...");
+        let manifest_path = workspace.join("package.json");
+        let package_json = serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/pre-and-postinstall-scripts-example": "1.0.0",
+                "@pnpm.e2e/install-script-example": "1.0.0",
+            },
+            "pnpm": {
+                "allowBuilds": {
+                    "@pnpm.e2e/install-script-example": true,
+                },
+            },
+        });
+        fs::write(&manifest_path, package_json.to_string()).expect("write package.json");
+
+        eprintln!("Running pacquet install...");
+        pacquet.with_arg("install").assert().success();
+
+        allow_known_failure!(build_deps_ran(&workspace));
+
+        let virtual_store = workspace.join("node_modules/.pnpm");
+
+        let denied_pkg = virtual_store.join(
+            "@pnpm.e2e+pre-and-postinstall-scripts-example@1.0.0\
+             /node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example",
+        );
+        assert!(!denied_pkg.join("generated-by-preinstall.js").exists());
+        assert!(!denied_pkg.join("generated-by-postinstall.js").exists());
+
+        let allowed_pkg = virtual_store.join(
+            "@pnpm.e2e+install-script-example@1.0.0\
+             /node_modules/@pnpm.e2e/install-script-example",
+        );
+        assert!(allowed_pkg.join("generated-by-install.js").exists());
+
+        drop((root, mock_instance));
+    }
+
+    // Ported from https://github.com/pnpm/pnpm/blob/7e91e4b35f/installing/deps-installer/test/install/lifecycleScripts.ts#L543
+    #[test]
+    fn selectively_allow_scripts_by_allow_builds_exact_versions() {
+        let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+            CommandTempCwd::init().add_mocked_registry();
+        let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+        eprintln!("Creating package.json with exact-version allowBuilds...");
+        let manifest_path = workspace.join("package.json");
+        let package_json = serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/pre-and-postinstall-scripts-example": "1.0.0",
+                "@pnpm.e2e/install-script-example": "1.0.0",
+            },
+            "pnpm": {
+                "allowBuilds": {
+                    "@pnpm.e2e/install-script-example@1.0.0": true,
+                },
+            },
+        });
+        fs::write(&manifest_path, package_json.to_string()).expect("write package.json");
+
+        eprintln!("Running pacquet install...");
+        pacquet.with_arg("install").assert().success();
+
+        allow_known_failure!(build_deps_ran(&workspace));
+
+        let virtual_store = workspace.join("node_modules/.pnpm");
+
+        let denied_pkg = virtual_store.join(
+            "@pnpm.e2e+pre-and-postinstall-scripts-example@1.0.0\
+             /node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example",
+        );
+        assert!(!denied_pkg.join("generated-by-preinstall.js").exists());
+        assert!(!denied_pkg.join("generated-by-postinstall.js").exists());
+
+        let allowed_pkg = virtual_store.join(
+            "@pnpm.e2e+install-script-example@1.0.0\
+             /node_modules/@pnpm.e2e/install-script-example",
+        );
+        assert!(allowed_pkg.join("generated-by-install.js").exists());
 
         drop((root, mock_instance));
     }

--- a/crates/executor/Cargo.toml
+++ b/crates/executor/Cargo.toml
@@ -11,7 +11,8 @@ license.workspace     = true
 repository.workspace  = true
 
 [dependencies]
-pacquet-reporter = { workspace = true }
+pacquet-package-manifest = { workspace = true }
+pacquet-reporter         = { workspace = true }
 
 derive_more = { workspace = true }
 miette      = { workspace = true }

--- a/crates/executor/Cargo.toml
+++ b/crates/executor/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace     = true
 repository.workspace  = true
 
 [dependencies]
-derive_more  = { workspace = true }
-miette       = { workspace = true }
-serde_json   = { workspace = true }
-tracing      = { workspace = true }
+derive_more = { workspace = true }
+miette      = { workspace = true }
+serde_json  = { workspace = true }
+tracing     = { workspace = true }

--- a/crates/executor/Cargo.toml
+++ b/crates/executor/Cargo.toml
@@ -11,7 +11,13 @@ license.workspace     = true
 repository.workspace  = true
 
 [dependencies]
+pacquet-reporter = { workspace = true }
+
 derive_more = { workspace = true }
 miette      = { workspace = true }
 serde_json  = { workspace = true }
 tracing     = { workspace = true }
+
+[dev-dependencies]
+pretty_assertions = { workspace = true }
+tempfile          = { workspace = true }

--- a/crates/executor/Cargo.toml
+++ b/crates/executor/Cargo.toml
@@ -11,5 +11,7 @@ license.workspace     = true
 repository.workspace  = true
 
 [dependencies]
-derive_more = { workspace = true }
-miette      = { workspace = true }
+derive_more  = { workspace = true }
+miette       = { workspace = true }
+serde_json   = { workspace = true }
+tracing      = { workspace = true }

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -1,3 +1,7 @@
+mod lifecycle;
+
+pub use lifecycle::{LifecycleScriptError, RunPostinstallHooks, run_postinstall_hooks};
+
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use std::process::Command;

--- a/crates/executor/src/lifecycle.rs
+++ b/crates/executor/src/lifecycle.rs
@@ -1,0 +1,204 @@
+use derive_more::{Display, Error};
+use miette::Diagnostic;
+use std::{
+    collections::HashMap,
+    env,
+    path::{Path, PathBuf},
+    process::{Command, ExitStatus, Stdio},
+};
+
+/// Error from running lifecycle scripts.
+///
+/// Ports pnpm's error shape from `exec/lifecycle/src/runLifecycleHook.ts`.
+#[derive(Debug, Display, Error, Diagnostic)]
+#[non_exhaustive]
+pub enum LifecycleScriptError {
+    #[display("Failed to read package.json at {path}: {source}")]
+    #[diagnostic(code(pacquet_executor::read_manifest))]
+    ReadManifest {
+        path: String,
+        #[error(source)]
+        source: std::io::Error,
+    },
+
+    #[display("Failed to parse package.json at {path}: {source}")]
+    #[diagnostic(code(pacquet_executor::parse_manifest))]
+    ParseManifest {
+        path: String,
+        #[error(source)]
+        source: serde_json::Error,
+    },
+
+    #[display("{dep_path} {stage}: `{script}` exited with {status}")]
+    #[diagnostic(code(pacquet_executor::lifecycle_script_failed))]
+    ScriptFailed { dep_path: String, stage: String, script: String, status: ExitStatus },
+
+    #[display("Failed to spawn lifecycle script for {dep_path} {stage}: {source}")]
+    #[diagnostic(code(pacquet_executor::spawn_lifecycle))]
+    Spawn {
+        dep_path: String,
+        stage: String,
+        #[error(source)]
+        source: std::io::Error,
+    },
+
+    #[display("Failed waiting for lifecycle script for {dep_path} {stage}: {source}")]
+    #[diagnostic(code(pacquet_executor::wait_lifecycle))]
+    Wait {
+        dep_path: String,
+        stage: String,
+        #[error(source)]
+        source: std::io::Error,
+    },
+}
+
+/// Options for [`run_postinstall_hooks`].
+///
+/// Ports the subset of `RunLifecycleHookOptions` from
+/// `exec/lifecycle/src/runLifecycleHook.ts` that the headless
+/// installer needs.
+pub struct RunPostinstallHooks<'a> {
+    pub dep_path: &'a str,
+    pub pkg_root: &'a Path,
+    pub root_modules_dir: &'a Path,
+    pub init_cwd: &'a Path,
+    pub extra_bin_paths: &'a [PathBuf],
+    pub extra_env: &'a HashMap<String, String>,
+    pub optional: bool,
+}
+
+/// Run the preinstall, install, and postinstall lifecycle scripts for
+/// a single dependency.
+///
+/// Ports `runPostinstallHooks` from
+/// `https://github.com/pnpm/pnpm/blob/7e91e4b35f/exec/lifecycle/src/index.ts`.
+///
+/// Returns `true` if any script was present and executed.
+pub fn run_postinstall_hooks(opts: RunPostinstallHooks<'_>) -> Result<bool, LifecycleScriptError> {
+    let manifest_path = opts.pkg_root.join("package.json");
+    let manifest_text = match std::fs::read_to_string(&manifest_path) {
+        Ok(text) => text,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(err) => {
+            return Err(LifecycleScriptError::ReadManifest {
+                path: manifest_path.display().to_string(),
+                source: err,
+            });
+        }
+    };
+    let manifest: serde_json::Value = serde_json::from_str(&manifest_text).map_err(|e| {
+        LifecycleScriptError::ParseManifest { path: manifest_path.display().to_string(), source: e }
+    })?;
+
+    let scripts = manifest.get("scripts").and_then(|v| v.as_object());
+    let get_script =
+        |name: &str| -> Option<&str> { scripts.and_then(|s| s.get(name)).and_then(|v| v.as_str()) };
+
+    let has_preinstall = get_script("preinstall").is_some();
+    let has_postinstall = get_script("postinstall").is_some();
+
+    let mut ran_any = false;
+
+    if let Some(script) = get_script("preinstall") {
+        run_lifecycle_hook("preinstall", script, &opts)?;
+        ran_any = true;
+    }
+
+    let install_script = get_script("install").map(String::from).or_else(|| {
+        if get_script("preinstall").is_none() && opts.pkg_root.join("binding.gyp").exists() {
+            Some("node-gyp rebuild".to_string())
+        } else {
+            None
+        }
+    });
+    if let Some(script) = &install_script
+        && script != "npx only-allow pnpm"
+    {
+        run_lifecycle_hook("install", script, &opts)?;
+        ran_any = true;
+    }
+
+    if let Some(script) = get_script("postinstall") {
+        run_lifecycle_hook("postinstall", script, &opts)?;
+        ran_any = true;
+    }
+
+    Ok(has_preinstall || install_script.is_some() || has_postinstall || ran_any)
+}
+
+/// Run a single lifecycle hook.
+///
+/// Ports the core of `runLifecycleHook` from
+/// `https://github.com/pnpm/pnpm/blob/7e91e4b35f/exec/lifecycle/src/runLifecycleHook.ts`.
+fn run_lifecycle_hook(
+    stage: &str,
+    script: &str,
+    opts: &RunPostinstallHooks<'_>,
+) -> Result<(), LifecycleScriptError> {
+    tracing::debug!(
+        target: "pacquet::lifecycle",
+        dep_path = opts.dep_path,
+        stage,
+        script,
+        pkg_root = %opts.pkg_root.display(),
+    );
+
+    let path_env = build_path_env(opts.pkg_root, opts.extra_bin_paths);
+
+    let mut cmd = Command::new("sh");
+    cmd.arg("-c")
+        .arg(script)
+        .current_dir(opts.pkg_root)
+        .env("PATH", &path_env)
+        .env("INIT_CWD", opts.init_cwd)
+        .env("PNPM_SCRIPT_SRC_DIR", opts.pkg_root)
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+
+    for (key, value) in opts.extra_env {
+        cmd.env(key, value);
+    }
+
+    let status = cmd
+        .spawn()
+        .map_err(|e| LifecycleScriptError::Spawn {
+            dep_path: opts.dep_path.to_string(),
+            stage: stage.to_string(),
+            source: e,
+        })?
+        .wait()
+        .map_err(|e| LifecycleScriptError::Wait {
+            dep_path: opts.dep_path.to_string(),
+            stage: stage.to_string(),
+            source: e,
+        })?;
+
+    if !status.success() {
+        return Err(LifecycleScriptError::ScriptFailed {
+            dep_path: opts.dep_path.to_string(),
+            stage: stage.to_string(),
+            script: script.to_string(),
+            status,
+        });
+    }
+
+    Ok(())
+}
+
+/// Build the `PATH` environment variable for lifecycle scripts.
+///
+/// Prepends the package's own `node_modules/.bin`, any extra bin paths
+/// (from the caller), and the system PATH.
+fn build_path_env(pkg_root: &Path, extra_bin_paths: &[PathBuf]) -> String {
+    let own_bin = pkg_root.join("node_modules/.bin");
+    let system_path = env::var_os("PATH").unwrap_or_default();
+
+    let mut paths: Vec<PathBuf> = Vec::with_capacity(2 + extra_bin_paths.len());
+    paths.push(own_bin);
+    paths.extend_from_slice(extra_bin_paths);
+    for path in env::split_paths(&system_path) {
+        paths.push(path);
+    }
+
+    env::join_paths(paths).expect("join PATH entries").into_string().expect("PATH is valid UTF-8")
+}

--- a/crates/executor/src/lifecycle.rs
+++ b/crates/executor/src/lifecycle.rs
@@ -1,5 +1,6 @@
 use derive_more::{Display, Error};
 use miette::Diagnostic;
+use pacquet_package_manifest::{PackageManifestError, safe_read_package_json_from_dir};
 use pacquet_reporter::{
     LifecycleLog, LifecycleMessage, LifecycleStdio, LogEvent, LogLevel, Reporter,
 };
@@ -24,7 +25,7 @@ pub enum LifecycleScriptError {
     ReadManifest {
         path: String,
         #[error(source)]
-        source: std::io::Error,
+        source: PackageManifestError,
     },
 
     #[display("{dep_path} {stage}: `{script}` exited with {status}")]
@@ -74,20 +75,15 @@ pub struct RunPostinstallHooks<'a> {
 pub fn run_postinstall_hooks<R: Reporter>(
     opts: RunPostinstallHooks<'_>,
 ) -> Result<bool, LifecycleScriptError> {
-    let manifest_path = opts.pkg_root.join("package.json");
-    let manifest_text = match std::fs::read_to_string(&manifest_path) {
-        Ok(text) => text,
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(false),
-        Err(err) => {
+    let manifest = match safe_read_package_json_from_dir(opts.pkg_root) {
+        Ok(Some(value)) => value,
+        Ok(None) => return Ok(false),
+        Err(source) => {
             return Err(LifecycleScriptError::ReadManifest {
-                path: manifest_path.display().to_string(),
-                source: err,
+                path: opts.pkg_root.join("package.json").display().to_string(),
+                source,
             });
         }
-    };
-    let manifest: serde_json::Value = match serde_json::from_str(&manifest_text) {
-        Ok(v) => v,
-        Err(_) => return Ok(false),
     };
 
     let scripts = manifest.get("scripts").and_then(|v| v.as_object());

--- a/crates/executor/src/lifecycle.rs
+++ b/crates/executor/src/lifecycle.rs
@@ -1,11 +1,16 @@
 use derive_more::{Display, Error};
 use miette::Diagnostic;
+use pacquet_reporter::{
+    LifecycleLog, LifecycleMessage, LifecycleStdio, LogEvent, LogLevel, Reporter,
+};
 use std::{
     collections::HashMap,
     env,
     ffi::OsString,
+    io::{BufRead, BufReader, Read},
     path::{Path, PathBuf},
     process::{Command, ExitStatus, Stdio},
+    thread,
 };
 
 /// Error from running lifecycle scripts.
@@ -71,10 +76,12 @@ pub struct RunPostinstallHooks<'a> {
 /// a single dependency.
 ///
 /// Ports `runPostinstallHooks` from
-/// `https://github.com/pnpm/pnpm/blob/7e91e4b35f/exec/lifecycle/src/index.ts`.
+/// `https://github.com/pnpm/pnpm/blob/80037699fb/exec/lifecycle/src/index.ts`.
 ///
 /// Returns `true` if any script was present and executed.
-pub fn run_postinstall_hooks(opts: RunPostinstallHooks<'_>) -> Result<bool, LifecycleScriptError> {
+pub fn run_postinstall_hooks<R: Reporter>(
+    opts: RunPostinstallHooks<'_>,
+) -> Result<bool, LifecycleScriptError> {
     let manifest_path = opts.pkg_root.join("package.json");
     let manifest_text = match std::fs::read_to_string(&manifest_path) {
         Ok(text) => text,
@@ -97,7 +104,7 @@ pub fn run_postinstall_hooks(opts: RunPostinstallHooks<'_>) -> Result<bool, Life
     let mut ran_any = false;
 
     if let Some(script) = get_script("preinstall") {
-        run_lifecycle_hook("preinstall", script, &opts)?;
+        run_lifecycle_hook::<R>("preinstall", script, &opts)?;
         ran_any = true;
     }
 
@@ -111,23 +118,27 @@ pub fn run_postinstall_hooks(opts: RunPostinstallHooks<'_>) -> Result<bool, Life
     if let Some(script) = &install_script
         && script != "npx only-allow pnpm"
     {
-        run_lifecycle_hook("install", script, &opts)?;
+        run_lifecycle_hook::<R>("install", script, &opts)?;
         ran_any = true;
     }
 
     if let Some(script) = get_script("postinstall") {
-        run_lifecycle_hook("postinstall", script, &opts)?;
+        run_lifecycle_hook::<R>("postinstall", script, &opts)?;
         ran_any = true;
     }
 
     Ok(ran_any)
 }
 
-/// Run a single lifecycle hook.
+/// Run a single lifecycle hook and emit `pnpm:lifecycle` events.
 ///
 /// Ports the core of `runLifecycleHook` from
-/// `https://github.com/pnpm/pnpm/blob/7e91e4b35f/exec/lifecycle/src/runLifecycleHook.ts`.
-fn run_lifecycle_hook(
+/// `https://github.com/pnpm/pnpm/blob/80037699fb/exec/lifecycle/src/runLifecycleHook.ts`.
+///
+/// Mirrors the upstream emit ordering: a `Script` event before the spawn,
+/// `Stdio` events for each stdout/stderr line, then an `Exit` event with
+/// the resolved exit code.
+fn run_lifecycle_hook<R: Reporter>(
     stage: &str,
     script: &str,
     opts: &RunPostinstallHooks<'_>,
@@ -140,6 +151,21 @@ fn run_lifecycle_hook(
         pkg_root = %opts.pkg_root.display(),
     );
 
+    let pkg_root_str = opts.pkg_root.to_string_lossy().into_owned();
+
+    // Mirrors `lifecycleLogger.debug({ depPath, optional, script, stage, wd })`
+    // at <https://github.com/pnpm/pnpm/blob/80037699fb/exec/lifecycle/src/runLifecycleHook.ts#L102>.
+    R::emit(&LogEvent::Lifecycle(LifecycleLog {
+        level: LogLevel::Debug,
+        message: LifecycleMessage::Script {
+            dep_path: opts.dep_path.to_string(),
+            optional: false,
+            script: script.to_string(),
+            stage: stage.to_string(),
+            wd: pkg_root_str.clone(),
+        },
+    }));
+
     let path_env = build_path_env(opts.pkg_root, opts.extra_bin_paths);
 
     let mut cmd = Command::new("sh");
@@ -149,26 +175,56 @@ fn run_lifecycle_hook(
         .env("PATH", &path_env)
         .env("INIT_CWD", opts.init_cwd)
         .env("PNPM_SCRIPT_SRC_DIR", opts.pkg_root)
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit());
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
 
     for (key, value) in opts.extra_env {
         cmd.env(key, value);
     }
 
-    let status = cmd
-        .spawn()
-        .map_err(|e| LifecycleScriptError::Spawn {
+    let mut child = cmd.spawn().map_err(|e| LifecycleScriptError::Spawn {
+        dep_path: opts.dep_path.to_string(),
+        stage: stage.to_string(),
+        source: e,
+    })?;
+
+    let stdout = child.stdout.take();
+    let stderr = child.stderr.take();
+
+    let stdout_handle = stdout.map(|s| {
+        spawn_line_pump::<R>(s, LifecycleStdio::Stdout, opts.dep_path, stage, &pkg_root_str)
+    });
+    let stderr_handle = stderr.map(|s| {
+        spawn_line_pump::<R>(s, LifecycleStdio::Stderr, opts.dep_path, stage, &pkg_root_str)
+    });
+
+    let status = child.wait().map_err(|e| LifecycleScriptError::Wait {
+        dep_path: opts.dep_path.to_string(),
+        stage: stage.to_string(),
+        source: e,
+    })?;
+
+    // Joining the pumps after `wait` ensures every line they read is
+    // emitted before the `Exit` event below, matching pnpm's ordering.
+    if let Some(h) = stdout_handle {
+        let _ = h.join();
+    }
+    if let Some(h) = stderr_handle {
+        let _ = h.join();
+    }
+
+    // Mirrors `lifecycleLogger.debug({ depPath, exitCode, optional, stage, wd })`
+    // at <https://github.com/pnpm/pnpm/blob/80037699fb/exec/lifecycle/src/runLifecycleHook.ts#L165>.
+    R::emit(&LogEvent::Lifecycle(LifecycleLog {
+        level: LogLevel::Debug,
+        message: LifecycleMessage::Exit {
             dep_path: opts.dep_path.to_string(),
+            exit_code: status.code().unwrap_or(-1),
+            optional: false,
             stage: stage.to_string(),
-            source: e,
-        })?
-        .wait()
-        .map_err(|e| LifecycleScriptError::Wait {
-            dep_path: opts.dep_path.to_string(),
-            stage: stage.to_string(),
-            source: e,
-        })?;
+            wd: pkg_root_str,
+        },
+    }));
 
     if !status.success() {
         return Err(LifecycleScriptError::ScriptFailed {
@@ -180,6 +236,44 @@ fn run_lifecycle_hook(
     }
 
     Ok(())
+}
+
+/// Spawn a thread that reads `reader` line-by-line and emits a
+/// `LifecycleMessage::Stdio` event per line. Mirrors the per-chunk
+/// logging callback at
+/// <https://github.com/pnpm/pnpm/blob/80037699fb/exec/lifecycle/src/runLifecycleHook.ts#L147>.
+fn spawn_line_pump<R: Reporter>(
+    reader: impl Read + Send + 'static,
+    stdio: LifecycleStdio,
+    dep_path: &str,
+    stage: &str,
+    wd: &str,
+) -> thread::JoinHandle<()> {
+    let dep_path = dep_path.to_string();
+    let stage = stage.to_string();
+    let wd = wd.to_string();
+    thread::spawn(move || {
+        let buf = BufReader::new(reader);
+        for line in buf.lines() {
+            let Ok(line) = line else {
+                // Stop pumping on read error — an EBADF or EPIPE means
+                // the child closed the stream. Errors are not fatal to
+                // the install; the wait below will surface a non-zero
+                // exit code if the child failed because of them.
+                break;
+            };
+            R::emit(&LogEvent::Lifecycle(LifecycleLog {
+                level: LogLevel::Debug,
+                message: LifecycleMessage::Stdio {
+                    dep_path: dep_path.clone(),
+                    line,
+                    stage: stage.clone(),
+                    stdio,
+                    wd: wd.clone(),
+                },
+            }));
+        }
+    })
 }
 
 /// Build the `PATH` environment variable for lifecycle scripts.
@@ -199,3 +293,6 @@ fn build_path_env(pkg_root: &Path, extra_bin_paths: &[PathBuf]) -> OsString {
 
     env::join_paths(paths).unwrap_or(system_path)
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/executor/src/lifecycle.rs
+++ b/crates/executor/src/lifecycle.rs
@@ -3,6 +3,7 @@ use miette::Diagnostic;
 use std::{
     collections::HashMap,
     env,
+    ffi::OsString,
     path::{Path, PathBuf},
     process::{Command, ExitStatus, Stdio},
 };
@@ -93,9 +94,6 @@ pub fn run_postinstall_hooks(opts: RunPostinstallHooks<'_>) -> Result<bool, Life
     let get_script =
         |name: &str| -> Option<&str> { scripts.and_then(|s| s.get(name)).and_then(|v| v.as_str()) };
 
-    let has_preinstall = get_script("preinstall").is_some();
-    let has_postinstall = get_script("postinstall").is_some();
-
     let mut ran_any = false;
 
     if let Some(script) = get_script("preinstall") {
@@ -122,7 +120,7 @@ pub fn run_postinstall_hooks(opts: RunPostinstallHooks<'_>) -> Result<bool, Life
         ran_any = true;
     }
 
-    Ok(has_preinstall || install_script.is_some() || has_postinstall || ran_any)
+    Ok(ran_any)
 }
 
 /// Run a single lifecycle hook.
@@ -188,7 +186,7 @@ fn run_lifecycle_hook(
 ///
 /// Prepends the package's own `node_modules/.bin`, any extra bin paths
 /// (from the caller), and the system PATH.
-fn build_path_env(pkg_root: &Path, extra_bin_paths: &[PathBuf]) -> String {
+fn build_path_env(pkg_root: &Path, extra_bin_paths: &[PathBuf]) -> OsString {
     let own_bin = pkg_root.join("node_modules/.bin");
     let system_path = env::var_os("PATH").unwrap_or_default();
 
@@ -199,5 +197,5 @@ fn build_path_env(pkg_root: &Path, extra_bin_paths: &[PathBuf]) -> String {
         paths.push(path);
     }
 
-    env::join_paths(paths).expect("join PATH entries").into_string().expect("PATH is valid UTF-8")
+    env::join_paths(paths).unwrap_or(system_path)
 }

--- a/crates/executor/src/lifecycle.rs
+++ b/crates/executor/src/lifecycle.rs
@@ -27,14 +27,6 @@ pub enum LifecycleScriptError {
         source: std::io::Error,
     },
 
-    #[display("Failed to parse package.json at {path}: {source}")]
-    #[diagnostic(code(pacquet_executor::parse_manifest))]
-    ParseManifest {
-        path: String,
-        #[error(source)]
-        source: serde_json::Error,
-    },
-
     #[display("{dep_path} {stage}: `{script}` exited with {status}")]
     #[diagnostic(code(pacquet_executor::lifecycle_script_failed))]
     ScriptFailed { dep_path: String, stage: String, script: String, status: ExitStatus },
@@ -93,9 +85,10 @@ pub fn run_postinstall_hooks<R: Reporter>(
             });
         }
     };
-    let manifest: serde_json::Value = serde_json::from_str(&manifest_text).map_err(|e| {
-        LifecycleScriptError::ParseManifest { path: manifest_path.display().to_string(), source: e }
-    })?;
+    let manifest: serde_json::Value = match serde_json::from_str(&manifest_text) {
+        Ok(v) => v,
+        Err(_) => return Ok(false),
+    };
 
     let scripts = manifest.get("scripts").and_then(|v| v.as_object());
     let get_script =
@@ -103,7 +96,9 @@ pub fn run_postinstall_hooks<R: Reporter>(
 
     let mut ran_any = false;
 
-    if let Some(script) = get_script("preinstall") {
+    if let Some(script) = get_script("preinstall")
+        && script != "npx only-allow pnpm"
+    {
         run_lifecycle_hook::<R>("preinstall", script, &opts)?;
         ran_any = true;
     }
@@ -122,7 +117,9 @@ pub fn run_postinstall_hooks<R: Reporter>(
         ran_any = true;
     }
 
-    if let Some(script) = get_script("postinstall") {
+    if let Some(script) = get_script("postinstall")
+        && script != "npx only-allow pnpm"
+    {
         run_lifecycle_hook::<R>("postinstall", script, &opts)?;
         ran_any = true;
     }

--- a/crates/executor/src/lifecycle.rs
+++ b/crates/executor/src/lifecycle.rs
@@ -64,7 +64,6 @@ pub struct RunPostinstallHooks<'a> {
     pub init_cwd: &'a Path,
     pub extra_bin_paths: &'a [PathBuf],
     pub extra_env: &'a HashMap<String, String>,
-    pub optional: bool,
 }
 
 /// Run the preinstall, install, and postinstall lifecycle scripts for

--- a/crates/executor/src/lifecycle/tests.rs
+++ b/crates/executor/src/lifecycle/tests.rs
@@ -1,4 +1,5 @@
-use super::{RunPostinstallHooks, run_postinstall_hooks};
+use super::{LifecycleScriptError, RunPostinstallHooks, run_postinstall_hooks};
+use pacquet_package_manifest::PackageManifestError;
 use pacquet_reporter::{
     LifecycleMessage, LifecycleStdio, LogEvent, LogLevel, Reporter, SilentReporter,
 };
@@ -179,4 +180,66 @@ fn lifecycle_runs_under_silent_reporter() {
 
     let ran = run_postinstall_hooks::<SilentReporter>(opts).expect("postinstall");
     assert!(ran, "postinstall script should report executed: ran={ran}");
+}
+
+/// Missing `package.json` is treated as "no scripts to run" — mirrors
+/// upstream `safeReadPackageJsonFromDir` returning `null` on `ENOENT`
+/// and `runPostinstallHooks` returning `false` for `null` packages
+/// (`https://github.com/pnpm/pnpm/blob/80037699fb/exec/lifecycle/src/index.ts#L22-L23`).
+#[test]
+fn missing_manifest_returns_false() {
+    let dir = tempdir().expect("create temp dir");
+    let pkg_root = dir.path();
+    // No package.json written.
+
+    let extra_env: HashMap<String, String> = HashMap::new();
+    let extra_bin_paths: Vec<std::path::PathBuf> = vec![];
+    let opts = RunPostinstallHooks {
+        dep_path: "/missing@1.0.0",
+        pkg_root,
+        root_modules_dir: pkg_root,
+        init_cwd: pkg_root,
+        extra_bin_paths: &extra_bin_paths,
+        extra_env: &extra_env,
+    };
+
+    let ran = run_postinstall_hooks::<SilentReporter>(opts).expect("missing manifest is OK");
+    assert!(!ran, "missing manifest must report no scripts ran: ran={ran}");
+}
+
+/// Malformed `package.json` surfaces as a `ReadManifest` error wrapping
+/// `PackageManifestError::Serialization`. Mirrors upstream which throws
+/// `BAD_PACKAGE_JSON` from `readPackageJson` and lets it propagate
+/// through `safeReadPackageJsonFromDir` (only `ENOENT` is swallowed) at
+/// `https://github.com/pnpm/pnpm/blob/80037699fb/pkg-manifest/reader/src/index.ts#L20-L46`.
+#[test]
+fn malformed_manifest_propagates_error() {
+    let dir = tempdir().expect("create temp dir");
+    let pkg_root = dir.path();
+    fs::write(pkg_root.join("package.json"), "{ this is not valid json")
+        .expect("write malformed manifest");
+
+    let extra_env: HashMap<String, String> = HashMap::new();
+    let extra_bin_paths: Vec<std::path::PathBuf> = vec![];
+    let opts = RunPostinstallHooks {
+        dep_path: "/malformed@1.0.0",
+        pkg_root,
+        root_modules_dir: pkg_root,
+        init_cwd: pkg_root,
+        extra_bin_paths: &extra_bin_paths,
+        extra_env: &extra_env,
+    };
+
+    let err = run_postinstall_hooks::<SilentReporter>(opts).expect_err("malformed JSON must fail");
+    eprintln!("ERR: {err}");
+    assert!(
+        matches!(
+            err,
+            LifecycleScriptError::ReadManifest {
+                source: PackageManifestError::Serialization(_),
+                ..
+            },
+        ),
+        "expected ReadManifest(Serialization), got {err:?}",
+    );
 }

--- a/crates/executor/src/lifecycle/tests.rs
+++ b/crates/executor/src/lifecycle/tests.rs
@@ -1,0 +1,182 @@
+use super::{RunPostinstallHooks, run_postinstall_hooks};
+use pacquet_reporter::{
+    LifecycleMessage, LifecycleStdio, LogEvent, LogLevel, Reporter, SilentReporter,
+};
+use pretty_assertions::assert_eq;
+use std::{collections::HashMap, fs, sync::Mutex};
+use tempfile::tempdir;
+
+/// Recording-fake reporter that pushes every emitted [`LogEvent`] into
+/// `EVENTS`. The static lives in this test function's own scope, so
+/// other tests have independent buffers.
+#[test]
+fn lifecycle_emits_script_stdio_and_exit_in_order() {
+    static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
+    EVENTS.lock().expect("lock").clear();
+
+    struct RecordingReporter;
+    impl Reporter for RecordingReporter {
+        fn emit(event: &LogEvent) {
+            EVENTS.lock().expect("lock").push(event.clone());
+        }
+    }
+
+    let dir = tempdir().expect("create temp dir");
+    let pkg_root = dir.path();
+    let manifest = serde_json::json!({
+        "name": "x",
+        "version": "1.0.0",
+        "scripts": { "postinstall": "echo HELLO; echo BAD 1>&2" },
+    });
+    fs::write(pkg_root.join("package.json"), manifest.to_string()).expect("write manifest");
+
+    let extra_env: HashMap<String, String> = HashMap::new();
+    let extra_bin_paths: Vec<std::path::PathBuf> = vec![];
+    let opts = RunPostinstallHooks {
+        dep_path: "/x@1.0.0",
+        pkg_root,
+        root_modules_dir: pkg_root,
+        init_cwd: pkg_root,
+        extra_bin_paths: &extra_bin_paths,
+        extra_env: &extra_env,
+    };
+
+    let ran = run_postinstall_hooks::<RecordingReporter>(opts).expect("postinstall");
+    assert!(ran, "postinstall script should report executed");
+
+    let captured = EVENTS.lock().expect("lock").clone();
+    dbg!(&captured);
+
+    // Sequence: Script (postinstall) → some Stdio events → Exit (0).
+    let first = captured.first().expect("at least one event");
+    let LogEvent::Lifecycle(first) = first else {
+        panic!("first event must be Lifecycle, got {first:?}");
+    };
+    assert_eq!(first.level, LogLevel::Debug);
+    assert!(
+        matches!(
+            &first.message,
+            LifecycleMessage::Script { dep_path, stage, script, .. }
+                if dep_path == "/x@1.0.0"
+                && stage == "postinstall"
+                && script.contains("echo HELLO")
+        ),
+        "first event must be Script(postinstall): {first:?}",
+    );
+
+    let last = captured.last().expect("at least one event");
+    let LogEvent::Lifecycle(last) = last else {
+        panic!("last event must be Lifecycle, got {last:?}");
+    };
+    assert!(
+        matches!(
+            &last.message,
+            LifecycleMessage::Exit { dep_path, exit_code, stage, .. }
+                if dep_path == "/x@1.0.0" && *exit_code == 0 && stage == "postinstall"
+        ),
+        "last event must be Exit(0): {last:?}",
+    );
+
+    // Stdio events between Script and Exit. Match by line content rather
+    // than by index because the order between stdout and stderr is
+    // race-y (each pumps from its own thread).
+    let stdio: Vec<_> = captured
+        .iter()
+        .filter_map(|e| match e {
+            LogEvent::Lifecycle(l) => match &l.message {
+                LifecycleMessage::Stdio { line, stdio, .. } => Some((stdio, line.as_str())),
+                _ => None,
+            },
+            _ => None,
+        })
+        .collect();
+    dbg!(&stdio);
+    assert!(
+        stdio.iter().any(|(s, l)| **s == LifecycleStdio::Stdout && *l == "HELLO"),
+        "stdout 'HELLO' must be emitted: {stdio:?}",
+    );
+    assert!(
+        stdio.iter().any(|(s, l)| **s == LifecycleStdio::Stderr && *l == "BAD"),
+        "stderr 'BAD' must be emitted: {stdio:?}",
+    );
+}
+
+/// Failing scripts emit a Script event, the captured stdio, and an Exit
+/// event with the resolved non-zero exit code, then return a
+/// [`LifecycleScriptError::ScriptFailed`].
+#[test]
+fn lifecycle_emits_exit_with_nonzero_code_on_failure() {
+    static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
+    EVENTS.lock().expect("lock").clear();
+
+    struct RecordingReporter;
+    impl Reporter for RecordingReporter {
+        fn emit(event: &LogEvent) {
+            EVENTS.lock().expect("lock").push(event.clone());
+        }
+    }
+
+    let dir = tempdir().expect("create temp dir");
+    let pkg_root = dir.path();
+    let manifest = serde_json::json!({
+        "name": "y",
+        "version": "1.0.0",
+        "scripts": { "postinstall": "exit 7" },
+    });
+    fs::write(pkg_root.join("package.json"), manifest.to_string()).expect("write manifest");
+
+    let extra_env: HashMap<String, String> = HashMap::new();
+    let extra_bin_paths: Vec<std::path::PathBuf> = vec![];
+    let opts = RunPostinstallHooks {
+        dep_path: "/y@1.0.0",
+        pkg_root,
+        root_modules_dir: pkg_root,
+        init_cwd: pkg_root,
+        extra_bin_paths: &extra_bin_paths,
+        extra_env: &extra_env,
+    };
+
+    let err = run_postinstall_hooks::<RecordingReporter>(opts).expect_err("script must fail");
+    eprintln!("ERR: {err}");
+
+    let captured = EVENTS.lock().expect("lock").clone();
+    dbg!(&captured);
+
+    let last = captured.last().expect("at least one event");
+    let LogEvent::Lifecycle(last) = last else {
+        panic!("last event must be Lifecycle, got {last:?}");
+    };
+    assert!(
+        matches!(&last.message, LifecycleMessage::Exit { exit_code, .. } if *exit_code == 7),
+        "last event must be Exit(7): {last:?}",
+    );
+}
+
+/// `SilentReporter` works as the production no-op. Same script, but no
+/// recording — proves the function compiles and runs under the
+/// production sink without touching the wire.
+#[test]
+fn lifecycle_runs_under_silent_reporter() {
+    let dir = tempdir().expect("create temp dir");
+    let pkg_root = dir.path();
+    let manifest = serde_json::json!({
+        "name": "z",
+        "version": "1.0.0",
+        "scripts": { "postinstall": "echo z" },
+    });
+    fs::write(pkg_root.join("package.json"), manifest.to_string()).expect("write manifest");
+
+    let extra_env: HashMap<String, String> = HashMap::new();
+    let extra_bin_paths: Vec<std::path::PathBuf> = vec![];
+    let opts = RunPostinstallHooks {
+        dep_path: "/z@1.0.0",
+        pkg_root,
+        root_modules_dir: pkg_root,
+        init_cwd: pkg_root,
+        extra_bin_paths: &extra_bin_paths,
+        extra_env: &extra_env,
+    };
+
+    let ran = run_postinstall_hooks::<SilentReporter>(opts).expect("postinstall");
+    assert!(ran, "postinstall script should report executed: ran={ran}");
+}

--- a/crates/lockfile/src/package_metadata.rs
+++ b/crates/lockfile/src/package_metadata.rs
@@ -27,8 +27,6 @@ pub struct PackageMetadata {
     pub has_bin: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prepare: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub requires_build: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bundled_dependencies: Option<Vec<String>>,

--- a/crates/package-manager/Cargo.toml
+++ b/crates/package-manager/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace     = true
 repository.workspace  = true
 
 [dependencies]
+pacquet-executor         = { workspace = true }
 pacquet-fs               = { workspace = true }
 pacquet-lockfile         = { workspace = true }
 pacquet-modules-yaml     = { workspace = true }
@@ -30,6 +31,7 @@ httpdate        = { workspace = true }
 node-semver     = { workspace = true }
 pipe-trait      = { workspace = true }
 rayon           = { workspace = true }
+serde_json      = { workspace = true }
 reflink-copy    = { workspace = true }
 tokio           = { workspace = true }
 tracing         = { workspace = true }

--- a/crates/package-manager/src/build_modules.rs
+++ b/crates/package-manager/src/build_modules.rs
@@ -38,13 +38,30 @@ impl AllowBuildPolicy {
     /// explicitly listed in `allowBuilds` to run their scripts.
     pub fn from_manifest(manifest_dir: &Path) -> Self {
         let manifest_path = manifest_dir.join("package.json");
-        let text = match fs::read_to_string(manifest_path) {
+        let text = match fs::read_to_string(&manifest_path) {
             Ok(text) => text,
-            Err(_) => return Self::default(),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Self::default(),
+            Err(e) => {
+                tracing::warn!(
+                    target: "pacquet::build",
+                    path = %manifest_path.display(),
+                    error = %e,
+                    "failed to read package.json for build policy",
+                );
+                return Self::default();
+            }
         };
         let manifest: serde_json::Value = match serde_json::from_str(&text) {
             Ok(v) => v,
-            Err(_) => return Self::default(),
+            Err(e) => {
+                tracing::warn!(
+                    target: "pacquet::build",
+                    path = %manifest_path.display(),
+                    error = %e,
+                    "failed to parse package.json for build policy",
+                );
+                return Self::default();
+            }
         };
 
         let pnpm = manifest.get("pnpm");

--- a/crates/package-manager/src/build_modules.rs
+++ b/crates/package-manager/src/build_modules.rs
@@ -27,7 +27,7 @@ pub enum BuildModulesError {
 #[derive(Debug, Default)]
 pub struct AllowBuildPolicy {
     rules: HashMap<String, bool>,
-    has_any_rules: bool,
+    policy_present: bool,
 }
 
 impl AllowBuildPolicy {
@@ -54,9 +54,8 @@ impl AllowBuildPolicy {
             .iter()
             .filter_map(|(key, value)| value.as_bool().map(|v| (key.clone(), v)))
             .collect();
-        let has_any_rules = !rules.is_empty();
 
-        Self { rules, has_any_rules }
+        Self { rules, policy_present: true }
     }
 
     /// Check whether a package is allowed to run build scripts.
@@ -64,7 +63,7 @@ impl AllowBuildPolicy {
     /// `name` is the package name (e.g. `@pnpm.e2e/install-script-example`).
     /// `version` is the resolved version (e.g. `1.0.0`).
     pub fn check(&self, name: &str, version: &str) -> Option<bool> {
-        if !self.has_any_rules {
+        if !self.policy_present {
             return Some(true);
         }
 
@@ -123,7 +122,7 @@ impl<'a> BuildModules<'a> {
                 continue;
             }
 
-            let (name, version) = parse_name_version_from_key(&snapshot_key.to_string());
+            let (name, version) = parse_name_version_from_key(&metadata_key.to_string());
             match allow_build_policy.check(&name, &version) {
                 Some(false) => continue,
                 None => {
@@ -156,7 +155,6 @@ impl<'a> BuildModules<'a> {
                 init_cwd: lockfile_dir,
                 extra_bin_paths: &extra_bin_paths,
                 extra_env: &extra_env,
-                optional: false,
             })
             .map_err(BuildModulesError::LifecycleScript)?;
         }
@@ -248,7 +246,6 @@ impl<'a> BuildModulesByScanning<'a> {
                     init_cwd: lockfile_dir,
                     extra_bin_paths: &extra_bin_paths,
                     extra_env: &extra_env,
-                    optional: false,
                 }) {
                     Ok(_) => {}
                     Err(err) => {

--- a/crates/package-manager/src/build_modules.rs
+++ b/crates/package-manager/src/build_modules.rs
@@ -3,8 +3,9 @@ use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_executor::{LifecycleScriptError, RunPostinstallHooks, run_postinstall_hooks};
 use pacquet_lockfile::{PackageKey, PackageMetadata, ProjectSnapshot, SnapshotEntry};
+use pacquet_reporter::Reporter;
 use std::{
-    collections::HashMap,
+    collections::{BTreeSet, HashMap},
     fs,
     path::{Path, PathBuf},
 };
@@ -129,7 +130,13 @@ pub struct BuildModules<'a> {
 }
 
 impl<'a> BuildModules<'a> {
-    pub fn run(self) -> Result<(), BuildModulesError> {
+    /// Run the build, returning the sorted set of `name@version` keys whose
+    /// scripts were skipped because the package was not in `allowBuilds`.
+    ///
+    /// The caller is expected to fold the returned set into a single
+    /// `pnpm:ignored-scripts` event — mirroring upstream's emit at
+    /// <https://github.com/pnpm/pnpm/blob/80037699fb/installing/deps-installer/src/install/index.ts#L414>.
+    pub fn run<R: Reporter>(self) -> Result<Vec<String>, BuildModulesError> {
         let BuildModules {
             virtual_store_dir,
             modules_dir,
@@ -140,13 +147,17 @@ impl<'a> BuildModules<'a> {
             allow_build_policy,
         } = self;
 
-        let Some(snapshots) = snapshots else { return Ok(()) };
-        let Some(packages) = packages else { return Ok(()) };
+        let Some(snapshots) = snapshots else { return Ok(Vec::new()) };
+        let Some(packages) = packages else { return Ok(Vec::new()) };
 
         let extra_env = HashMap::new();
         let extra_bin_paths: Vec<PathBuf> = vec![];
 
         let chunks = build_sequence(packages, snapshots, importers);
+
+        // Collect peer-stripped keys so the final list is unique and
+        // sorted lexicographically — matches `dedupePackageNamesFromIgnoredBuilds`.
+        let mut ignored_builds: BTreeSet<String> = BTreeSet::new();
 
         for chunk in chunks {
             for snapshot_key in chunk {
@@ -163,11 +174,10 @@ impl<'a> BuildModules<'a> {
                 match allow_build_policy.check(&name, &version) {
                     Some(false) => continue,
                     None => {
-                        tracing::info!(
-                            target: "pacquet::build",
-                            package = %snapshot_key,
-                            "skipping build (not in allowBuilds)",
-                        );
+                        // "Not in allowBuilds" — surfaced as `pnpm:ignored-scripts`.
+                        // Explicit `false` is silently skipped (above), matching
+                        // upstream's switch in `building/during-install/src/index.ts:88-101`.
+                        ignored_builds.insert(metadata_key.to_string());
                         continue;
                     }
                     Some(true) => {}
@@ -178,14 +188,7 @@ impl<'a> BuildModules<'a> {
                     continue;
                 }
 
-                tracing::info!(
-                    target: "pacquet::build",
-                    package = %snapshot_key,
-                    dir = %pkg_dir.display(),
-                    "running lifecycle scripts",
-                );
-
-                run_postinstall_hooks(RunPostinstallHooks {
+                run_postinstall_hooks::<R>(RunPostinstallHooks {
                     dep_path: &snapshot_key.to_string(),
                     pkg_root: &pkg_dir,
                     root_modules_dir: modules_dir,
@@ -197,7 +200,7 @@ impl<'a> BuildModules<'a> {
             }
         }
 
-        Ok(())
+        Ok(ignored_builds.into_iter().collect())
     }
 }
 

--- a/crates/package-manager/src/build_modules.rs
+++ b/crates/package-manager/src/build_modules.rs
@@ -1,7 +1,8 @@
+use crate::build_sequence::build_sequence;
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_executor::{LifecycleScriptError, RunPostinstallHooks, run_postinstall_hooks};
-use pacquet_lockfile::{PackageKey, PackageMetadata, SnapshotEntry};
+use pacquet_lockfile::{PackageKey, PackageMetadata, ProjectSnapshot, SnapshotEntry};
 use std::{
     collections::HashMap,
     fs,
@@ -111,21 +112,19 @@ impl AllowBuildPolicy {
 /// Run lifecycle scripts for all packages that require a build.
 ///
 /// Ports the core of `buildModules` from
-/// `https://github.com/pnpm/pnpm/blob/7e91e4b35f/building/during-install/src/index.ts`.
+/// `https://github.com/pnpm/pnpm/blob/80037699fb/building/during-install/src/index.ts`.
 ///
-/// TODO: pnpm topologically sorts the dep graph via `buildSequence()`
-/// and runs each chunk concurrently (bounded by `childConcurrency`).
-/// This implementation iterates in arbitrary HashMap order and runs
-/// sequentially. If package A's postinstall depends on B having
-/// already built, it may fail non-deterministically. Port
-/// `buildSequence` from `building/during-install/src/buildSequence.ts`
-/// to fix this.
+/// Packages are visited in topological order (children before parents) via
+/// [`build_sequence`]. Within a chunk, members are independent and could run
+/// concurrently — pacquet currently runs them sequentially (TODO: honor
+/// `childConcurrency`).
 pub struct BuildModules<'a> {
     pub virtual_store_dir: &'a Path,
     pub modules_dir: &'a Path,
     pub lockfile_dir: &'a Path,
     pub packages: Option<&'a HashMap<PackageKey, PackageMetadata>>,
     pub snapshots: Option<&'a HashMap<PackageKey, SnapshotEntry>>,
+    pub importers: &'a HashMap<String, ProjectSnapshot>,
     pub allow_build_policy: &'a AllowBuildPolicy,
 }
 
@@ -137,6 +136,7 @@ impl<'a> BuildModules<'a> {
             lockfile_dir,
             packages,
             snapshots,
+            importers,
             allow_build_policy,
         } = self;
 
@@ -146,49 +146,55 @@ impl<'a> BuildModules<'a> {
         let extra_env = HashMap::new();
         let extra_bin_paths: Vec<PathBuf> = vec![];
 
-        for snapshot_key in snapshots.keys() {
-            let metadata_key = snapshot_key.without_peer();
-            let Some(metadata) = packages.get(&metadata_key) else { continue };
+        let chunks = build_sequence(packages, snapshots, importers);
 
-            if metadata.requires_build != Some(true) {
-                continue;
-            }
+        for chunk in chunks {
+            for snapshot_key in chunk {
+                let metadata_key = snapshot_key.without_peer();
+                let Some(metadata) = packages.get(&metadata_key) else { continue };
 
-            let (name, version) = parse_name_version_from_key(&metadata_key.to_string());
-            match allow_build_policy.check(&name, &version) {
-                Some(false) => continue,
-                None => {
-                    tracing::info!(
-                        target: "pacquet::build",
-                        package = %snapshot_key,
-                        "skipping build (not in allowBuilds)",
-                    );
+                // Ancestors-of-build packages are included in the sequence
+                // but only run scripts when they themselves require a build.
+                if metadata.requires_build != Some(true) {
                     continue;
                 }
-                Some(true) => {}
+
+                let (name, version) = parse_name_version_from_key(&metadata_key.to_string());
+                match allow_build_policy.check(&name, &version) {
+                    Some(false) => continue,
+                    None => {
+                        tracing::info!(
+                            target: "pacquet::build",
+                            package = %snapshot_key,
+                            "skipping build (not in allowBuilds)",
+                        );
+                        continue;
+                    }
+                    Some(true) => {}
+                }
+
+                let pkg_dir = virtual_store_dir_for_key(virtual_store_dir, &snapshot_key);
+                if !pkg_dir.exists() {
+                    continue;
+                }
+
+                tracing::info!(
+                    target: "pacquet::build",
+                    package = %snapshot_key,
+                    dir = %pkg_dir.display(),
+                    "running lifecycle scripts",
+                );
+
+                run_postinstall_hooks(RunPostinstallHooks {
+                    dep_path: &snapshot_key.to_string(),
+                    pkg_root: &pkg_dir,
+                    root_modules_dir: modules_dir,
+                    init_cwd: lockfile_dir,
+                    extra_bin_paths: &extra_bin_paths,
+                    extra_env: &extra_env,
+                })
+                .map_err(BuildModulesError::LifecycleScript)?;
             }
-
-            let pkg_dir = virtual_store_dir_for_key(virtual_store_dir, snapshot_key);
-            if !pkg_dir.exists() {
-                continue;
-            }
-
-            tracing::info!(
-                target: "pacquet::build",
-                package = %snapshot_key,
-                dir = %pkg_dir.display(),
-                "running lifecycle scripts",
-            );
-
-            run_postinstall_hooks(RunPostinstallHooks {
-                dep_path: &snapshot_key.to_string(),
-                pkg_root: &pkg_dir,
-                root_modules_dir: modules_dir,
-                init_cwd: lockfile_dir,
-                extra_bin_paths: &extra_bin_paths,
-                extra_env: &extra_env,
-            })
-            .map_err(BuildModulesError::LifecycleScript)?;
         }
 
         Ok(())

--- a/crates/package-manager/src/build_modules.rs
+++ b/crates/package-manager/src/build_modules.rs
@@ -27,11 +27,15 @@ pub enum BuildModulesError {
 #[derive(Debug, Default)]
 pub struct AllowBuildPolicy {
     rules: HashMap<String, bool>,
-    policy_present: bool,
+    dangerously_allow_all: bool,
 }
 
 impl AllowBuildPolicy {
-    /// Read `pnpm.allowBuilds` from a project's `package.json`.
+    /// Read `pnpm.allowBuilds` and `pnpm.dangerouslyAllowAllBuilds`
+    /// from a project's `package.json`.
+    ///
+    /// pnpm 11 denies lifecycle scripts by default. Packages must be
+    /// explicitly listed in `allowBuilds` to run their scripts.
     pub fn from_manifest(manifest_dir: &Path) -> Self {
         let manifest_path = manifest_dir.join("package.json");
         let text = match fs::read_to_string(manifest_path) {
@@ -43,27 +47,34 @@ impl AllowBuildPolicy {
             Err(_) => return Self::default(),
         };
 
-        let allow_builds =
-            manifest.get("pnpm").and_then(|v| v.get("allowBuilds")).and_then(|v| v.as_object());
+        let pnpm = manifest.get("pnpm");
 
-        let Some(allow_builds) = allow_builds else {
-            return Self::default();
-        };
+        let dangerously_allow_all = pnpm
+            .and_then(|v| v.get("dangerouslyAllowAllBuilds"))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        let allow_builds = pnpm.and_then(|v| v.get("allowBuilds")).and_then(|v| v.as_object());
 
         let rules: HashMap<String, bool> = allow_builds
-            .iter()
-            .filter_map(|(key, value)| value.as_bool().map(|v| (key.clone(), v)))
-            .collect();
+            .map(|obj| {
+                obj.iter()
+                    .filter_map(|(key, value)| value.as_bool().map(|v| (key.clone(), v)))
+                    .collect()
+            })
+            .unwrap_or_default();
 
-        Self { rules, policy_present: true }
+        Self { rules, dangerously_allow_all }
     }
 
     /// Check whether a package is allowed to run build scripts.
     ///
-    /// `name` is the package name (e.g. `@pnpm.e2e/install-script-example`).
-    /// `version` is the resolved version (e.g. `1.0.0`).
+    /// Returns:
+    /// - `Some(true)`: explicitly allowed (or `dangerouslyAllowAllBuilds`)
+    /// - `Some(false)`: explicitly denied, silently skip
+    /// - `None`: not in the list, skip and report as ignored
     pub fn check(&self, name: &str, version: &str) -> Option<bool> {
-        if !self.policy_present {
+        if self.dangerously_allow_all {
             return Some(true);
         }
 

--- a/crates/package-manager/src/build_modules.rs
+++ b/crates/package-manager/src/build_modules.rs
@@ -33,11 +33,26 @@ pub struct AllowBuildPolicy {
 }
 
 impl AllowBuildPolicy {
+    /// Build a policy from already-parsed `pnpm.allowBuilds` rules and
+    /// `pnpm.dangerouslyAllowAllBuilds`. Pure constructor — no IO — so
+    /// the policy logic is tested directly with in-memory inputs (mirrors
+    /// upstream's `createAllowBuildFunction(opts)` in
+    /// <https://github.com/pnpm/pnpm/blob/80037699fb/building/policy/src/index.ts>).
+    pub fn new(rules: HashMap<String, bool>, dangerously_allow_all: bool) -> Self {
+        Self { rules, dangerously_allow_all }
+    }
+
     /// Read `pnpm.allowBuilds` and `pnpm.dangerouslyAllowAllBuilds`
-    /// from a project's `package.json`.
+    /// from a project's `package.json` and build a policy.
     ///
     /// pnpm 11 denies lifecycle scripts by default. Packages must be
     /// explicitly listed in `allowBuilds` to run their scripts.
+    ///
+    /// IO and JSON parse errors are tolerated and surface as the empty
+    /// default policy (with a warning). Upstream sources these settings
+    /// from `Config` (npmrc/workspace), so there is no upstream behavior
+    /// to mirror for a manifest-read failure here. See pnpm/pacquet#397
+    /// item 5 for the longer-term config-source migration.
     pub fn from_manifest(manifest_dir: &Path) -> Self {
         let manifest_path = manifest_dir.join("package.json");
         let text = match fs::read_to_string(&manifest_path) {
@@ -83,7 +98,7 @@ impl AllowBuildPolicy {
             })
             .unwrap_or_default();
 
-        Self { rules, dangerously_allow_all }
+        Self::new(rules, dangerously_allow_all)
     }
 
     /// Check whether a package is allowed to run build scripts.

--- a/crates/package-manager/src/build_modules.rs
+++ b/crates/package-manager/src/build_modules.rs
@@ -96,9 +96,13 @@ impl AllowBuildPolicy {
 /// Ports the core of `buildModules` from
 /// `https://github.com/pnpm/pnpm/blob/7e91e4b35f/building/during-install/src/index.ts`.
 ///
-/// This is a simplified implementation that runs scripts sequentially.
-/// A future iteration should topologically sort the dep graph and run
-/// scripts concurrently within each chunk.
+/// TODO: pnpm topologically sorts the dep graph via `buildSequence()`
+/// and runs each chunk concurrently (bounded by `childConcurrency`).
+/// This implementation iterates in arbitrary HashMap order and runs
+/// sequentially. If package A's postinstall depends on B having
+/// already built, it may fail non-deterministically. Port
+/// `buildSequence` from `building/during-install/src/buildSequence.ts`
+/// to fix this.
 pub struct BuildModules<'a> {
     pub virtual_store_dir: &'a Path,
     pub modules_dir: &'a Path,
@@ -174,152 +178,6 @@ impl<'a> BuildModules<'a> {
     }
 }
 
-/// Run lifecycle scripts by scanning the virtual store directory.
-///
-/// Used by the non-frozen install path which does not have lockfile
-/// metadata to determine `requires_build`. Instead, each package's
-/// `package.json` is checked for lifecycle scripts directly.
-pub struct BuildModulesByScanning<'a> {
-    pub virtual_store_dir: &'a Path,
-    pub modules_dir: &'a Path,
-    pub lockfile_dir: &'a Path,
-    pub allow_build_policy: &'a AllowBuildPolicy,
-}
-
-impl<'a> BuildModulesByScanning<'a> {
-    pub fn run(self) -> Result<(), BuildModulesError> {
-        let BuildModulesByScanning {
-            virtual_store_dir,
-            modules_dir,
-            lockfile_dir,
-            allow_build_policy,
-        } = self;
-
-        if !virtual_store_dir.exists() {
-            return Ok(());
-        }
-
-        let extra_env = HashMap::new();
-        let extra_bin_paths: Vec<PathBuf> = vec![];
-
-        let entries = match fs::read_dir(virtual_store_dir) {
-            Ok(entries) => entries,
-            Err(_) => return Ok(()),
-        };
-
-        for entry in entries.flatten() {
-            let store_entry = entry.path();
-            let node_modules = store_entry.join("node_modules");
-            if !node_modules.is_dir() {
-                continue;
-            }
-
-            let dep_path = store_entry
-                .file_name()
-                .map(|n| n.to_string_lossy().to_string())
-                .unwrap_or_default();
-
-            for pkg_entry in walk_package_dirs(&node_modules) {
-                if !has_lifecycle_scripts(&pkg_entry) {
-                    continue;
-                }
-
-                let (name, version) = parse_name_version_from_store_entry(&dep_path);
-                match allow_build_policy.check(&name, &version) {
-                    Some(false) => continue,
-                    None => {
-                        tracing::info!(
-                            target: "pacquet::build",
-                            dep_path,
-                            "skipping build (not in allowBuilds)",
-                        );
-                        continue;
-                    }
-                    Some(true) => {}
-                }
-
-                tracing::info!(
-                    target: "pacquet::build",
-                    dep_path,
-                    dir = %pkg_entry.display(),
-                    "running lifecycle scripts (scan)",
-                );
-
-                // Warn instead of failing: the scanning path lacks
-                // dependency bin linking, so scripts that invoke
-                // dependency bins will exit 127. The frozen-lockfile
-                // path (BuildModules) propagates errors because it
-                // has full lockfile metadata to decide what to build.
-                match run_postinstall_hooks(RunPostinstallHooks {
-                    dep_path: &dep_path,
-                    pkg_root: &pkg_entry,
-                    root_modules_dir: modules_dir,
-                    init_cwd: lockfile_dir,
-                    extra_bin_paths: &extra_bin_paths,
-                    extra_env: &extra_env,
-                }) {
-                    Ok(_) => {}
-                    Err(err) => {
-                        tracing::warn!(
-                            target: "pacquet::build",
-                            dep_path,
-                            error = %err,
-                            "lifecycle script failed; continuing",
-                        );
-                    }
-                }
-            }
-        }
-
-        Ok(())
-    }
-}
-
-/// Walk the `node_modules` directory inside a virtual store entry,
-/// yielding each package directory (handles scoped packages).
-fn walk_package_dirs(node_modules: &Path) -> Vec<PathBuf> {
-    let mut dirs = Vec::new();
-    let entries = match fs::read_dir(node_modules) {
-        Ok(entries) => entries,
-        Err(_) => return dirs,
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        let name = entry.file_name();
-        let name_str = name.to_string_lossy();
-        if name_str.starts_with('@') {
-            if let Ok(scoped) = fs::read_dir(&path) {
-                for scoped_entry in scoped.flatten() {
-                    dirs.push(scoped_entry.path());
-                }
-            }
-        } else if name_str != ".bin" {
-            dirs.push(path);
-        }
-    }
-    dirs
-}
-
-/// Check whether a package directory has lifecycle scripts.
-fn has_lifecycle_scripts(pkg_dir: &Path) -> bool {
-    let manifest_path = pkg_dir.join("package.json");
-    let text = match fs::read_to_string(manifest_path) {
-        Ok(text) => text,
-        Err(_) => return false,
-    };
-    let manifest: serde_json::Value = match serde_json::from_str(&text) {
-        Ok(v) => v,
-        Err(_) => return false,
-    };
-    let Some(scripts) = manifest.get("scripts").and_then(|v| v.as_object()) else {
-        return pkg_dir.join("binding.gyp").exists();
-    };
-    scripts.contains_key("preinstall")
-        || scripts.contains_key("install")
-        || scripts.contains_key("postinstall")
-        || pkg_dir.join("binding.gyp").exists()
-}
-
 /// Compute the package directory inside the virtual store for a snapshot key.
 ///
 /// Uses `without_peer()` to strip any peer-dependency suffix before
@@ -346,17 +204,6 @@ fn parse_name_version_from_key(key: &str) -> (String, String) {
         Some(idx) if idx > 0 => (s[..idx].to_string(), s[idx + 1..].to_string()),
         _ => (s.to_string(), String::new()),
     }
-}
-
-/// Parse `name` and `version` from a virtual store entry name like
-/// `@pnpm.e2e+install-script-example@1.0.0`.
-fn parse_name_version_from_store_entry(entry: &str) -> (String, String) {
-    let name_version = match entry.rfind('@') {
-        Some(idx) if idx > 0 => (&entry[..idx], &entry[idx + 1..]),
-        _ => (entry, ""),
-    };
-    let name = name_version.0.replacen('+', "/", 1);
-    (name, name_version.1.to_string())
 }
 
 #[cfg(test)]

--- a/crates/package-manager/src/build_modules.rs
+++ b/crates/package-manager/src/build_modules.rs
@@ -1,0 +1,218 @@
+use derive_more::{Display, Error};
+use miette::Diagnostic;
+use pacquet_executor::{LifecycleScriptError, RunPostinstallHooks, run_postinstall_hooks};
+use pacquet_lockfile::{PackageKey, PackageMetadata, SnapshotEntry};
+use std::{
+    collections::HashMap,
+    fs,
+    path::{Path, PathBuf},
+};
+
+/// Error from the build-modules step.
+#[derive(Debug, Display, Error, Diagnostic)]
+pub enum BuildModulesError {
+    #[diagnostic(transparent)]
+    LifecycleScript(#[error(source)] LifecycleScriptError),
+}
+
+/// Run lifecycle scripts for all packages that require a build.
+///
+/// Ports the core of `buildModules` from
+/// `https://github.com/pnpm/pnpm/blob/7e91e4b35f/building/during-install/src/index.ts`.
+///
+/// This is a simplified implementation that runs scripts sequentially.
+/// A future iteration should topologically sort the dep graph and run
+/// scripts concurrently within each chunk.
+pub struct BuildModules<'a> {
+    pub virtual_store_dir: &'a Path,
+    pub modules_dir: &'a Path,
+    pub lockfile_dir: &'a Path,
+    pub packages: Option<&'a HashMap<PackageKey, PackageMetadata>>,
+    pub snapshots: Option<&'a HashMap<PackageKey, SnapshotEntry>>,
+}
+
+impl<'a> BuildModules<'a> {
+    pub fn run(self) -> Result<(), BuildModulesError> {
+        let BuildModules { virtual_store_dir, modules_dir, lockfile_dir, packages, snapshots } =
+            self;
+
+        let Some(snapshots) = snapshots else { return Ok(()) };
+        let Some(packages) = packages else { return Ok(()) };
+
+        let extra_env = HashMap::new();
+        let extra_bin_paths: Vec<PathBuf> = vec![];
+
+        for snapshot_key in snapshots.keys() {
+            let metadata_key = snapshot_key.without_peer();
+            let Some(metadata) = packages.get(&metadata_key) else { continue };
+
+            if metadata.requires_build != Some(true) {
+                continue;
+            }
+
+            let pkg_dir = virtual_store_dir_for_key(virtual_store_dir, snapshot_key);
+            if !pkg_dir.exists() {
+                continue;
+            }
+
+            tracing::info!(
+                target: "pacquet::build",
+                package = %snapshot_key,
+                dir = %pkg_dir.display(),
+                "running lifecycle scripts",
+            );
+
+            run_postinstall_hooks(RunPostinstallHooks {
+                dep_path: &snapshot_key.to_string(),
+                pkg_root: &pkg_dir,
+                root_modules_dir: modules_dir,
+                init_cwd: lockfile_dir,
+                extra_bin_paths: &extra_bin_paths,
+                extra_env: &extra_env,
+                optional: false,
+            })
+            .map_err(BuildModulesError::LifecycleScript)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Run lifecycle scripts by scanning the virtual store directory.
+///
+/// Used by the non-frozen install path which does not have lockfile
+/// metadata to determine `requires_build`. Instead, each package's
+/// `package.json` is checked for lifecycle scripts directly.
+pub struct BuildModulesByScanning<'a> {
+    pub virtual_store_dir: &'a Path,
+    pub modules_dir: &'a Path,
+    pub lockfile_dir: &'a Path,
+}
+
+impl<'a> BuildModulesByScanning<'a> {
+    pub fn run(self) -> Result<(), BuildModulesError> {
+        let BuildModulesByScanning { virtual_store_dir, modules_dir, lockfile_dir } = self;
+
+        if !virtual_store_dir.exists() {
+            return Ok(());
+        }
+
+        let extra_env = HashMap::new();
+        let extra_bin_paths: Vec<PathBuf> = vec![];
+
+        let entries = match fs::read_dir(virtual_store_dir) {
+            Ok(entries) => entries,
+            Err(_) => return Ok(()),
+        };
+
+        for entry in entries.flatten() {
+            let store_entry = entry.path();
+            let node_modules = store_entry.join("node_modules");
+            if !node_modules.is_dir() {
+                continue;
+            }
+
+            for pkg_entry in walk_package_dirs(&node_modules) {
+                if !has_lifecycle_scripts(&pkg_entry) {
+                    continue;
+                }
+
+                let dep_path = store_entry
+                    .file_name()
+                    .map(|n| n.to_string_lossy().to_string())
+                    .unwrap_or_default();
+
+                tracing::info!(
+                    target: "pacquet::build",
+                    dep_path,
+                    dir = %pkg_entry.display(),
+                    "running lifecycle scripts (scan)",
+                );
+
+                match run_postinstall_hooks(RunPostinstallHooks {
+                    dep_path: &dep_path,
+                    pkg_root: &pkg_entry,
+                    root_modules_dir: modules_dir,
+                    init_cwd: lockfile_dir,
+                    extra_bin_paths: &extra_bin_paths,
+                    extra_env: &extra_env,
+                    optional: false,
+                }) {
+                    Ok(_) => {}
+                    Err(err) => {
+                        tracing::warn!(
+                            target: "pacquet::build",
+                            dep_path,
+                            error = %err,
+                            "lifecycle script failed; continuing",
+                        );
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Walk the `node_modules` directory inside a virtual store entry,
+/// yielding each package directory (handles scoped packages).
+fn walk_package_dirs(node_modules: &Path) -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    let entries = match fs::read_dir(node_modules) {
+        Ok(entries) => entries,
+        Err(_) => return dirs,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        if name_str.starts_with('@') {
+            if let Ok(scoped) = fs::read_dir(&path) {
+                for scoped_entry in scoped.flatten() {
+                    dirs.push(scoped_entry.path());
+                }
+            }
+        } else if name_str != ".bin" {
+            dirs.push(path);
+        }
+    }
+    dirs
+}
+
+/// Check whether a package directory has lifecycle scripts.
+fn has_lifecycle_scripts(pkg_dir: &Path) -> bool {
+    let manifest_path = pkg_dir.join("package.json");
+    let text = match fs::read_to_string(manifest_path) {
+        Ok(text) => text,
+        Err(_) => return false,
+    };
+    let manifest: serde_json::Value = match serde_json::from_str(&text) {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+    let Some(scripts) = manifest.get("scripts").and_then(|v| v.as_object()) else {
+        return pkg_dir.join("binding.gyp").exists();
+    };
+    scripts.contains_key("preinstall")
+        || scripts.contains_key("install")
+        || scripts.contains_key("postinstall")
+        || pkg_dir.join("binding.gyp").exists()
+}
+
+/// Compute the package directory inside the virtual store for a snapshot key.
+///
+/// For a key like `/@pnpm.e2e/pre-and-postinstall-scripts-example@1.0.0`,
+/// the directory is:
+/// `<virtual_store>/@pnpm.e2e+pre-and-postinstall-scripts-example@1.0.0/node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example`
+fn virtual_store_dir_for_key(virtual_store_dir: &Path, key: &PackageKey) -> PathBuf {
+    let key_str = key.to_string();
+    let name_version = key_str.strip_prefix('/').unwrap_or(&key_str);
+
+    let at_idx = name_version.rfind('@').unwrap_or(name_version.len());
+    let name = &name_version[..at_idx];
+
+    let store_name = name_version.replace('/', "+");
+
+    virtual_store_dir.join(&store_name).join("node_modules").join(name)
+}

--- a/crates/package-manager/src/build_modules.rs
+++ b/crates/package-manager/src/build_modules.rs
@@ -15,6 +15,72 @@ pub enum BuildModulesError {
     LifecycleScript(#[error(source)] LifecycleScriptError),
 }
 
+/// Build policy derived from `pnpm.allowBuilds` in the project manifest.
+///
+/// Ports pnpm's `createAllowBuildFunction` from
+/// `https://github.com/pnpm/pnpm/blob/7e91e4b35f/building/policy/src/index.ts`.
+///
+/// The tri-state return from [`AllowBuildPolicy::check`]:
+/// - `Some(true)`: explicitly allowed, run scripts
+/// - `Some(false)`: explicitly denied, silently skip
+/// - `None`: not in the list, skip and report as ignored
+#[derive(Debug, Default)]
+pub struct AllowBuildPolicy {
+    rules: HashMap<String, bool>,
+    has_any_rules: bool,
+}
+
+impl AllowBuildPolicy {
+    /// Read `pnpm.allowBuilds` from a project's `package.json`.
+    pub fn from_manifest(manifest_dir: &Path) -> Self {
+        let manifest_path = manifest_dir.join("package.json");
+        let text = match fs::read_to_string(manifest_path) {
+            Ok(text) => text,
+            Err(_) => return Self::default(),
+        };
+        let manifest: serde_json::Value = match serde_json::from_str(&text) {
+            Ok(v) => v,
+            Err(_) => return Self::default(),
+        };
+
+        let allow_builds =
+            manifest.get("pnpm").and_then(|v| v.get("allowBuilds")).and_then(|v| v.as_object());
+
+        let Some(allow_builds) = allow_builds else {
+            return Self::default();
+        };
+
+        let rules: HashMap<String, bool> = allow_builds
+            .iter()
+            .filter_map(|(key, value)| value.as_bool().map(|v| (key.clone(), v)))
+            .collect();
+        let has_any_rules = !rules.is_empty();
+
+        Self { rules, has_any_rules }
+    }
+
+    /// Check whether a package is allowed to run build scripts.
+    ///
+    /// `name` is the package name (e.g. `@pnpm.e2e/install-script-example`).
+    /// `version` is the resolved version (e.g. `1.0.0`).
+    pub fn check(&self, name: &str, version: &str) -> Option<bool> {
+        if !self.has_any_rules {
+            return Some(true);
+        }
+
+        let exact_key = format!("{name}@{version}");
+        if let Some(&allowed) = self.rules.get(&exact_key) {
+            return Some(allowed);
+        }
+
+        if let Some(&allowed) = self.rules.get(name) {
+            return Some(allowed);
+        }
+
+        None
+    }
+}
+
 /// Run lifecycle scripts for all packages that require a build.
 ///
 /// Ports the core of `buildModules` from
@@ -29,12 +95,19 @@ pub struct BuildModules<'a> {
     pub lockfile_dir: &'a Path,
     pub packages: Option<&'a HashMap<PackageKey, PackageMetadata>>,
     pub snapshots: Option<&'a HashMap<PackageKey, SnapshotEntry>>,
+    pub allow_build_policy: &'a AllowBuildPolicy,
 }
 
 impl<'a> BuildModules<'a> {
     pub fn run(self) -> Result<(), BuildModulesError> {
-        let BuildModules { virtual_store_dir, modules_dir, lockfile_dir, packages, snapshots } =
-            self;
+        let BuildModules {
+            virtual_store_dir,
+            modules_dir,
+            lockfile_dir,
+            packages,
+            snapshots,
+            allow_build_policy,
+        } = self;
 
         let Some(snapshots) = snapshots else { return Ok(()) };
         let Some(packages) = packages else { return Ok(()) };
@@ -48,6 +121,20 @@ impl<'a> BuildModules<'a> {
 
             if metadata.requires_build != Some(true) {
                 continue;
+            }
+
+            let (name, version) = parse_name_version_from_key(&snapshot_key.to_string());
+            match allow_build_policy.check(&name, &version) {
+                Some(false) => continue,
+                None => {
+                    tracing::info!(
+                        target: "pacquet::build",
+                        package = %snapshot_key,
+                        "skipping build (not in allowBuilds)",
+                    );
+                    continue;
+                }
+                Some(true) => {}
             }
 
             let pkg_dir = virtual_store_dir_for_key(virtual_store_dir, snapshot_key);
@@ -87,11 +174,17 @@ pub struct BuildModulesByScanning<'a> {
     pub virtual_store_dir: &'a Path,
     pub modules_dir: &'a Path,
     pub lockfile_dir: &'a Path,
+    pub allow_build_policy: &'a AllowBuildPolicy,
 }
 
 impl<'a> BuildModulesByScanning<'a> {
     pub fn run(self) -> Result<(), BuildModulesError> {
-        let BuildModulesByScanning { virtual_store_dir, modules_dir, lockfile_dir } = self;
+        let BuildModulesByScanning {
+            virtual_store_dir,
+            modules_dir,
+            lockfile_dir,
+            allow_build_policy,
+        } = self;
 
         if !virtual_store_dir.exists() {
             return Ok(());
@@ -112,15 +205,29 @@ impl<'a> BuildModulesByScanning<'a> {
                 continue;
             }
 
+            let dep_path = store_entry
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_default();
+
             for pkg_entry in walk_package_dirs(&node_modules) {
                 if !has_lifecycle_scripts(&pkg_entry) {
                     continue;
                 }
 
-                let dep_path = store_entry
-                    .file_name()
-                    .map(|n| n.to_string_lossy().to_string())
-                    .unwrap_or_default();
+                let (name, version) = parse_name_version_from_store_entry(&dep_path);
+                match allow_build_policy.check(&name, &version) {
+                    Some(false) => continue,
+                    None => {
+                        tracing::info!(
+                            target: "pacquet::build",
+                            dep_path,
+                            "skipping build (not in allowBuilds)",
+                        );
+                        continue;
+                    }
+                    Some(true) => {}
+                }
 
                 tracing::info!(
                     target: "pacquet::build",
@@ -215,4 +322,25 @@ fn virtual_store_dir_for_key(virtual_store_dir: &Path, key: &PackageKey) -> Path
     let store_name = name_version.replace('/', "+");
 
     virtual_store_dir.join(&store_name).join("node_modules").join(name)
+}
+
+/// Parse `name` and `version` from a lockfile snapshot key like
+/// `/@pnpm.e2e/install-script-example@1.0.0`.
+fn parse_name_version_from_key(key: &str) -> (String, String) {
+    let s = key.strip_prefix('/').unwrap_or(key);
+    match s.rfind('@') {
+        Some(idx) if idx > 0 => (s[..idx].to_string(), s[idx + 1..].to_string()),
+        _ => (s.to_string(), String::new()),
+    }
+}
+
+/// Parse `name` and `version` from a virtual store entry name like
+/// `@pnpm.e2e+install-script-example@1.0.0`.
+fn parse_name_version_from_store_entry(entry: &str) -> (String, String) {
+    let name_version = match entry.rfind('@') {
+        Some(idx) if idx > 0 => (&entry[..idx], &entry[idx + 1..]),
+        _ => (entry, ""),
+    };
+    let name = name_version.0.replacen('+', "/", 1);
+    (name, name_version.1.to_string())
 }

--- a/crates/package-manager/src/build_modules.rs
+++ b/crates/package-manager/src/build_modules.rs
@@ -2,7 +2,8 @@ use crate::build_sequence::build_sequence;
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_executor::{LifecycleScriptError, RunPostinstallHooks, run_postinstall_hooks};
-use pacquet_lockfile::{PackageKey, PackageMetadata, ProjectSnapshot, SnapshotEntry};
+use pacquet_lockfile::{PackageKey, ProjectSnapshot, SnapshotEntry};
+use pacquet_package_manifest::pkg_requires_build;
 use pacquet_reporter::Reporter;
 use std::{
     collections::{BTreeSet, HashMap},
@@ -138,7 +139,6 @@ pub struct BuildModules<'a> {
     pub virtual_store_dir: &'a Path,
     pub modules_dir: &'a Path,
     pub lockfile_dir: &'a Path,
-    pub packages: Option<&'a HashMap<PackageKey, PackageMetadata>>,
     pub snapshots: Option<&'a HashMap<PackageKey, SnapshotEntry>>,
     pub importers: &'a HashMap<String, ProjectSnapshot>,
     pub allow_build_policy: &'a AllowBuildPolicy,
@@ -156,19 +156,33 @@ impl<'a> BuildModules<'a> {
             virtual_store_dir,
             modules_dir,
             lockfile_dir,
-            packages,
             snapshots,
             importers,
             allow_build_policy,
         } = self;
 
         let Some(snapshots) = snapshots else { return Ok(Vec::new()) };
-        let Some(packages) = packages else { return Ok(Vec::new()) };
 
         let extra_env = HashMap::new();
         let extra_bin_paths: Vec<PathBuf> = vec![];
 
-        let chunks = build_sequence(packages, snapshots, importers);
+        // Compute requires_build per snapshot from each extracted package
+        // directory. Mirrors upstream where the worker computes
+        // `node.requiresBuild` from the package's manifest scripts and the
+        // presence of `binding.gyp` / `.hooks/` after extraction
+        // (`https://github.com/pnpm/pnpm/blob/80037699fb/building/pkg-requires-build/src/index.ts`).
+        // Pacquet does this here rather than in a worker because the worker
+        // does not exist yet — it is the same per-package on-disk inspection,
+        // moved to the build entry point.
+        let requires_build_map: HashMap<PackageKey, bool> = snapshots
+            .keys()
+            .map(|key| {
+                let pkg_dir = virtual_store_dir_for_key(virtual_store_dir, key);
+                (key.clone(), pkg_requires_build(&pkg_dir))
+            })
+            .collect();
+
+        let chunks = build_sequence(&requires_build_map, snapshots, importers);
 
         // Collect peer-stripped keys so the final list is unique and
         // sorted lexicographically — matches `dedupePackageNamesFromIgnoredBuilds`.
@@ -176,15 +190,13 @@ impl<'a> BuildModules<'a> {
 
         for chunk in chunks {
             for snapshot_key in chunk {
-                let metadata_key = snapshot_key.without_peer();
-                let Some(metadata) = packages.get(&metadata_key) else { continue };
-
                 // Ancestors-of-build packages are included in the sequence
                 // but only run scripts when they themselves require a build.
-                if metadata.requires_build != Some(true) {
+                if !requires_build_map.get(&snapshot_key).copied().unwrap_or(false) {
                     continue;
                 }
 
+                let metadata_key = snapshot_key.without_peer();
                 let (name, version) = parse_name_version_from_key(&metadata_key.to_string());
                 match allow_build_policy.check(&name, &version) {
                     Some(false) => continue,

--- a/crates/package-manager/src/build_modules.rs
+++ b/crates/package-manager/src/build_modules.rs
@@ -236,6 +236,11 @@ impl<'a> BuildModulesByScanning<'a> {
                     "running lifecycle scripts (scan)",
                 );
 
+                // Warn instead of failing: the scanning path lacks
+                // dependency bin linking, so scripts that invoke
+                // dependency bins will exit 127. The frozen-lockfile
+                // path (BuildModules) propagates errors because it
+                // has full lockfile metadata to decide what to build.
                 match run_postinstall_hooks(RunPostinstallHooks {
                     dep_path: &dep_path,
                     pkg_root: &pkg_entry,
@@ -309,11 +314,12 @@ fn has_lifecycle_scripts(pkg_dir: &Path) -> bool {
 
 /// Compute the package directory inside the virtual store for a snapshot key.
 ///
-/// For a key like `/@pnpm.e2e/pre-and-postinstall-scripts-example@1.0.0`,
-/// the directory is:
-/// `<virtual_store>/@pnpm.e2e+pre-and-postinstall-scripts-example@1.0.0/node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example`
+/// Uses `without_peer()` to strip any peer-dependency suffix before
+/// computing the path, so keys like
+/// `/@pnpm.e2e/foo@1.0.0(@pnpm.e2e/bar@2.0.0)` resolve correctly.
 fn virtual_store_dir_for_key(virtual_store_dir: &Path, key: &PackageKey) -> PathBuf {
-    let key_str = key.to_string();
+    let bare_key = key.without_peer();
+    let key_str = bare_key.to_string();
     let name_version = key_str.strip_prefix('/').unwrap_or(&key_str);
 
     let at_idx = name_version.rfind('@').unwrap_or(name_version.len());
@@ -344,3 +350,6 @@ fn parse_name_version_from_store_entry(entry: &str) -> (String, String) {
     let name = name_version.0.replacen('+', "/", 1);
     (name, name_version.1.to_string())
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/package-manager/src/build_modules/tests.rs
+++ b/crates/package-manager/src/build_modules/tests.rs
@@ -1,0 +1,119 @@
+use super::{AllowBuildPolicy, parse_name_version_from_key, parse_name_version_from_store_entry};
+use pretty_assertions::assert_eq;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn parse_scoped_key() {
+    let (name, version) = parse_name_version_from_key("/@pnpm.e2e/install-script-example@1.0.0");
+    assert_eq!(name, "@pnpm.e2e/install-script-example");
+    assert_eq!(version, "1.0.0");
+}
+
+#[test]
+fn parse_unscoped_key() {
+    let (name, version) = parse_name_version_from_key("/is-positive@1.0.0");
+    assert_eq!(name, "is-positive");
+    assert_eq!(version, "1.0.0");
+}
+
+#[test]
+fn parse_key_without_leading_slash() {
+    let (name, version) = parse_name_version_from_key("express@4.18.1");
+    assert_eq!(name, "express");
+    assert_eq!(version, "4.18.1");
+}
+
+#[test]
+fn parse_scoped_store_entry() {
+    let (name, version) =
+        parse_name_version_from_store_entry("@pnpm.e2e+install-script-example@1.0.0");
+    assert_eq!(name, "@pnpm.e2e/install-script-example");
+    assert_eq!(version, "1.0.0");
+}
+
+#[test]
+fn parse_unscoped_store_entry() {
+    let (name, version) = parse_name_version_from_store_entry("is-positive@1.0.0");
+    assert_eq!(name, "is-positive");
+    assert_eq!(version, "1.0.0");
+}
+
+#[test]
+fn allow_build_policy_no_rules_allows_all() {
+    let policy = AllowBuildPolicy::default();
+    assert_eq!(policy.check("any-package", "1.0.0"), Some(true));
+}
+
+#[test]
+fn allow_build_policy_explicit_allow() {
+    let dir = tempdir().expect("create temp dir");
+    let manifest = serde_json::json!({
+        "pnpm": {
+            "allowBuilds": {
+                "@pnpm.e2e/install-script-example": true,
+            },
+        },
+    });
+    fs::write(dir.path().join("package.json"), manifest.to_string()).expect("write manifest");
+
+    let policy = AllowBuildPolicy::from_manifest(dir.path());
+    assert_eq!(policy.check("@pnpm.e2e/install-script-example", "1.0.0"), Some(true));
+}
+
+#[test]
+fn allow_build_policy_explicit_deny() {
+    let dir = tempdir().expect("create temp dir");
+    let manifest = serde_json::json!({
+        "pnpm": {
+            "allowBuilds": {
+                "@pnpm.e2e/bad-package": false,
+            },
+        },
+    });
+    fs::write(dir.path().join("package.json"), manifest.to_string()).expect("write manifest");
+
+    let policy = AllowBuildPolicy::from_manifest(dir.path());
+    assert_eq!(policy.check("@pnpm.e2e/bad-package", "1.0.0"), Some(false));
+}
+
+#[test]
+fn allow_build_policy_unlisted_returns_none() {
+    let dir = tempdir().expect("create temp dir");
+    let manifest = serde_json::json!({
+        "pnpm": {
+            "allowBuilds": {
+                "@pnpm.e2e/allowed": true,
+            },
+        },
+    });
+    fs::write(dir.path().join("package.json"), manifest.to_string()).expect("write manifest");
+
+    let policy = AllowBuildPolicy::from_manifest(dir.path());
+    assert_eq!(policy.check("@pnpm.e2e/not-listed", "1.0.0"), None);
+}
+
+#[test]
+fn allow_build_policy_exact_version_match() {
+    let dir = tempdir().expect("create temp dir");
+    let manifest = serde_json::json!({
+        "pnpm": {
+            "allowBuilds": {
+                "@pnpm.e2e/pkg@1.0.0": true,
+                "@pnpm.e2e/pkg": false,
+            },
+        },
+    });
+    fs::write(dir.path().join("package.json"), manifest.to_string()).expect("write manifest");
+
+    let policy = AllowBuildPolicy::from_manifest(dir.path());
+    assert_eq!(policy.check("@pnpm.e2e/pkg", "1.0.0"), Some(true));
+    assert_eq!(policy.check("@pnpm.e2e/pkg", "2.0.0"), Some(false));
+}
+
+#[test]
+fn allow_build_policy_missing_manifest() {
+    let dir = tempdir().expect("create temp dir");
+    let policy = AllowBuildPolicy::from_manifest(dir.path());
+    assert_eq!(policy.check("anything", "1.0.0"), Some(true));
+}

--- a/crates/package-manager/src/build_modules/tests.rs
+++ b/crates/package-manager/src/build_modules/tests.rs
@@ -1,6 +1,12 @@
-use super::{AllowBuildPolicy, parse_name_version_from_key};
+use super::{AllowBuildPolicy, BuildModules, parse_name_version_from_key};
+use pacquet_lockfile::{
+    LockfileResolution, PackageKey, PackageMetadata, PkgName, PkgVerPeer, ProjectSnapshot,
+    RegistryResolution, ResolvedDependencyMap, ResolvedDependencySpec, SnapshotEntry,
+};
+use pacquet_reporter::{IgnoredScriptsLog, LogEvent, Reporter, SilentReporter};
 use pretty_assertions::assert_eq;
-use std::fs;
+use ssri::Integrity;
+use std::{collections::HashMap, fs, sync::Mutex};
 use tempfile::tempdir;
 
 #[test]
@@ -147,4 +153,175 @@ fn dangerously_allow_all_overrides_deny() {
 
     let policy = AllowBuildPolicy::from_manifest(dir.path());
     assert_eq!(policy.check("@pnpm.e2e/pkg", "1.0.0"), Some(true));
+}
+
+fn name(s: &str) -> PkgName {
+    PkgName::parse(s).expect("parse pkg name")
+}
+
+fn ver(s: &str) -> PkgVerPeer {
+    s.parse().expect("parse PkgVerPeer")
+}
+
+fn key(n: &str, v: &str) -> PackageKey {
+    PackageKey::new(name(n), ver(v))
+}
+
+fn pkg_meta(requires_build: Option<bool>) -> PackageMetadata {
+    PackageMetadata {
+        resolution: LockfileResolution::Registry(RegistryResolution {
+            integrity: "sha512-deadbeef".parse::<Integrity>().expect("parse integrity"),
+        }),
+        engines: None,
+        cpu: None,
+        os: None,
+        libc: None,
+        deprecated: None,
+        has_bin: None,
+        prepare: None,
+        requires_build,
+        bundled_dependencies: None,
+        peer_dependencies: None,
+        peer_dependencies_meta: None,
+    }
+}
+
+fn root_importers(deps: &[(&str, &str)]) -> HashMap<String, ProjectSnapshot> {
+    let map: ResolvedDependencyMap = deps
+        .iter()
+        .map(|(n, v)| {
+            (name(n), ResolvedDependencySpec { specifier: (*v).to_string(), version: ver(v) })
+        })
+        .collect();
+    HashMap::from([(
+        ".".to_string(),
+        ProjectSnapshot {
+            specifiers: None,
+            dependencies: (!map.is_empty()).then_some(map),
+            optional_dependencies: None,
+            dev_dependencies: None,
+            dependencies_meta: None,
+            publish_directory: None,
+        },
+    )])
+}
+
+/// Default-deny: a `requires_build: true` package not listed in
+/// `allowBuilds` lands in the returned ignored set, sorted lexically.
+#[test]
+fn build_modules_collects_ignored_builds() {
+    let snapshots = HashMap::from([
+        (key("zzz", "1.0.0"), SnapshotEntry::default()),
+        (key("aaa", "2.0.0"), SnapshotEntry::default()),
+    ]);
+    let packages = HashMap::from([
+        (key("zzz", "1.0.0"), pkg_meta(Some(true))),
+        (key("aaa", "2.0.0"), pkg_meta(Some(true))),
+    ]);
+    let importers = root_importers(&[("zzz", "1.0.0"), ("aaa", "2.0.0")]);
+    let policy = AllowBuildPolicy::default(); // empty → default-deny
+
+    let virtual_store_dir = tempdir().expect("create temp dir");
+    let modules_dir = tempdir().expect("create temp dir");
+    let lockfile_dir = tempdir().expect("create temp dir");
+
+    let ignored = BuildModules {
+        virtual_store_dir: virtual_store_dir.path(),
+        modules_dir: modules_dir.path(),
+        lockfile_dir: lockfile_dir.path(),
+        packages: Some(&packages),
+        snapshots: Some(&snapshots),
+        importers: &importers,
+        allow_build_policy: &policy,
+    }
+    .run::<SilentReporter>()
+    .expect("run BuildModules");
+    dbg!(&ignored);
+
+    assert_eq!(
+        ignored,
+        vec!["aaa@2.0.0".to_string(), "zzz@1.0.0".to_string()],
+        "ignored set must be sorted lexicographically: {ignored:?}",
+    );
+}
+
+/// Explicit `false` in `allowBuilds` is silently skipped — it does NOT
+/// land in the ignored-scripts list. Mirrors upstream
+/// `building/during-install/src/index.ts:91-93`.
+#[test]
+fn build_modules_excludes_explicit_deny_from_ignored() {
+    let snapshots = HashMap::from([
+        (key("denied", "1.0.0"), SnapshotEntry::default()),
+        (key("ignored", "1.0.0"), SnapshotEntry::default()),
+    ]);
+    let packages = HashMap::from([
+        (key("denied", "1.0.0"), pkg_meta(Some(true))),
+        (key("ignored", "1.0.0"), pkg_meta(Some(true))),
+    ]);
+    let importers = root_importers(&[("denied", "1.0.0"), ("ignored", "1.0.0")]);
+
+    let manifest_dir = tempdir().expect("create temp dir");
+    let manifest = serde_json::json!({
+        "pnpm": { "allowBuilds": { "denied": false } },
+    });
+    fs::write(manifest_dir.path().join("package.json"), manifest.to_string())
+        .expect("write manifest");
+    let policy = AllowBuildPolicy::from_manifest(manifest_dir.path());
+
+    let virtual_store_dir = tempdir().expect("create temp dir");
+    let modules_dir = tempdir().expect("create temp dir");
+
+    let ignored = BuildModules {
+        virtual_store_dir: virtual_store_dir.path(),
+        modules_dir: modules_dir.path(),
+        lockfile_dir: manifest_dir.path(),
+        packages: Some(&packages),
+        snapshots: Some(&snapshots),
+        importers: &importers,
+        allow_build_policy: &policy,
+    }
+    .run::<SilentReporter>()
+    .expect("run BuildModules");
+    dbg!(&ignored);
+
+    assert_eq!(
+        ignored,
+        vec!["ignored@1.0.0".to_string()],
+        "explicit-false must NOT appear in ignored set: {ignored:?}",
+    );
+}
+
+/// Recording fake confirms `pnpm:ignored-scripts` is the right channel
+/// for the package list. The frozen-install path emits this once after
+/// `BuildModules::run` returns; this test exercises the equivalent
+/// emit shape directly so `LogEvent::IgnoredScripts` stays connected
+/// to the BuildModules return value.
+#[test]
+fn ignored_scripts_event_carries_returned_names() {
+    static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
+    EVENTS.lock().expect("lock").clear();
+
+    struct RecordingReporter;
+    impl Reporter for RecordingReporter {
+        fn emit(event: &LogEvent) {
+            EVENTS.lock().expect("lock").push(event.clone());
+        }
+    }
+
+    let names = vec!["a@1.0.0".to_string(), "b@2.0.0".to_string()];
+    RecordingReporter::emit(&LogEvent::IgnoredScripts(IgnoredScriptsLog {
+        level: pacquet_reporter::LogLevel::Debug,
+        package_names: names.clone(),
+    }));
+
+    let captured = EVENTS.lock().expect("lock").clone();
+    dbg!(&captured);
+    assert!(
+        matches!(
+            captured.as_slice(),
+            [LogEvent::IgnoredScripts(IgnoredScriptsLog { package_names, .. })]
+                if package_names == &names
+        ),
+        "captured: {captured:?}"
+    );
 }

--- a/crates/package-manager/src/build_modules/tests.rs
+++ b/crates/package-manager/src/build_modules/tests.rs
@@ -1,12 +1,16 @@
 use super::{AllowBuildPolicy, BuildModules, parse_name_version_from_key};
 use pacquet_lockfile::{
-    LockfileResolution, PackageKey, PackageMetadata, PkgName, PkgVerPeer, ProjectSnapshot,
-    RegistryResolution, ResolvedDependencyMap, ResolvedDependencySpec, SnapshotEntry,
+    PackageKey, PkgName, PkgVerPeer, ProjectSnapshot, ResolvedDependencyMap,
+    ResolvedDependencySpec, SnapshotEntry,
 };
 use pacquet_reporter::{IgnoredScriptsLog, LogEvent, Reporter, SilentReporter};
 use pretty_assertions::assert_eq;
-use ssri::Integrity;
-use std::{collections::HashMap, fs, sync::Mutex};
+use std::{
+    collections::HashMap,
+    fs,
+    path::{Path, PathBuf},
+    sync::Mutex,
+};
 use tempfile::tempdir;
 
 /// Build a rules map from a list of (name, allowed) pairs, for tests.
@@ -138,23 +142,23 @@ fn key(n: &str, v: &str) -> PackageKey {
     PackageKey::new(name(n), ver(v))
 }
 
-fn pkg_meta(requires_build: Option<bool>) -> PackageMetadata {
-    PackageMetadata {
-        resolution: LockfileResolution::Registry(RegistryResolution {
-            integrity: "sha512-deadbeef".parse::<Integrity>().expect("parse integrity"),
-        }),
-        engines: None,
-        cpu: None,
-        os: None,
-        libc: None,
-        deprecated: None,
-        has_bin: None,
-        prepare: None,
-        requires_build,
-        bundled_dependencies: None,
-        peer_dependencies: None,
-        peer_dependencies_meta: None,
-    }
+/// Materialize a `<virtual_store_dir>/<store_name>/node_modules/<pkg_name>/package.json`
+/// fixture so `pkg_requires_build` returns true for `key`. The script body
+/// is harmless (`true`) — the existing tests rely on the policy gate to block
+/// execution, so the script never actually runs.
+fn create_buildable_pkg(virtual_store_dir: &Path, key: &PackageKey) -> PathBuf {
+    let key_str = key.without_peer().to_string();
+    let name_version = key_str.strip_prefix('/').unwrap_or(&key_str);
+    let at_idx = name_version.rfind('@').unwrap_or(name_version.len());
+    let pkg_name = &name_version[..at_idx];
+    let store_name = name_version.replace('/', "+");
+    let pkg_dir = virtual_store_dir.join(&store_name).join("node_modules").join(pkg_name);
+    fs::create_dir_all(&pkg_dir).expect("create pkg dir");
+    let manifest = serde_json::json!({
+        "scripts": { "postinstall": "true" },
+    });
+    fs::write(pkg_dir.join("package.json"), manifest.to_string()).expect("write manifest");
+    pkg_dir
 }
 
 fn root_importers(deps: &[(&str, &str)]) -> HashMap<String, ProjectSnapshot> {
@@ -177,17 +181,15 @@ fn root_importers(deps: &[(&str, &str)]) -> HashMap<String, ProjectSnapshot> {
     )])
 }
 
-/// Default-deny: a `requires_build: true` package not listed in
-/// `allowBuilds` lands in the returned ignored set, sorted lexically.
+/// Default-deny: a buildable package not listed in `allowBuilds` lands in
+/// the returned ignored set, sorted lexically. "Buildable" is computed from
+/// the extracted package directory (postinstall in package.json), matching
+/// upstream's `pkgRequiresBuild`.
 #[test]
 fn build_modules_collects_ignored_builds() {
     let snapshots = HashMap::from([
         (key("zzz", "1.0.0"), SnapshotEntry::default()),
         (key("aaa", "2.0.0"), SnapshotEntry::default()),
-    ]);
-    let packages = HashMap::from([
-        (key("zzz", "1.0.0"), pkg_meta(Some(true))),
-        (key("aaa", "2.0.0"), pkg_meta(Some(true))),
     ]);
     let importers = root_importers(&[("zzz", "1.0.0"), ("aaa", "2.0.0")]);
     let policy = AllowBuildPolicy::default(); // empty → default-deny
@@ -196,11 +198,13 @@ fn build_modules_collects_ignored_builds() {
     let modules_dir = tempdir().expect("create temp dir");
     let lockfile_dir = tempdir().expect("create temp dir");
 
+    create_buildable_pkg(virtual_store_dir.path(), &key("zzz", "1.0.0"));
+    create_buildable_pkg(virtual_store_dir.path(), &key("aaa", "2.0.0"));
+
     let ignored = BuildModules {
         virtual_store_dir: virtual_store_dir.path(),
         modules_dir: modules_dir.path(),
         lockfile_dir: lockfile_dir.path(),
-        packages: Some(&packages),
         snapshots: Some(&snapshots),
         importers: &importers,
         allow_build_policy: &policy,
@@ -225,10 +229,6 @@ fn build_modules_excludes_explicit_deny_from_ignored() {
         (key("denied", "1.0.0"), SnapshotEntry::default()),
         (key("ignored", "1.0.0"), SnapshotEntry::default()),
     ]);
-    let packages = HashMap::from([
-        (key("denied", "1.0.0"), pkg_meta(Some(true))),
-        (key("ignored", "1.0.0"), pkg_meta(Some(true))),
-    ]);
     let importers = root_importers(&[("denied", "1.0.0"), ("ignored", "1.0.0")]);
 
     let policy = AllowBuildPolicy::new(rules([("denied", false)]), false);
@@ -237,11 +237,13 @@ fn build_modules_excludes_explicit_deny_from_ignored() {
     let modules_dir = tempdir().expect("create temp dir");
     let lockfile_dir = tempdir().expect("create temp dir");
 
+    create_buildable_pkg(virtual_store_dir.path(), &key("denied", "1.0.0"));
+    create_buildable_pkg(virtual_store_dir.path(), &key("ignored", "1.0.0"));
+
     let ignored = BuildModules {
         virtual_store_dir: virtual_store_dir.path(),
         modules_dir: modules_dir.path(),
         lockfile_dir: lockfile_dir.path(),
-        packages: Some(&packages),
         snapshots: Some(&snapshots),
         importers: &importers,
         allow_build_policy: &policy,

--- a/crates/package-manager/src/build_modules/tests.rs
+++ b/crates/package-manager/src/build_modules/tests.rs
@@ -117,3 +117,17 @@ fn allow_build_policy_missing_manifest() {
     let policy = AllowBuildPolicy::from_manifest(dir.path());
     assert_eq!(policy.check("anything", "1.0.0"), Some(true));
 }
+
+#[test]
+fn allow_build_policy_empty_object_blocks_unlisted() {
+    let dir = tempdir().expect("create temp dir");
+    let manifest = serde_json::json!({
+        "pnpm": {
+            "allowBuilds": {},
+        },
+    });
+    fs::write(dir.path().join("package.json"), manifest.to_string()).expect("write manifest");
+
+    let policy = AllowBuildPolicy::from_manifest(dir.path());
+    assert_eq!(policy.check("any-package", "1.0.0"), None);
+}

--- a/crates/package-manager/src/build_modules/tests.rs
+++ b/crates/package-manager/src/build_modules/tests.rs
@@ -9,6 +9,11 @@ use ssri::Integrity;
 use std::{collections::HashMap, fs, sync::Mutex};
 use tempfile::tempdir;
 
+/// Build a rules map from a list of (name, allowed) pairs, for tests.
+fn rules<const N: usize>(entries: [(&str, bool); N]) -> HashMap<String, bool> {
+    entries.into_iter().map(|(k, v)| (k.to_string(), v)).collect()
+}
+
 #[test]
 fn parse_scoped_key() {
     let (name, version) = parse_name_version_from_key("/@pnpm.e2e/install-script-example@1.0.0");
@@ -30,6 +35,13 @@ fn parse_key_without_leading_slash() {
     assert_eq!(version, "4.18.1");
 }
 
+// Policy-logic tests below mirror upstream `building/policy/test/index.ts`
+// (`https://github.com/pnpm/pnpm/blob/80037699fb/building/policy/test/index.ts`).
+// They drive `AllowBuildPolicy::new` directly with in-memory rule maps so the
+// policy logic stays decoupled from the manifest reader, exactly the way
+// upstream tests drive `createAllowBuildFunction(opts)` decoupled from
+// `Config` parsing.
+
 #[test]
 fn default_policy_denies_all() {
     let policy = AllowBuildPolicy::default();
@@ -38,69 +50,54 @@ fn default_policy_denies_all() {
 
 #[test]
 fn explicit_allow() {
-    let dir = tempdir().expect("create temp dir");
-    let manifest = serde_json::json!({
-        "pnpm": {
-            "allowBuilds": {
-                "@pnpm.e2e/install-script-example": true,
-            },
-        },
-    });
-    fs::write(dir.path().join("package.json"), manifest.to_string()).expect("write manifest");
-
-    let policy = AllowBuildPolicy::from_manifest(dir.path());
+    let policy = AllowBuildPolicy::new(rules([("@pnpm.e2e/install-script-example", true)]), false);
     assert_eq!(policy.check("@pnpm.e2e/install-script-example", "1.0.0"), Some(true));
 }
 
 #[test]
 fn explicit_deny() {
-    let dir = tempdir().expect("create temp dir");
-    let manifest = serde_json::json!({
-        "pnpm": {
-            "allowBuilds": {
-                "@pnpm.e2e/bad-package": false,
-            },
-        },
-    });
-    fs::write(dir.path().join("package.json"), manifest.to_string()).expect("write manifest");
-
-    let policy = AllowBuildPolicy::from_manifest(dir.path());
+    let policy = AllowBuildPolicy::new(rules([("@pnpm.e2e/bad-package", false)]), false);
     assert_eq!(policy.check("@pnpm.e2e/bad-package", "1.0.0"), Some(false));
 }
 
 #[test]
 fn unlisted_returns_none() {
-    let dir = tempdir().expect("create temp dir");
-    let manifest = serde_json::json!({
-        "pnpm": {
-            "allowBuilds": {
-                "@pnpm.e2e/allowed": true,
-            },
-        },
-    });
-    fs::write(dir.path().join("package.json"), manifest.to_string()).expect("write manifest");
-
-    let policy = AllowBuildPolicy::from_manifest(dir.path());
+    let policy = AllowBuildPolicy::new(rules([("@pnpm.e2e/allowed", true)]), false);
     assert_eq!(policy.check("@pnpm.e2e/not-listed", "1.0.0"), None);
 }
 
 #[test]
 fn exact_version_takes_precedence() {
-    let dir = tempdir().expect("create temp dir");
-    let manifest = serde_json::json!({
-        "pnpm": {
-            "allowBuilds": {
-                "@pnpm.e2e/pkg@1.0.0": true,
-                "@pnpm.e2e/pkg": false,
-            },
-        },
-    });
-    fs::write(dir.path().join("package.json"), manifest.to_string()).expect("write manifest");
-
-    let policy = AllowBuildPolicy::from_manifest(dir.path());
+    let policy = AllowBuildPolicy::new(
+        rules([("@pnpm.e2e/pkg@1.0.0", true), ("@pnpm.e2e/pkg", false)]),
+        false,
+    );
     assert_eq!(policy.check("@pnpm.e2e/pkg", "1.0.0"), Some(true));
     assert_eq!(policy.check("@pnpm.e2e/pkg", "2.0.0"), Some(false));
 }
+
+#[test]
+fn empty_rules_denies_all() {
+    let policy = AllowBuildPolicy::new(HashMap::new(), false);
+    assert_eq!(policy.check("any-package", "1.0.0"), None);
+}
+
+#[test]
+fn dangerously_allow_all_builds() {
+    let policy = AllowBuildPolicy::new(HashMap::new(), true);
+    assert_eq!(policy.check("any-package", "1.0.0"), Some(true));
+    assert_eq!(policy.check("other-package", "2.0.0"), Some(true));
+}
+
+#[test]
+fn dangerously_allow_all_overrides_deny() {
+    let policy = AllowBuildPolicy::new(rules([("@pnpm.e2e/pkg", false)]), true);
+    assert_eq!(policy.check("@pnpm.e2e/pkg", "1.0.0"), Some(true));
+}
+
+// The next two tests exercise `from_manifest` end-to-end: missing manifest
+// folds to the empty default, and a real `package.json` round-trips through
+// the parser into the same logic the in-memory tests above cover.
 
 #[test]
 fn missing_manifest_denies_all() {
@@ -110,49 +107,23 @@ fn missing_manifest_denies_all() {
 }
 
 #[test]
-fn empty_allow_builds_denies_all() {
+fn from_manifest_parses_pnpm_section() {
     let dir = tempdir().expect("create temp dir");
     let manifest = serde_json::json!({
         "pnpm": {
-            "allowBuilds": {},
-        },
-    });
-    fs::write(dir.path().join("package.json"), manifest.to_string()).expect("write manifest");
-
-    let policy = AllowBuildPolicy::from_manifest(dir.path());
-    assert_eq!(policy.check("any-package", "1.0.0"), None);
-}
-
-#[test]
-fn dangerously_allow_all_builds() {
-    let dir = tempdir().expect("create temp dir");
-    let manifest = serde_json::json!({
-        "pnpm": {
-            "dangerouslyAllowAllBuilds": true,
-        },
-    });
-    fs::write(dir.path().join("package.json"), manifest.to_string()).expect("write manifest");
-
-    let policy = AllowBuildPolicy::from_manifest(dir.path());
-    assert_eq!(policy.check("any-package", "1.0.0"), Some(true));
-    assert_eq!(policy.check("other-package", "2.0.0"), Some(true));
-}
-
-#[test]
-fn dangerously_allow_all_overrides_deny() {
-    let dir = tempdir().expect("create temp dir");
-    let manifest = serde_json::json!({
-        "pnpm": {
-            "dangerouslyAllowAllBuilds": true,
+            "dangerouslyAllowAllBuilds": false,
             "allowBuilds": {
-                "@pnpm.e2e/pkg": false,
+                "@pnpm.e2e/install-script-example": true,
+                "@pnpm.e2e/bad-package": false,
             },
         },
     });
     fs::write(dir.path().join("package.json"), manifest.to_string()).expect("write manifest");
 
     let policy = AllowBuildPolicy::from_manifest(dir.path());
-    assert_eq!(policy.check("@pnpm.e2e/pkg", "1.0.0"), Some(true));
+    assert_eq!(policy.check("@pnpm.e2e/install-script-example", "1.0.0"), Some(true));
+    assert_eq!(policy.check("@pnpm.e2e/bad-package", "1.0.0"), Some(false));
+    assert_eq!(policy.check("@pnpm.e2e/unrelated", "1.0.0"), None);
 }
 
 fn name(s: &str) -> PkgName {
@@ -260,21 +231,16 @@ fn build_modules_excludes_explicit_deny_from_ignored() {
     ]);
     let importers = root_importers(&[("denied", "1.0.0"), ("ignored", "1.0.0")]);
 
-    let manifest_dir = tempdir().expect("create temp dir");
-    let manifest = serde_json::json!({
-        "pnpm": { "allowBuilds": { "denied": false } },
-    });
-    fs::write(manifest_dir.path().join("package.json"), manifest.to_string())
-        .expect("write manifest");
-    let policy = AllowBuildPolicy::from_manifest(manifest_dir.path());
+    let policy = AllowBuildPolicy::new(rules([("denied", false)]), false);
 
     let virtual_store_dir = tempdir().expect("create temp dir");
     let modules_dir = tempdir().expect("create temp dir");
+    let lockfile_dir = tempdir().expect("create temp dir");
 
     let ignored = BuildModules {
         virtual_store_dir: virtual_store_dir.path(),
         modules_dir: modules_dir.path(),
-        lockfile_dir: manifest_dir.path(),
+        lockfile_dir: lockfile_dir.path(),
         packages: Some(&packages),
         snapshots: Some(&snapshots),
         importers: &importers,

--- a/crates/package-manager/src/build_modules/tests.rs
+++ b/crates/package-manager/src/build_modules/tests.rs
@@ -40,13 +40,13 @@ fn parse_unscoped_store_entry() {
 }
 
 #[test]
-fn allow_build_policy_no_rules_allows_all() {
+fn default_policy_denies_all() {
     let policy = AllowBuildPolicy::default();
-    assert_eq!(policy.check("any-package", "1.0.0"), Some(true));
+    assert_eq!(policy.check("any-package", "1.0.0"), None);
 }
 
 #[test]
-fn allow_build_policy_explicit_allow() {
+fn explicit_allow() {
     let dir = tempdir().expect("create temp dir");
     let manifest = serde_json::json!({
         "pnpm": {
@@ -62,7 +62,7 @@ fn allow_build_policy_explicit_allow() {
 }
 
 #[test]
-fn allow_build_policy_explicit_deny() {
+fn explicit_deny() {
     let dir = tempdir().expect("create temp dir");
     let manifest = serde_json::json!({
         "pnpm": {
@@ -78,7 +78,7 @@ fn allow_build_policy_explicit_deny() {
 }
 
 #[test]
-fn allow_build_policy_unlisted_returns_none() {
+fn unlisted_returns_none() {
     let dir = tempdir().expect("create temp dir");
     let manifest = serde_json::json!({
         "pnpm": {
@@ -94,7 +94,7 @@ fn allow_build_policy_unlisted_returns_none() {
 }
 
 #[test]
-fn allow_build_policy_exact_version_match() {
+fn exact_version_takes_precedence() {
     let dir = tempdir().expect("create temp dir");
     let manifest = serde_json::json!({
         "pnpm": {
@@ -112,14 +112,14 @@ fn allow_build_policy_exact_version_match() {
 }
 
 #[test]
-fn allow_build_policy_missing_manifest() {
+fn missing_manifest_denies_all() {
     let dir = tempdir().expect("create temp dir");
     let policy = AllowBuildPolicy::from_manifest(dir.path());
-    assert_eq!(policy.check("anything", "1.0.0"), Some(true));
+    assert_eq!(policy.check("anything", "1.0.0"), None);
 }
 
 #[test]
-fn allow_build_policy_empty_object_blocks_unlisted() {
+fn empty_allow_builds_denies_all() {
     let dir = tempdir().expect("create temp dir");
     let manifest = serde_json::json!({
         "pnpm": {
@@ -130,4 +130,36 @@ fn allow_build_policy_empty_object_blocks_unlisted() {
 
     let policy = AllowBuildPolicy::from_manifest(dir.path());
     assert_eq!(policy.check("any-package", "1.0.0"), None);
+}
+
+#[test]
+fn dangerously_allow_all_builds() {
+    let dir = tempdir().expect("create temp dir");
+    let manifest = serde_json::json!({
+        "pnpm": {
+            "dangerouslyAllowAllBuilds": true,
+        },
+    });
+    fs::write(dir.path().join("package.json"), manifest.to_string()).expect("write manifest");
+
+    let policy = AllowBuildPolicy::from_manifest(dir.path());
+    assert_eq!(policy.check("any-package", "1.0.0"), Some(true));
+    assert_eq!(policy.check("other-package", "2.0.0"), Some(true));
+}
+
+#[test]
+fn dangerously_allow_all_overrides_deny() {
+    let dir = tempdir().expect("create temp dir");
+    let manifest = serde_json::json!({
+        "pnpm": {
+            "dangerouslyAllowAllBuilds": true,
+            "allowBuilds": {
+                "@pnpm.e2e/pkg": false,
+            },
+        },
+    });
+    fs::write(dir.path().join("package.json"), manifest.to_string()).expect("write manifest");
+
+    let policy = AllowBuildPolicy::from_manifest(dir.path());
+    assert_eq!(policy.check("@pnpm.e2e/pkg", "1.0.0"), Some(true));
 }

--- a/crates/package-manager/src/build_modules/tests.rs
+++ b/crates/package-manager/src/build_modules/tests.rs
@@ -1,4 +1,4 @@
-use super::{AllowBuildPolicy, parse_name_version_from_key, parse_name_version_from_store_entry};
+use super::{AllowBuildPolicy, parse_name_version_from_key};
 use pretty_assertions::assert_eq;
 use std::fs;
 use tempfile::tempdir;
@@ -22,21 +22,6 @@ fn parse_key_without_leading_slash() {
     let (name, version) = parse_name_version_from_key("express@4.18.1");
     assert_eq!(name, "express");
     assert_eq!(version, "4.18.1");
-}
-
-#[test]
-fn parse_scoped_store_entry() {
-    let (name, version) =
-        parse_name_version_from_store_entry("@pnpm.e2e+install-script-example@1.0.0");
-    assert_eq!(name, "@pnpm.e2e/install-script-example");
-    assert_eq!(version, "1.0.0");
-}
-
-#[test]
-fn parse_unscoped_store_entry() {
-    let (name, version) = parse_name_version_from_store_entry("is-positive@1.0.0");
-    assert_eq!(name, "is-positive");
-    assert_eq!(version, "1.0.0");
 }
 
 #[test]

--- a/crates/package-manager/src/build_sequence.rs
+++ b/crates/package-manager/src/build_sequence.rs
@@ -1,5 +1,5 @@
 use crate::graph_sequencer::{GraphSequencerResult, graph_sequencer};
-use pacquet_lockfile::{PackageKey, PackageMetadata, ProjectSnapshot, SnapshotEntry};
+use pacquet_lockfile::{PackageKey, ProjectSnapshot, SnapshotEntry};
 use std::collections::{HashMap, HashSet};
 
 /// Compute topologically ordered chunks of packages that need building.
@@ -12,11 +12,16 @@ use std::collections::{HashMap, HashSet};
 /// chunk are independent and could run concurrently (pacquet currently runs
 /// them sequentially).
 ///
-/// Only nodes whose subtree contains at least one `requires_build` package
-/// appear in the output. Snapshots not reachable from any importer are
-/// excluded — matching pnpm's `getSubgraphToBuild` walk.
+/// Only nodes whose subtree contains at least one build candidate appear in
+/// the output. Snapshots not reachable from any importer are excluded —
+/// matching pnpm's `getSubgraphToBuild` walk.
+///
+/// `requires_build` is the per-snapshot map computed by the caller after
+/// extraction (from each package's manifest scripts and presence of
+/// `binding.gyp` / `.hooks/`). Mirrors the role of `node.requiresBuild`
+/// upstream, which the worker computes from the extracted package contents.
 pub fn build_sequence(
-    packages: &HashMap<PackageKey, PackageMetadata>,
+    requires_build: &HashMap<PackageKey, bool>,
     snapshots: &HashMap<PackageKey, SnapshotEntry>,
     importers: &HashMap<String, ProjectSnapshot>,
 ) -> Vec<Vec<PackageKey>> {
@@ -29,7 +34,7 @@ pub fn build_sequence(
     get_subgraph_to_build(
         &root_dep_paths,
         &children,
-        packages,
+        requires_build,
         &mut nodes_to_build_set,
         &mut nodes_to_build,
         &mut walked,
@@ -125,8 +130,7 @@ fn collect_root_dep_paths(
 }
 
 /// Walk the dep graph from `entry_nodes`, filling `nodes_to_build` with
-/// packages whose subtree (including themselves) contains a `requires_build`
-/// node.
+/// packages whose subtree (including themselves) contains a build candidate.
 ///
 /// Ports `getSubgraphToBuild` from
 /// `https://github.com/pnpm/pnpm/blob/80037699fb/building/during-install/src/buildSequence.ts`.
@@ -135,7 +139,7 @@ fn collect_root_dep_paths(
 fn get_subgraph_to_build(
     entry_nodes: &[PackageKey],
     children: &HashMap<PackageKey, Vec<PackageKey>>,
-    packages: &HashMap<PackageKey, PackageMetadata>,
+    requires_build: &HashMap<PackageKey, bool>,
     nodes_to_build_set: &mut HashSet<PackageKey>,
     nodes_to_build: &mut Vec<PackageKey>,
     walked: &mut HashSet<PackageKey>,
@@ -154,19 +158,17 @@ fn get_subgraph_to_build(
         let child_should_be_built = get_subgraph_to_build(
             &child_paths,
             children,
-            packages,
+            requires_build,
             nodes_to_build_set,
             nodes_to_build,
             walked,
         );
 
-        let metadata_key = dep_path.without_peer();
-        let requires_build =
-            packages.get(&metadata_key).and_then(|m| m.requires_build).unwrap_or(false);
+        let needs_build = requires_build.get(dep_path).copied().unwrap_or(false);
         // TODO: also trigger on `patch != null` when pacquet supports
         // `patchedDependencies`.
 
-        if child_should_be_built || requires_build {
+        if child_should_be_built || needs_build {
             if nodes_to_build_set.insert(dep_path.clone()) {
                 nodes_to_build.push(dep_path.clone());
             }

--- a/crates/package-manager/src/build_sequence.rs
+++ b/crates/package-manager/src/build_sequence.rs
@@ -1,0 +1,180 @@
+use crate::graph_sequencer::{GraphSequencerResult, graph_sequencer};
+use pacquet_lockfile::{PackageKey, PackageMetadata, ProjectSnapshot, SnapshotEntry};
+use std::collections::{HashMap, HashSet};
+
+/// Compute topologically ordered chunks of packages that need building.
+///
+/// Ports `buildSequence` from
+/// `https://github.com/pnpm/pnpm/blob/80037699fb/building/during-install/src/buildSequence.ts`.
+///
+/// The returned chunks are ordered children-first: every chunk may safely
+/// run only after every preceding chunk has finished. Members of the same
+/// chunk are independent and could run concurrently (pacquet currently runs
+/// them sequentially).
+///
+/// Only nodes whose subtree contains at least one `requires_build` package
+/// appear in the output. Snapshots not reachable from any importer are
+/// excluded — matching pnpm's `getSubgraphToBuild` walk.
+pub fn build_sequence(
+    packages: &HashMap<PackageKey, PackageMetadata>,
+    snapshots: &HashMap<PackageKey, SnapshotEntry>,
+    importers: &HashMap<String, ProjectSnapshot>,
+) -> Vec<Vec<PackageKey>> {
+    let children = build_children_map(snapshots);
+    let root_dep_paths = collect_root_dep_paths(importers, snapshots);
+
+    let mut nodes_to_build_set: HashSet<PackageKey> = HashSet::new();
+    let mut nodes_to_build: Vec<PackageKey> = Vec::new();
+    let mut walked: HashSet<PackageKey> = HashSet::new();
+    get_subgraph_to_build(
+        &root_dep_paths,
+        &children,
+        packages,
+        &mut nodes_to_build_set,
+        &mut nodes_to_build,
+        &mut walked,
+    );
+
+    if nodes_to_build.is_empty() {
+        return Vec::new();
+    }
+
+    let filtered_graph: HashMap<PackageKey, Vec<PackageKey>> = nodes_to_build
+        .iter()
+        .map(|k| {
+            let edges = children
+                .get(k)
+                .map(|cs| cs.iter().filter(|c| nodes_to_build_set.contains(c)).cloned().collect())
+                .unwrap_or_default();
+            (k.clone(), edges)
+        })
+        .collect();
+
+    let GraphSequencerResult { chunks, safe, .. } =
+        graph_sequencer(&filtered_graph, &nodes_to_build);
+    if !safe {
+        tracing::warn!(
+            target: "pacquet::build",
+            "dependency cycle detected while computing build order; \
+             packages inside the cycle will run in arbitrary order",
+        );
+    }
+    chunks
+}
+
+/// Build the `node → children` adjacency map from the snapshot map.
+///
+/// Children are the resolved snapshot keys of `dependencies` and
+/// `optional_dependencies`. Edges to keys not present in the snapshot map
+/// are dropped (matches pnpm: missing nodes mean the dependency was already
+/// in `node_modules` and not part of this install's graph).
+fn build_children_map(
+    snapshots: &HashMap<PackageKey, SnapshotEntry>,
+) -> HashMap<PackageKey, Vec<PackageKey>> {
+    let mut children: HashMap<PackageKey, Vec<PackageKey>> =
+        HashMap::with_capacity(snapshots.len());
+    for (key, snap) in snapshots {
+        let mut child_keys: Vec<PackageKey> = Vec::new();
+        for deps in
+            [snap.dependencies.as_ref(), snap.optional_dependencies.as_ref()].into_iter().flatten()
+        {
+            for (alias, dep_ref) in deps {
+                let resolved = dep_ref.resolve(alias);
+                if snapshots.contains_key(&resolved) {
+                    child_keys.push(resolved);
+                }
+            }
+        }
+        children.insert(key.clone(), child_keys);
+    }
+    children
+}
+
+/// Gather snapshot keys for every direct dependency declared by an importer.
+///
+/// Iterates `dependencies`, `devDependencies`, and `optionalDependencies` of
+/// every importer. Keys whose constructed snapshot key is not in `snapshots`
+/// are dropped silently (e.g. workspace links that are not separate packages).
+fn collect_root_dep_paths(
+    importers: &HashMap<String, ProjectSnapshot>,
+    snapshots: &HashMap<PackageKey, SnapshotEntry>,
+) -> Vec<PackageKey> {
+    let mut roots: Vec<PackageKey> = Vec::new();
+    let mut seen: HashSet<PackageKey> = HashSet::new();
+    for snapshot in importers.values() {
+        for map in [
+            snapshot.dependencies.as_ref(),
+            snapshot.optional_dependencies.as_ref(),
+            snapshot.dev_dependencies.as_ref(),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            for (name, spec) in map {
+                let key = PackageKey::new(name.clone(), spec.version.clone());
+                if !snapshots.contains_key(&key) {
+                    continue;
+                }
+                if seen.insert(key.clone()) {
+                    roots.push(key);
+                }
+            }
+        }
+    }
+    roots
+}
+
+/// Walk the dep graph from `entry_nodes`, filling `nodes_to_build` with
+/// packages whose subtree (including themselves) contains a `requires_build`
+/// node.
+///
+/// Ports `getSubgraphToBuild` from
+/// `https://github.com/pnpm/pnpm/blob/80037699fb/building/during-install/src/buildSequence.ts`.
+///
+/// Returns whether *any* of the entry nodes (or their subtrees) needs to build.
+fn get_subgraph_to_build(
+    entry_nodes: &[PackageKey],
+    children: &HashMap<PackageKey, Vec<PackageKey>>,
+    packages: &HashMap<PackageKey, PackageMetadata>,
+    nodes_to_build_set: &mut HashSet<PackageKey>,
+    nodes_to_build: &mut Vec<PackageKey>,
+    walked: &mut HashSet<PackageKey>,
+) -> bool {
+    let mut current_should_be_built = false;
+    for dep_path in entry_nodes {
+        if !children.contains_key(dep_path) {
+            continue; // already in node_modules / not part of this graph
+        }
+        if walked.contains(dep_path) {
+            continue;
+        }
+        walked.insert(dep_path.clone());
+
+        let child_paths = children.get(dep_path).cloned().unwrap_or_default();
+        let child_should_be_built = get_subgraph_to_build(
+            &child_paths,
+            children,
+            packages,
+            nodes_to_build_set,
+            nodes_to_build,
+            walked,
+        );
+
+        let metadata_key = dep_path.without_peer();
+        let requires_build =
+            packages.get(&metadata_key).and_then(|m| m.requires_build).unwrap_or(false);
+        // TODO: also trigger on `patch != null` when pacquet supports
+        // `patchedDependencies`.
+
+        if child_should_be_built || requires_build {
+            if nodes_to_build_set.insert(dep_path.clone()) {
+                nodes_to_build.push(dep_path.clone());
+            }
+            current_should_be_built = true;
+        }
+    }
+    current_should_be_built
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/package-manager/src/build_sequence/tests.rs
+++ b/crates/package-manager/src/build_sequence/tests.rs
@@ -159,7 +159,10 @@ fn unrelated_subgraph_excluded() {
     assert!(flat.contains(&key("a", "1.0.0")), "ancestor of build leaf must appear: {flat:?}");
     assert!(flat.contains(&key("b", "1.0.0")), "build leaf must appear: {flat:?}");
     assert!(!flat.contains(&key("x", "1.0.0")), "unreachable ancestor must be excluded: {flat:?}");
-    assert!(!flat.contains(&key("y", "1.0.0")), "unreachable build leaf must be excluded: {flat:?}");
+    assert!(
+        !flat.contains(&key("y", "1.0.0")),
+        "unreachable build leaf must be excluded: {flat:?}"
+    );
 }
 
 #[test]

--- a/crates/package-manager/src/build_sequence/tests.rs
+++ b/crates/package-manager/src/build_sequence/tests.rs
@@ -75,7 +75,8 @@ fn root_importers(deps: &[(&str, &str)]) -> HashMap<String, ProjectSnapshot> {
 #[test]
 fn empty_inputs() {
     let chunks = build_sequence(&HashMap::new(), &HashMap::new(), &HashMap::new());
-    assert!(chunks.is_empty());
+    dbg!(&chunks);
+    assert!(chunks.is_empty(), "empty inputs ⇒ no chunks: {chunks:?}");
 }
 
 #[test]
@@ -89,7 +90,8 @@ fn no_requires_build_yields_empty() {
     let importers = root_importers(&[("a", "1.0.0")]);
 
     let chunks = build_sequence(&packages, &snapshots, &importers);
-    assert!(chunks.is_empty());
+    dbg!(&chunks);
+    assert!(chunks.is_empty(), "no requires_build ⇒ no chunks: {chunks:?}");
 }
 
 #[test]
@@ -153,10 +155,11 @@ fn unrelated_subgraph_excluded() {
 
     let chunks = build_sequence(&packages, &snapshots, &importers);
     let flat: Vec<_> = chunks.into_iter().flatten().collect();
-    assert!(flat.contains(&key("a", "1.0.0")));
-    assert!(flat.contains(&key("b", "1.0.0")));
-    assert!(!flat.contains(&key("x", "1.0.0")));
-    assert!(!flat.contains(&key("y", "1.0.0")));
+    dbg!(&flat);
+    assert!(flat.contains(&key("a", "1.0.0")), "ancestor of build leaf must appear: {flat:?}");
+    assert!(flat.contains(&key("b", "1.0.0")), "build leaf must appear: {flat:?}");
+    assert!(!flat.contains(&key("x", "1.0.0")), "unreachable ancestor must be excluded: {flat:?}");
+    assert!(!flat.contains(&key("y", "1.0.0")), "unreachable build leaf must be excluded: {flat:?}");
 }
 
 #[test]

--- a/crates/package-manager/src/build_sequence/tests.rs
+++ b/crates/package-manager/src/build_sequence/tests.rs
@@ -1,0 +1,185 @@
+use super::build_sequence;
+use pacquet_lockfile::{
+    LockfileResolution, PackageKey, PackageMetadata, PkgName, PkgVerPeer, ProjectSnapshot,
+    RegistryResolution, ResolvedDependencyMap, ResolvedDependencySpec, SnapshotDepRef,
+    SnapshotEntry,
+};
+use pretty_assertions::assert_eq;
+use ssri::Integrity;
+use std::collections::HashMap;
+
+fn name(s: &str) -> PkgName {
+    PkgName::parse(s).expect("parse pkg name")
+}
+
+fn ver(s: &str) -> PkgVerPeer {
+    s.parse().expect("parse PkgVerPeer")
+}
+
+fn key(n: &str, v: &str) -> PackageKey {
+    PackageKey::new(name(n), ver(v))
+}
+
+fn pkg_meta(requires_build: Option<bool>) -> PackageMetadata {
+    PackageMetadata {
+        resolution: LockfileResolution::Registry(RegistryResolution {
+            integrity: "sha512-deadbeef".parse::<Integrity>().expect("parse integrity"),
+        }),
+        engines: None,
+        cpu: None,
+        os: None,
+        libc: None,
+        deprecated: None,
+        has_bin: None,
+        prepare: None,
+        requires_build,
+        bundled_dependencies: None,
+        peer_dependencies: None,
+        peer_dependencies_meta: None,
+    }
+}
+
+fn snap(deps: &[(&str, &str)]) -> SnapshotEntry {
+    let map: HashMap<PkgName, SnapshotDepRef> =
+        deps.iter().map(|(n, v)| (name(n), SnapshotDepRef::Plain(ver(v)))).collect();
+    SnapshotEntry {
+        id: None,
+        dependencies: (!map.is_empty()).then_some(map),
+        optional_dependencies: None,
+        transitive_peer_dependencies: None,
+        patched: None,
+    }
+}
+
+fn importer(deps: &[(&str, &str)]) -> ProjectSnapshot {
+    let map: ResolvedDependencyMap = deps
+        .iter()
+        .map(|(n, v)| {
+            (name(n), ResolvedDependencySpec { specifier: (*v).to_string(), version: ver(v) })
+        })
+        .collect();
+    ProjectSnapshot {
+        specifiers: None,
+        dependencies: (!map.is_empty()).then_some(map),
+        optional_dependencies: None,
+        dev_dependencies: None,
+        dependencies_meta: None,
+        publish_directory: None,
+    }
+}
+
+fn root_importers(deps: &[(&str, &str)]) -> HashMap<String, ProjectSnapshot> {
+    HashMap::from([(".".to_string(), importer(deps))])
+}
+
+#[test]
+fn empty_inputs() {
+    let chunks = build_sequence(&HashMap::new(), &HashMap::new(), &HashMap::new());
+    assert!(chunks.is_empty());
+}
+
+#[test]
+fn no_requires_build_yields_empty() {
+    let snapshots = HashMap::from([
+        (key("a", "1.0.0"), snap(&[("b", "1.0.0")])),
+        (key("b", "1.0.0"), snap(&[])),
+    ]);
+    let packages =
+        HashMap::from([(key("a", "1.0.0"), pkg_meta(None)), (key("b", "1.0.0"), pkg_meta(None))]);
+    let importers = root_importers(&[("a", "1.0.0")]);
+
+    let chunks = build_sequence(&packages, &snapshots, &importers);
+    assert!(chunks.is_empty());
+}
+
+#[test]
+fn leaf_with_requires_build_runs_first() {
+    // a depends on b; only b requires build. Both nodes are added to the
+    // build sequence (a is an ancestor of a buildable node), but the order
+    // must be b before a.
+    let snapshots = HashMap::from([
+        (key("a", "1.0.0"), snap(&[("b", "1.0.0")])),
+        (key("b", "1.0.0"), snap(&[])),
+    ]);
+    let packages = HashMap::from([
+        (key("a", "1.0.0"), pkg_meta(None)),
+        (key("b", "1.0.0"), pkg_meta(Some(true))),
+    ]);
+    let importers = root_importers(&[("a", "1.0.0")]);
+
+    let chunks = build_sequence(&packages, &snapshots, &importers);
+    assert_eq!(chunks, vec![vec![key("b", "1.0.0")], vec![key("a", "1.0.0")]]);
+}
+
+#[test]
+fn deep_chain_orders_leaf_first() {
+    // a -> b -> c, only c requires build. Sequence: [c], [b], [a].
+    let snapshots = HashMap::from([
+        (key("a", "1.0.0"), snap(&[("b", "1.0.0")])),
+        (key("b", "1.0.0"), snap(&[("c", "1.0.0")])),
+        (key("c", "1.0.0"), snap(&[])),
+    ]);
+    let packages = HashMap::from([
+        (key("a", "1.0.0"), pkg_meta(None)),
+        (key("b", "1.0.0"), pkg_meta(None)),
+        (key("c", "1.0.0"), pkg_meta(Some(true))),
+    ]);
+    let importers = root_importers(&[("a", "1.0.0")]);
+
+    let chunks = build_sequence(&packages, &snapshots, &importers);
+    assert_eq!(
+        chunks,
+        vec![vec![key("c", "1.0.0")], vec![key("b", "1.0.0")], vec![key("a", "1.0.0")]],
+    );
+}
+
+#[test]
+fn unrelated_subgraph_excluded() {
+    // a -> b (b builds), x -> y (y builds). Importer only depends on a.
+    // Only the `a` subgraph should appear.
+    let snapshots = HashMap::from([
+        (key("a", "1.0.0"), snap(&[("b", "1.0.0")])),
+        (key("b", "1.0.0"), snap(&[])),
+        (key("x", "1.0.0"), snap(&[("y", "1.0.0")])),
+        (key("y", "1.0.0"), snap(&[])),
+    ]);
+    let packages = HashMap::from([
+        (key("a", "1.0.0"), pkg_meta(None)),
+        (key("b", "1.0.0"), pkg_meta(Some(true))),
+        (key("x", "1.0.0"), pkg_meta(None)),
+        (key("y", "1.0.0"), pkg_meta(Some(true))),
+    ]);
+    let importers = root_importers(&[("a", "1.0.0")]);
+
+    let chunks = build_sequence(&packages, &snapshots, &importers);
+    let flat: Vec<_> = chunks.into_iter().flatten().collect();
+    assert!(flat.contains(&key("a", "1.0.0")));
+    assert!(flat.contains(&key("b", "1.0.0")));
+    assert!(!flat.contains(&key("x", "1.0.0")));
+    assert!(!flat.contains(&key("y", "1.0.0")));
+}
+
+#[test]
+fn parallel_build_leaves_share_chunk() {
+    // root depends on a and b; both a and b have requires_build but no shared
+    // descendants. Both build leaves should land in the same chunk; root
+    // follows in the next chunk as their ancestor.
+    let snapshots = HashMap::from([
+        (key("root", "1.0.0"), snap(&[("a", "1.0.0"), ("b", "1.0.0")])),
+        (key("a", "1.0.0"), snap(&[])),
+        (key("b", "1.0.0"), snap(&[])),
+    ]);
+    let packages = HashMap::from([
+        (key("root", "1.0.0"), pkg_meta(None)),
+        (key("a", "1.0.0"), pkg_meta(Some(true))),
+        (key("b", "1.0.0"), pkg_meta(Some(true))),
+    ]);
+    let importers = root_importers(&[("root", "1.0.0")]);
+
+    let chunks = build_sequence(&packages, &snapshots, &importers);
+    assert_eq!(chunks.len(), 2);
+    let mut leaves = chunks[0].clone();
+    leaves.sort_by_key(|k| k.to_string());
+    assert_eq!(leaves, vec![key("a", "1.0.0"), key("b", "1.0.0")]);
+    assert_eq!(chunks[1], vec![key("root", "1.0.0")]);
+}

--- a/crates/package-manager/src/build_sequence/tests.rs
+++ b/crates/package-manager/src/build_sequence/tests.rs
@@ -1,11 +1,9 @@
 use super::build_sequence;
 use pacquet_lockfile::{
-    LockfileResolution, PackageKey, PackageMetadata, PkgName, PkgVerPeer, ProjectSnapshot,
-    RegistryResolution, ResolvedDependencyMap, ResolvedDependencySpec, SnapshotDepRef,
-    SnapshotEntry,
+    PackageKey, PkgName, PkgVerPeer, ProjectSnapshot, ResolvedDependencyMap,
+    ResolvedDependencySpec, SnapshotDepRef, SnapshotEntry,
 };
 use pretty_assertions::assert_eq;
-use ssri::Integrity;
 use std::collections::HashMap;
 
 fn name(s: &str) -> PkgName {
@@ -20,23 +18,11 @@ fn key(n: &str, v: &str) -> PackageKey {
     PackageKey::new(name(n), ver(v))
 }
 
-fn pkg_meta(requires_build: Option<bool>) -> PackageMetadata {
-    PackageMetadata {
-        resolution: LockfileResolution::Registry(RegistryResolution {
-            integrity: "sha512-deadbeef".parse::<Integrity>().expect("parse integrity"),
-        }),
-        engines: None,
-        cpu: None,
-        os: None,
-        libc: None,
-        deprecated: None,
-        has_bin: None,
-        prepare: None,
-        requires_build,
-        bundled_dependencies: None,
-        peer_dependencies: None,
-        peer_dependencies_meta: None,
-    }
+/// Build a `requires_build` map for tests from a list of (key, requires_build)
+/// pairs. Mirrors the per-snapshot map the runtime computes from each
+/// extracted package's `pkg_requires_build`.
+fn requires<const N: usize>(entries: [(PackageKey, bool); N]) -> HashMap<PackageKey, bool> {
+    entries.into_iter().collect()
 }
 
 fn snap(deps: &[(&str, &str)]) -> SnapshotEntry {
@@ -85,11 +71,10 @@ fn no_requires_build_yields_empty() {
         (key("a", "1.0.0"), snap(&[("b", "1.0.0")])),
         (key("b", "1.0.0"), snap(&[])),
     ]);
-    let packages =
-        HashMap::from([(key("a", "1.0.0"), pkg_meta(None)), (key("b", "1.0.0"), pkg_meta(None))]);
+    let requires_build = requires([(key("a", "1.0.0"), false), (key("b", "1.0.0"), false)]);
     let importers = root_importers(&[("a", "1.0.0")]);
 
-    let chunks = build_sequence(&packages, &snapshots, &importers);
+    let chunks = build_sequence(&requires_build, &snapshots, &importers);
     dbg!(&chunks);
     assert!(chunks.is_empty(), "no requires_build ⇒ no chunks: {chunks:?}");
 }
@@ -103,13 +88,10 @@ fn leaf_with_requires_build_runs_first() {
         (key("a", "1.0.0"), snap(&[("b", "1.0.0")])),
         (key("b", "1.0.0"), snap(&[])),
     ]);
-    let packages = HashMap::from([
-        (key("a", "1.0.0"), pkg_meta(None)),
-        (key("b", "1.0.0"), pkg_meta(Some(true))),
-    ]);
+    let requires_build = requires([(key("a", "1.0.0"), false), (key("b", "1.0.0"), true)]);
     let importers = root_importers(&[("a", "1.0.0")]);
 
-    let chunks = build_sequence(&packages, &snapshots, &importers);
+    let chunks = build_sequence(&requires_build, &snapshots, &importers);
     assert_eq!(chunks, vec![vec![key("b", "1.0.0")], vec![key("a", "1.0.0")]]);
 }
 
@@ -121,14 +103,14 @@ fn deep_chain_orders_leaf_first() {
         (key("b", "1.0.0"), snap(&[("c", "1.0.0")])),
         (key("c", "1.0.0"), snap(&[])),
     ]);
-    let packages = HashMap::from([
-        (key("a", "1.0.0"), pkg_meta(None)),
-        (key("b", "1.0.0"), pkg_meta(None)),
-        (key("c", "1.0.0"), pkg_meta(Some(true))),
+    let requires_build = requires([
+        (key("a", "1.0.0"), false),
+        (key("b", "1.0.0"), false),
+        (key("c", "1.0.0"), true),
     ]);
     let importers = root_importers(&[("a", "1.0.0")]);
 
-    let chunks = build_sequence(&packages, &snapshots, &importers);
+    let chunks = build_sequence(&requires_build, &snapshots, &importers);
     assert_eq!(
         chunks,
         vec![vec![key("c", "1.0.0")], vec![key("b", "1.0.0")], vec![key("a", "1.0.0")]],
@@ -145,15 +127,15 @@ fn unrelated_subgraph_excluded() {
         (key("x", "1.0.0"), snap(&[("y", "1.0.0")])),
         (key("y", "1.0.0"), snap(&[])),
     ]);
-    let packages = HashMap::from([
-        (key("a", "1.0.0"), pkg_meta(None)),
-        (key("b", "1.0.0"), pkg_meta(Some(true))),
-        (key("x", "1.0.0"), pkg_meta(None)),
-        (key("y", "1.0.0"), pkg_meta(Some(true))),
+    let requires_build = requires([
+        (key("a", "1.0.0"), false),
+        (key("b", "1.0.0"), true),
+        (key("x", "1.0.0"), false),
+        (key("y", "1.0.0"), true),
     ]);
     let importers = root_importers(&[("a", "1.0.0")]);
 
-    let chunks = build_sequence(&packages, &snapshots, &importers);
+    let chunks = build_sequence(&requires_build, &snapshots, &importers);
     let flat: Vec<_> = chunks.into_iter().flatten().collect();
     dbg!(&flat);
     assert!(flat.contains(&key("a", "1.0.0")), "ancestor of build leaf must appear: {flat:?}");
@@ -175,14 +157,14 @@ fn parallel_build_leaves_share_chunk() {
         (key("a", "1.0.0"), snap(&[])),
         (key("b", "1.0.0"), snap(&[])),
     ]);
-    let packages = HashMap::from([
-        (key("root", "1.0.0"), pkg_meta(None)),
-        (key("a", "1.0.0"), pkg_meta(Some(true))),
-        (key("b", "1.0.0"), pkg_meta(Some(true))),
+    let requires_build = requires([
+        (key("root", "1.0.0"), false),
+        (key("a", "1.0.0"), true),
+        (key("b", "1.0.0"), true),
     ]);
     let importers = root_importers(&[("root", "1.0.0")]);
 
-    let chunks = build_sequence(&packages, &snapshots, &importers);
+    let chunks = build_sequence(&requires_build, &snapshots, &importers);
     assert_eq!(chunks.len(), 2);
     let mut leaves = chunks[0].clone();
     leaves.sort_by_key(|k| k.to_string());

--- a/crates/package-manager/src/build_snapshot.rs
+++ b/crates/package-manager/src/build_snapshot.rs
@@ -96,7 +96,6 @@ pub fn build_package_snapshot(
         deprecated: None,
         has_bin: None,
         prepare: None,
-        requires_build: None,
         bundled_dependencies: None,
         peer_dependencies: None,
         peer_dependencies_meta: None,

--- a/crates/package-manager/src/graph_sequencer.rs
+++ b/crates/package-manager/src/graph_sequencer.rs
@@ -1,0 +1,161 @@
+use std::{
+    collections::{HashMap, HashSet, VecDeque},
+    hash::Hash,
+};
+
+/// Output of [`graph_sequencer`].
+///
+/// Ports the `Result<T>` shape from
+/// `https://github.com/pnpm/pnpm/blob/80037699fb/deps/graph-sequencer/src/index.ts`.
+#[derive(Debug)]
+pub struct GraphSequencerResult<T> {
+    /// `false` when at least one cycle of length > 1 was found.
+    pub safe: bool,
+    /// Topologically ordered groups. Every node in chunk `i` has all of its
+    /// outgoing edges (within the included subset) pointing into earlier
+    /// chunks `0..i`, so chunk `i` may run only after chunks `0..i` finish.
+    pub chunks: Vec<Vec<T>>,
+    /// Cycles encountered while sorting. Each cycle is a list of nodes.
+    pub cycles: Vec<Vec<T>>,
+}
+
+/// Topologically sort a graph into chunks.
+///
+/// Ports `graphSequencer` from
+/// `https://github.com/pnpm/pnpm/blob/80037699fb/deps/graph-sequencer/src/index.ts`.
+///
+/// `graph` is a node → outgoing-edges map. `included` selects the subset of
+/// nodes to be sorted. Edges to nodes outside the included set are ignored.
+///
+/// Iteration order follows `included`, so the output is deterministic for a
+/// given input order.
+pub fn graph_sequencer<T>(graph: &HashMap<T, Vec<T>>, included: &[T]) -> GraphSequencerResult<T>
+where
+    T: Eq + Hash + Clone,
+{
+    let mut reverse_graph: HashMap<T, Vec<T>> =
+        graph.keys().map(|k| (k.clone(), Vec::new())).collect();
+
+    let mut remaining: HashSet<T> = included.iter().cloned().collect();
+    let mut visited: HashSet<T> = HashSet::new();
+    let mut out_degree: HashMap<T, usize> = HashMap::new();
+
+    for (from, edges) in graph {
+        out_degree.insert(from.clone(), 0);
+        for to in edges {
+            if remaining.contains(from) && remaining.contains(to) {
+                *out_degree.entry(from.clone()).or_insert(0) += 1;
+                reverse_graph.entry(to.clone()).or_default().push(from.clone());
+            }
+        }
+        if !remaining.contains(from) {
+            visited.insert(from.clone());
+        }
+    }
+
+    let mut chunks: Vec<Vec<T>> = Vec::new();
+    let mut cycles: Vec<Vec<T>> = Vec::new();
+    let mut safe = true;
+
+    while !remaining.is_empty() {
+        let mut chunk: Vec<T> = Vec::new();
+        let mut min_degree: usize = usize::MAX;
+        for node in included {
+            if !remaining.contains(node) {
+                continue;
+            }
+            let degree = *out_degree.get(node).unwrap_or(&0);
+            if degree == 0 {
+                chunk.push(node.clone());
+            }
+            if degree < min_degree {
+                min_degree = degree;
+            }
+        }
+
+        if min_degree == 0 {
+            for node in &chunk {
+                remove_node(node, &reverse_graph, &mut out_degree, &mut visited, &mut remaining);
+            }
+            chunks.push(chunk);
+        } else {
+            let mut cycle_nodes: Vec<T> = Vec::new();
+            for node in included {
+                if !remaining.contains(node) {
+                    continue;
+                }
+                let cycle = find_cycle(node, graph, &visited);
+                if cycle.is_empty() {
+                    continue;
+                }
+                if cycle.len() > 1 {
+                    safe = false;
+                }
+                for n in &cycle {
+                    remove_node(n, &reverse_graph, &mut out_degree, &mut visited, &mut remaining);
+                }
+                cycle_nodes.extend(cycle.iter().cloned());
+                cycles.push(cycle);
+            }
+            chunks.push(cycle_nodes);
+        }
+    }
+
+    GraphSequencerResult { safe, chunks, cycles }
+}
+
+fn remove_node<T>(
+    node: &T,
+    reverse_graph: &HashMap<T, Vec<T>>,
+    out_degree: &mut HashMap<T, usize>,
+    visited: &mut HashSet<T>,
+    remaining: &mut HashSet<T>,
+) where
+    T: Eq + Hash + Clone,
+{
+    if let Some(parents) = reverse_graph.get(node) {
+        for parent in parents {
+            if let Some(deg) = out_degree.get_mut(parent)
+                && *deg > 0
+            {
+                *deg -= 1;
+            }
+        }
+    }
+    visited.insert(node.clone());
+    remaining.remove(node);
+}
+
+fn find_cycle<T>(start: &T, graph: &HashMap<T, Vec<T>>, visited: &HashSet<T>) -> Vec<T>
+where
+    T: Eq + Hash + Clone,
+{
+    let mut queue: VecDeque<(T, Vec<T>)> = VecDeque::new();
+    queue.push_back((start.clone(), vec![start.clone()]));
+    let mut cycle_visited: HashSet<T> = HashSet::new();
+    let mut found_cycles: Vec<Vec<T>> = Vec::new();
+
+    while let Some((id, cycle)) = queue.pop_front() {
+        let Some(edges) = graph.get(&id) else { continue };
+        for to in edges {
+            if to == start {
+                cycle_visited.insert(to.clone());
+                found_cycles.push(cycle.clone());
+                continue;
+            }
+            if visited.contains(to) || cycle_visited.contains(to) {
+                continue;
+            }
+            cycle_visited.insert(to.clone());
+            let mut new_cycle = cycle.clone();
+            new_cycle.push(to.clone());
+            queue.push_back((to.clone(), new_cycle));
+        }
+    }
+
+    found_cycles.sort_by_key(|c| std::cmp::Reverse(c.len()));
+    found_cycles.into_iter().next().unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/package-manager/src/graph_sequencer/tests.rs
+++ b/crates/package-manager/src/graph_sequencer/tests.rs
@@ -17,9 +17,10 @@ fn included(nodes: &[&str]) -> Vec<String> {
 fn empty_graph() {
     let g: HashMap<String, Vec<String>> = HashMap::new();
     let r = graph_sequencer(&g, &[]);
-    assert!(r.safe);
-    assert!(r.chunks.is_empty());
-    assert!(r.cycles.is_empty());
+    dbg!(&r);
+    assert!(r.safe, "empty graph is trivially safe");
+    assert!(r.chunks.is_empty(), "no included nodes ⇒ no chunks");
+    assert!(r.cycles.is_empty(), "no nodes ⇒ no cycles");
 }
 
 #[test]
@@ -28,7 +29,8 @@ fn linear_chain_runs_leaf_first() {
     let g = graph(&[("a", &["b"]), ("b", &["c"]), ("c", &[])]);
     let nodes = included(&["a", "b", "c"]);
     let r = graph_sequencer(&g, &nodes);
-    assert!(r.safe);
+    dbg!(&r);
+    assert!(r.safe, "DAG must sort safely: {r:?}");
     assert_eq!(r.chunks, vec![vec!["c".to_string()], vec!["b".to_string()], vec!["a".to_string()]]);
 }
 
@@ -38,7 +40,8 @@ fn parallel_siblings_share_chunk() {
     let g = graph(&[("root", &["a", "b", "c"]), ("a", &[]), ("b", &[]), ("c", &[])]);
     let nodes = included(&["root", "a", "b", "c"]);
     let r = graph_sequencer(&g, &nodes);
-    assert!(r.safe);
+    dbg!(&r);
+    assert!(r.safe, "DAG must sort safely: {r:?}");
     assert_eq!(r.chunks.len(), 2);
     let mut first = r.chunks[0].clone();
     first.sort();
@@ -52,7 +55,8 @@ fn diamond_dag() {
     let g = graph(&[("a", &["b", "c"]), ("b", &["d"]), ("c", &["d"]), ("d", &[])]);
     let nodes = included(&["a", "b", "c", "d"]);
     let r = graph_sequencer(&g, &nodes);
-    assert!(r.safe);
+    dbg!(&r);
+    assert!(r.safe, "DAG must sort safely: {r:?}");
     assert_eq!(r.chunks.len(), 3);
     assert_eq!(r.chunks[0], vec!["d".to_string()]);
     let mut middle = r.chunks[1].clone();
@@ -67,7 +71,8 @@ fn excluded_nodes_are_ignored() {
     let g = graph(&[("a", &["b"]), ("b", &["c"]), ("c", &[])]);
     let nodes = included(&["a", "c"]);
     let r = graph_sequencer(&g, &nodes);
-    assert!(r.safe);
+    dbg!(&r);
+    assert!(r.safe, "excluded-edge subgraph must sort safely: {r:?}");
     // a's only outgoing edge is to b which is excluded, so a has degree 0.
     // c also has degree 0.
     assert_eq!(r.chunks.len(), 1);
@@ -82,8 +87,9 @@ fn cycle_marks_unsafe_and_groups_cycle_nodes() {
     let g = graph(&[("a", &["b"]), ("b", &["a"])]);
     let nodes = included(&["a", "b"]);
     let r = graph_sequencer(&g, &nodes);
-    assert!(!r.safe);
-    assert!(!r.cycles.is_empty());
+    dbg!(&r);
+    assert!(!r.safe, "length-2 cycle must mark unsafe: {r:?}");
+    assert!(!r.cycles.is_empty(), "cycle list must record the cycle: {r:?}");
     // Both nodes still appear in some chunk.
     let flat: Vec<String> = r.chunks.into_iter().flatten().collect();
     let mut sorted = flat.clone();
@@ -97,7 +103,8 @@ fn self_loop_not_safe_flag() {
     let g = graph(&[("a", &["a"])]);
     let nodes = included(&["a"]);
     let r = graph_sequencer(&g, &nodes);
-    assert!(r.safe);
+    dbg!(&r);
+    assert!(r.safe, "length-1 self-loop must not mark unsafe: {r:?}");
     assert_eq!(r.chunks.len(), 1);
     assert_eq!(r.chunks[0], vec!["a".to_string()]);
 }

--- a/crates/package-manager/src/graph_sequencer/tests.rs
+++ b/crates/package-manager/src/graph_sequencer/tests.rs
@@ -1,0 +1,113 @@
+use super::graph_sequencer;
+use pretty_assertions::assert_eq;
+use std::collections::HashMap;
+
+fn graph(edges: &[(&str, &[&str])]) -> HashMap<String, Vec<String>> {
+    edges
+        .iter()
+        .map(|(k, vs)| ((*k).to_string(), vs.iter().map(|s| (*s).to_string()).collect()))
+        .collect()
+}
+
+fn included(nodes: &[&str]) -> Vec<String> {
+    nodes.iter().map(|s| (*s).to_string()).collect()
+}
+
+#[test]
+fn empty_graph() {
+    let g: HashMap<String, Vec<String>> = HashMap::new();
+    let r = graph_sequencer(&g, &[]);
+    assert!(r.safe);
+    assert!(r.chunks.is_empty());
+    assert!(r.cycles.is_empty());
+}
+
+#[test]
+fn linear_chain_runs_leaf_first() {
+    // a -> b -> c. c must build first, then b, then a.
+    let g = graph(&[("a", &["b"]), ("b", &["c"]), ("c", &[])]);
+    let nodes = included(&["a", "b", "c"]);
+    let r = graph_sequencer(&g, &nodes);
+    assert!(r.safe);
+    assert_eq!(r.chunks, vec![vec!["c".to_string()], vec!["b".to_string()], vec!["a".to_string()]]);
+}
+
+#[test]
+fn parallel_siblings_share_chunk() {
+    // root -> {a, b, c}; siblings have no edges among themselves.
+    let g = graph(&[("root", &["a", "b", "c"]), ("a", &[]), ("b", &[]), ("c", &[])]);
+    let nodes = included(&["root", "a", "b", "c"]);
+    let r = graph_sequencer(&g, &nodes);
+    assert!(r.safe);
+    assert_eq!(r.chunks.len(), 2);
+    let mut first = r.chunks[0].clone();
+    first.sort();
+    assert_eq!(first, vec!["a".to_string(), "b".to_string(), "c".to_string()]);
+    assert_eq!(r.chunks[1], vec!["root".to_string()]);
+}
+
+#[test]
+fn diamond_dag() {
+    // a -> {b, c}; both b and c -> d.
+    let g = graph(&[("a", &["b", "c"]), ("b", &["d"]), ("c", &["d"]), ("d", &[])]);
+    let nodes = included(&["a", "b", "c", "d"]);
+    let r = graph_sequencer(&g, &nodes);
+    assert!(r.safe);
+    assert_eq!(r.chunks.len(), 3);
+    assert_eq!(r.chunks[0], vec!["d".to_string()]);
+    let mut middle = r.chunks[1].clone();
+    middle.sort();
+    assert_eq!(middle, vec!["b".to_string(), "c".to_string()]);
+    assert_eq!(r.chunks[2], vec!["a".to_string()]);
+}
+
+#[test]
+fn excluded_nodes_are_ignored() {
+    // a -> b -> c, but only sequence {a, c}; b is not in `included`.
+    let g = graph(&[("a", &["b"]), ("b", &["c"]), ("c", &[])]);
+    let nodes = included(&["a", "c"]);
+    let r = graph_sequencer(&g, &nodes);
+    assert!(r.safe);
+    // a's only outgoing edge is to b which is excluded, so a has degree 0.
+    // c also has degree 0.
+    assert_eq!(r.chunks.len(), 1);
+    let mut only = r.chunks[0].clone();
+    only.sort();
+    assert_eq!(only, vec!["a".to_string(), "c".to_string()]);
+}
+
+#[test]
+fn cycle_marks_unsafe_and_groups_cycle_nodes() {
+    // a -> b -> a. Cycle of length 2: not safe.
+    let g = graph(&[("a", &["b"]), ("b", &["a"])]);
+    let nodes = included(&["a", "b"]);
+    let r = graph_sequencer(&g, &nodes);
+    assert!(!r.safe);
+    assert!(!r.cycles.is_empty());
+    // Both nodes still appear in some chunk.
+    let flat: Vec<String> = r.chunks.into_iter().flatten().collect();
+    let mut sorted = flat.clone();
+    sorted.sort();
+    assert_eq!(sorted, vec!["a".to_string(), "b".to_string()]);
+}
+
+#[test]
+fn self_loop_not_safe_flag() {
+    // a -> a. A self-loop has cycle length 1; pnpm does not mark length-1 as unsafe.
+    let g = graph(&[("a", &["a"])]);
+    let nodes = included(&["a"]);
+    let r = graph_sequencer(&g, &nodes);
+    assert!(r.safe);
+    assert_eq!(r.chunks.len(), 1);
+    assert_eq!(r.chunks[0], vec!["a".to_string()]);
+}
+
+#[test]
+fn deterministic_order_follows_included() {
+    // Three independent leaves; chunk order should follow the `included` slice.
+    let g = graph(&[("x", &[]), ("y", &[]), ("z", &[])]);
+    let r1 = graph_sequencer(&g, &included(&["x", "y", "z"]));
+    let r2 = graph_sequencer(&g, &included(&["z", "y", "x"]));
+    assert_eq!(r1.chunks[0], vec!["x".to_string(), "y".to_string(), "z".to_string()]);
+    assert_eq!(r2.chunks[0], vec!["z".to_string(), "y".to_string(), "x".to_string()]);
+}

--- a/crates/package-manager/src/install.rs
+++ b/crates/package-manager/src/install.rs
@@ -204,11 +204,12 @@ where
 
         tracing::info!(target: "pacquet::install", "Complete all");
 
-        R::emit(&LogEvent::Stage(StageLog {
-            level: LogLevel::Debug,
-            prefix: prefix.clone(),
-            stage: Stage::ImportingDone,
-        }));
+        // `Stage::ImportingDone` is emitted inside the install paths
+        // (`InstallFrozenLockfile` between symlink and build, and
+        // `InstallWithoutLockfile` after the writer task) so that any
+        // subsequent `pnpm:lifecycle` events render after the import
+        // progress display has closed. Mirrors upstream's emit point in
+        // <https://github.com/pnpm/pnpm/blob/80037699fb/installing/deps-installer/src/install/link.ts#L167>.
 
         // Write `node_modules/.modules.yaml`. Mirrors upstream's
         // `writeModulesManifest` call at

--- a/crates/package-manager/src/install/tests.rs
+++ b/crates/package-manager/src/install/tests.rs
@@ -482,12 +482,14 @@ async fn install_emits_pnpm_event_sequence() {
 
     // Event ordering matches pnpm: manifest snapshot, context,
     // importing_started, the `pnpm:stats` added/removed pair from
-    // `CreateVirtualStore::run`, the `pnpm:ignored-scripts` summary
-    // emitted after `BuildModules::run`, importing_done, and summary
-    // closing the run. The empty snapshot map still triggers the
-    // stats emit (`added: 0`, `removed: 0`), matching pnpm's
-    // unconditional emit at link time. The empty lockfile produces
-    // no ignored builds, so `ignored-scripts` carries an empty list.
+    // `CreateVirtualStore::run`, then `importing_done` once extraction
+    // and symlink linking are complete (mirrors upstream `link.ts:167`),
+    // followed by the `pnpm:ignored-scripts` summary that
+    // `BuildModules::run` produces, then summary closing the run. The
+    // empty snapshot map still triggers the stats emit (`added: 0`,
+    // `removed: 0`), matching pnpm's unconditional emit at link time.
+    // The empty lockfile produces no ignored builds, so
+    // `ignored-scripts` carries an empty list.
     assert!(
         matches!(
             captured.as_slice(),
@@ -500,8 +502,8 @@ async fn install_emits_pnpm_event_sequence() {
                 LogEvent::Stage(StageLog { stage: Stage::ImportingStarted, .. }),
                 LogEvent::Stats(StatsLog { message: StatsMessage::Added { added: 0, .. }, .. }),
                 LogEvent::Stats(StatsLog { message: StatsMessage::Removed { removed: 0, .. }, .. }),
-                LogEvent::IgnoredScripts(_),
                 LogEvent::Stage(StageLog { stage: Stage::ImportingDone, .. }),
+                LogEvent::IgnoredScripts(_),
                 LogEvent::Summary(_),
             ]
         ),
@@ -509,8 +511,8 @@ async fn install_emits_pnpm_event_sequence() {
     );
 
     // Empty lockfile produces no ignored builds.
-    let LogEvent::IgnoredScripts(IgnoredScriptsLog { package_names, .. }) = &captured[5] else {
-        unreachable!("ignored-scripts at index 5, asserted above");
+    let LogEvent::IgnoredScripts(IgnoredScriptsLog { package_names, .. }) = &captured[6] else {
+        unreachable!("ignored-scripts at index 6, asserted above");
     };
     assert!(package_names.is_empty(), "no builds in empty lockfile: {package_names:?}");
 

--- a/crates/package-manager/src/install/tests.rs
+++ b/crates/package-manager/src/install/tests.rs
@@ -8,8 +8,8 @@ use pacquet_npmrc::Npmrc;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_registry_mock::AutoMockInstance;
 use pacquet_reporter::{
-    ContextLog, LogEvent, PackageManifestLog, PackageManifestMessage, Reporter, SilentReporter,
-    Stage, StageLog, StatsLog, StatsMessage, SummaryLog,
+    ContextLog, IgnoredScriptsLog, LogEvent, PackageManifestLog, PackageManifestMessage, Reporter,
+    SilentReporter, Stage, StageLog, StatsLog, StatsMessage, SummaryLog,
 };
 use pacquet_testing_utils::fs::{get_all_folders, is_symlink_or_junction};
 use pipe_trait::Pipe;
@@ -482,10 +482,12 @@ async fn install_emits_pnpm_event_sequence() {
 
     // Event ordering matches pnpm: manifest snapshot, context,
     // importing_started, the `pnpm:stats` added/removed pair from
-    // `CreateVirtualStore::run`, importing_done, and summary
+    // `CreateVirtualStore::run`, the `pnpm:ignored-scripts` summary
+    // emitted after `BuildModules::run`, importing_done, and summary
     // closing the run. The empty snapshot map still triggers the
     // stats emit (`added: 0`, `removed: 0`), matching pnpm's
-    // unconditional emit at link time.
+    // unconditional emit at link time. The empty lockfile produces
+    // no ignored builds, so `ignored-scripts` carries an empty list.
     assert!(
         matches!(
             captured.as_slice(),
@@ -498,12 +500,19 @@ async fn install_emits_pnpm_event_sequence() {
                 LogEvent::Stage(StageLog { stage: Stage::ImportingStarted, .. }),
                 LogEvent::Stats(StatsLog { message: StatsMessage::Added { added: 0, .. }, .. }),
                 LogEvent::Stats(StatsLog { message: StatsMessage::Removed { removed: 0, .. }, .. }),
+                LogEvent::IgnoredScripts(_),
                 LogEvent::Stage(StageLog { stage: Stage::ImportingDone, .. }),
                 LogEvent::Summary(_),
             ]
         ),
         "unexpected event sequence: {captured:?}",
     );
+
+    // Empty lockfile produces no ignored builds.
+    let LogEvent::IgnoredScripts(IgnoredScriptsLog { package_names, .. }) = &captured[5] else {
+        unreachable!("ignored-scripts at index 5, asserted above");
+    };
+    assert!(package_names.is_empty(), "no builds in empty lockfile: {package_names:?}");
 
     let expected_prefix = manifest.path().parent().unwrap().to_string_lossy().into_owned();
 

--- a/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/crates/package-manager/src/install_frozen_lockfile.rs
@@ -8,7 +8,7 @@ use pacquet_lockfile::{PackageKey, PackageMetadata, ProjectSnapshot, SnapshotEnt
 use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
 use pacquet_package_manifest::DependencyGroup;
-use pacquet_reporter::Reporter;
+use pacquet_reporter::{IgnoredScriptsLog, LogEvent, LogLevel, Reporter};
 use std::{collections::HashMap, path::Path, sync::atomic::AtomicU8};
 
 /// This subroutine installs dependencies from a frozen lockfile.
@@ -82,7 +82,7 @@ where
         let manifest_dir = Path::new(requester);
         let allow_build_policy = AllowBuildPolicy::from_manifest(manifest_dir);
 
-        BuildModules {
+        let ignored_builds = BuildModules {
             virtual_store_dir: &config.virtual_store_dir,
             modules_dir: &config.modules_dir,
             lockfile_dir: manifest_dir,
@@ -91,8 +91,17 @@ where
             importers,
             allow_build_policy: &allow_build_policy,
         }
-        .run()
+        .run::<R>()
         .map_err(InstallFrozenLockfileError::BuildModules)?;
+
+        // Mirrors upstream's single emit at the end of the build phase:
+        // <https://github.com/pnpm/pnpm/blob/80037699fb/installing/deps-installer/src/install/index.ts#L414>.
+        // Always emitted (with an empty list when nothing was ignored), so
+        // the reporter can display a consistent "no ignored scripts" state.
+        R::emit(&LogEvent::IgnoredScripts(IgnoredScriptsLog {
+            level: LogLevel::Debug,
+            package_names: ignored_builds,
+        }));
 
         Ok(())
     }

--- a/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/crates/package-manager/src/install_frozen_lockfile.rs
@@ -88,6 +88,7 @@ where
             lockfile_dir: &cwd,
             packages,
             snapshots,
+            importers,
             allow_build_policy: &allow_build_policy,
         }
         .run()

--- a/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/crates/package-manager/src/install_frozen_lockfile.rs
@@ -86,7 +86,6 @@ where
             virtual_store_dir: &config.virtual_store_dir,
             modules_dir: &config.modules_dir,
             lockfile_dir: manifest_dir,
-            packages,
             snapshots,
             importers,
             allow_build_policy: &allow_build_policy,

--- a/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/crates/package-manager/src/install_frozen_lockfile.rs
@@ -1,5 +1,5 @@
 use crate::{
-    BuildModules, BuildModulesError, CreateVirtualStore, CreateVirtualStoreError,
+    AllowBuildPolicy, BuildModules, BuildModulesError, CreateVirtualStore, CreateVirtualStoreError,
     SymlinkDirectDependencies, SymlinkDirectDependenciesError,
 };
 use derive_more::{Display, Error};
@@ -79,12 +79,16 @@ where
             .run::<R>()
             .map_err(InstallFrozenLockfileError::SymlinkDirectDependencies)?;
 
+        let cwd = std::env::current_dir().unwrap_or_default();
+        let allow_build_policy = AllowBuildPolicy::from_manifest(&cwd);
+
         BuildModules {
             virtual_store_dir: &config.virtual_store_dir,
             modules_dir: &config.modules_dir,
-            lockfile_dir: &std::env::current_dir().unwrap_or_default(),
+            lockfile_dir: &cwd,
             packages,
             snapshots,
+            allow_build_policy: &allow_build_policy,
         }
         .run()
         .map_err(InstallFrozenLockfileError::BuildModules)?;

--- a/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/crates/package-manager/src/install_frozen_lockfile.rs
@@ -9,7 +9,7 @@ use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
 use pacquet_package_manifest::DependencyGroup;
 use pacquet_reporter::Reporter;
-use std::{collections::HashMap, sync::atomic::AtomicU8};
+use std::{collections::HashMap, path::Path, sync::atomic::AtomicU8};
 
 /// This subroutine installs dependencies from a frozen lockfile.
 ///
@@ -79,13 +79,13 @@ where
             .run::<R>()
             .map_err(InstallFrozenLockfileError::SymlinkDirectDependencies)?;
 
-        let cwd = std::env::current_dir().unwrap_or_default();
-        let allow_build_policy = AllowBuildPolicy::from_manifest(&cwd);
+        let manifest_dir = Path::new(requester);
+        let allow_build_policy = AllowBuildPolicy::from_manifest(manifest_dir);
 
         BuildModules {
             virtual_store_dir: &config.virtual_store_dir,
             modules_dir: &config.modules_dir,
-            lockfile_dir: &cwd,
+            lockfile_dir: manifest_dir,
             packages,
             snapshots,
             importers,

--- a/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/crates/package-manager/src/install_frozen_lockfile.rs
@@ -8,7 +8,7 @@ use pacquet_lockfile::{PackageKey, PackageMetadata, ProjectSnapshot, SnapshotEnt
 use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
 use pacquet_package_manifest::DependencyGroup;
-use pacquet_reporter::{IgnoredScriptsLog, LogEvent, LogLevel, Reporter};
+use pacquet_reporter::{IgnoredScriptsLog, LogEvent, LogLevel, Reporter, Stage, StageLog};
 use std::{collections::HashMap, path::Path, sync::atomic::AtomicU8};
 
 /// This subroutine installs dependencies from a frozen lockfile.
@@ -78,6 +78,17 @@ where
         SymlinkDirectDependencies { config, importers, dependency_groups, requester }
             .run::<R>()
             .map_err(InstallFrozenLockfileError::SymlinkDirectDependencies)?;
+
+        // Mirrors upstream `link.ts:167-170` — `importing_done` fires once
+        // extraction and symlink linking are complete, before any build
+        // phase. Reporters use it to close the import progress display so
+        // subsequent `pnpm:lifecycle` events render in their own section.
+        // <https://github.com/pnpm/pnpm/blob/80037699fb/installing/deps-installer/src/install/link.ts#L167>
+        R::emit(&LogEvent::Stage(StageLog {
+            level: LogLevel::Debug,
+            prefix: requester.to_string(),
+            stage: Stage::ImportingDone,
+        }));
 
         let manifest_dir = Path::new(requester);
         let allow_build_policy = AllowBuildPolicy::from_manifest(manifest_dir);

--- a/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/crates/package-manager/src/install_frozen_lockfile.rs
@@ -1,6 +1,6 @@
 use crate::{
-    CreateVirtualStore, CreateVirtualStoreError, SymlinkDirectDependencies,
-    SymlinkDirectDependenciesError,
+    BuildModules, BuildModulesError, CreateVirtualStore, CreateVirtualStoreError,
+    SymlinkDirectDependencies, SymlinkDirectDependenciesError,
 };
 use derive_more::{Display, Error};
 use miette::Diagnostic;
@@ -46,6 +46,9 @@ pub enum InstallFrozenLockfileError {
 
     #[diagnostic(transparent)]
     SymlinkDirectDependencies(#[error(source)] SymlinkDirectDependenciesError),
+
+    #[diagnostic(transparent)]
+    BuildModules(#[error(source)] BuildModulesError),
 }
 
 impl<'a, DependencyGroupList> InstallFrozenLockfile<'a, DependencyGroupList>
@@ -75,6 +78,16 @@ where
         SymlinkDirectDependencies { config, importers, dependency_groups, requester }
             .run::<R>()
             .map_err(InstallFrozenLockfileError::SymlinkDirectDependencies)?;
+
+        BuildModules {
+            virtual_store_dir: &config.virtual_store_dir,
+            modules_dir: &config.modules_dir,
+            lockfile_dir: &std::env::current_dir().unwrap_or_default(),
+            packages,
+            snapshots,
+        }
+        .run()
+        .map_err(InstallFrozenLockfileError::BuildModules)?;
 
         Ok(())
     }

--- a/crates/package-manager/src/install_without_lockfile.rs
+++ b/crates/package-manager/src/install_without_lockfile.rs
@@ -11,7 +11,7 @@ use pacquet_network::ThrottledClient;
 use pacquet_npmrc::Npmrc;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_registry::PackageVersion;
-use pacquet_reporter::Reporter;
+use pacquet_reporter::{LogEvent, LogLevel, Reporter, Stage, StageLog};
 use pacquet_store_dir::{SharedVerifiedFilesCache, StoreIndex, StoreIndexWriter};
 use pacquet_tarball::MemCache;
 use pipe_trait::Pipe;
@@ -181,6 +181,17 @@ impl<'a, DependencyGroupList> InstallWithoutLockfile<'a, DependencyGroupList> {
                 "store-index writer task panicked; some rows may not be persisted",
             ),
         }
+
+        // Mirrors upstream `link.ts:167-170` — `importing_done` fires once
+        // extraction and symlink linking are complete. The without-lockfile
+        // path does not run lifecycle scripts today, so emitting here also
+        // marks end-of-install for reporters.
+        // <https://github.com/pnpm/pnpm/blob/80037699fb/installing/deps-installer/src/install/link.ts#L167>
+        R::emit(&LogEvent::Stage(StageLog {
+            level: LogLevel::Debug,
+            prefix: requester.to_string(),
+            stage: Stage::ImportingDone,
+        }));
 
         Ok(())
     }

--- a/crates/package-manager/src/install_without_lockfile.rs
+++ b/crates/package-manager/src/install_without_lockfile.rs
@@ -1,6 +1,6 @@
 use crate::{
-    AllowBuildPolicy, BuildModulesByScanning, BuildModulesError, InstallPackageFromRegistry,
-    InstallPackageFromRegistryError, store_init::init_store_dir_best_effort,
+    InstallPackageFromRegistry, InstallPackageFromRegistryError,
+    store_init::init_store_dir_best_effort,
 };
 use async_recursion::async_recursion;
 use dashmap::DashSet;
@@ -52,9 +52,6 @@ pub struct InstallWithoutLockfile<'a, DependencyGroupList> {
 pub enum InstallWithoutLockfileError {
     #[diagnostic(transparent)]
     InstallPackageFromRegistry(#[error(source)] InstallPackageFromRegistryError),
-
-    #[diagnostic(transparent)]
-    BuildModules(#[error(source)] BuildModulesError),
 }
 
 impl<'a, DependencyGroupList> InstallWithoutLockfile<'a, DependencyGroupList> {
@@ -184,18 +181,6 @@ impl<'a, DependencyGroupList> InstallWithoutLockfile<'a, DependencyGroupList> {
                 "store-index writer task panicked; some rows may not be persisted",
             ),
         }
-
-        let cwd = std::env::current_dir().unwrap_or_default();
-        let allow_build_policy = AllowBuildPolicy::from_manifest(&cwd);
-
-        BuildModulesByScanning {
-            virtual_store_dir: &config.virtual_store_dir,
-            modules_dir: &config.modules_dir,
-            lockfile_dir: &cwd,
-            allow_build_policy: &allow_build_policy,
-        }
-        .run()
-        .map_err(InstallWithoutLockfileError::BuildModules)?;
 
         Ok(())
     }

--- a/crates/package-manager/src/install_without_lockfile.rs
+++ b/crates/package-manager/src/install_without_lockfile.rs
@@ -1,5 +1,5 @@
 use crate::{
-    BuildModulesByScanning, BuildModulesError, InstallPackageFromRegistry,
+    AllowBuildPolicy, BuildModulesByScanning, BuildModulesError, InstallPackageFromRegistry,
     InstallPackageFromRegistryError, store_init::init_store_dir_best_effort,
 };
 use async_recursion::async_recursion;
@@ -185,10 +185,14 @@ impl<'a, DependencyGroupList> InstallWithoutLockfile<'a, DependencyGroupList> {
             ),
         }
 
+        let cwd = std::env::current_dir().unwrap_or_default();
+        let allow_build_policy = AllowBuildPolicy::from_manifest(&cwd);
+
         BuildModulesByScanning {
             virtual_store_dir: &config.virtual_store_dir,
             modules_dir: &config.modules_dir,
-            lockfile_dir: &std::env::current_dir().unwrap_or_default(),
+            lockfile_dir: &cwd,
+            allow_build_policy: &allow_build_policy,
         }
         .run()
         .map_err(InstallWithoutLockfileError::BuildModules)?;

--- a/crates/package-manager/src/install_without_lockfile.rs
+++ b/crates/package-manager/src/install_without_lockfile.rs
@@ -1,6 +1,6 @@
 use crate::{
-    InstallPackageFromRegistry, InstallPackageFromRegistryError,
-    store_init::init_store_dir_best_effort,
+    BuildModulesByScanning, BuildModulesError, InstallPackageFromRegistry,
+    InstallPackageFromRegistryError, store_init::init_store_dir_best_effort,
 };
 use async_recursion::async_recursion;
 use dashmap::DashSet;
@@ -52,6 +52,9 @@ pub struct InstallWithoutLockfile<'a, DependencyGroupList> {
 pub enum InstallWithoutLockfileError {
     #[diagnostic(transparent)]
     InstallPackageFromRegistry(#[error(source)] InstallPackageFromRegistryError),
+
+    #[diagnostic(transparent)]
+    BuildModules(#[error(source)] BuildModulesError),
 }
 
 impl<'a, DependencyGroupList> InstallWithoutLockfile<'a, DependencyGroupList> {
@@ -181,6 +184,14 @@ impl<'a, DependencyGroupList> InstallWithoutLockfile<'a, DependencyGroupList> {
                 "store-index writer task panicked; some rows may not be persisted",
             ),
         }
+
+        BuildModulesByScanning {
+            virtual_store_dir: &config.virtual_store_dir,
+            modules_dir: &config.modules_dir,
+            lockfile_dir: &std::env::current_dir().unwrap_or_default(),
+        }
+        .run()
+        .map_err(InstallWithoutLockfileError::BuildModules)?;
 
         Ok(())
     }

--- a/crates/package-manager/src/lib.rs
+++ b/crates/package-manager/src/lib.rs
@@ -1,4 +1,5 @@
 mod add;
+mod build_modules;
 mod build_snapshot;
 mod create_cas_files;
 mod create_symlink_layout;
@@ -16,6 +17,7 @@ mod symlink_direct_dependencies;
 mod symlink_package;
 
 pub use add::*;
+pub use build_modules::*;
 pub use build_snapshot::*;
 pub use create_cas_files::*;
 pub use create_symlink_layout::*;

--- a/crates/package-manager/src/lib.rs
+++ b/crates/package-manager/src/lib.rs
@@ -1,10 +1,12 @@
 mod add;
 mod build_modules;
+mod build_sequence;
 mod build_snapshot;
 mod create_cas_files;
 mod create_symlink_layout;
 mod create_virtual_dir_by_snapshot;
 mod create_virtual_store;
+mod graph_sequencer;
 mod install;
 mod install_frozen_lockfile;
 mod install_package_by_snapshot;
@@ -18,11 +20,13 @@ mod symlink_package;
 
 pub use add::*;
 pub use build_modules::*;
+pub use build_sequence::*;
 pub use build_snapshot::*;
 pub use create_cas_files::*;
 pub use create_symlink_layout::*;
 pub use create_virtual_dir_by_snapshot::*;
 pub use create_virtual_store::*;
+pub use graph_sequencer::*;
 pub use install::*;
 pub use install_frozen_lockfile::*;
 pub use install_package_by_snapshot::*;

--- a/crates/package-manifest/src/lib.rs
+++ b/crates/package-manifest/src/lib.rs
@@ -1,6 +1,6 @@
 use std::{
     fs,
-    io::Write,
+    io::{self, Write},
     path::{Path, PathBuf},
 };
 
@@ -234,6 +234,23 @@ impl PackageManifest {
 
         if if_present { Ok(None) } else { Err(PackageManifestError::NoScript(command.to_string())) }
     }
+}
+
+/// Read `<dir>/package.json` if it exists, returning `Ok(None)` when the file
+/// is absent. Other IO errors and JSON parse errors propagate.
+///
+/// Mirrors upstream `safeReadPackageJsonFromDir` from
+/// <https://github.com/pnpm/pnpm/blob/80037699fb/pkg-manifest/reader/src/index.ts#L48>.
+/// Upstream returns `null` only on `ENOENT`; malformed JSON surfaces as a
+/// `BAD_PACKAGE_JSON` error and other IO errors propagate.
+pub fn safe_read_package_json_from_dir(dir: &Path) -> Result<Option<Value>, PackageManifestError> {
+    let path = dir.join("package.json");
+    let text = match fs::read_to_string(&path) {
+        Ok(text) => text,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(PackageManifestError::Io(err)),
+    };
+    serde_json::from_str(&text).map(Some).map_err(PackageManifestError::Serialization)
 }
 
 #[cfg(test)]

--- a/crates/package-manifest/src/lib.rs
+++ b/crates/package-manifest/src/lib.rs
@@ -253,5 +253,33 @@ pub fn safe_read_package_json_from_dir(dir: &Path) -> Result<Option<Value>, Pack
     serde_json::from_str(&text).map(Some).map_err(PackageManifestError::Serialization)
 }
 
+/// Decide whether a package directory needs a build pass.
+///
+/// Mirrors upstream `pkgRequiresBuild` from
+/// <https://github.com/pnpm/pnpm/blob/80037699fb/building/pkg-requires-build/src/index.ts>:
+/// true when the package's manifest declares any of `preinstall`, `install`,
+/// or `postinstall`, or when the package contains `binding.gyp` or a `.hooks/`
+/// directory. Missing manifests, IO errors, and parse errors all collapse to
+/// `false` — pacquet cannot meaningfully build a package whose extracted
+/// content cannot be inspected.
+pub fn pkg_requires_build(pkg_root: &Path) -> bool {
+    if pkg_root.join("binding.gyp").exists() || pkg_root.join(".hooks").is_dir() {
+        return true;
+    }
+    let manifest = match safe_read_package_json_from_dir(pkg_root) {
+        Ok(Some(value)) => value,
+        _ => return false,
+    };
+    manifest
+        .get("scripts")
+        .and_then(Value::as_object)
+        .map(|scripts| {
+            scripts.contains_key("preinstall")
+                || scripts.contains_key("install")
+                || scripts.contains_key("postinstall")
+        })
+        .unwrap_or(false)
+}
+
 #[cfg(test)]
 mod tests;

--- a/crates/reporter/src/lib.rs
+++ b/crates/reporter/src/lib.rs
@@ -128,6 +128,27 @@ pub enum LogEvent {
     /// Emit site: <https://github.com/pnpm/pnpm/blob/086c5e91e8/fetching/tarball-fetcher/src/remoteTarballFetcher.ts#L91>.
     #[serde(rename = "pnpm:request-retry")]
     RequestRetry(RequestRetryLog),
+
+    /// Per-script lifecycle output (`pnpm:lifecycle`). Three flavors,
+    /// distinguished by which optional fields the record carries:
+    /// `Script` fires once before the script spawns, `Stdio` fires per
+    /// stdout/stderr line, and `Exit` fires once after the script
+    /// returns. All three carry `depPath`, `stage`, and `wd`.
+    ///
+    /// Upstream: <https://github.com/pnpm/pnpm/blob/80037699fb/core/core-loggers/src/lifecycleLogger.ts>.
+    /// Emit site: <https://github.com/pnpm/pnpm/blob/80037699fb/exec/lifecycle/src/runLifecycleHook.ts>.
+    #[serde(rename = "pnpm:lifecycle")]
+    Lifecycle(LifecycleLog),
+
+    /// One per install run, listing every package whose lifecycle
+    /// scripts were skipped because the package was not in
+    /// `allowBuilds` (`pnpm:ignored-scripts`). pnpm's reporter renders
+    /// the list to remind the user they can opt in.
+    ///
+    /// Upstream: <https://github.com/pnpm/pnpm/blob/80037699fb/core/core-loggers/src/ignoredScriptsLogger.ts>.
+    /// Emit site: <https://github.com/pnpm/pnpm/blob/80037699fb/installing/deps-installer/src/install/index.ts#L414>.
+    #[serde(rename = "pnpm:ignored-scripts")]
+    IgnoredScripts(IgnoredScriptsLog),
 }
 
 /// `pnpm:context` payload.
@@ -422,6 +443,78 @@ pub struct RequestRetryError {
     pub errno: Option<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub code: Option<String>,
+}
+
+/// `pnpm:lifecycle` payload. Same flatten-on-presence pattern as
+/// [`PackageManifestLog`] / [`RootLog`].
+#[derive(Debug, Clone, Serialize)]
+pub struct LifecycleLog {
+    pub level: LogLevel,
+    #[serde(flatten)]
+    pub message: LifecycleMessage,
+}
+
+/// `pnpm:lifecycle` discriminated payload. pnpm's
+/// [`LifecycleMessage`](https://github.com/pnpm/pnpm/blob/80037699fb/core/core-loggers/src/lifecycleLogger.ts)
+/// is a TypeScript union of three shapes that pnpm's reporter
+/// dispatches on by presence of `script`, `line`, or `exitCode`.
+/// `#[serde(untagged)]` matches that shape so consumers
+/// (notably `@pnpm/cli.default-reporter`) accept the record unchanged.
+#[derive(Debug, Clone, Serialize)]
+#[serde(untagged)]
+pub enum LifecycleMessage {
+    /// `ScriptLifecycleMessage` upstream: emitted once before each
+    /// hook spawns.
+    Script {
+        #[serde(rename = "depPath")]
+        dep_path: String,
+        optional: bool,
+        script: String,
+        stage: String,
+        wd: String,
+    },
+    /// `StdioLifecycleMessage` upstream: one event per stdout/stderr
+    /// line read from the spawned script. `line` is the raw text of
+    /// the output line.
+    Stdio {
+        #[serde(rename = "depPath")]
+        dep_path: String,
+        line: String,
+        stage: String,
+        stdio: LifecycleStdio,
+        wd: String,
+    },
+    /// `ExitLifecycleMessage` upstream: emitted once after the script
+    /// exits with the resolved exit code.
+    Exit {
+        #[serde(rename = "depPath")]
+        dep_path: String,
+        #[serde(rename = "exitCode")]
+        exit_code: i32,
+        optional: bool,
+        stage: String,
+        wd: String,
+    },
+}
+
+/// Stdio channel discriminator on a [`LifecycleMessage::Stdio`] event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LifecycleStdio {
+    Stdout,
+    Stderr,
+}
+
+/// `pnpm:ignored-scripts` payload. Emitted once per install with the
+/// names of every package whose lifecycle scripts were skipped because
+/// the package was not in `allowBuilds`. Names are in `name@version`
+/// form, matching upstream's `dedupePackageNamesFromIgnoredBuilds`
+/// output.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IgnoredScriptsLog {
+    pub level: LogLevel,
+    pub package_names: Vec<String>,
 }
 
 /// Severity level on the [bunyan]-shaped envelope.

--- a/crates/reporter/src/tests.rs
+++ b/crates/reporter/src/tests.rs
@@ -6,10 +6,11 @@ use serde_json::Value;
 
 use crate::{
     AddedRoot, ContextLog, DependencyType, Envelope, FetchingProgressLog, FetchingProgressMessage,
-    GetHostName, LogEvent, LogLevel, PackageImportMethod, PackageImportMethodLog,
-    PackageManifestLog, PackageManifestMessage, ProgressLog, ProgressMessage, RealApi, RemovedRoot,
-    Reporter, RequestRetryError, RequestRetryLog, RootLog, RootMessage, SilentReporter, Stage,
-    StageLog, StatsLog, StatsMessage, SummaryLog,
+    GetHostName, IgnoredScriptsLog, LifecycleLog, LifecycleMessage, LifecycleStdio, LogEvent,
+    LogLevel, PackageImportMethod, PackageImportMethodLog, PackageManifestLog,
+    PackageManifestMessage, ProgressLog, ProgressMessage, RealApi, RemovedRoot, Reporter,
+    RequestRetryError, RequestRetryLog, RootLog, RootMessage, SilentReporter, Stage, StageLog,
+    StatsLog, StatsMessage, SummaryLog,
 };
 
 /// Context log serializes with the camelCase field names
@@ -462,6 +463,117 @@ fn request_retry_event_matches_pnpm_wire_shape() {
     for k in ["status", "errno", "code"] {
         assert!(json["error"].get(k).is_none(), "error.{k} should be absent, got {json:?}");
     }
+}
+
+/// `pnpm:lifecycle` is presence-tagged on `script` / `line` / `exitCode`.
+/// pnpm's reporter dispatches on which of those is present rather than
+/// on a `status` discriminator. The shared fields (`depPath`, `stage`,
+/// `wd`) appear on every record. Field names use camelCase
+/// (`depPath`, `exitCode`) so `@pnpm/cli.default-reporter` parses them.
+#[test]
+fn lifecycle_event_matches_pnpm_wire_shape() {
+    eprintln!("CASE: Script");
+    let event = LogEvent::Lifecycle(LifecycleLog {
+        level: LogLevel::Debug,
+        message: LifecycleMessage::Script {
+            dep_path: "/x@1.0.0".to_string(),
+            optional: false,
+            script: "node build.js".to_string(),
+            stage: "postinstall".to_string(),
+            wd: "/proj/node_modules/.pacquet/x@1.0.0/node_modules/x".to_string(),
+        },
+    });
+    let envelope = Envelope { time: 1_700_000_000_000, hostname: "host", pid: 4242, event: &event };
+    let json: Value = envelope
+        .pipe_ref(serde_json::to_string)
+        .expect("serialize envelope")
+        .pipe_as_ref(serde_json::from_str)
+        .expect("parse JSON");
+    dbg!(&json);
+    assert_eq!(json["name"], "pnpm:lifecycle");
+    assert_eq!(json["level"], "debug");
+    assert_eq!(json["depPath"], "/x@1.0.0");
+    assert_eq!(json["optional"], false);
+    assert_eq!(json["script"], "node build.js");
+    assert_eq!(json["stage"], "postinstall");
+    assert_eq!(json["wd"], "/proj/node_modules/.pacquet/x@1.0.0/node_modules/x");
+    for k in ["line", "stdio", "exitCode"] {
+        assert!(json.get(k).is_none(), "Script must not carry {k}, got {json:?}");
+    }
+
+    eprintln!("CASE: Stdio");
+    let event = LogEvent::Lifecycle(LifecycleLog {
+        level: LogLevel::Debug,
+        message: LifecycleMessage::Stdio {
+            dep_path: "/x@1.0.0".to_string(),
+            line: "hello world".to_string(),
+            stage: "postinstall".to_string(),
+            stdio: LifecycleStdio::Stdout,
+            wd: "/wd".to_string(),
+        },
+    });
+    let envelope = Envelope { time: 1_700_000_000_000, hostname: "host", pid: 4242, event: &event };
+    let json: Value = envelope
+        .pipe_ref(serde_json::to_string)
+        .expect("serialize envelope")
+        .pipe_as_ref(serde_json::from_str)
+        .expect("parse JSON");
+    dbg!(&json);
+    assert_eq!(json["depPath"], "/x@1.0.0");
+    assert_eq!(json["line"], "hello world");
+    assert_eq!(json["stdio"], "stdout");
+    assert_eq!(json["stage"], "postinstall");
+    assert_eq!(json["wd"], "/wd");
+    for k in ["script", "exitCode", "optional"] {
+        assert!(json.get(k).is_none(), "Stdio must not carry {k}, got {json:?}");
+    }
+
+    eprintln!("CASE: Exit");
+    let event = LogEvent::Lifecycle(LifecycleLog {
+        level: LogLevel::Debug,
+        message: LifecycleMessage::Exit {
+            dep_path: "/x@1.0.0".to_string(),
+            exit_code: 0,
+            optional: false,
+            stage: "postinstall".to_string(),
+            wd: "/wd".to_string(),
+        },
+    });
+    let envelope = Envelope { time: 1_700_000_000_000, hostname: "host", pid: 4242, event: &event };
+    let json: Value = envelope
+        .pipe_ref(serde_json::to_string)
+        .expect("serialize envelope")
+        .pipe_as_ref(serde_json::from_str)
+        .expect("parse JSON");
+    dbg!(&json);
+    assert_eq!(json["depPath"], "/x@1.0.0");
+    assert_eq!(json["exitCode"], 0);
+    assert_eq!(json["optional"], false);
+    assert_eq!(json["stage"], "postinstall");
+    assert_eq!(json["wd"], "/wd");
+    for k in ["script", "line", "stdio"] {
+        assert!(json.get(k).is_none(), "Exit must not carry {k}, got {json:?}");
+    }
+}
+
+/// `pnpm:ignored-scripts` carries a single field: `packageNames` (camelCase).
+/// Default-reporter needs the camelCase spelling.
+#[test]
+fn ignored_scripts_event_matches_pnpm_wire_shape() {
+    let event = LogEvent::IgnoredScripts(IgnoredScriptsLog {
+        level: LogLevel::Debug,
+        package_names: vec!["foo@1.0.0".to_string(), "bar@2.0.0".to_string()],
+    });
+    let envelope = Envelope { time: 1_700_000_000_000, hostname: "host", pid: 4242, event: &event };
+    let json: Value = envelope
+        .pipe_ref(serde_json::to_string)
+        .expect("serialize envelope")
+        .pipe_as_ref(serde_json::from_str)
+        .expect("parse JSON");
+    dbg!(&json);
+    assert_eq!(json["name"], "pnpm:ignored-scripts");
+    assert_eq!(json["level"], "debug");
+    assert_eq!(json["packageNames"], serde_json::json!(["foo@1.0.0", "bar@2.0.0"]));
 }
 
 /// Phase markers serialize as the snake_case strings pnpm uses.

--- a/plans/TEST_PORTING.md
+++ b/plans/TEST_PORTING.md
@@ -166,27 +166,27 @@ Rust port notes:
 
 Primary frozen/headless tests:
 
-- [ ] `TypeScript repo: installing/deps-installer/test/install/lifecycleScripts.ts:331` `lifecycle scripts run before linking bins` removes `node_modules`, reinstalls frozen, and verifies generated bins are executable.
+- [x] `TypeScript repo: installing/deps-installer/test/install/lifecycleScripts.ts:331` `lifecycle scripts run before linking bins` removes `node_modules`, reinstalls frozen, and verifies generated bins are executable.
 - [ ] `TypeScript repo: installing/deps-installer/test/install/lifecycleScripts.ts:351` `hoisting does not fail on commands that will be created by lifecycle scripts on a later stage` covers `hoistPattern: '*'` and frozen install.
-- [ ] `TypeScript repo: installing/deps-installer/test/install/lifecycleScripts.ts:372` `bins are linked even if lifecycle scripts are ignored` verifies bin linking after frozen reinstall with ignored scripts.
+- [x] `TypeScript repo: installing/deps-installer/test/install/lifecycleScripts.ts:372` `bins are linked even if lifecycle scripts are ignored` verifies bin linking after frozen reinstall with ignored scripts.
 - [ ] `TypeScript repo: installing/deps-installer/test/install/lifecycleScripts.ts:408` `dependency should not be added to current lockfile if it was not built successfully during headless install` covers failed build during frozen/headless install.
-- [ ] `TypeScript repo: installing/deps-installer/test/install/lifecycleScripts.ts:445` `selectively ignore scripts in some dependencies by allowBuilds (not others)` covers frozen reinstall with selective build policy.
-- [ ] `TypeScript repo: installing/deps-installer/test/install/lifecycleScripts.ts:466` `selectively allow scripts in some dependencies by allowBuilds` covers frozen reinstall and ignored script reporting.
-- [ ] `TypeScript repo: installing/deps-installer/test/install/lifecycleScripts.ts:504` `selectively allow scripts in some dependencies by allowBuilds using exact versions` covers exact-version allow list.
-- [ ] `TypeScript repo: installing/deps-installer/test/install/lifecycleScripts.ts:552` `lifecycle scripts run after linking root dependencies` verifies builds can require root dependencies during frozen install.
-- [ ] `TypeScript repo: installing/deps-installer/test/install/lifecycleScripts.ts:724` `build dependencies that were not previously built after allowBuilds changes` covers rebuilding newly allowed dependencies with frozen install.
+- [x] `TypeScript repo: installing/deps-installer/test/install/lifecycleScripts.ts:445` `selectively ignore scripts in some dependencies by allowBuilds (not others)` covers frozen reinstall with selective build policy.
+- [x] `TypeScript repo: installing/deps-installer/test/install/lifecycleScripts.ts:466` `selectively allow scripts in some dependencies by allowBuilds` covers frozen reinstall and ignored script reporting.
+- [x] `TypeScript repo: installing/deps-installer/test/install/lifecycleScripts.ts:504` `selectively allow scripts in some dependencies by allowBuilds using exact versions` covers exact-version allow list.
+- [x] `TypeScript repo: installing/deps-installer/test/install/lifecycleScripts.ts:552` `lifecycle scripts run after linking root dependencies` verifies builds can require root dependencies during frozen install.
+- [x] `TypeScript repo: installing/deps-installer/test/install/lifecycleScripts.ts:724` `build dependencies that were not previously built after allowBuilds changes` covers rebuilding newly allowed dependencies with frozen install.
 - [ ] `TypeScript repo: installing/deps-installer/test/install/multipleImporters.ts:1902` `link the bin file of a workspace project that is created by a lifecycle script` covers workspace build-created bin behavior and frozen reinstall.
 
 Supporting tests:
 
-- [ ] `TypeScript repo: installing/deps-restorer/test/index.ts:362` `run pre/postinstall scripts` verifies headless build execution and `pendingBuilds` when scripts are ignored.
+- [x] `TypeScript repo: installing/deps-restorer/test/index.ts:362` `run pre/postinstall scripts` verifies headless build execution and `pendingBuilds` when scripts are ignored.
 - [ ] `TypeScript repo: pnpm/test/install/lifecycleScripts.ts:245` `the list of ignored builds is preserved after a repeat install` covers CLI-level `.modules.yaml.ignoredBuilds` persistence.
 - [ ] `TypeScript repo: pnpm/test/install/lifecycleScripts.ts:303` `strictDepBuilds fails for packages with cached side-effects (#11035)` ensures cached side effects do not bypass build approval.
-- [ ] `TypeScript repo: installing/deps-installer/test/install/lifecycleScripts.ts:26` `run pre/postinstall scripts`
+- [x] `TypeScript repo: installing/deps-installer/test/install/lifecycleScripts.ts:26` `run pre/postinstall scripts`
 - [ ] `TypeScript repo: installing/deps-installer/test/install/lifecycleScripts.ts:60` `return the list of packages that should be build`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/lifecycleScripts.ts:121` `run install scripts`
+- [x] `TypeScript repo: installing/deps-installer/test/install/lifecycleScripts.ts:121` `run install scripts`
 - [ ] `TypeScript repo: installing/deps-installer/test/install/lifecycleScripts.ts:175` `installation fails if lifecycle script fails`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/lifecycleScripts.ts:303` `run lifecycle scripts of dependent packages after running scripts of their deps`
+- [x] `TypeScript repo: installing/deps-installer/test/install/lifecycleScripts.ts:303` `run lifecycle scripts of dependent packages after running scripts of their deps`
 
 Rust port notes:
 


### PR DESCRIPTION
## Summary

- Add lifecycle script runner to `pacquet-executor`: preinstall, install, postinstall in correct order, `binding.gyp` auto-detection, `INIT_CWD`/`PNPM_SCRIPT_SRC_DIR`/PATH environment setup
- Add `allowBuilds` build policy matching pnpm 11's default-deny behavior, with `dangerouslyAllowAllBuilds` escape hatch
- Wire build step into the frozen-lockfile install path
- Port `buildSequence` + `graphSequencer` so packages with `requires_build` run children-first
- Add `pnpm:lifecycle` and `pnpm:ignored-scripts` reporter channels — script start/stdio/exit events flow through the same NDJSON pipeline `@pnpm/cli.default-reporter` consumes from upstream pnpm
- Port 11 upstream lifecycle script tests as `known_failures`

Upstream refs:
- [`runPostinstallHooks`](https://github.com/pnpm/pnpm/blob/7e91e4b35f/exec/lifecycle/src/index.ts)
- [`runLifecycleHook`](https://github.com/pnpm/pnpm/blob/80037699fb/exec/lifecycle/src/runLifecycleHook.ts)
- [`createAllowBuildFunction`](https://github.com/pnpm/pnpm/blob/7e91e4b35f/building/policy/src/index.ts)
- [`buildSequence`](https://github.com/pnpm/pnpm/blob/80037699fb/building/during-install/src/buildSequence.ts)
- [`graphSequencer`](https://github.com/pnpm/pnpm/blob/80037699fb/deps/graph-sequencer/src/index.ts)
- [`lifecycleLogger`](https://github.com/pnpm/pnpm/blob/80037699fb/core/core-loggers/src/lifecycleLogger.ts)
- [`ignoredScriptsLogger`](https://github.com/pnpm/pnpm/blob/80037699fb/core/core-loggers/src/ignoredScriptsLogger.ts)

## What's implemented

- `run_postinstall_hooks` in `pacquet-executor` faithfully ports pnpm's hook runner. The hook is now generic over `R: Reporter` and emits `pnpm:lifecycle` events through the standard pacquet reporter pipeline: `Script` before each spawn, one `Stdio` event per stdout/stderr line read through `Stdio::piped()` byline buffering, and `Exit` after the script returns
- `AllowBuildPolicy` reads `pnpm.allowBuilds` and `pnpm.dangerouslyAllowAllBuilds` from `package.json` with correct tri-state semantics (allow/deny/ignored)
- Default-deny matches pnpm 11: packages must be explicitly listed in `allowBuilds` to run their scripts
- `BuildModules::run::<R>` runs lifecycle scripts for `requires_build: true` packages in the frozen-lockfile path and returns the sorted (peer-stripped) list of packages whose scripts were skipped because they weren't in `allowBuilds`. `InstallFrozenLockfile::run` emits one `pnpm:ignored-scripts` event with that list (always, even when empty), mirroring upstream
- `build_sequence` walks the dep graph from each importer, keeps only nodes whose subtree contains a build node, and feeds that subgraph into `graph_sequencer` to produce topologically ordered chunks. `BuildModules` iterates the chunks in order so children build before parents
- `AllowBuildPolicy` and `BuildModules.lockfile_dir` use the existing `requester` field (derived from `manifest.path().parent()`) instead of `std::env::current_dir()`
- New `LogEvent::Lifecycle` and `LogEvent::IgnoredScripts` variants with wire-shape tests
- Recording-fake reporter tests for `run_postinstall_hooks` (Script→Stdio→Exit ordering, non-zero exit propagation) and for `BuildModules::run` (sorted ignored-builds, explicit-deny exclusion). Existing `install_emits_pnpm_event_sequence` updated to expect the new `IgnoredScripts` event between `Stats` and `ImportingDone`
- Unit tests for the build policy, key parsing, `graph_sequencer`, and `build_sequence`

## What's not yet exercisable end-to-end

All 11 integration tests are `known_failures` because:
1. The non-frozen install path does not write a lockfile, so tests cannot exercise `--frozen-lockfile` yet
2. Bin linking (#330) is not implemented, so scripts that invoke dependency binaries fail

Once either lockfile writing or pre-generated lockfile fixtures land, the tests that use simple `node` scripts (no dependency bins) can be promoted. The rest need pnpm/pacquet#330.

## Known limitations / follow-ups

The remaining gaps vs upstream pnpm are tracked in pnpm/pacquet#397, including missing `npm_*` lifecycle env vars, ancestor-`node_modules/.bin` PATH walking, `linkBinsOfDependencies` before scripts, Windows shell selection, optional-dep failure tolerance, `patchedDependencies`, `isBuilt`/side-effects-cache skipping, build concurrency, and a few minor items.

This PR also still has:
- `ignoreScripts` config flag — not yet wired
- `pendingBuilds`/`ignoredBuilds` persistence in `.modules.yaml` — not yet wired
- Build chunks run sequentially — pnpm runs each chunk concurrently bounded by `childConcurrency` (perf-only)

## Test plan

- [x] `cargo test -p pacquet-package-manager build_modules::tests` (15 unit tests, including the new ignored-builds tests)
- [x] `cargo test -p pacquet-package-manager build_sequence::tests` (5 unit tests)
- [x] `cargo test -p pacquet-package-manager graph_sequencer::tests` (8 unit tests)
- [x] `cargo test -p pacquet-executor lifecycle::tests` (3 unit tests, recording-fake reporter)
- [x] `cargo test -p pacquet-reporter lifecycle_event ignored_scripts` (2 wire-shape tests)
- [x] `cargo test -p pacquet-cli --test lifecycle_scripts` (11 known_failures)
- [x] `just ready`
- [x] `taplo format --check`

Covers: pnpm/pnpm#11633 (Stage 1, "Support building dependencies")

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added lifecycle script execution support for dependencies (preinstall, install, postinstall) during installation with proper build ordering
  * Added `pnpm.allowBuilds` configuration to selectively enable or disable lifecycle scripts per package

* **Tests**
  * Added comprehensive test coverage for lifecycle script execution scenarios and build dependency management

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pacquet/pull/391)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->