### PR TITLE
docs(style): add guidance on serde `Cow<'de, str>` vs `String` source types

### DIFF
--- a/CODE_STYLE_GUIDE.md
+++ b/CODE_STYLE_GUIDE.md
@@ -452,13 +452,15 @@ fn walk_deps_inner(/* ... */) { /* ... */ }
 
 When wiring a type into `serde` with `#[serde(try_from = "...")]` or `#[serde(from = "...")]`, pick the source according to whether the deserialized value retains the string.
 
-Do not use `&'de str`. Text formats such as JSON, YAML, and TOML accept escape sequences like `"\u{61}"`, and the deserializer must decode them into a fresh buffer. Borrowed `&'de str` deserialization rejects every input that requires decoding, so the type fails on values the format itself accepts.
+Do not use `&'de str`. Text formats such as JSON, YAML, and TOML accept escape sequences (for example, JSON's `"\u0061"`) that the deserializer must decode into a fresh buffer. Borrowed `&'de str` deserialization rejects every input that requires decoding, so the type fails on values the format itself accepts.
 
-Prefer `Cow<'de, str>` when the conversion discards the string, for example when it parses into a number, an enum discriminant, or any value that no longer references the original characters. The deserializer borrows from the input when no decoding is needed and allocates only when escapes force it.
+Prefer `Cow<'de, str>` when the conversion discards the string or splits it into pieces, for example when it parses into a number, an enum discriminant, or a struct whose fields are substrings of the input. The deserializer borrows from the input when no decoding is needed and allocates only when escapes force it.
 
-Prefer `String` when the conversion keeps the string. Taking `String` lets the conversion move the buffer into the resulting value without an extra clone.
+Prefer `String` when the entire input is moved into the resulting value verbatim. Taking `String` lets the conversion store the buffer directly without re-cloning.
 
 ```rust
+use std::borrow::Cow;
+
 #[derive(serde::Deserialize)]
 #[serde(try_from = "Cow<'de, str>")]
 struct Port(u16);

--- a/CODE_STYLE_GUIDE.md
+++ b/CODE_STYLE_GUIDE.md
@@ -448,43 +448,42 @@ pub fn build_lockfile(/* ... */) { /* ... */ }
 fn walk_deps_inner(/* ... */) { /* ... */ }
 ```
 
-### Serde `&'de str` vs `String` source types
+### Serde `Cow<'de, str>` vs `String` source types
 
-When wiring a type into `serde` with `#[serde(try_from = "...")]` or `#[serde(from = "...")]`, choose the source type based on whether the deserialized value retains the string data.
+When wiring a type into `serde` with `#[serde(try_from = "...")]` or `#[serde(from = "...")]`, pick the source according to whether the deserialized value retains the string.
 
-- **Prefer `&'de str`** when the conversion can save an allocation. If an owned `String` would be wasteful — for example, when the input is parsed into a number, a unit-like type, an enum discriminant, or any other value that no longer references the original characters — the deserializer can borrow directly from the input buffer and avoid allocating a `String` that is immediately discarded.
-- **Prefer `String`** when the allocated string would be moved into the resulting value. If the conversion stores the original characters (a validating newtype around a `String`, a struct that keeps the raw text, etc.), taking `String` lets the conversion move the buffer into the value rather than borrowing it and then cloning.
+Do not use `&'de str`. Text formats such as JSON, YAML, and TOML accept escape sequences like `"\u{61}"`, and the deserializer must decode them into a fresh buffer. Borrowed `&'de str` deserialization rejects every input that requires decoding, so the type fails on values the format itself accepts.
+
+Prefer `Cow<'de, str>` when the conversion discards the string, for example when it parses into a number, an enum discriminant, or any value that no longer references the original characters. The deserializer borrows from the input when no decoding is needed and allocates only when escapes force it.
+
+Prefer `String` when the conversion keeps the string. Taking `String` lets the conversion move the buffer into the resulting value without an extra clone.
 
 ```rust
-// Good: parsed into an integer; the original string is discarded.
 #[derive(serde::Deserialize)]
-#[serde(try_from = "&'de str")]
+#[serde(try_from = "Cow<'de, str>")]
 struct Port(u16);
 
-impl TryFrom<&str> for Port {
+impl<'a> TryFrom<Cow<'a, str>> for Port {
     type Error = std::num::ParseIntError;
-    fn try_from(s: &str) -> Result<Self, Self::Error> {
-        s.parse().map(Port)
+    fn try_from(value: Cow<'a, str>) -> Result<Self, Self::Error> {
+        value.parse().map(Port)
     }
 }
 
-// Good: validated newtype that stores the input verbatim.
 #[derive(serde::Deserialize)]
 #[serde(try_from = "String")]
 struct PackageName(String);
 
 impl TryFrom<String> for PackageName {
     type Error = InvalidPackageName;
-    fn try_from(s: String) -> Result<Self, Self::Error> {
-        validate_package_name(&s)?;
-        Ok(PackageName(s))
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        validate(&value)?;
+        Ok(PackageName(value))
     }
 }
 ```
 
-The same trade-off applies to the infallible `#[serde(from = "...")]` form: pick `&'de str` when the conversion drops the string and `String` when it keeps it.
-
-See also the branded-string rules in [`AGENTS.md`](./AGENTS.md), which describe when a branded newtype must round-trip through serde and which validation discipline applies.
+The same trade-off applies to the infallible `#[serde(from = "...")]` form.
 
 ### Error Handling
 

--- a/CODE_STYLE_GUIDE.md
+++ b/CODE_STYLE_GUIDE.md
@@ -448,6 +448,44 @@ pub fn build_lockfile(/* ... */) { /* ... */ }
 fn walk_deps_inner(/* ... */) { /* ... */ }
 ```
 
+### Serde `&'de str` vs `String` source types
+
+When wiring a type into `serde` with `#[serde(try_from = "...")]` or `#[serde(from = "...")]`, choose the source type based on whether the deserialized value retains the string data.
+
+- **Prefer `&'de str`** when the conversion can save an allocation. If an owned `String` would be wasteful — for example, when the input is parsed into a number, a unit-like type, an enum discriminant, or any other value that no longer references the original characters — the deserializer can borrow directly from the input buffer and avoid allocating a `String` that is immediately discarded.
+- **Prefer `String`** when the allocated string would be moved into the resulting value. If the conversion stores the original characters (a validating newtype around a `String`, a struct that keeps the raw text, etc.), taking `String` lets the conversion move the buffer into the value rather than borrowing it and then cloning.
+
+```rust
+// Good: parsed into an integer; the original string is discarded.
+#[derive(serde::Deserialize)]
+#[serde(try_from = "&'de str")]
+struct Port(u16);
+
+impl TryFrom<&str> for Port {
+    type Error = std::num::ParseIntError;
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        s.parse().map(Port)
+    }
+}
+
+// Good: validated newtype that stores the input verbatim.
+#[derive(serde::Deserialize)]
+#[serde(try_from = "String")]
+struct PackageName(String);
+
+impl TryFrom<String> for PackageName {
+    type Error = InvalidPackageName;
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        validate_package_name(&s)?;
+        Ok(PackageName(s))
+    }
+}
+```
+
+The same trade-off applies to the infallible `#[serde(from = "...")]` form: pick `&'de str` when the conversion drops the string and `String` when it keeps it.
+
+See also the branded-string rules in [`AGENTS.md`](./AGENTS.md), which describe when a branded newtype must round-trip through serde and which validation discipline applies.
+
 ### Error Handling
 
 - Use `derive_more` for error types. Only derive the traits that are actually used:

--- a/crates/lockfile/src/comver.rs
+++ b/crates/lockfile/src/comver.rs
@@ -1,13 +1,13 @@
 use derive_more::{Display, Error};
 use serde::{Deserialize, Serialize};
-use std::{num::ParseIntError, str::FromStr};
+use std::{borrow::Cow, num::ParseIntError, str::FromStr};
 
 /// Information of the top-level field `lockfileVersion`.
 ///
 /// It contains only major and minor.
 #[derive(Debug, Display, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[display("{major}.{minor}")]
-#[serde(try_from = "&'de str", into = "String")]
+#[serde(try_from = "Cow<'de, str>", into = "String")]
 pub struct ComVer {
     pub major: u16,
     pub minor: u16,
@@ -41,9 +41,9 @@ impl FromStr for ComVer {
     }
 }
 
-impl<'a> TryFrom<&'a str> for ComVer {
+impl<'a> TryFrom<Cow<'a, str>> for ComVer {
     type Error = ParseComVerError;
-    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
+    fn try_from(value: Cow<'a, str>) -> Result<Self, Self::Error> {
         value.parse()
     }
 }

--- a/crates/lockfile/src/pkg_name.rs
+++ b/crates/lockfile/src/pkg_name.rs
@@ -2,7 +2,7 @@ use derive_more::{Display, Error};
 use pipe_trait::Pipe;
 use serde::{Deserialize, Serialize};
 use split_first_char::SplitFirstChar;
-use std::{fmt, str::FromStr};
+use std::{borrow::Cow, fmt, str::FromStr};
 
 /// Represent the name of an npm package.
 ///
@@ -10,7 +10,7 @@ use std::{fmt, str::FromStr};
 /// * Without scope: `{bare}`
 /// * With scope: `@{scope}/bare`
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
-#[serde(try_from = "&'de str", into = "String")]
+#[serde(try_from = "Cow<'de, str>", into = "String")]
 pub struct PkgName {
     /// The scope (if any) without the `@` prefix.
     pub scope: Option<String>,
@@ -57,9 +57,9 @@ impl TryFrom<String> for PkgName {
     }
 }
 
-impl<'a> TryFrom<&'a str> for PkgName {
+impl<'a> TryFrom<Cow<'a, str>> for PkgName {
     type Error = ParsePkgNameError;
-    fn try_from(input: &'a str) -> Result<Self, Self::Error> {
+    fn try_from(input: Cow<'a, str>) -> Result<Self, Self::Error> {
         PkgName::parse(input)
     }
 }

--- a/crates/lockfile/src/pkg_name/tests.rs
+++ b/crates/lockfile/src/pkg_name/tests.rs
@@ -35,6 +35,7 @@ fn deserialize_decodes_escape_sequences() {
     let input = r##""\u0040foo/bar""##;
     eprintln!("CASE: {input:?}");
     let actual: PkgName = serde_saphyr::from_str(input).unwrap();
+    dbg!(&actual);
     assert_eq!(actual, PkgName { scope: Some("foo".to_string()), bare: "bar".to_string() });
 }
 

--- a/crates/lockfile/src/pkg_name/tests.rs
+++ b/crates/lockfile/src/pkg_name/tests.rs
@@ -28,7 +28,7 @@ fn deserialize_ok() {
 
 #[test]
 fn deserialize_decodes_escape_sequences() {
-    // The YAML scalar `"@foo/bar"` decodes the `@` escape
+    // The YAML scalar `"\u0040foo/bar"` decodes the `\u0040` escape
     // to `@`, yielding `@foo/bar`. The deserializer must allocate a
     // fresh buffer to apply the escape, so a borrowed `&'de str`
     // source would reject this input.

--- a/crates/lockfile/src/pkg_name/tests.rs
+++ b/crates/lockfile/src/pkg_name/tests.rs
@@ -27,6 +27,18 @@ fn deserialize_ok() {
 }
 
 #[test]
+fn deserialize_decodes_escape_sequences() {
+    // The YAML scalar `"@foo/bar"` decodes the `@` escape
+    // to `@`, yielding `@foo/bar`. The deserializer must allocate a
+    // fresh buffer to apply the escape, so a borrowed `&'de str`
+    // source would reject this input.
+    let input = r##""\u0040foo/bar""##;
+    eprintln!("CASE: {input:?}");
+    let actual: PkgName = serde_saphyr::from_str(input).unwrap();
+    assert_eq!(actual, PkgName { scope: Some("foo".to_string()), bare: "bar".to_string() });
+}
+
+#[test]
 fn parse_err() {
     macro_rules! case {
         ($input:expr => $message:expr, $pattern:pat) => {{

--- a/crates/lockfile/src/pkg_name_suffix.rs
+++ b/crates/lockfile/src/pkg_name_suffix.rs
@@ -2,7 +2,7 @@ use crate::{ParsePkgNameError, PkgName};
 use derive_more::{Display, Error};
 use serde::{Deserialize, Serialize};
 use split_first_char::SplitFirstChar;
-use std::str::FromStr;
+use std::{borrow::Cow, str::FromStr};
 
 /// Syntax: `{name}@{suffix}`
 ///
@@ -12,7 +12,7 @@ use std::str::FromStr;
 #[derive(Debug, Display, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
 #[display(bound(Suffix: std::fmt::Display))]
 #[display("{name}@{suffix}")]
-#[serde(try_from = "&'de str", into = "String")]
+#[serde(try_from = "Cow<'de, str>", into = "String")]
 #[serde(bound(
     deserialize = "Suffix: FromStr, Suffix::Err: std::fmt::Display",
     serialize = "Suffix: std::fmt::Display + Clone",
@@ -74,9 +74,9 @@ impl<Suffix: FromStr> FromStr for PkgNameSuffix<Suffix> {
     }
 }
 
-impl<'a, Suffix: FromStr> TryFrom<&'a str> for PkgNameSuffix<Suffix> {
+impl<'a, Suffix: FromStr> TryFrom<Cow<'a, str>> for PkgNameSuffix<Suffix> {
     type Error = ParsePkgNameSuffixError<Suffix::Err>;
-    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
+    fn try_from(value: Cow<'a, str>) -> Result<Self, Self::Error> {
         value.parse()
     }
 }

--- a/crates/lockfile/src/pkg_ver_peer.rs
+++ b/crates/lockfile/src/pkg_ver_peer.rs
@@ -1,7 +1,7 @@
 use derive_more::{Display, Error};
 use node_semver::{SemverError, Version};
 use serde::{Deserialize, Serialize};
-use std::str::FromStr;
+use std::{borrow::Cow, str::FromStr};
 
 /// Suffix type of [`PkgNameVerPeer`](crate::PkgNameVerPeer) and
 /// type of [`ResolvedDependencySpec::version`](crate::ResolvedDependencySpec::version).
@@ -11,7 +11,7 @@ use std::str::FromStr;
 /// **NOTE:** The peer part isn't guaranteed to be correct. It is only assumed to be.
 #[derive(Debug, Display, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[display("{version}{peer}")]
-#[serde(try_from = "&'de str", into = "String")]
+#[serde(try_from = "Cow<'de, str>", into = "String")]
 pub struct PkgVerPeer {
     version: Version,
     peer: String,
@@ -66,9 +66,9 @@ impl FromStr for PkgVerPeer {
     }
 }
 
-impl<'a> TryFrom<&'a str> for PkgVerPeer {
+impl<'a> TryFrom<Cow<'a, str>> for PkgVerPeer {
     type Error = ParsePkgVerPeerError;
-    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
+    fn try_from(value: Cow<'a, str>) -> Result<Self, Self::Error> {
         value.parse()
     }
 }

--- a/crates/lockfile/src/snapshot_dep_ref.rs
+++ b/crates/lockfile/src/snapshot_dep_ref.rs
@@ -1,7 +1,7 @@
 use crate::{ParsePkgNameSuffixError, ParsePkgVerPeerError, PkgName, PkgNameVerPeer, PkgVerPeer};
 use derive_more::{Display, Error};
 use serde::{Deserialize, Serialize};
-use std::str::FromStr;
+use std::{borrow::Cow, str::FromStr};
 
 /// Value of a single entry in [`SnapshotEntry::dependencies`](crate::SnapshotEntry::dependencies)
 /// (or `optional_dependencies`).
@@ -33,7 +33,7 @@ use std::str::FromStr;
 ///
 /// Reference: <https://github.com/pnpm/pnpm/blob/1819226b51/deps/path/src/index.ts>
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(try_from = "&'de str", into = "String")]
+#[serde(try_from = "Cow<'de, str>", into = "String")]
 pub enum SnapshotDepRef {
     Plain(PkgVerPeer),
     Alias(PkgNameVerPeer),
@@ -109,9 +109,9 @@ impl FromStr for SnapshotDepRef {
     }
 }
 
-impl<'a> TryFrom<&'a str> for SnapshotDepRef {
+impl<'a> TryFrom<Cow<'a, str>> for SnapshotDepRef {
     type Error = ParseSnapshotDepRefError;
-    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
+    fn try_from(value: Cow<'a, str>) -> Result<Self, Self::Error> {
         value.parse()
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on choosing borrowed vs owned string sources for serialization/deserialization.

* **Improvements**
  * Broadened lockfile parsing to accept more flexible string input forms, improving robustness with decoded/escaped inputs.

* **Tests**
  * Added a test ensuring escape sequences are correctly decoded during string deserialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->