### PR TITLE
docs(agents): add PR/issue/comment workflow rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,6 +266,25 @@ feat(lockfile): support npm-alias dependencies in snapshots
 perf(store-dir): share one read-only StoreIndex across cache lookups
 ```
 
+## Working with GitHub PRs, issues, and comments
+
+- **Keep PR titles and descriptions current.** When pushing new changes to a
+  PR, review the title and description and update them if they no longer
+  accurately reflect what the PR does.
+- **Reply to and resolve review conversations.** Once a review comment has
+  been addressed, reply to the thread with a description of the resolution
+  including the commit hash that fixed it, then mark the conversation as
+  resolved.
+- **Sign all agent-authored content.** When posting a comment, creating an
+  issue, or opening a PR, append a footer to the message indicating that it
+  was written by an agent. The footer must include the name of the agent and
+  the name of the model used. Example:
+
+  ```markdown
+  ---
+  Written by an agent (Claude Code, claude-opus-4-7).
+  ```
+
 ## Things not to do
 
 - Do not add features, flags, or behaviors that pnpm does not have.


### PR DESCRIPTION
## Summary
Mirror the new "Working with GitHub PRs, Issues, and Comments" section that
just landed upstream in `pnpm/pnpm` AGENTS.md ([PR #11475](https://github.com/pnpm/pnpm/pull/11475)). Three rules:

- Keep PR title and description in sync with the changes after every push.
- Reply to addressed review threads with the resolution + commit hash, then mark them resolved.
- Sign agent-authored comments, issues, and PRs with a footer naming the agent and the model.

## Test plan
- [x] Docs-only change; no code paths affected.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced contribution guidelines with documentation covering GitHub workflow best practices and standards for managing pull requests and issues. Includes protocols for responding to code review feedback, resolving review threads, maintaining accurate pull request descriptions, and requirements for identifying content authorship in collaborative development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->