### PR TITLE
docs(ai): make the AI double-check code style guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ repository, not only `pnpm/pnpm`.
 ## Follow the project guides
 
 1. Follow the contributing guide in [`CONTRIBUTING.md`](./CONTRIBUTING.md). It covers commit message format, writing style, setup, and the automated checks to run before committing.
-2. Follow the code style guide in [`CODE_STYLE_GUIDE.md`](./CODE_STYLE_GUIDE.md). It covers code-level conventions not enforced by tooling: imports, modules, naming, ownership and borrowing, parameter type selection, trait bounds, pattern matching, `pipe-trait`, error handling, test layout, logging during tests, and cloning of `Arc` and `Rc`. **ALWAYS** check the generated code against `CODE_STYLE_GUIDE.md` before committing and pushing.
+2. **ALWAYS** follow the code style guide in [`CODE_STYLE_GUIDE.md`](./CODE_STYLE_GUIDE.md). It covers code-level conventions not enforced by tooling: imports, modules, naming, ownership and borrowing, parameter type selection, trait bounds, pattern matching, `pipe-trait`, error handling, test layout, logging during tests, and cloning of `Arc` and `Rc`.
 
 ## Repo layout
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,8 +57,8 @@ repository, not only `pnpm/pnpm`.
 
 ## Follow the project guides
 
-1. Follow the contributing guide in [`CONTRIBUTING.md`](./CONTRIBUTING.md), and **ALWAYS** double check before committing. It covers commit message format, writing style, setup, and the automated checks to run before committing.
-2. Follow the code style guide in [`CODE_STYLE_GUIDE.md`](./CODE_STYLE_GUIDE.md), and **ALWAYS** double check before committing. It covers code-level conventions not enforced by tooling: imports, modules, naming, ownership and borrowing, parameter type selection, trait bounds, pattern matching, `pipe-trait`, error handling, test layout, logging during tests, and cloning of `Arc` and `Rc`.
+1. Follow the contributing guide in [`CONTRIBUTING.md`](./CONTRIBUTING.md), and **ALWAYS** double-check before committing. It covers commit message format, writing style, setup, and the automated checks to run before committing.
+2. Follow the code style guide in [`CODE_STYLE_GUIDE.md`](./CODE_STYLE_GUIDE.md), and **ALWAYS** double-check before committing. It covers code-level conventions not enforced by tooling: imports, modules, naming, ownership and borrowing, parameter type selection, trait bounds, pattern matching, `pipe-trait`, error handling, test layout, logging during tests, and cloning of `Arc` and `Rc`.
 
 ## Repo layout
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,8 +57,8 @@ repository, not only `pnpm/pnpm`.
 
 ## Follow the project guides
 
-1. Follow the contributing guide in [`CONTRIBUTING.md`](./CONTRIBUTING.md). It covers commit message format, writing style, setup, and the automated checks to run before committing.
-2. **ALWAYS** follow the code style guide in [`CODE_STYLE_GUIDE.md`](./CODE_STYLE_GUIDE.md). It covers code-level conventions not enforced by tooling: imports, modules, naming, ownership and borrowing, parameter type selection, trait bounds, pattern matching, `pipe-trait`, error handling, test layout, logging during tests, and cloning of `Arc` and `Rc`.
+1. Follow the contributing guide in [`CONTRIBUTING.md`](./CONTRIBUTING.md), and **ALWAYS** double check before committing. It covers commit message format, writing style, setup, and the automated checks to run before committing.
+2. Follow the code style guide in [`CODE_STYLE_GUIDE.md`](./CODE_STYLE_GUIDE.md), and **ALWAYS** double check before committing. It covers code-level conventions not enforced by tooling: imports, modules, naming, ownership and borrowing, parameter type selection, trait bounds, pattern matching, `pipe-trait`, error handling, test layout, logging during tests, and cloning of `Arc` and `Rc`.
 
 ## Repo layout
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ repository, not only `pnpm/pnpm`.
 ## Follow the project guides
 
 1. Follow the contributing guide in [`CONTRIBUTING.md`](./CONTRIBUTING.md). It covers commit message format, writing style, setup, and the automated checks to run before committing.
-2. Follow the code style guide in [`CODE_STYLE_GUIDE.md`](./CODE_STYLE_GUIDE.md). It covers code-level conventions not enforced by tooling: imports, modules, naming, ownership and borrowing, parameter type selection, trait bounds, pattern matching, `pipe-trait`, error handling, test layout, logging during tests, and cloning of `Arc` and `Rc`.
+2. Follow the code style guide in [`CODE_STYLE_GUIDE.md`](./CODE_STYLE_GUIDE.md). It covers code-level conventions not enforced by tooling: imports, modules, naming, ownership and borrowing, parameter type selection, trait bounds, pattern matching, `pipe-trait`, error handling, test layout, logging during tests, and cloning of `Arc` and `Rc`. **ALWAYS** check the generated code against `CODE_STYLE_GUIDE.md` before commit and push.
 
 ## Repo layout
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ repository, not only `pnpm/pnpm`.
 ## Follow the project guides
 
 1. Follow the contributing guide in [`CONTRIBUTING.md`](./CONTRIBUTING.md). It covers commit message format, writing style, setup, and the automated checks to run before committing.
-2. Follow the code style guide in [`CODE_STYLE_GUIDE.md`](./CODE_STYLE_GUIDE.md). It covers code-level conventions not enforced by tooling: imports, modules, naming, ownership and borrowing, parameter type selection, trait bounds, pattern matching, `pipe-trait`, error handling, test layout, logging during tests, and cloning of `Arc` and `Rc`. **ALWAYS** check the generated code against `CODE_STYLE_GUIDE.md` before commit and push.
+2. Follow the code style guide in [`CODE_STYLE_GUIDE.md`](./CODE_STYLE_GUIDE.md). It covers code-level conventions not enforced by tooling: imports, modules, naming, ownership and borrowing, parameter type selection, trait bounds, pattern matching, `pipe-trait`, error handling, test layout, logging during tests, and cloning of `Arc` and `Rc`. **ALWAYS** check the generated code against `CODE_STYLE_GUIDE.md` before committing and pushing.
 
 ## Repo layout
 


### PR DESCRIPTION
Emphasize the importance of checking generated code against the code style guide before committing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reinforced contributor guidance by adding an explicit “ALWAYS double-check before committing” requirement to both contributing and code-style guidance.
  * Clarified the "Follow the project guides" section to emphasize pre-commit verification.
  * No changes to exported APIs or runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->