### PR TITLE
fix: render NDJSON output cleanly through @pnpm/default-reporter

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -29,6 +29,7 @@ pacquet-diagnostics      = { workspace = true }
 
 clap        = { workspace = true }
 derive_more = { workspace = true }
+dunce       = { workspace = true }
 home        = { workspace = true }
 miette      = { workspace = true }
 pipe-trait  = { workspace = true }
@@ -40,7 +41,6 @@ pacquet-store-dir     = { workspace = true }
 pacquet-testing-utils = { workspace = true }
 
 assert_cmd        = { workspace = true }
-dunce             = { workspace = true }
 command-extra     = { workspace = true }
 insta             = { workspace = true }
 pretty_assertions = { workspace = true }

--- a/crates/cli/src/cli_args.rs
+++ b/crates/cli/src/cli_args.rs
@@ -7,7 +7,7 @@ use crate::State;
 use add::AddArgs;
 use clap::{Parser, Subcommand, ValueEnum};
 use install::InstallArgs;
-use miette::Context;
+use miette::{Context, IntoDiagnostic};
 use pacquet_executor::execute_shell;
 use pacquet_npmrc::Npmrc;
 use pacquet_package_manifest::PackageManifest;
@@ -82,6 +82,19 @@ impl CliArgs {
     /// Execute the command
     pub async fn run(self) -> miette::Result<()> {
         let CliArgs { command, dir, reporter } = self;
+        // Canonicalize `--dir` so the bunyan-envelope `prefix` emitted by
+        // the reporter is the same absolute, symlink-resolved path that
+        // `@pnpm/cli.default-reporter` derives via `process.cwd()`. Without
+        // this, a default `--dir=.` leaves `prefix` as `"."`, the reporter
+        // never matches it against its `cwd`, and every progress / stats
+        // line gets a redundant `.` path prefix prepended. Mirrors pnpm's
+        // <https://github.com/pnpm/pnpm/blob/8eb1be4988/config/reader/src/index.ts#L270>
+        // `cwd = fs.realpathSync(betterPathResolve(cliOptions.dir ...))`,
+        // later assigned to `pnpmConfig.dir` (used as the install
+        // `lockfileDir`, threaded into every event's `prefix`).
+        let dir = dunce::canonicalize(&dir)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("canonicalizing the working directory: {}", dir.display()))?;
         let manifest_path = || dir.join("package.json");
         let npmrc = || Npmrc::current(env::current_dir, home::home_dir, Default::default).leak();
         // `require_lockfile` is the "this subcommand cannot run without a

--- a/crates/cli/src/cli_args.rs
+++ b/crates/cli/src/cli_args.rs
@@ -94,7 +94,7 @@ impl CliArgs {
         // `lockfileDir`, threaded into every event's `prefix`).
         let dir = dunce::canonicalize(&dir)
             .into_diagnostic()
-            .wrap_err_with(|| format!("canonicalizing the working directory: {}", dir.display()))?;
+            .wrap_err_with(|| format!("canonicalizing the `--dir` argument: {}", dir.display()))?;
         let manifest_path = || dir.join("package.json");
         let npmrc = || Npmrc::current(env::current_dir, home::home_dir, Default::default).leak();
         // `require_lockfile` is the "this subcommand cannot run without a

--- a/crates/cli/tests/install.rs
+++ b/crates/cli/tests/install.rs
@@ -170,6 +170,62 @@ fn frozen_lockfile_should_be_able_to_handle_big_lockfile() {
     drop((root, mock_instance)); // cleanup
 }
 
+/// Regression test for the NDJSON `prefix` field. `--reporter=ndjson`
+/// must emit each bunyan envelope with the canonicalized install root
+/// — not the relative `"."` that `dir.join("package.json").parent()`
+/// produced when `--dir` defaulted to `.`. The downstream consumer
+/// (`@pnpm/cli.default-reporter` running in a separate process) compares
+/// every event's `prefix` to its own `process.cwd()` and prepends a
+/// redundant `<prefix> | ` adornment whenever they disagree, so a `"."`
+/// prefix made every progress / stats line render with `.   |   `.
+#[test]
+fn install_emits_canonical_prefix_in_ndjson_events() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    eprintln!("Creating package.json...");
+    let manifest_path = workspace.join("package.json");
+    let package_json = serde_json::json!({
+        "dependencies": {
+            "@pnpm.e2e/hello-world-js-bin-parent": "1.0.0",
+        },
+    });
+    fs::write(&manifest_path, package_json.to_string()).expect("write to package.json");
+
+    eprintln!("Executing command with --reporter=ndjson...");
+    let output =
+        pacquet.with_args(["--reporter=ndjson", "install"]).output().expect("run pacquet install");
+    assert!(
+        output.status.success(),
+        "pacquet install exited non-zero: stderr={}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    eprintln!("Collecting `prefix` values from NDJSON stderr...");
+    let stderr = String::from_utf8(output.stderr).expect("stderr is utf-8");
+    let prefixes: Vec<String> = stderr
+        .lines()
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .filter_map(|val| val.get("prefix").and_then(|p| p.as_str()).map(str::to_owned))
+        .collect();
+    assert!(
+        !prefixes.is_empty(),
+        "expected at least one event with a `prefix` field; stderr was:\n{stderr}",
+    );
+
+    let expected = dunce::canonicalize(&workspace).expect("canonicalize workspace");
+    let expected = expected.to_str().expect("workspace path is UTF-8");
+    for prefix in &prefixes {
+        assert_eq!(
+            prefix, expected,
+            "every event's prefix must be the canonicalized install root, not relative",
+        );
+    }
+
+    drop((root, mock_instance)); // cleanup
+}
+
 #[test]
 fn should_install_circular_dependencies() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =

--- a/crates/cli/tests/snapshots/init__should_create_package_json.snap
+++ b/crates/cli/tests/snapshots/init__should_create_package_json.snap
@@ -1,10 +1,9 @@
 ---
 source: crates/cli/tests/init.rs
-assertion_line: 31
 expression: package_json_content
 ---
 {
-  "name": "",
+  "name": "workspace",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/crates/cli/tests/snapshots/init__should_create_package_json.snap
+++ b/crates/cli/tests/snapshots/init__should_create_package_json.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/cli/tests/init.rs
-assertion_line: 0
+assertion_line: 20
 expression: package_json_content
 ---
 {

--- a/crates/cli/tests/snapshots/init__should_create_package_json.snap
+++ b/crates/cli/tests/snapshots/init__should_create_package_json.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/cli/tests/init.rs
+assertion_line: 0
 expression: package_json_content
 ---
 {

--- a/crates/reporter/src/tests.rs
+++ b/crates/reporter/src/tests.rs
@@ -232,7 +232,7 @@ fn fetching_progress_event_matches_pnpm_wire_shape() {
     let event = LogEvent::FetchingProgress(FetchingProgressLog {
         level: LogLevel::Debug,
         message: FetchingProgressMessage::Started {
-            attempt: 0,
+            attempt: 1,
             package_id: "react@18.0.0".to_string(),
             size: None,
         },

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -838,12 +838,21 @@ async fn fetch_and_extract_once<R: Reporter>(
     // reporter checks `size != null` before rendering a percent
     // gauge, so this admits "we don't know yet" only when we truly
     // don't know.
+    //
+    // `attempt` is one-indexed (the in-flight attempt) to match
+    // pnpm's wire shape — `node-retry`'s `op.attempt(cb)` callback
+    // hands `cb` a 1-indexed counter, which `packageRequester`
+    // forwards verbatim into the `attempt` field. Pacquet's loop
+    // counter is zero-indexed, so emit `attempt + 1`. The default
+    // reporter's `reportBigTarballsProgress` filters on
+    // `log.attempt === 1` (so retries don't reset the progress
+    // line), so a zero would silence every "Downloading …" line.
     let send_result = client.get(package_url).send().await;
     let size = send_result.as_ref().ok().and_then(|r| r.content_length());
     R::emit(&LogEvent::FetchingProgress(FetchingProgressLog {
         level: LogLevel::Debug,
         message: FetchingProgressMessage::Started {
-            attempt,
+            attempt: attempt + 1,
             package_id: package_id.to_owned(),
             size,
         },

--- a/crates/tarball/src/tests.rs
+++ b/crates/tarball/src/tests.rs
@@ -1548,8 +1548,10 @@ async fn run_with_mem_cache_recovers_from_owning_fetch_error() {
 /// tarball pipeline:
 ///
 /// * `pnpm:fetching-progress started` once per *attempt* — so a 503 +
-///   200 retry pattern emits twice with `attempt = 0` then
-///   `attempt = 1`. `size` carries the response's `Content-Length`
+///   200 retry pattern emits twice with `attempt = 1` then
+///   `attempt = 2` (one-indexed, matching pnpm's wire shape — the
+///   default reporter's `reportBigTarballsProgress` filters on
+///   `attempt === 1`). `size` carries the response's `Content-Length`
 ///   (mockito sends one for `with_body`).
 /// * `pnpm:fetching-progress in_progress` is throttled to ~200ms; the
 ///   tiny FASTIFY tarball used here downloads in well under that, so
@@ -1621,7 +1623,7 @@ async fn fetching_progress_and_fetched_events_fire_during_download() {
         })
         .collect();
     let attempts: Vec<u32> = started.iter().map(|(a, _)| *a).collect();
-    assert_eq!(attempts, vec![0, 1], "started must fire once per attempt; got {captured:?}");
+    assert_eq!(attempts, vec![1, 2], "started must fire once per attempt; got {captured:?}");
     // Both attempts have a response head (mockito sends Content-Length
     // for `with_body(...)` and `with_status(503)` likewise), so both
     // `started` events must carry a populated `size`. Pinning this


### PR DESCRIPTION
Two fixes for piping `pacquet --reporter=ndjson` into `@pnpm/cli.default-reporter` running as a subprocess.

## 1. Redundant `.   |   ` path prefix on every progress / stats line

```
.                                        |    +1352 +++…
.                                        | Progress: resolved 1352, reused 1352, downloaded 0, added 1352, done
```

The bunyan-envelope `prefix` field was the literal `"."` (derived from `Path::parent` of `./package.json`). The default-reporter subprocess compares each event's `prefix` to its own `cwd` — an absolute, canonical path from `process.cwd()` — and the mismatch routed every log through `zoomOut`, prepending the formatted prefix.

**Fix:** canonicalize `--dir` once at the top of `CliArgs::run`, mirroring pnpm's [`config/reader/src/index.ts#L270`](https://github.com/pnpm/pnpm/blob/8eb1be4988/config/reader/src/index.ts#L270):

```ts
const cwd = fs.realpathSync(betterPathResolve(cliOptions.dir ?? npmrcResult.localPrefix))
…
pnpmConfig.dir = cwd
```

`pnpmConfig.dir` becomes `lockfileDir`, which is threaded into every event's `prefix`. Pacquet now does the equivalent via `dunce::canonicalize`, so the manifest path — and therefore the `prefix` field — is the same canonical absolute path the subprocess sees. After the fix:

```
Packages: +1352
+++++++++++++…
Progress: resolved 1352, reused 1352, downloaded 0, added 1352, done
```

**Side effect:** `pacquet init` now derives the package `name` from the working-directory basename (matching pnpm) instead of leaving it as `""`. The previous empty value was a symptom of the same bug — `Path::parent("./package.json").file_name()` returns `None`. Init snapshot updated.

## 2. `Downloading <pkg>: …/<size>` lines never rendered

Even when a real download was happening, no big-tarball progress lines were emitted by the reporter. The default reporter's `reportBigTarballsProgress` filters started events with `log.attempt === 1` (so a transient retry doesn't reset the line). Pacquet's retry loop counter is zero-indexed and was being passed straight through, so `pnpm:fetching-progress started` always carried `attempt: 0` and the reporter silently dropped the entire channel.

Pnpm's underlying `node-retry` `op.attempt(cb)` callback hands `cb` a 1-indexed counter, which `packageRequester` forwards into the log verbatim. **Fix:** emit `attempt + 1`, mirroring the same `+ 1` adjustment already present at the neighbouring `pnpm:request-retry` site. After the fix, with a tarball ≥ 5 MB:

```
Downloading highcharts@11.4.8: 0.00 B/9.48 MB
Downloading highcharts@11.4.8: 726.00 B/9.48 MB
Downloading highcharts@11.4.8: 9.48 MB/9.48 MB, done
```

## Test plan

- [x] `cargo nextest run -p pacquet-cli -p pacquet-tarball -p pacquet-reporter` passes
- [x] Manually re-ran the user's NDJSON-piped command in a symlinked path → no `.   |   ` prefix
- [x] Forced a cold install of a 9.48 MB tarball → `Downloading …` lines render correctly with `attempt: 1` on the wire
- [x] `cargo fmt --check`, `taplo format --check`, `cargo clippy --locked -- --deny warnings` all clean
- [ ] CI green

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Directory paths are now canonicalized for consistency.

* **Bug Fixes**
  * Progress event attempt numbering changed to 1-indexed format.
  * Reporter prefix output now displays canonical paths instead of relative paths.

* **Documentation**
  * Enhanced error messages for path canonicalization failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->