### PR TITLE
feat(cli): add support for "run" as fallback command

### DIFF
--- a/crates/cli/src/cli_args.rs
+++ b/crates/cli/src/cli_args.rs
@@ -68,6 +68,9 @@ pub enum CliCommand {
     /// Managing the package store.
     #[clap(subcommand)]
     Store(StoreCommand),
+    /// Fallback command if the first argument is not a valid command
+    #[clap(external_subcommand)]
+    Fallback(Vec<String>),
 }
 
 impl CliArgs {
@@ -142,6 +145,24 @@ impl CliArgs {
                 execute_shell(command).wrap_err(format!("executing command: \"{0}\"", command))?;
             }
             CliCommand::Store(command) => command.run(|| npmrc().map(|m| &*m))?,
+            CliCommand::Fallback(mut args) => {
+                // Since the top-level flags have already been parsed,
+                // re-parse the rest of the arguments as if they were just passed to the "run" command
+                let fallback_command = String::from("run");
+                let binary_name = String::from("pacquet");
+
+                args.insert(0, fallback_command);
+                args.insert(0, binary_name);
+
+                let cli_args = CliArgs::parse_from(args);
+
+                match cli_args.command {
+                    CliCommand::Run(args) => args.run(manifest_path())?,
+                    _ => {
+                        return Err(miette::Error::msg("Invalid fallback command provided"));
+                    }
+                }
+            }
         }
 
         Ok(())

--- a/crates/cli/tests/fallback.rs
+++ b/crates/cli/tests/fallback.rs
@@ -1,0 +1,113 @@
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_testing_utils::bin::CommandTempCwd;
+use std::fs;
+
+#[test]
+fn should_run_a_script() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+
+    let build_txt_path = workspace.join("build.txt");
+    let build_txt_content = "Build output";
+
+    let write_script =
+        format!(r#"require("fs").writeFileSync({build_txt_path:?}, "{build_txt_content}")"#);
+
+    let package_json_path = workspace.join("package.json");
+    let package_json_content = serde_json::json!({
+          "scripts": {
+       "build": format!("node -e '{write_script}'"),
+         },
+    })
+    .to_string();
+
+    fs::write(package_json_path, package_json_content).expect("write to package.json");
+
+    pacquet.with_arg("build").assert().success();
+
+    let output = fs::read_to_string(build_txt_path).expect("read build.txt");
+
+    assert_eq!(output, build_txt_content);
+
+    drop(root);
+}
+
+#[test]
+fn should_run_a_script_with_arguments() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+
+    let build_txt_path = workspace.join("build.txt");
+
+    let record_args_script = format!(
+        r#"require("fs").writeFileSync({build_txt_path:?}, process.argv.slice(1).join(" "))"#
+    );
+
+    let package_json_path = workspace.join("package.json");
+    let package_json_content = serde_json::json!({
+        "scripts": {
+            "build": format!("node -e '{record_args_script}'"),
+        },
+    })
+    .to_string();
+
+    fs::write(package_json_path, package_json_content).expect("write to package.json");
+
+    pacquet.with_arg("build").arg("arg1").arg("arg2").arg("--").arg("--flag1").assert().success();
+
+    let output = fs::read_to_string(build_txt_path).expect("read build.txt");
+
+    assert_eq!(output, "arg1 arg2 --flag1");
+
+    drop(root);
+}
+
+#[test]
+fn should_fail_if_script_does_not_exist() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+
+    let package_json_path = workspace.join("package.json");
+    let package_json_content = serde_json::json!({
+        "scripts": {}
+    })
+    .to_string();
+
+    fs::write(package_json_path, package_json_content).expect("write to package.json");
+
+    pacquet.with_arg("build").assert().failure();
+
+    drop(root);
+}
+
+#[test]
+fn should_not_fail_if_script_does_not_exist_but_if_present_flag_is_set() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+
+    let package_json_path = workspace.join("package.json");
+    let package_json_content = serde_json::json!({
+        "scripts": {}
+    })
+    .to_string();
+
+    fs::write(package_json_path, package_json_content).expect("write to package.json");
+
+    pacquet.with_arg("build").arg("--if-present").assert().success();
+
+    drop(root);
+}
+
+#[test]
+fn should_fail_if_no_command_is_specified() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+
+    let package_json_path = workspace.join("package.json");
+    let package_json_content = serde_json::json!({
+        "scripts": {}
+    })
+    .to_string();
+
+    fs::write(package_json_path, package_json_content).expect("write to package.json");
+
+    pacquet.with_arg("--this-flag-does-not-exist").assert().failure();
+
+    drop(root);
+}

--- a/crates/cli/tests/run.rs
+++ b/crates/cli/tests/run.rs
@@ -1,0 +1,104 @@
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_testing_utils::bin::CommandTempCwd;
+use std::fs;
+
+#[test]
+fn should_run_a_script() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+
+    let build_txt_path = workspace.join("build.txt");
+    let build_txt_content = "Build output";
+
+    let write_script =
+        format!(r#"require("fs").writeFileSync({build_txt_path:?}, "{build_txt_content}")"#);
+
+    let package_json_path = workspace.join("package.json");
+    let package_json_content = serde_json::json!({
+          "scripts": {
+       "build": format!("node -e '{write_script}'"),
+         },
+    })
+    .to_string();
+
+    fs::write(package_json_path, package_json_content).expect("write to package.json");
+
+    pacquet.with_arg("run").arg("build").assert().success();
+
+    let output = fs::read_to_string(build_txt_path).expect("read build.txt");
+
+    assert_eq!(output, build_txt_content);
+
+    drop(root);
+}
+
+#[test]
+fn should_run_a_script_with_arguments() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+
+    let build_txt_path = workspace.join("build.txt");
+
+    let record_args_script = format!(
+        r#"require("fs").writeFileSync({build_txt_path:?}, process.argv.slice(1).join(" "))"#
+    );
+
+    let package_json_path = workspace.join("package.json");
+    let package_json_content = serde_json::json!({
+        "scripts": {
+            "build": format!("node -e '{record_args_script}'"),
+        },
+    })
+    .to_string();
+
+    fs::write(package_json_path, package_json_content).expect("write to package.json");
+
+    pacquet
+        .with_arg("run")
+        .arg("build")
+        .arg("arg1")
+        .arg("arg2")
+        .arg("--")
+        .arg("--flag1")
+        .assert()
+        .success();
+
+    let output = fs::read_to_string(build_txt_path).expect("read build.txt");
+
+    assert_eq!(output, "arg1 arg2 --flag1");
+
+    drop(root);
+}
+
+#[test]
+fn should_fail_if_script_does_not_exist() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+
+    let package_json_path = workspace.join("package.json");
+    let package_json_content = serde_json::json!({
+        "scripts": {}
+    })
+    .to_string();
+
+    fs::write(package_json_path, package_json_content).expect("write to package.json");
+
+    pacquet.with_arg("run").arg("build").assert().failure();
+
+    drop(root);
+}
+
+#[test]
+fn should_not_fail_if_script_does_not_exist_but_if_present_flag_is_set() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+
+    let package_json_path = workspace.join("package.json");
+    let package_json_content = serde_json::json!({
+        "scripts": {}
+    })
+    .to_string();
+
+    fs::write(package_json_path, package_json_content).expect("write to package.json");
+
+    pacquet.with_arg("run").arg("build").arg("--if-present").assert().success();
+
+    drop(root);
+}


### PR DESCRIPTION
https://pnpm.io/cli/run

> Another thing to note for those that like to save keystrokes and time is that all scripts get aliased in as pnpm commands, so ultimately pnpm watch is just shorthand for pnpm run watch (ONLY for scripts that do not share the same name as already existing pnpm commands).

This PR also adds tests for the run command to aid in future changes

What this does not support though is "run" flags coming before the script name

So "pnpm --if-present script" would fail because --if-present is not one of the CLI flags for the pacquet command, meaning clap errors out before reaching the external subcommand branch

If this is something we would like to support please let me know and I can figure out how to implement it, though it is a little strange

My first attempt was something like this in `lib.rs`

```rust
let os_args: Vec<OsString> = std::env::args_os().collect()

match CliArgs::try_parse_from(&os_args) {
        Ok(args) => run_command(args).await,
        Err(err) => attempt_fallback_command(err, os_args).await,
    }
```

Though figuring out where to inject "run" into the args and which error to show to the user is quite tricky

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI now supports automatic fallback routing—unrecognized commands are treated as script execution, allowing simpler command invocation.

* **Tests**
  * Added integration test suites for fallback command handling, script argument forwarding, and edge cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pacquet/pull/408)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->