### PR TITLE
docs: add guidelines for porting branded string types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,8 +94,10 @@ Rules when porting code that uses a branded string type:
    JSON, YAML, or INI boundary (manifest files, lockfiles, state files,
    config files, and similar), wire the wrapper into serde so the
    validation policy survives serialization:
-   - `#[serde(try_from = "String")]` for deserialization, so deserialized
-     values go through the validator.
+   - `#[serde(try_from = "&'de str")]` for deserialization, so
+     deserialized values go through the validator without allocating an
+     owned `String`. Use `try_from = "String"` only when the validator
+     genuinely needs an owned input.
    - `#[serde(into = "String")]` for serialization.
    Use both when the type is round-tripped.
 6. **Derive simple conversions with `derive_more`.** When the conversion

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,48 @@ disambiguate a commit in any real-world repository. Resolve the SHA with
 GitHub and trimming the SHA segment. This rule applies to every GitHub
 repository, not only `pnpm/pnpm`.
 
+## Porting branded string types
+
+TypeScript pnpm leans on *branded* string types — strings narrowed by a
+phantom property (e.g. `type PkgName = string & { __brand: 'PkgName' }`) so
+the type system tracks intent that the runtime can't see. Some are stamped
+through a validating constructor; others are minted with a bare `as`
+type-cast. Pacquet must preserve that distinction, because it is part of the
+public contract pnpm exposes through manifest, lockfile, state, and config
+files.
+
+Rules when porting code that uses a branded string type:
+
+1. **Declare a newtype wrapper.** Do not collapse the brand into a plain
+   `String` or `&str`. Give the type its own struct so misuse is a type
+   error in pacquet too.
+2. **If upstream always validates before construction, validate too.**
+   When every brand site in pnpm runs through a checking factory, pacquet's
+   wrapper must construct only via `TryFrom<String>` and/or `FromStr` (i.e.
+   no infallible public constructor that takes an arbitrary string).
+3. **If upstream occasionally constructs without validation, expose
+   `from_str_unchecked`.** When pnpm sometimes mints the brand via a bare
+   `as` cast (skipping its validator), add a `from_str_unchecked` (or
+   similarly named) constructor on the Rust side so callers can opt into
+   the same un-checked path explicitly. Keep the validating constructor
+   too — `from_str_unchecked` is the escape hatch, not the default.
+4. **Match upstream serde behavior.** If the branded type crosses a
+   JSON / YAML / INI boundary (manifest files, lockfiles, state files,
+   config files, etc.), wire the wrapper into serde so the validation
+   policy survives serialization:
+   - `#[serde(try_from = "String")]` for deserialization (so deserialized
+     values go through the validator),
+   - `#[serde(into = "String")]` for serialization.
+   Use both when the type is round-tripped.
+5. **String-literal unions become `enum`s.** If upstream uses a string
+   literal type or a union of string literals (e.g.
+   `'auto' | 'always' | 'never'`), model it as a Rust `enum`, not a
+   newtype wrapper. The set of valid values is closed; encode that.
+6. **Template literal types are branded strings.** If upstream uses a
+   string template literal type (e.g. ``` `${string}@${string}` ```),
+   treat it the same as a branded string type — newtype wrapper with the
+   validation discipline in rules 2–4 above.
+
 ## Follow the project guides
 
 1. Follow the contributing guide in [`CONTRIBUTING.md`](./CONTRIBUTING.md), and **ALWAYS** double-check before committing. It covers commit message format, writing style, setup, and the automated checks to run before committing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,9 +111,9 @@ Rules when porting code that uses a branded string type:
    newtype wrapper. The set of valid values is closed, so encode that.
 8. **Template literal types are branded strings.** If upstream uses a
    string template literal type (for example,
-   <code>&#96;${string}@${string}&#96;</code>), treat it the same as a
-   branded string type. Use a newtype wrapper with the validation
-   discipline from rules 2 through 5 above.
+   ``` `${string}@${string}` ```), treat it the same as a branded string
+   type. Use a newtype wrapper with the validation discipline from rules
+   2 through 5 above.
 
 ## Follow the project guides
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,9 +94,8 @@ Rules when porting code that uses a branded string type:
    JSON, YAML, or INI boundary (manifest files, lockfiles, state files,
    config files, and similar), wire the wrapper into serde so the
    validation policy survives serialization:
-   - `#[serde(try_from = "&'de str")]` for deserialization, so
-     deserialized values go through the validator without allocating an
-     owned `String` for every value.
+   - `#[serde(try_from = "String")]` for deserialization, so
+     deserialized values go through the validator.
    - `#[serde(into = "String")]` for serialization.
    Use both when the type is round-tripped.
 6. **Derive simple conversions with `derive_more`.** When the conversion

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,13 +57,14 @@ repository, not only `pnpm/pnpm`.
 
 ## Porting branded string types
 
-TypeScript pnpm leans on *branded* string types — strings narrowed by a
-phantom property (e.g. `type PkgName = string & { __brand: 'PkgName' }`) so
-the type system tracks intent that the runtime can't see. Some are stamped
-through a validating constructor; others are minted with a bare `as`
-type-cast. Pacquet must preserve that distinction, because it is part of the
-public contract pnpm exposes through manifest, lockfile, state, and config
-files.
+TypeScript pnpm leans on *branded* string types. A branded string is a
+plain string narrowed by a phantom property (for example,
+`type PkgName = string & { __brand: 'PkgName' }`), so the type system can
+track intent that the runtime cannot see. Some brands are stamped through
+a validating constructor. Others are minted with a bare `as` type-cast and
+have no runtime check at all. Pacquet must preserve that distinction,
+because it is part of the public contract pnpm exposes through manifest,
+lockfile, state, and config files.
 
 Rules when porting code that uses a branded string type:
 
@@ -72,44 +73,47 @@ Rules when porting code that uses a branded string type:
    error in pacquet too.
 2. **If upstream always validates before construction, validate too.**
    When every brand site in pnpm runs through a checking factory, pacquet's
-   wrapper must construct only via `TryFrom<String>` and/or `FromStr` (i.e.
-   no infallible public constructor that takes an arbitrary string).
+   wrapper must construct only via `TryFrom<String>` and/or `FromStr`. Do
+   not provide an infallible public constructor that takes an arbitrary
+   string.
 3. **If upstream never validates, just brand for type-safety.** Some
    upstream brands exist purely to keep the type system from confusing
-   one string slot with another (e.g. preventing a `PkgId` from being
-   passed where a `PkgName` is expected) and are never validated at
-   runtime. In that case the Rust wrapper should expose an infallible
-   `From<String>` (and/or `From<&str>`) — the type-safety win is the
-   whole point, no validator is needed.
+   one string slot with another. For example, a brand may exist to prevent
+   a `PkgId` from being passed where a `PkgName` is expected, even though
+   the value is never validated at runtime. In that case the Rust wrapper
+   should expose an infallible `From<String>` (and `From<&str>` when
+   convenient). The type-safety win is the whole point, and no validator
+   is needed.
 4. **If upstream occasionally constructs without validation, expose
    `from_str_unchecked`.** When pnpm sometimes mints the brand via a bare
-   `as` cast (skipping its validator), add a `from_str_unchecked` (or
+   `as` cast, skipping its validator, add a `from_str_unchecked` (or
    similarly named) constructor on the Rust side so callers can opt into
-   the same un-checked path explicitly. Keep the validating constructor
-   too — `from_str_unchecked` is the escape hatch, not the default.
+   the same unchecked path explicitly. Keep the validating constructor as
+   well. `from_str_unchecked` is the escape hatch, not the default.
 5. **Match upstream serde behavior.** If the branded type crosses a
-   JSON / YAML / INI boundary (manifest files, lockfiles, state files,
-   config files, etc.), wire the wrapper into serde so the validation
-   policy survives serialization:
-   - `#[serde(try_from = "String")]` for deserialization (so deserialized
-     values go through the validator),
+   JSON, YAML, or INI boundary (manifest files, lockfiles, state files,
+   config files, and similar), wire the wrapper into serde so the
+   validation policy survives serialization:
+   - `#[serde(try_from = "String")]` for deserialization, so deserialized
+     values go through the validator.
    - `#[serde(into = "String")]` for serialization.
    Use both when the type is round-tripped.
 6. **Derive simple conversions with `derive_more`.** When the conversion
    impls implied by the rules above are mechanical (a one-liner that
    wraps or unwraps the inner field), use `#[derive(derive_more::From)]`
-   / `#[derive(derive_more::Into)]` rather than handwriting an `impl`
-   block. Only fall back to a manual `impl` when the conversion needs
-   custom logic (e.g. validation or normalization). `derive_more` is
+   and `#[derive(derive_more::Into)]` rather than handwriting an `impl`
+   block. Fall back to a manual `impl` only when the conversion needs
+   custom logic, such as validation or normalization. `derive_more` is
    already a workspace dependency.
 7. **String-literal unions become `enum`s.** If upstream uses a string
-   literal type or a union of string literals (e.g.
+   literal type or a union of string literals (for example,
    `'auto' | 'always' | 'never'`), model it as a Rust `enum`, not a
-   newtype wrapper. The set of valid values is closed; encode that.
+   newtype wrapper. The set of valid values is closed, so encode that.
 8. **Template literal types are branded strings.** If upstream uses a
-   string template literal type (e.g. ``` `${string}@${string}` ```),
-   treat it the same as a branded string type — newtype wrapper with the
-   validation discipline in rules 2–5 above.
+   string template literal type (for example,
+   <code>&#96;${string}@${string}&#96;</code>), treat it the same as a
+   branded string type. Use a newtype wrapper with the validation
+   discipline from rules 2 through 5 above.
 
 ## Follow the project guides
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,8 +96,7 @@ Rules when porting code that uses a branded string type:
    validation policy survives serialization:
    - `#[serde(try_from = "&'de str")]` for deserialization, so
      deserialized values go through the validator without allocating an
-     owned `String`. Use `try_from = "String"` only when the validator
-     genuinely needs an owned input.
+     owned `String` for every value.
    - `#[serde(into = "String")]` for serialization.
    Use both when the type is round-tripped.
 6. **Derive simple conversions with `derive_more`.** When the conversion

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,13 +74,20 @@ Rules when porting code that uses a branded string type:
    When every brand site in pnpm runs through a checking factory, pacquet's
    wrapper must construct only via `TryFrom<String>` and/or `FromStr` (i.e.
    no infallible public constructor that takes an arbitrary string).
-3. **If upstream occasionally constructs without validation, expose
+3. **If upstream never validates, just brand for type-safety.** Some
+   upstream brands exist purely to keep the type system from confusing
+   one string slot with another (e.g. preventing a `PkgId` from being
+   passed where a `PkgName` is expected) and are never validated at
+   runtime. In that case the Rust wrapper should expose an infallible
+   `From<String>` (and/or `From<&str>`) — the type-safety win is the
+   whole point, no validator is needed.
+4. **If upstream occasionally constructs without validation, expose
    `from_str_unchecked`.** When pnpm sometimes mints the brand via a bare
    `as` cast (skipping its validator), add a `from_str_unchecked` (or
    similarly named) constructor on the Rust side so callers can opt into
    the same un-checked path explicitly. Keep the validating constructor
    too — `from_str_unchecked` is the escape hatch, not the default.
-4. **Match upstream serde behavior.** If the branded type crosses a
+5. **Match upstream serde behavior.** If the branded type crosses a
    JSON / YAML / INI boundary (manifest files, lockfiles, state files,
    config files, etc.), wire the wrapper into serde so the validation
    policy survives serialization:
@@ -88,14 +95,21 @@ Rules when porting code that uses a branded string type:
      values go through the validator),
    - `#[serde(into = "String")]` for serialization.
    Use both when the type is round-tripped.
-5. **String-literal unions become `enum`s.** If upstream uses a string
+6. **Derive simple conversions with `derive_more`.** When the conversion
+   impls implied by the rules above are mechanical (a one-liner that
+   wraps or unwraps the inner field), use `#[derive(derive_more::From)]`
+   / `#[derive(derive_more::Into)]` rather than handwriting an `impl`
+   block. Only fall back to a manual `impl` when the conversion needs
+   custom logic (e.g. validation or normalization). `derive_more` is
+   already a workspace dependency.
+7. **String-literal unions become `enum`s.** If upstream uses a string
    literal type or a union of string literals (e.g.
    `'auto' | 'always' | 'never'`), model it as a Rust `enum`, not a
    newtype wrapper. The set of valid values is closed; encode that.
-6. **Template literal types are branded strings.** If upstream uses a
+8. **Template literal types are branded strings.** If upstream uses a
    string template literal type (e.g. ``` `${string}@${string}` ```),
    treat it the same as a branded string type — newtype wrapper with the
-   validation discipline in rules 2–4 above.
+   validation discipline in rules 2–5 above.
 
 ## Follow the project guides
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ TypeScript pnpm leans on *branded* string types. A branded string is a
 plain string narrowed by a phantom property (for example,
 `type PkgName = string & { __brand: 'PkgName' }`), so the type system can
 track intent that the runtime cannot see. Some brands are stamped through
-a validating constructor. Others are minted with a bare `as` type-cast and
+a validating constructor. Others are minted with a bare `as` type assertion and
 have no runtime check at all. Pacquet must preserve that distinction,
 because it is part of the public contract pnpm exposes through manifest,
 lockfile, state, and config files.
@@ -86,7 +86,7 @@ Rules when porting code that uses a branded string type:
    is needed.
 4. **If upstream occasionally constructs without validation, expose
    `from_str_unchecked`.** When pnpm sometimes mints the brand via a bare
-   `as` cast, skipping its validator, add a `from_str_unchecked` (or
+   `as` assertion, skipping its validator, add a `from_str_unchecked` (or
    similarly named) constructor on the Rust side so callers can opt into
    the same unchecked path explicitly. Keep the validating constructor as
    well. `from_str_unchecked` is the escape hatch, not the default.


### PR DESCRIPTION
## Summary

Adds a new "Porting branded string types" section to `AGENTS.md` that documents how to translate TypeScript pnpm's branded string types, string-literal unions, and template literal types into pacquet, so the type-safety and validation contracts upstream relies on survive the port.

## Rules

The new section in `AGENTS.md` lays out eight rules:

1. **Declare a newtype wrapper.** Never collapse a brand to a plain `String` or `&str`.
2. **If upstream always validates, validate too.** Construct only via `TryFrom<String>` and/or `FromStr`; no infallible public constructor.
3. **If upstream never validates, just brand for type-safety.** Expose an infallible `From<String>` (and `From<&str>` when convenient).
4. **If upstream occasionally constructs without validation, expose `from_str_unchecked`.** Keep the validating constructor as the default; the unchecked path is an explicit escape hatch.
5. **Match upstream serde behavior.** Wire `#[serde(try_from = "String")]` and `#[serde(into = "String")]` when the brand crosses a JSON/YAML/INI boundary.
6. **Derive simple conversions with `derive_more`.** Use `derive_more::From` / `derive_more::Into` for mechanical wrap/unwrap impls; reserve manual `impl` blocks for conversions that need custom logic.
7. **String-literal unions become `enum`s.** Closed sets of values are encoded as enums, not newtypes.
8. **Template literal types are branded strings.** Apply rules 2 through 5 to wrappers backing TypeScript template literal types.

## Notes

- Prose follows the writing style in `CONTRIBUTING.md` (no mid-sentence em dashes, complete sentences).
- Uses TypeScript's "type assertion" terminology for `as`, since `as` performs no runtime conversion.

https://claude.ai/code/session_01U5wP1SGLNZVNNL3qFDvxq7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance for porting branded string types to the Rust port. Introduces eight rules covering newtype wrappers, validation pathways, conversion and error-handling patterns, serialization (serde) considerations, and code-generation helper recommendations to ensure consistent branding, validation behavior, and interoperability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->