### PR TITLE
docs(cli): fix long and wrong help messages

### DIFF
--- a/crates/cli/src/cli_args.rs
+++ b/crates/cli/src/cli_args.rs
@@ -30,27 +30,11 @@ pub struct CliArgs {
     #[clap(short = 'C', long, default_value = ".")]
     pub dir: PathBuf,
 
-    /// How install progress is rendered.
-    ///
-    /// `ndjson` writes pnpm-shaped log records as newline-delimited JSON
-    /// to stderr, suitable for piping into `@pnpm/cli.default-reporter`.
-    /// `silent` drops every event. The default is `silent` until the
-    /// in-process default renderer lands; the spawn-and-pipe wiring is
-    /// tracked separately (see #344).
-    ///
-    /// `global = true` makes the flag accepted on either side of the
-    /// subcommand (`pacquet --reporter=ndjson install` and
-    /// `pacquet install --reporter=ndjson` both work), matching pnpm.
+    /// Output format.
     #[clap(long, value_enum, default_value_t = ReporterType::Silent, global = true)]
     pub reporter: ReporterType,
 }
 
-/// Selectable rendering strategy for log events.
-///
-/// Mirrors the names pnpm uses for `--reporter` (`default`, `ndjson`,
-/// `silent`, `append-only`). Only the variants pacquet currently supports
-/// are listed; the others land alongside the default-reporter spawn-and-
-/// pipe (tracked under #344).
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum ReporterType {
     /// Newline-delimited JSON in pnpm's wire format on stderr.

--- a/crates/cli/src/cli_args.rs
+++ b/crates/cli/src/cli_args.rs
@@ -35,6 +35,14 @@ pub struct CliArgs {
     pub reporter: ReporterType,
 }
 
+/// Selectable rendering strategy for log events.
+///
+/// Mirrors the names pnpm uses for `--reporter` (`default`, `ndjson`,
+/// `silent`, `append-only`). Only the variants pacquet currently supports
+/// are listed; the others land alongside the default-reporter spawn-and-
+/// pipe (tracked under [#344]).
+///
+/// [#344]: https://github.com/pnpm/pacquet/issues/344
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum ReporterType {
     /// Newline-delimited JSON in pnpm's wire format on stderr.

--- a/crates/cli/src/cli_args.rs
+++ b/crates/cli/src/cli_args.rs
@@ -30,7 +30,7 @@ pub struct CliArgs {
     #[clap(short = 'C', long, default_value = ".")]
     pub dir: PathBuf,
 
-    /// Output format.
+    /// Reporter output format.
     #[clap(long, value_enum, default_value_t = ReporterType::Silent, global = true)]
     pub reporter: ReporterType,
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Shortened CLI --reporter option help text for a concise “Reporter output format” description.
  * Clarified reporter type documentation by converting an inline issue reference into an explicit reference-style link for behavior details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->