### PR TITLE
docs: gate PR scope to stage 1 of the roadmap

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,48 @@
+<!--
+Thanks for contributing to pacquet!
+
+Before opening this PR, please read the "Scope and Roadmap" section of
+CONTRIBUTING.md. Stage 1 covers a single command, `install`. New top-level
+commands are out of scope. New settings or user-visible features must be
+listed under Stage 1 of the roadmap (https://github.com/pnpm/pacquet/issues/299)
+to be considered. PRs outside that scope will be closed.
+
+Bug fixes, performance work, tests, and documentation for existing behavior
+do not need a roadmap entry.
+-->
+
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+## Linked issue
+
+<!--
+Optional when the change is in Stage 1 and exactly mirrors how the pnpm CLI
+works. Required when the right approach is not obvious from upstream code,
+or to coordinate on in-flight work.
+
+If linked, the issue must correspond to an item under Stage 1 of the
+roadmap (#299).
+
+Deviating from pnpm's behavior is not an option in pacquet. If pnpm itself
+should change, raise it in https://github.com/pnpm/pnpm first.
+
+Not required for bug fixes, perf, tests, or docs.
+-->
+
+Fixes #
+
+## Upstream reference
+
+<!--
+If this PR ports behavior from pnpm/pnpm, link the upstream commit or PR.
+Use a permalink with a 10-character SHA, not a branch URL.
+See AGENTS.md for the convention.
+-->
+
+## Checklist
+
+- [ ] The change matches pnpm's behavior on `main` (or this PR is a bug fix, perf, test, or docs change that does not alter behavior).
+- [ ] `just ready` passes locally.
+- [ ] Tests added or updated where applicable.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,10 +2,11 @@
 Thanks for contributing to pacquet!
 
 Before opening this PR, please read the "Scope and Roadmap" section of
-CONTRIBUTING.md. Stage 1 covers a single command, `install`. New top-level
-commands are out of scope. New settings or user-visible features must be
-listed under Stage 1 of the roadmap (https://github.com/pnpm/pacquet/issues/299)
-to be considered. PRs outside that scope will be closed.
+CONTRIBUTING.md. Stage 1 focuses on `pacquet install`. Other existing
+top-level commands are not part of Stage 1, and new top-level commands are
+out of scope. New settings or user-visible features must be listed under
+Stage 1 of the roadmap (https://github.com/pnpm/pacquet/issues/299) to be
+considered. PRs outside that scope will be closed.
 
 Bug fixes, performance work, tests, and documentation for existing behavior
 do not need a roadmap entry.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,11 +6,11 @@ See also [`CODE_STYLE_GUIDE.md`](./CODE_STYLE_GUIDE.md) for the code style guide
 
 pacquet's scope is defined by the roadmap in [#299](https://github.com/pnpm/pacquet/issues/299). The current focus is **Stage 1 — Headless installer**: making `pacquet install --frozen-lockfile` feature-complete with `pnpm install --frozen-lockfile`.
 
-Stage 1 covers a single command, `install`, with the settings and behavior needed to match `pnpm install --frozen-lockfile`. New top-level commands are out of scope. pacquet is intended to be executed by the pnpm CLI under the hood, so configuration arrives through pnpm settings (such as `.npmrc` and `pnpm-workspace.yaml`) rather than through new command-line flags.
+Stage 1 focuses on `pacquet install` and the settings and behavior needed to match `pnpm install --frozen-lockfile`. Other top-level commands exist in the CLI today, but they are not part of Stage 1 and are not receiving feature work, and new top-level commands are out of scope. pacquet is intended to be executed by the pnpm CLI under the hood, so configuration arrives through pnpm settings (such as `.npmrc` and `pnpm-workspace.yaml`) rather than through new command-line flags.
 
 Before opening a pull request that adds a new setting or user-visible feature, **confirm the feature is listed under Stage 1 of the roadmap**. Work that does not appear under Stage 1 will not be reviewed or merged at this time, regardless of implementation quality. Stage 2 and later items are deferred until Stage 1 is complete.
 
-Opening an issue first is optional when the change is in Stage 1 *and* the implementation exactly mirrors how the pnpm CLI works (same behavior, same defaults, same error codes, same file formats — see [`AGENTS.md`](./AGENTS.md) for the parity rule). Open an issue first when the right approach is not obvious from upstream code, or to coordinate on in-flight work.
+Opening an issue first is optional when the change is in Stage 1 *and* the implementation exactly mirrors how the pnpm CLI works: same behavior, same defaults, same error codes, same file formats. See [`AGENTS.md`](./AGENTS.md) for the parity rule. Open an issue first when the right approach is not obvious from upstream code, or to coordinate on in-flight work.
 
 Deviating from pnpm's behavior is not an option in pacquet. If you believe pnpm itself should change, raise it in the [pnpm repository](https://github.com/pnpm/pnpm) first. Once the change has landed in pnpm and shipped, the corresponding port can be made here.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,22 @@
 
 See also [`CODE_STYLE_GUIDE.md`](./CODE_STYLE_GUIDE.md) for the code style guide.
 
+## Scope and Roadmap
+
+pacquet's scope is defined by the roadmap in [#299](https://github.com/pnpm/pacquet/issues/299). The current focus is **Stage 1 — Headless installer**: making `pacquet install --frozen-lockfile` feature-complete with `pnpm install --frozen-lockfile`.
+
+Stage 1 covers a single command, `install`, with the settings and behavior needed to match `pnpm install --frozen-lockfile`. New top-level commands are out of scope. pacquet is intended to be executed by the pnpm CLI under the hood, so configuration arrives through pnpm settings (such as `.npmrc` and `pnpm-workspace.yaml`) rather than through new command-line flags.
+
+Before opening a pull request that adds a new setting or user-visible feature, **confirm the feature is listed under Stage 1 of the roadmap**. Work that does not appear under Stage 1 will not be reviewed or merged at this time, regardless of implementation quality. Stage 2 and later items are deferred until Stage 1 is complete.
+
+Opening an issue first is optional when the change is in Stage 1 *and* the implementation exactly mirrors how the pnpm CLI works (same behavior, same defaults, same error codes, same file formats — see [`AGENTS.md`](./AGENTS.md) for the parity rule). Open an issue first when the right approach is not obvious from upstream code, or to coordinate on in-flight work.
+
+Deviating from pnpm's behavior is not an option in pacquet. If you believe pnpm itself should change, raise it in the [pnpm repository](https://github.com/pnpm/pnpm) first. Once the change has landed in pnpm and shipped, the corresponding port can be made here.
+
+Bug fixes, performance improvements, tests, and documentation for behavior that already exists do not need a roadmap entry and may be sent directly as pull requests.
+
+Pull requests for new top-level commands, or for features outside the current Stage 1 scope, will be closed with a pointer to the roadmap.
+
 ## Commit Message Convention
 
 This project uses [Conventional Commits](https://www.conventionalcommits.org/).


### PR DESCRIPTION
## Summary

We frequently get PRs proposing new commands or features that are not on the roadmap (#299). This adds an explicit scope gate so contributors learn the rule *before* they write code, rather than after a PR is opened and then closed.

Two new pieces of documentation:

- **`CONTRIBUTING.md` — new "Scope and Roadmap" section** explaining that:
  - Work outside Stage 1 of the roadmap will not be merged at this time.
  - Stage 1 covers a single command, `install`. New top-level commands are out of scope.
  - pacquet is meant to run under the pnpm CLI, so configuration arrives through pnpm settings (`.npmrc`, `pnpm-workspace.yaml`) rather than through new command-line flags.
  - Opening an issue first is optional when the change is in Stage 1 *and* exactly mirrors the pnpm CLI; required otherwise.
  - Deviating from pnpm's behavior is not an option. If pnpm itself should change, raise it in `pnpm/pnpm` first and port the change here once it has shipped.
  - Bug fixes, perf, tests, and docs do not need a roadmap entry.
- **`.github/pull_request_template.md` — new PR template** that surfaces the same scope gate at PR-open time, plus an upstream-reference section and a `just ready` checklist item.

## Test plan

- [x] `just ready` passes locally (it does).
- [ ] After merge, opening a new PR shows the new template.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a standardized pull request template with contributor guidance, required sections (summary, linked issue, fixes, upstream reference) and a checklist for readiness and tests.
  * Expanded contribution guidelines with a clear project scope and roadmap for the current development stage, plus rules for what can be submitted directly and when to open an issue first.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pacquet/pull/409)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->