### PR TITLE
ci(integrated-benchmark): list open PRs to find fork-PR head SHA

### DIFF
--- a/.github/workflows/integrated-benchmark-comment.yml
+++ b/.github/workflows/integrated-benchmark-comment.yml
@@ -32,12 +32,17 @@ jobs:
     steps:
       - name: Resolve PR number from workflow_run trigger
         # `workflow_run.pull_requests` is empty for fork PRs (the case
-        # this workflow exists to fix), so fall back to the API lookup
-        # via the trusted `head_sha`. Querying through the BASE repo's
-        # `commits/{sha}/pulls` endpoint returns PRs targeting this
-        # repo regardless of whether the head branch lives on a fork.
-        # The PR number is never read from the artifact — that would
-        # let a fork redirect the comment to an arbitrary PR.
+        # this workflow exists to fix), so fall back to listing open
+        # PRs in this repo and filtering by `head.sha`. The base repo's
+        # `commits/{sha}/pulls` endpoint *only* finds PRs whose head
+        # commit exists on the base repo — for fork PRs the head lives
+        # on the fork, so the lookup returns `[]`. Listing PRs and
+        # filtering works for both cases.
+        #
+        # `head_sha` is sourced from the `workflow_run` event payload,
+        # which GitHub fills in for us — not from the artifact, since
+        # the artifact is fork-controlled and could otherwise redirect
+        # the comment to an arbitrary PR.
         id: meta
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -49,15 +54,16 @@ jobs:
           set -eu
           if [[ -n "${TRIGGER_PR:-}" ]]; then
             # Same-repo PR: GitHub already gave us the number on the
-            # trigger payload. Trusted source.
+            # trigger payload. Trusted source, no API call needed.
             pr="$TRIGGER_PR"
           else
-            # Fork PR: look up the PR by head SHA via the API. The SHA
-            # comes from the workflow_run trigger payload, which is
-            # filled in by GitHub itself, not by the fork.
+            # Fork PR: walk every open PR and match by head.sha. The
+            # 40-char SHA is a unique identifier; multiple PRs sharing
+            # one is essentially impossible, but the count check below
+            # still flags it loudly if it ever happens.
             pr=$(
-              gh api "repos/$REPO/commits/$HEAD_SHA/pulls" \
-                --jq '[.[] | select(.state == "open") | .number] | unique'
+              gh api "repos/$REPO/pulls?state=open&per_page=100" --paginate \
+                --jq "[.[] | select(.head.sha == \"$HEAD_SHA\") | .number] | unique"
             )
             count=$(echo "$pr" | jq 'length')
             if [[ "$count" == "0" ]]; then

--- a/.github/workflows/integrated-benchmark-comment.yml
+++ b/.github/workflows/integrated-benchmark-comment.yml
@@ -61,9 +61,18 @@ jobs:
             # 40-char SHA is a unique identifier; multiple PRs sharing
             # one is essentially impossible, but the count check below
             # still flags it loudly if it ever happens.
+            #
+            # `--paginate --jq '.[]'` emits each PR object on its own
+            # line so `jq -s` can slurp the whole stream into a single
+            # array; using `--paginate --jq '[...]'` would apply the
+            # filter per-page and produce one array per page (broken
+            # past 100 open PRs). `--arg sha` keeps the head SHA out
+            # of the jq program text — defensive against any future
+            # change to where HEAD_SHA is sourced from.
             pr=$(
-              gh api "repos/$REPO/pulls?state=open&per_page=100" --paginate \
-                --jq "[.[] | select(.head.sha == \"$HEAD_SHA\") | .number] | unique"
+              gh api "repos/$REPO/pulls?state=open&per_page=100" --paginate --jq '.[]' \
+                | jq -s --arg sha "$HEAD_SHA" \
+                    '[.[] | select(.head.sha == $sha) | .number] | unique'
             )
             count=$(echo "$pr" | jq 'length')
             if [[ "$count" == "0" ]]; then


### PR DESCRIPTION
## Summary

Fix the comment-posting workflow's fork-PR fallback. Verified failing on the test rebase of #391: the Stage-2 workflow erred with `no open PR matches head_sha=b965c5e... in pnpm/pacquet`.

## Why the previous fallback failed

The fallback in #398 used `gh api repos/$REPO/commits/$HEAD_SHA/pulls` — but that endpoint only returns PRs whose head commit lives on the **base** repo. For fork PRs, the head SHA only exists on the fork (`Saturate/pacquet` for #391), so the base-repo lookup returns `[]`. The exact case the workflow exists to support hits the wrong endpoint.

I tested both endpoints directly against PR #391's head SHA `b965c5ef03ee15caffb65bddcbe43510d5f47f8d`:

```bash
$ gh api repos/pnpm/pacquet/commits/b965c5ef03ee15caffb65bddcbe43510d5f47f8d/pulls --jq '[.[].number]'
[]                                  # ← what the workflow saw

$ gh api 'repos/pnpm/pacquet/pulls?state=open&per_page=100' --paginate \
    --jq '[.[] | select(.head.sha == "b965c5ef03ee15caffb65bddcbe43510d5f47f8d") | .number]'
[391]                               # ← what we want
```

## What changes

Switch the fork-PR fallback from `commits/{sha}/pulls` to `pulls?state=open` + jq filter on `head.sha`. The PRs API records each PR's head SHA on the base-repo side regardless of where the head branch lives, so one code path covers both same-repo and fork.

Same-repo PRs still bypass the API call entirely via `workflow_run.pull_requests[0].number`. The fallback only runs when that array is empty (fork PRs).

## Trust model unchanged

`HEAD_SHA` still comes from the trusted `workflow_run` event payload, never from the artifact. The artifact still carries only `SUMMARY.md`. The collision-on-SHA check (`count != 1` ⇒ error) still fires loudly if the impossible happens.

## Test plan

- [x] `actionlint` clean.
- [ ] Validates end-to-end on the next benchmark run of any fork PR. Will rebase #391 again once this lands to confirm.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed benchmark workflow PR detection for forked contributions so benchmark comments are reliably posted to the correct pull request.
  * Added stricter matching and safeguards to prevent ambiguous or incorrect PR attribution for benchmark artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->