### PR TITLE
feat(executor): port makeEnv, extendPath, and shell selection for lifecycle scripts (#397)

### DIFF
--- a/crates/executor/src/extend_path.rs
+++ b/crates/executor/src/extend_path.rs
@@ -1,6 +1,6 @@
 use std::{
     env,
-    ffi::OsString,
+    ffi::{OsStr, OsString},
     path::{self, Path, PathBuf},
 };
 
@@ -77,12 +77,28 @@ pub fn extend_path(
         }
     }
 
-    env::join_paths(joined).unwrap_or_else(|_| {
-        // join_paths only errors if a component contains the platform
-        // separator. Fall back to the original PATH so we never spawn
-        // with an empty PATH.
-        original_path.cloned().unwrap_or_default()
-    })
+    join_paths_lossy(&joined)
+}
+
+/// Join `paths` with the platform PATH separator (`;` on Windows,
+/// `:` elsewhere). Mirrors upstream's
+/// `pathArr.join(process.platform === 'win32' ? ';' : ':')` at
+/// <https://github.com/pnpm/npm-lifecycle/blob/d2d8e790/lib/extendPath.js#L26>
+/// exactly — including the lack of validation. If a path component
+/// itself contains the separator the spawned shell sees an embedded
+/// entry, which is the same behavior the upstream string-join
+/// produces. `std::env::join_paths` would have erred and dropped
+/// the entire computed PATH in that case.
+fn join_paths_lossy(paths: &[PathBuf]) -> OsString {
+    let sep: &OsStr = if cfg!(windows) { OsStr::new(";") } else { OsStr::new(":") };
+    let mut out = OsString::new();
+    for (i, p) in paths.iter().enumerate() {
+        if i > 0 {
+            out.push(sep);
+        }
+        out.push(p);
+    }
+    out
 }
 
 /// Returns the sequence of `node_modules/.bin` directories implied by

--- a/crates/executor/src/extend_path.rs
+++ b/crates/executor/src/extend_path.rs
@@ -1,0 +1,132 @@
+use std::{
+    env,
+    ffi::OsString,
+    path::{self, Path, PathBuf},
+};
+
+/// Controls whether the dir containing the current `node` interpreter
+/// is appended to PATH. Tri-state from
+/// <https://github.com/pnpm/npm-lifecycle/blob/d2d8e790/lib/extendPath.js#L29-L61>.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ScriptsPrependNodePath {
+    /// `scriptsPrependNodePath: true` — always prepend.
+    Always,
+    /// `scriptsPrependNodePath: false` (or `null`) — never prepend.
+    #[default]
+    Never,
+    /// `scriptsPrependNodePath: 'warn-only'` — emit a warning if the
+    /// node in PATH differs from `process.execPath`, but do not
+    /// prepend.
+    WarnOnly,
+}
+
+/// Build the `PATH` env value for a lifecycle script spawn.
+///
+/// Ports `extendPath` from
+/// <https://github.com/pnpm/npm-lifecycle/blob/d2d8e790/lib/extendPath.js#L5-L27>.
+///
+/// Order, highest-priority first:
+/// 1. The wd's own `<wd>/node_modules/.bin`,
+/// 2. Each ancestor `node_modules/.bin` walking back up through the
+///    `node_modules/` segments of `wd`,
+/// 3. The bundled `node-gyp-bin` directory (when supplied),
+/// 4. `extra_bin_paths` (caller-supplied),
+/// 5. `dirname(node_execpath)` when `scripts_prepend_node_path` is
+///    [`Always`](ScriptsPrependNodePath::Always),
+/// 6. `original_path` (typically the inherited system PATH).
+pub fn extend_path(
+    wd: &Path,
+    original_path: Option<&OsString>,
+    node_gyp_bin: Option<&Path>,
+    extra_bin_paths: &[PathBuf],
+    scripts_prepend_node_path: ScriptsPrependNodePath,
+    node_execpath: Option<&Path>,
+) -> OsString {
+    let mut path_arr: Vec<PathBuf> = Vec::new();
+
+    // 1+2. Walk the wd's node_modules ancestors, deepest first.
+    for bin in ancestor_node_modules_bins(wd) {
+        path_arr.push(bin);
+    }
+
+    // 3. Bundled node-gyp-bin.
+    if let Some(p) = node_gyp_bin {
+        path_arr.push(p.to_path_buf());
+    }
+
+    // 4. Caller-supplied extra paths.
+    path_arr.extend_from_slice(extra_bin_paths);
+
+    // 5. dirname(node) when scriptsPrependNodePath is `Always`.
+    //    `WarnOnly` only emits a warning upstream; the actual prepend
+    //    is gated on `cfgsetting === true` at lib/extendPath.js:32.
+    //    We omit the warn-emission here; the caller (with reporter
+    //    context) is a better place for it.
+    if scripts_prepend_node_path == ScriptsPrependNodePath::Always
+        && let Some(node) = node_execpath
+        && let Some(parent) = node.parent()
+    {
+        path_arr.push(parent.to_path_buf());
+    }
+
+    // 6. originalPath at the end.
+    let mut joined: Vec<PathBuf> = path_arr;
+    if let Some(orig) = original_path {
+        for p in env::split_paths(orig) {
+            joined.push(p);
+        }
+    }
+
+    env::join_paths(joined).unwrap_or_else(|_| {
+        // join_paths only errors if a component contains the platform
+        // separator. Fall back to the original PATH so we never spawn
+        // with an empty PATH.
+        original_path.cloned().unwrap_or_default()
+    })
+}
+
+/// Returns the sequence of `node_modules/.bin` directories implied by
+/// `wd`, ordered deepest-first to match the upstream `unshift` walk
+/// at lib/extendPath.js:14-18.
+///
+/// The walk mirrors upstream's `wd.split(/[\\/]node_modules[\\/]/)`
+/// scheme: it does *not* walk parent directories beyond the first
+/// `node_modules/` ancestor of `wd`. If `wd` contains no
+/// `node_modules/` segment, only `<wd>/node_modules/.bin` is
+/// produced.
+fn ancestor_node_modules_bins(wd: &Path) -> Vec<PathBuf> {
+    let normalized = normalize_for_split(wd);
+    let parts: Vec<&str> = normalized.split("/node_modules/").collect();
+
+    // First part is the project root (everything before the first
+    // `/node_modules/` segment); remaining parts are intermediate
+    // `node_modules/<pp>` slots.
+    let (head, tail) = parts.split_first().expect("split always yields at least one element");
+    let head_path = PathBuf::from(head);
+    let mut acc = path::absolute(&head_path).unwrap_or(head_path);
+
+    let mut bins: Vec<PathBuf> = Vec::with_capacity(parts.len());
+
+    // Each pp in the tail contributes a `${acc}/node_modules/.bin`
+    // (from the parent slot), then `acc` advances to
+    // `${acc}/node_modules/${pp}`. After the loop, the final
+    // `${acc}/node_modules/.bin` is the deepest one (the wd itself).
+    for pp in tail {
+        bins.push(acc.join("node_modules").join(".bin"));
+        acc = acc.join("node_modules").join(pp);
+    }
+    bins.push(acc.join("node_modules").join(".bin"));
+
+    // Upstream `unshift`es each entry so the deepest .bin ends up
+    // first; collect in the natural order then reverse.
+    bins.reverse();
+    bins
+}
+
+fn normalize_for_split(wd: &Path) -> String {
+    let s = wd.to_string_lossy().into_owned();
+    if cfg!(windows) { s.replace('\\', "/") } else { s }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/executor/src/extend_path.rs
+++ b/crates/executor/src/extend_path.rs
@@ -102,8 +102,21 @@ fn ancestor_node_modules_bins(wd: &Path) -> Vec<PathBuf> {
     // `/node_modules/` segment); remaining parts are intermediate
     // `node_modules/<pp>` slots.
     let (head, tail) = parts.split_first().expect("split always yields at least one element");
-    let head_path = PathBuf::from(head);
-    let mut acc = path::absolute(&head_path).unwrap_or(head_path);
+
+    // Match upstream's `path.resolve(p.shift())` at
+    // lib/extendPath.js:8: absolute paths stay as-is, relative
+    // paths anchor against the process cwd, and an empty head
+    // (which happens when `wd` starts with `node_modules/`) means
+    // "use cwd". This anchoring carries upstream's cwd-dependence
+    // when the caller passes a relative wd — pacquet's production
+    // call sites always pass an absolute pkg_root, so the
+    // dependency is a non-issue in practice.
+    let mut acc = if head.is_empty() {
+        env::current_dir().unwrap_or_else(|_| PathBuf::new())
+    } else {
+        let head_path = PathBuf::from(head);
+        path::absolute(&head_path).unwrap_or(head_path)
+    };
 
     let mut bins: Vec<PathBuf> = Vec::with_capacity(parts.len());
 

--- a/crates/executor/src/extend_path/tests.rs
+++ b/crates/executor/src/extend_path/tests.rs
@@ -26,18 +26,17 @@ fn node_gyp_comes_after_node_modules_dot_bin() {
     let wd = Path::new("/Users/x/project");
     let node_gyp = PathBuf::from("/lib/node-gyp-bin");
     let extra: Vec<PathBuf> = vec![];
-    let path = extend_path(
-        wd,
-        None,
-        Some(&node_gyp),
-        &extra,
-        ScriptsPrependNodePath::Never,
-        None,
-    );
+    let path = extend_path(wd, None, Some(&node_gyp), &extra, ScriptsPrependNodePath::Never, None);
     let parts = segments(&path);
     let bin_idx = parts
         .iter()
-        .position(|p| p.ends_with(&format!("project{}node_modules{}.bin", std::path::MAIN_SEPARATOR, std::path::MAIN_SEPARATOR)))
+        .position(|p| {
+            p.ends_with(&format!(
+                "project{}node_modules{}.bin",
+                std::path::MAIN_SEPARATOR,
+                std::path::MAIN_SEPARATOR
+            ))
+        })
         .unwrap_or_else(|| panic!("missing node_modules/.bin in {parts:?}"));
     let gyp_idx = parts
         .iter()
@@ -94,14 +93,7 @@ fn extra_bin_paths_come_after_bins_and_node_gyp() {
     let wd = Path::new("/proj");
     let node_gyp = PathBuf::from("/bundled/node-gyp-bin");
     let extra: Vec<PathBuf> = vec![PathBuf::from("/extra/one"), PathBuf::from("/extra/two")];
-    let path = extend_path(
-        wd,
-        None,
-        Some(&node_gyp),
-        &extra,
-        ScriptsPrependNodePath::Never,
-        None,
-    );
+    let path = extend_path(wd, None, Some(&node_gyp), &extra, ScriptsPrependNodePath::Never, None);
     let parts = segments(&path);
     let bin_idx = parts.iter().position(|p| p.contains("proj") && p.ends_with(".bin")).unwrap();
     let gyp_idx = parts.iter().position(|p| p.contains("node-gyp-bin")).unwrap();

--- a/crates/executor/src/extend_path/tests.rs
+++ b/crates/executor/src/extend_path/tests.rs
@@ -169,6 +169,33 @@ fn scripts_prepend_node_path_always_appends_dirname_of_node() {
     );
 }
 
+/// Regression: a path component containing the platform separator
+/// must not cause `extend_path` to drop the computed entries.
+/// Upstream's `pathArr.join(':')` produces the embedded-separator
+/// string verbatim; pacquet must match. Skipping on Windows where
+/// `;` is far less likely to appear in real paths, but the
+/// invariant holds there too.
+#[cfg(unix)]
+#[test]
+fn separator_in_path_component_does_not_drop_other_entries() {
+    // A bin path that itself contains a colon — exotic, but valid
+    // on POSIX. `env::join_paths` would reject it; the naive join
+    // mirrors upstream by embedding it verbatim.
+    let wd = Path::new("/proj");
+    let weird = PathBuf::from("/tmp/a:b/.bin");
+    let path = extend_path(
+        wd,
+        None,
+        None,
+        std::slice::from_ref(&weird),
+        ScriptsPrependNodePath::Never,
+        None,
+    );
+    let s = path.to_string_lossy();
+    assert!(s.contains("/proj/node_modules/.bin"), "wd .bin must survive: {s:?}");
+    assert!(s.contains("/tmp/a:b/.bin"), "the weird extra path must survive verbatim: {s:?}");
+}
+
 /// Tri-state: `Never` and `WarnOnly` both skip the actual prepend
 /// (mirroring the `cfgsetting === true` gate at lib/extendPath.js:32).
 /// `WarnOnly` would emit a warning upstream; pacquet's reporter-side

--- a/crates/executor/src/extend_path/tests.rs
+++ b/crates/executor/src/extend_path/tests.rs
@@ -34,7 +34,7 @@ fn node_gyp_comes_after_node_modules_dot_bin() {
             p.ends_with(&format!(
                 "project{}node_modules{}.bin",
                 std::path::MAIN_SEPARATOR,
-                std::path::MAIN_SEPARATOR
+                std::path::MAIN_SEPARATOR,
             ))
         })
         .unwrap_or_else(|| panic!("missing node_modules/.bin in {parts:?}"));

--- a/crates/executor/src/extend_path/tests.rs
+++ b/crates/executor/src/extend_path/tests.rs
@@ -1,0 +1,170 @@
+use super::{ScriptsPrependNodePath, extend_path};
+use pretty_assertions::assert_eq;
+use std::{
+    env,
+    ffi::OsString,
+    path::{Path, PathBuf},
+};
+
+#[cfg(unix)]
+const SEP: char = ':';
+#[cfg(windows)]
+const SEP: char = ';';
+
+fn segments(path: &OsString) -> Vec<String> {
+    env::split_paths(path).map(|p| p.to_string_lossy().into_owned()).collect()
+}
+
+/// Ports `test('the path to node-gyp should be added after the path
+/// to node_modules/.bin')` from
+/// <https://github.com/pnpm/npm-lifecycle/blob/d2d8e790/test/extendPath.test.js#L5-L8>.
+///
+/// The only upstream test for extendPath; assertion is purely
+/// ordering between `node_modules/.bin` and the bundled `node-gyp`.
+#[test]
+fn node_gyp_comes_after_node_modules_dot_bin() {
+    let wd = Path::new("/Users/x/project");
+    let node_gyp = PathBuf::from("/lib/node-gyp-bin");
+    let extra: Vec<PathBuf> = vec![];
+    let path = extend_path(
+        wd,
+        None,
+        Some(&node_gyp),
+        &extra,
+        ScriptsPrependNodePath::Never,
+        None,
+    );
+    let parts = segments(&path);
+    let bin_idx = parts
+        .iter()
+        .position(|p| p.ends_with(&format!("project{}node_modules{}.bin", std::path::MAIN_SEPARATOR, std::path::MAIN_SEPARATOR)))
+        .unwrap_or_else(|| panic!("missing node_modules/.bin in {parts:?}"));
+    let gyp_idx = parts
+        .iter()
+        .position(|p| p.contains("node-gyp-bin"))
+        .unwrap_or_else(|| panic!("missing node-gyp-bin in {parts:?}"));
+    assert!(
+        bin_idx < gyp_idx,
+        ".bin must precede node-gyp; got bin@{bin_idx}, gyp@{gyp_idx} in {parts:?}",
+    );
+}
+
+/// `wd` with no `node_modules` segment yields exactly one
+/// `<wd>/node_modules/.bin` entry — no ancestor walk happens. Mirrors
+/// the upstream split where `wd.split('/node_modules/')` returns a
+/// single-element array and the loop body never runs.
+#[test]
+fn no_ancestors_when_wd_has_no_node_modules_segment() {
+    let wd = Path::new("/home/me/project");
+    let extra: Vec<PathBuf> = vec![];
+    let path = extend_path(wd, None, None, &extra, ScriptsPrependNodePath::Never, None);
+    let parts = segments(&path);
+    assert_eq!(parts.len(), 1, "expected exactly one .bin entry, got {parts:?}");
+    assert!(parts[0].ends_with(".bin"), "must be a .bin path: {:?}", parts[0]);
+}
+
+/// Two-level pnpm virtual store wd:
+/// `<root>/node_modules/.pnpm/foo@1.0.0/node_modules/foo`. The walk
+/// must produce three `.bin` paths, ordered deepest-first.
+#[test]
+fn pnpm_virtual_store_layout_yields_three_bins_deepest_first() {
+    let wd = Path::new("/proj/node_modules/.pnpm/foo@1.0.0/node_modules/foo");
+    let extra: Vec<PathBuf> = vec![];
+    let path = extend_path(wd, None, None, &extra, ScriptsPrependNodePath::Never, None);
+    let parts = segments(&path);
+    assert_eq!(parts.len(), 3, "expected three bin paths, got {parts:?}");
+
+    let normalized: Vec<String> = parts.into_iter().map(|p| p.replace('\\', "/")).collect();
+    assert_eq!(
+        normalized,
+        vec![
+            "/proj/node_modules/.pnpm/foo@1.0.0/node_modules/foo/node_modules/.bin".to_string(),
+            "/proj/node_modules/.pnpm/foo@1.0.0/node_modules/.bin".to_string(),
+            "/proj/node_modules/.bin".to_string(),
+        ],
+    );
+}
+
+/// `extra_bin_paths` slot in after the .bin walk and after node-gyp.
+/// Upstream order at lib/extendPath.js:6-19:
+///   `pathArr = [...extraBinPaths]` then unshift node-gyp, then
+///   unshift each .bin → final order [bins…, nodeGyp, …extraBinPaths].
+#[test]
+fn extra_bin_paths_come_after_bins_and_node_gyp() {
+    let wd = Path::new("/proj");
+    let node_gyp = PathBuf::from("/bundled/node-gyp-bin");
+    let extra: Vec<PathBuf> = vec![PathBuf::from("/extra/one"), PathBuf::from("/extra/two")];
+    let path = extend_path(
+        wd,
+        None,
+        Some(&node_gyp),
+        &extra,
+        ScriptsPrependNodePath::Never,
+        None,
+    );
+    let parts = segments(&path);
+    let bin_idx = parts.iter().position(|p| p.contains("proj") && p.ends_with(".bin")).unwrap();
+    let gyp_idx = parts.iter().position(|p| p.contains("node-gyp-bin")).unwrap();
+    let extra1_idx = parts.iter().position(|p| p == "/extra/one" || p == "\\extra\\one").unwrap();
+    let extra2_idx = parts.iter().position(|p| p == "/extra/two" || p == "\\extra\\two").unwrap();
+    assert!(
+        bin_idx < gyp_idx && gyp_idx < extra1_idx && extra1_idx < extra2_idx,
+        "expected order .bin < nodeGyp < extra1 < extra2; got {parts:?}",
+    );
+}
+
+/// `original_path` is appended verbatim at the end of the joined
+/// PATH. The system PATH thus stays lowest-priority while the
+/// .bin walk and node-gyp take precedence.
+#[test]
+fn original_path_is_appended_last() {
+    let wd = Path::new("/proj");
+    let extra: Vec<PathBuf> = vec![];
+    let sys_path = {
+        let mut s = OsString::new();
+        s.push("/usr/local/bin");
+        s.push(SEP.to_string());
+        s.push("/usr/bin");
+        s
+    };
+    let path = extend_path(wd, Some(&sys_path), None, &extra, ScriptsPrependNodePath::Never, None);
+    let parts = segments(&path);
+    assert_eq!(parts.len(), 3, "1 bin + 2 sys = 3 entries, got {parts:?}");
+    assert_eq!(parts[1], "/usr/local/bin");
+    assert_eq!(parts[2], "/usr/bin");
+}
+
+/// `scripts_prepend_node_path: Always` appends `dirname(node)` after
+/// extra_bin_paths but before originalPath.
+#[test]
+fn scripts_prepend_node_path_always_appends_dirname_of_node() {
+    let wd = Path::new("/proj");
+    let node = PathBuf::from("/opt/node/bin/node");
+    let extra: Vec<PathBuf> = vec![];
+    let path = extend_path(wd, None, None, &extra, ScriptsPrependNodePath::Always, Some(&node));
+    let parts = segments(&path);
+    assert!(
+        parts.iter().any(|p| p == "/opt/node/bin"),
+        "expected dirname(node) in PATH, got {parts:?}",
+    );
+}
+
+/// Tri-state: `Never` and `WarnOnly` both skip the actual prepend
+/// (mirroring the `cfgsetting === true` gate at lib/extendPath.js:32).
+/// `WarnOnly` would emit a warning upstream; pacquet's reporter-side
+/// emission is decoupled from extendPath, so this function just
+/// skips.
+#[test]
+fn scripts_prepend_node_path_never_and_warn_only_do_not_prepend() {
+    let wd = Path::new("/proj");
+    let node = PathBuf::from("/opt/node/bin/node");
+    let extra: Vec<PathBuf> = vec![];
+    for variant in [ScriptsPrependNodePath::Never, ScriptsPrependNodePath::WarnOnly] {
+        let path = extend_path(wd, None, None, &extra, variant, Some(&node));
+        let parts = segments(&path);
+        assert!(
+            !parts.iter().any(|p| p == "/opt/node/bin"),
+            "variant {variant:?} must not prepend dirname(node), got {parts:?}",
+        );
+    }
+}

--- a/crates/executor/src/extend_path/tests.rs
+++ b/crates/executor/src/extend_path/tests.rs
@@ -107,10 +107,7 @@ fn virtual_store_walk_orders_deepest_first() {
     for window in parts.windows(2) {
         let deeper = &window[0];
         let shallower = &window[1];
-        assert!(
-            deeper.len() > shallower.len(),
-            "{deeper:?} must be deeper than {shallower:?}",
-        );
+        assert!(deeper.len() > shallower.len(), "{deeper:?} must be deeper than {shallower:?}");
         assert!(deeper.ends_with(".bin") && shallower.ends_with(".bin"));
     }
 }

--- a/crates/executor/src/extend_path/tests.rs
+++ b/crates/executor/src/extend_path/tests.rs
@@ -65,23 +65,54 @@ fn no_ancestors_when_wd_has_no_node_modules_segment() {
 /// Two-level pnpm virtual store wd:
 /// `<root>/node_modules/.pnpm/foo@1.0.0/node_modules/foo`. The walk
 /// must produce three `.bin` paths, ordered deepest-first.
+///
+/// Unix-only because `path::absolute("/proj")` on Windows resolves
+/// against the current drive (`C:\proj`), which makes the hard-coded
+/// expected values racy. The structural invariants (count + deepest-
+/// first ordering) are covered platform-neutrally in
+/// [`virtual_store_walk_orders_deepest_first`] below.
+#[cfg(unix)]
 #[test]
 fn pnpm_virtual_store_layout_yields_three_bins_deepest_first() {
     let wd = Path::new("/proj/node_modules/.pnpm/foo@1.0.0/node_modules/foo");
     let extra: Vec<PathBuf> = vec![];
     let path = extend_path(wd, None, None, &extra, ScriptsPrependNodePath::Never, None);
     let parts = segments(&path);
-    assert_eq!(parts.len(), 3, "expected three bin paths, got {parts:?}");
-
-    let normalized: Vec<String> = parts.into_iter().map(|p| p.replace('\\', "/")).collect();
     assert_eq!(
-        normalized,
+        parts,
         vec![
             "/proj/node_modules/.pnpm/foo@1.0.0/node_modules/foo/node_modules/.bin".to_string(),
             "/proj/node_modules/.pnpm/foo@1.0.0/node_modules/.bin".to_string(),
             "/proj/node_modules/.bin".to_string(),
         ],
     );
+}
+
+/// Platform-neutral version of the virtual-store walk test: assert
+/// the count and the deepest-first ordering (each entry must be a
+/// strict prefix of the entry before it after stripping the trailing
+/// `node_modules/.bin`) without anchoring to any absolute root.
+#[test]
+fn virtual_store_walk_orders_deepest_first() {
+    let wd = Path::new("proj")
+        .join("node_modules")
+        .join(".pnpm")
+        .join("foo@1.0.0")
+        .join("node_modules")
+        .join("foo");
+    let extra: Vec<PathBuf> = vec![];
+    let path = extend_path(&wd, None, None, &extra, ScriptsPrependNodePath::Never, None);
+    let parts = segments(&path);
+    assert_eq!(parts.len(), 3, "expected three bin paths, got {parts:?}");
+    for window in parts.windows(2) {
+        let deeper = &window[0];
+        let shallower = &window[1];
+        assert!(
+            deeper.len() > shallower.len(),
+            "{deeper:?} must be deeper than {shallower:?}",
+        );
+        assert!(deeper.ends_with(".bin") && shallower.ends_with(".bin"));
+    }
 }
 
 /// `extra_bin_paths` slot in after the .bin walk and after node-gyp.

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -1,6 +1,8 @@
+mod extend_path;
 mod lifecycle;
 mod make_env;
 
+pub use extend_path::{ScriptsPrependNodePath, extend_path};
 pub use lifecycle::{LifecycleScriptError, RunPostinstallHooks, run_postinstall_hooks};
 pub use make_env::{EnvBuild, EnvOptions, build_env};
 

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -1,10 +1,12 @@
 mod extend_path;
 mod lifecycle;
 mod make_env;
+mod shell;
 
 pub use extend_path::{ScriptsPrependNodePath, extend_path};
 pub use lifecycle::{LifecycleScriptError, RunPostinstallHooks, run_postinstall_hooks};
 pub use make_env::{EnvBuild, EnvOptions, build_env};
+pub use shell::{ScriptShellError, SelectedShell, select_shell};
 
 use derive_more::{Display, Error};
 use miette::Diagnostic;

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -1,6 +1,8 @@
 mod lifecycle;
+mod make_env;
 
 pub use lifecycle::{LifecycleScriptError, RunPostinstallHooks, run_postinstall_hooks};
+pub use make_env::{EnvBuild, EnvOptions, build_env};
 
 use derive_more::{Display, Error};
 use miette::Diagnostic;

--- a/crates/executor/src/lifecycle.rs
+++ b/crates/executor/src/lifecycle.rs
@@ -80,9 +80,9 @@ pub struct RunPostinstallHooks<'a> {
     pub extra_bin_paths: &'a [PathBuf],
     pub extra_env: &'a HashMap<String, String>,
     /// Path to a `node` binary for `npm_node_execpath` / `NODE`. When
-    /// `None`, [`build_env`](crate::build_env) falls back to looking
-    /// `node` up on `PATH`. Required for native postinstalls that
-    /// shell out via `$NODE`.
+    /// `None`, [`crate::build_env`] falls back to looking `node` up
+    /// on `PATH`. Required for native postinstalls that shell out
+    /// via `$NODE`.
     pub node_execpath: Option<&'a Path>,
     /// Path written into `npm_execpath` so postinstalls can re-invoke
     /// the package manager. When `None`, `std::env::current_exe()`

--- a/crates/executor/src/lifecycle.rs
+++ b/crates/executor/src/lifecycle.rs
@@ -1,6 +1,6 @@
 use crate::{
     extend_path::{ScriptsPrependNodePath, extend_path},
-    make_env::{EnvOptions, build_env},
+    make_env::{EnvOptions, build_env, path_value},
     shell::{ScriptShellError, select_shell},
 };
 use derive_more::{Display, Error};
@@ -137,12 +137,18 @@ pub fn run_postinstall_hooks<R: Reporter>(
     let get_script =
         |name: &str| -> Option<&str> { scripts.and_then(|s| s.get(name)).and_then(|v| v.as_str()) };
 
+    // Snapshot the process env once for this package. Each of
+    // preinstall/install/postinstall reads from this snapshot, which
+    // keeps the three runs observably consistent and avoids three
+    // separate calls to `env::vars()` over a thread-shared global.
+    let parent_env: HashMap<String, String> = env::vars().collect();
+
     let mut ran_any = false;
 
     if let Some(script) = get_script("preinstall")
         && script != "npx only-allow pnpm"
     {
-        run_lifecycle_hook::<R>("preinstall", script, &opts, &manifest)?;
+        run_lifecycle_hook::<R>("preinstall", script, &opts, &manifest, &parent_env)?;
         ran_any = true;
     }
 
@@ -156,14 +162,14 @@ pub fn run_postinstall_hooks<R: Reporter>(
     if let Some(script) = &install_script
         && script != "npx only-allow pnpm"
     {
-        run_lifecycle_hook::<R>("install", script, &opts, &manifest)?;
+        run_lifecycle_hook::<R>("install", script, &opts, &manifest, &parent_env)?;
         ran_any = true;
     }
 
     if let Some(script) = get_script("postinstall")
         && script != "npx only-allow pnpm"
     {
-        run_lifecycle_hook::<R>("postinstall", script, &opts, &manifest)?;
+        run_lifecycle_hook::<R>("postinstall", script, &opts, &manifest, &parent_env)?;
         ran_any = true;
     }
 
@@ -183,6 +189,7 @@ fn run_lifecycle_hook<R: Reporter>(
     script: &str,
     opts: &RunPostinstallHooks<'_>,
     manifest: &Value,
+    parent_env: &HashMap<String, String>,
 ) -> Result<(), LifecycleScriptError> {
     tracing::debug!(
         target: "pacquet::lifecycle",
@@ -220,26 +227,27 @@ fn run_lifecycle_hook<R: Reporter>(
         unsafe_perm: opts.unsafe_perm,
         extra_env: opts.extra_env,
     };
-    let built = build_env(&env_opts, manifest, env::vars().collect());
+    let built = build_env(&env_opts, manifest, parent_env.clone());
 
     if let Some(tmpdir) = &built.tmpdir {
-        // Mirrors index.js:97-102 — create the dir, swallow EEXIST,
-        // propagate everything else as a spawn error.
-        if let Err(e) = fs::create_dir_all(tmpdir)
-            && e.kind() != std::io::ErrorKind::AlreadyExists
-        {
-            return Err(LifecycleScriptError::Spawn {
-                dep_path: opts.dep_path.to_string(),
-                stage: stage.to_string(),
-                source: e,
-            });
-        }
+        // `fs::create_dir_all` is idempotent for existing
+        // directories (it returns `Ok(())`), so the upstream
+        // `EEXIST` swallow at index.js:97-102 doesn't translate.
+        // Treat any error here — including `AlreadyExists`, which
+        // signals a *file* at that path — as a real spawn failure.
+        fs::create_dir_all(tmpdir).map_err(|e| LifecycleScriptError::Spawn {
+            dep_path: opts.dep_path.to_string(),
+            stage: stage.to_string(),
+            source: e,
+        })?;
     }
 
     // Mirrors the `env[PATH] = extendPath(...)` line in `lifecycle_`
     // at index.js:116, with the original PATH coming from the
     // (already-filtered) parent env captured during `build_env`.
-    let original_path = built.env.get("PATH").map(|v| OsString::from(v.as_str()));
+    // Lookup is case-insensitive because Windows preserves the
+    // system casing (typically `Path`) on env keys.
+    let original_path = path_value(&built.env).map(OsString::from);
     let path_env = extend_path(
         opts.pkg_root,
         original_path.as_ref(),

--- a/crates/executor/src/lifecycle.rs
+++ b/crates/executor/src/lifecycle.rs
@@ -1,13 +1,16 @@
+use crate::make_env::{EnvOptions, build_env};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_package_manifest::{PackageManifestError, safe_read_package_json_from_dir};
 use pacquet_reporter::{
     LifecycleLog, LifecycleMessage, LifecycleStdio, LogEvent, LogLevel, Reporter,
 };
+use serde_json::Value;
 use std::{
     collections::HashMap,
     env,
     ffi::OsString,
+    fs,
     io::{BufRead, BufReader, Read},
     path::{Path, PathBuf},
     process::{Command, ExitStatus, Stdio},
@@ -63,6 +66,27 @@ pub struct RunPostinstallHooks<'a> {
     pub init_cwd: &'a Path,
     pub extra_bin_paths: &'a [PathBuf],
     pub extra_env: &'a HashMap<String, String>,
+    /// Path to a `node` binary for `npm_node_execpath` / `NODE`. When
+    /// `None`, [`build_env`](crate::build_env) falls back to looking
+    /// `node` up on `PATH`. Required for native postinstalls that
+    /// shell out via `$NODE`.
+    pub node_execpath: Option<&'a Path>,
+    /// Path written into `npm_execpath` so postinstalls can re-invoke
+    /// the package manager. When `None`, `std::env::current_exe()`
+    /// is used.
+    pub npm_execpath: Option<&'a Path>,
+    /// Bundled `node-gyp` wrapper path written into
+    /// `npm_config_node_gyp`. Pacquet does not ship one yet, so
+    /// callers pass `None`.
+    pub node_gyp_path: Option<&'a Path>,
+    /// Value written into `npm_config_user_agent`. Caller-supplied
+    /// (typically `"pacquet/<version>"`); `None` skips the stamp.
+    pub user_agent: Option<&'a str>,
+    /// When `false`, a per-package `node_modules/.tmp` directory is
+    /// created and exposed as `TMPDIR`. Pacquet currently passes
+    /// `true` everywhere — item #14 (`unsafe-perm` uid/gid drop)
+    /// will revisit this.
+    pub unsafe_perm: bool,
 }
 
 /// Run the preinstall, install, and postinstall lifecycle scripts for
@@ -95,7 +119,7 @@ pub fn run_postinstall_hooks<R: Reporter>(
     if let Some(script) = get_script("preinstall")
         && script != "npx only-allow pnpm"
     {
-        run_lifecycle_hook::<R>("preinstall", script, &opts)?;
+        run_lifecycle_hook::<R>("preinstall", script, &opts, &manifest)?;
         ran_any = true;
     }
 
@@ -109,14 +133,14 @@ pub fn run_postinstall_hooks<R: Reporter>(
     if let Some(script) = &install_script
         && script != "npx only-allow pnpm"
     {
-        run_lifecycle_hook::<R>("install", script, &opts)?;
+        run_lifecycle_hook::<R>("install", script, &opts, &manifest)?;
         ran_any = true;
     }
 
     if let Some(script) = get_script("postinstall")
         && script != "npx only-allow pnpm"
     {
-        run_lifecycle_hook::<R>("postinstall", script, &opts)?;
+        run_lifecycle_hook::<R>("postinstall", script, &opts, &manifest)?;
         ran_any = true;
     }
 
@@ -135,6 +159,7 @@ fn run_lifecycle_hook<R: Reporter>(
     stage: &str,
     script: &str,
     opts: &RunPostinstallHooks<'_>,
+    manifest: &Value,
 ) -> Result<(), LifecycleScriptError> {
     tracing::debug!(
         target: "pacquet::lifecycle",
@@ -147,7 +172,7 @@ fn run_lifecycle_hook<R: Reporter>(
     let pkg_root_str = opts.pkg_root.to_string_lossy().into_owned();
 
     // Mirrors `lifecycleLogger.debug({ depPath, optional, script, stage, wd })`
-    // at <https://github.com/pnpm/pnpm/blob/80037699fb/exec/lifecycle/src/runLifecycleHook.ts#L102>.
+    // at <https://github.com/pnpm/pnpm/blob/b4f8f47ac2/exec/lifecycle/src/runLifecycleHook.ts#L102>.
     R::emit(&LogEvent::Lifecycle(LifecycleLog {
         level: LogLevel::Debug,
         message: LifecycleMessage::Script {
@@ -159,21 +184,49 @@ fn run_lifecycle_hook<R: Reporter>(
         },
     }));
 
+    let env_opts = EnvOptions {
+        stage,
+        script,
+        pkg_root: opts.pkg_root,
+        init_cwd: opts.init_cwd,
+        script_src_dir: opts.pkg_root,
+        node_execpath: opts.node_execpath,
+        npm_execpath: opts.npm_execpath,
+        node_gyp_path: opts.node_gyp_path,
+        user_agent: opts.user_agent,
+        unsafe_perm: opts.unsafe_perm,
+        extra_env: opts.extra_env,
+    };
+    let built = build_env(&env_opts, manifest, env::vars().collect());
+
+    if let Some(tmpdir) = &built.tmpdir {
+        // Mirrors index.js:97-102 — create the dir, swallow EEXIST,
+        // propagate everything else as a spawn error.
+        if let Err(e) = fs::create_dir_all(tmpdir)
+            && e.kind() != std::io::ErrorKind::AlreadyExists
+        {
+            return Err(LifecycleScriptError::Spawn {
+                dep_path: opts.dep_path.to_string(),
+                stage: stage.to_string(),
+                source: e,
+            });
+        }
+    }
+
     let path_env = build_path_env(opts.pkg_root, opts.extra_bin_paths);
 
     let mut cmd = Command::new("sh");
     cmd.arg("-c")
         .arg(script)
         .current_dir(opts.pkg_root)
+        // Stripping inherited env so leftover npm_* keys from a wrapping
+        // invocation cannot leak in. `build_env` already folded the
+        // surviving parent keys into `built.env`.
+        .env_clear()
+        .envs(&built.env)
         .env("PATH", &path_env)
-        .env("INIT_CWD", opts.init_cwd)
-        .env("PNPM_SCRIPT_SRC_DIR", opts.pkg_root)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-
-    for (key, value) in opts.extra_env {
-        cmd.env(key, value);
-    }
 
     let mut child = cmd.spawn().map_err(|e| LifecycleScriptError::Spawn {
         dep_path: opts.dep_path.to_string(),

--- a/crates/executor/src/lifecycle.rs
+++ b/crates/executor/src/lifecycle.rs
@@ -1,6 +1,7 @@
 use crate::{
     extend_path::{ScriptsPrependNodePath, extend_path},
     make_env::{EnvOptions, build_env},
+    shell::{ScriptShellError, select_shell},
 };
 use derive_more::{Display, Error};
 use miette::Diagnostic;
@@ -55,6 +56,15 @@ pub enum LifecycleScriptError {
         #[error(source)]
         source: std::io::Error,
     },
+
+    #[display("Invalid script shell for {dep_path} {stage}: {source}")]
+    #[diagnostic(code(pacquet_executor::invalid_script_shell))]
+    ScriptShell {
+        dep_path: String,
+        stage: String,
+        #[error(source)]
+        source: ScriptShellError,
+    },
 }
 
 /// Options for [`run_postinstall_hooks`].
@@ -96,6 +106,10 @@ pub struct RunPostinstallHooks<'a> {
     /// Tri-state from `scriptsPrependNodePath` config. `Never` is the
     /// safe default; `Always` appends `dirname(node)` to `PATH`.
     pub scripts_prepend_node_path: ScriptsPrependNodePath,
+    /// Custom shell from `scriptShell` config (e.g. `bash`,
+    /// `/usr/local/bin/bash`). `None` means use the platform default
+    /// (`sh -c` on POSIX, `cmd /d /s /c` on Windows).
+    pub script_shell: Option<&'a Path>,
 }
 
 /// Run the preinstall, install, and postinstall lifecycle scripts for
@@ -235,8 +249,20 @@ fn run_lifecycle_hook<R: Reporter>(
         opts.node_execpath,
     );
 
-    let mut cmd = Command::new("sh");
-    cmd.arg("-c")
+    // Pick the shell up front so a misconfigured `scriptShell` fails
+    // before we touch the filesystem (TMPDIR etc. already created
+    // above — that's a minor leak, but matches upstream where
+    // `makeEnv` runs before the `runCmd_` shell pick anyway).
+    let shell = select_shell(opts.script_shell, cfg!(windows)).map_err(|source| {
+        LifecycleScriptError::ScriptShell {
+            dep_path: opts.dep_path.to_string(),
+            stage: stage.to_string(),
+            source,
+        }
+    })?;
+
+    let mut cmd = Command::new(&shell.program);
+    cmd.args(&shell.args)
         .arg(script)
         .current_dir(opts.pkg_root)
         // Stripping inherited env so leftover npm_* keys from a wrapping
@@ -247,6 +273,10 @@ fn run_lifecycle_hook<R: Reporter>(
         .env("PATH", &path_env)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+    // `windowsVerbatimArguments` from `npm-lifecycle/index.js:251`.
+    // Wire up Rust's equivalent (`raw_arg` on Windows) when we have a
+    // way to test it. For now the field signals intent for follow-up.
+    let _ = shell.windows_verbatim_args;
 
     let mut child = cmd.spawn().map_err(|e| LifecycleScriptError::Spawn {
         dep_path: opts.dep_path.to_string(),

--- a/crates/executor/src/lifecycle.rs
+++ b/crates/executor/src/lifecycle.rs
@@ -1,4 +1,7 @@
-use crate::make_env::{EnvOptions, build_env};
+use crate::{
+    extend_path::{ScriptsPrependNodePath, extend_path},
+    make_env::{EnvOptions, build_env},
+};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_package_manifest::{PackageManifestError, safe_read_package_json_from_dir};
@@ -87,6 +90,12 @@ pub struct RunPostinstallHooks<'a> {
     /// `true` everywhere — item #14 (`unsafe-perm` uid/gid drop)
     /// will revisit this.
     pub unsafe_perm: bool,
+    /// Bundled `node-gyp` shim directory prepended to `PATH`. Pacquet
+    /// does not ship one yet; callers pass `None`.
+    pub node_gyp_bin: Option<&'a Path>,
+    /// Tri-state from `scriptsPrependNodePath` config. `Never` is the
+    /// safe default; `Always` appends `dirname(node)` to `PATH`.
+    pub scripts_prepend_node_path: ScriptsPrependNodePath,
 }
 
 /// Run the preinstall, install, and postinstall lifecycle scripts for
@@ -213,7 +222,18 @@ fn run_lifecycle_hook<R: Reporter>(
         }
     }
 
-    let path_env = build_path_env(opts.pkg_root, opts.extra_bin_paths);
+    // Mirrors the `env[PATH] = extendPath(...)` line in `lifecycle_`
+    // at index.js:116, with the original PATH coming from the
+    // (already-filtered) parent env captured during `build_env`.
+    let original_path = built.env.get("PATH").map(|v| OsString::from(v.as_str()));
+    let path_env = extend_path(
+        opts.pkg_root,
+        original_path.as_ref(),
+        opts.node_gyp_bin,
+        opts.extra_bin_paths,
+        opts.scripts_prepend_node_path,
+        opts.node_execpath,
+    );
 
     let mut cmd = Command::new("sh");
     cmd.arg("-c")
@@ -320,24 +340,6 @@ fn spawn_line_pump<R: Reporter>(
             }));
         }
     })
-}
-
-/// Build the `PATH` environment variable for lifecycle scripts.
-///
-/// Prepends the package's own `node_modules/.bin`, any extra bin paths
-/// (from the caller), and the system PATH.
-fn build_path_env(pkg_root: &Path, extra_bin_paths: &[PathBuf]) -> OsString {
-    let own_bin = pkg_root.join("node_modules/.bin");
-    let system_path = env::var_os("PATH").unwrap_or_default();
-
-    let mut paths: Vec<PathBuf> = Vec::with_capacity(2 + extra_bin_paths.len());
-    paths.push(own_bin);
-    paths.extend_from_slice(extra_bin_paths);
-    for path in env::split_paths(&system_path) {
-        paths.push(path);
-    }
-
-    env::join_paths(paths).unwrap_or(system_path)
 }
 
 #[cfg(test)]

--- a/crates/executor/src/lifecycle.rs
+++ b/crates/executor/src/lifecycle.rs
@@ -96,9 +96,10 @@ pub struct RunPostinstallHooks<'a> {
     /// (typically `"pacquet/<version>"`); `None` skips the stamp.
     pub user_agent: Option<&'a str>,
     /// When `false`, a per-package `node_modules/.tmp` directory is
-    /// created and exposed as `TMPDIR`. Pacquet currently passes
-    /// `true` everywhere — item #14 (`unsafe-perm` uid/gid drop)
-    /// will revisit this.
+    /// created and exposed as `TMPDIR`, and (on POSIX) lifecycle
+    /// scripts run with a dropped uid/gid. Pacquet does not yet
+    /// surface the privilege drop, so callers currently pass
+    /// `true` everywhere.
     pub unsafe_perm: bool,
     /// Bundled `node-gyp` shim directory prepended to `PATH`. Pacquet
     /// does not ship one yet; callers pass `None`.

--- a/crates/executor/src/lifecycle.rs
+++ b/crates/executor/src/lifecycle.rs
@@ -270,6 +270,15 @@ fn run_lifecycle_hook<R: Reporter>(
         }
     })?;
 
+    // Drop any inherited PATH-like key (`Path` on Windows, `PATH`
+    // on POSIX) from the env map before spawning — otherwise on
+    // Windows the spawn would see both that and the explicit `PATH`
+    // we set below, and `Command::env` deduplicates them with an
+    // unspecified winner.
+    let mut child_env = built.env;
+    child_env.retain(|k, _| !k.eq_ignore_ascii_case("PATH"));
+    child_env.insert("PATH".to_string(), path_env.to_string_lossy().into_owned());
+
     let mut cmd = Command::new(&shell.program);
     cmd.args(&shell.args)
         .arg(script)
@@ -278,8 +287,7 @@ fn run_lifecycle_hook<R: Reporter>(
         // invocation cannot leak in. `build_env` already folded the
         // surviving parent keys into `built.env`.
         .env_clear()
-        .envs(&built.env)
-        .env("PATH", &path_env)
+        .envs(&child_env)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     // `windowsVerbatimArguments` from `npm-lifecycle/index.js:251`.

--- a/crates/executor/src/lifecycle/tests.rs
+++ b/crates/executor/src/lifecycle/tests.rs
@@ -261,14 +261,20 @@ fn missing_manifest_returns_false() {
 #[cfg(unix)]
 #[test]
 fn child_sees_stamped_npm_package_and_no_leaked_npm_config() {
-    // SAFETY: this test mutates the process's own env to seed a
-    // would-be-leaked `npm_config_*` key. nextest runs each test in
-    // its own thread, so concurrent reads from `env::vars()` in
-    // sibling tests could observe this. Wrapping in `unsafe` is
-    // unavoidable since stdlib's set/remove are `unsafe` to call.
-    unsafe {
-        std::env::set_var("npm_config_should_be_stripped", "leak");
+    /// RAII guard that removes a process env var on drop, so an
+    /// assertion failure can't leak the seed into sibling tests.
+    /// Stdlib `set_var`/`remove_var` are `unsafe` in current Rust;
+    /// SAFETY: nextest runs each test in its own thread, so the
+    /// only risk is sibling tests calling `env::vars()`
+    /// concurrently — the guard's `Drop` still runs on panic.
+    struct EnvGuard(&'static str);
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            unsafe { std::env::remove_var(self.0) }
+        }
     }
+    let _guard = EnvGuard("npm_config_should_be_stripped");
+    unsafe { std::env::set_var("npm_config_should_be_stripped", "leak") };
 
     let dir = tempdir().expect("create temp dir");
     let pkg_root = dir.path();
@@ -310,15 +316,9 @@ fn child_sees_stamped_npm_package_and_no_leaked_npm_config() {
     };
 
     let ran = run_postinstall_hooks::<SilentReporter>(opts).expect("postinstall");
-    assert!(ran);
+    assert!(ran, "run_postinstall_hooks must report at least one script ran: ran={ran}");
 
-    unsafe {
-        std::env::remove_var("npm_config_should_be_stripped");
-    }
-
-    let dumped = fs::read_to_string(&dump_path).expect("read env dump");
-    let dump = &dumped;
-    dbg!(dump);
+    let dump = fs::read_to_string(&dump_path).expect("read env dump");
 
     let expected_init_cwd = pkg_root.to_string_lossy();
     let expected_pairs = [

--- a/crates/executor/src/lifecycle/tests.rs
+++ b/crates/executor/src/lifecycle/tests.rs
@@ -48,6 +48,7 @@ fn lifecycle_emits_script_stdio_and_exit_in_order() {
         unsafe_perm: true,
         node_gyp_bin: None,
         scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+        script_shell: None,
     };
 
     let ran = run_postinstall_hooks::<RecordingReporter>(opts).expect("postinstall");
@@ -150,6 +151,7 @@ fn lifecycle_emits_exit_with_nonzero_code_on_failure() {
         unsafe_perm: true,
         node_gyp_bin: None,
         scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+        script_shell: None,
     };
 
     let err = run_postinstall_hooks::<RecordingReporter>(opts).expect_err("script must fail");
@@ -198,6 +200,7 @@ fn lifecycle_runs_under_silent_reporter() {
         unsafe_perm: true,
         node_gyp_bin: None,
         scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+        script_shell: None,
     };
 
     let ran = run_postinstall_hooks::<SilentReporter>(opts).expect("postinstall");
@@ -230,6 +233,7 @@ fn missing_manifest_returns_false() {
         unsafe_perm: true,
         node_gyp_bin: None,
         scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+        script_shell: None,
     };
 
     let ran = run_postinstall_hooks::<SilentReporter>(opts).expect("missing manifest is OK");
@@ -289,6 +293,7 @@ fn child_sees_stamped_npm_package_and_no_leaked_npm_config() {
         unsafe_perm: true,
         node_gyp_bin: None,
         scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+        script_shell: None,
     };
 
     let ran = run_postinstall_hooks::<SilentReporter>(opts).expect("postinstall");
@@ -348,6 +353,7 @@ fn malformed_manifest_propagates_error() {
         unsafe_perm: true,
         node_gyp_bin: None,
         scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+        script_shell: None,
     };
 
     let err = run_postinstall_hooks::<SilentReporter>(opts).expect_err("malformed JSON must fail");

--- a/crates/executor/src/lifecycle/tests.rs
+++ b/crates/executor/src/lifecycle/tests.rs
@@ -11,6 +11,13 @@ use tempfile::tempdir;
 /// Recording-fake reporter that pushes every emitted [`LogEvent`] into
 /// `EVENTS`. The static lives in this test function's own scope, so
 /// other tests have independent buffers.
+///
+/// Unix-only: the script body uses `;` and `1>&2`, which `cmd /d /s /c`
+/// (the default shell pacquet now picks on Windows, per item #4)
+/// does not interpret the same way. Windows e2e coverage for
+/// lifecycle spawning is a follow-up — for now the cmd path is
+/// exercised by the unit tests in [`crate::shell`].
+#[cfg(unix)]
 #[test]
 fn lifecycle_emits_script_stdio_and_exit_in_order() {
     static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
@@ -246,6 +253,12 @@ fn missing_manifest_returns_false() {
 /// from this process's env. Adapts the upstream test at
 /// <https://github.com/pnpm/pnpm/blob/b4f8f47ac2/exec/lifecycle/test/index.ts#L65-L77>
 /// to a file-dump model so we don't need an IPC fixture.
+///
+/// Unix-only: relies on `printf` and `$VAR` expansion, which `cmd`
+/// (the Windows default per item #4) doesn't speak. Env stamping
+/// itself is platform-agnostic and covered by the unit tests in
+/// [`crate::make_env`].
+#[cfg(unix)]
 #[test]
 fn child_sees_stamped_npm_package_and_no_leaked_npm_config() {
     // SAFETY: this test mutates the process's own env to seed a

--- a/crates/executor/src/lifecycle/tests.rs
+++ b/crates/executor/src/lifecycle/tests.rs
@@ -40,6 +40,11 @@ fn lifecycle_emits_script_stdio_and_exit_in_order() {
         init_cwd: pkg_root,
         extra_bin_paths: &extra_bin_paths,
         extra_env: &extra_env,
+        node_execpath: None,
+        npm_execpath: None,
+        node_gyp_path: None,
+        user_agent: None,
+        unsafe_perm: true,
     };
 
     let ran = run_postinstall_hooks::<RecordingReporter>(opts).expect("postinstall");
@@ -135,6 +140,11 @@ fn lifecycle_emits_exit_with_nonzero_code_on_failure() {
         init_cwd: pkg_root,
         extra_bin_paths: &extra_bin_paths,
         extra_env: &extra_env,
+        node_execpath: None,
+        npm_execpath: None,
+        node_gyp_path: None,
+        user_agent: None,
+        unsafe_perm: true,
     };
 
     let err = run_postinstall_hooks::<RecordingReporter>(opts).expect_err("script must fail");
@@ -176,6 +186,11 @@ fn lifecycle_runs_under_silent_reporter() {
         init_cwd: pkg_root,
         extra_bin_paths: &extra_bin_paths,
         extra_env: &extra_env,
+        node_execpath: None,
+        npm_execpath: None,
+        node_gyp_path: None,
+        user_agent: None,
+        unsafe_perm: true,
     };
 
     let ran = run_postinstall_hooks::<SilentReporter>(opts).expect("postinstall");
@@ -201,10 +216,97 @@ fn missing_manifest_returns_false() {
         init_cwd: pkg_root,
         extra_bin_paths: &extra_bin_paths,
         extra_env: &extra_env,
+        node_execpath: None,
+        npm_execpath: None,
+        node_gyp_path: None,
+        user_agent: None,
+        unsafe_perm: true,
     };
 
     let ran = run_postinstall_hooks::<SilentReporter>(opts).expect("missing manifest is OK");
     assert!(!ran, "missing manifest must report no scripts ran: ran={ran}");
+}
+
+/// End-to-end check that the spawned child sees `npm_lifecycle_event`,
+/// `npm_lifecycle_script`, `INIT_CWD`, `npm_package_name`, and
+/// `npm_package_version`, and does NOT see leaked `npm_config_*` keys
+/// from this process's env. Adapts the upstream test at
+/// <https://github.com/pnpm/pnpm/blob/b4f8f47ac2/exec/lifecycle/test/index.ts#L65-L77>
+/// to a file-dump model so we don't need an IPC fixture.
+#[test]
+fn child_sees_stamped_npm_package_and_no_leaked_npm_config() {
+    // SAFETY: this test mutates the process's own env to seed a
+    // would-be-leaked `npm_config_*` key. nextest runs each test in
+    // its own thread, so concurrent reads from `env::vars()` in
+    // sibling tests could observe this. Wrapping in `unsafe` is
+    // unavoidable since stdlib's set/remove are `unsafe` to call.
+    unsafe {
+        std::env::set_var("npm_config_should_be_stripped", "leak");
+    }
+
+    let dir = tempdir().expect("create temp dir");
+    let pkg_root = dir.path();
+    let dump_path = pkg_root.join("env.dump");
+
+    let manifest = serde_json::json!({
+        "name": "stamp-target",
+        "version": "9.9.9",
+        "config": { "myKey": "myValue" },
+        "scripts": {
+            // Write a handful of env vars to the dump file; using
+            // printf so the line endings are deterministic across
+            // shells.
+            "postinstall": format!(
+                "printf 'stage=%s\\nscript=%s\\nname=%s\\nver=%s\\nconfig=%s\\ninit_cwd=%s\\nleak=%s\\n' \"$npm_lifecycle_event\" \"$npm_lifecycle_script\" \"$npm_package_name\" \"$npm_package_version\" \"$npm_package_config_myKey\" \"$INIT_CWD\" \"$npm_config_should_be_stripped\" > {}",
+                dump_path.display(),
+            ),
+        },
+    });
+    fs::write(pkg_root.join("package.json"), manifest.to_string()).expect("write manifest");
+
+    let extra_env: HashMap<String, String> = HashMap::new();
+    let extra_bin_paths: Vec<std::path::PathBuf> = vec![];
+    let opts = RunPostinstallHooks {
+        dep_path: "/stamp-target@9.9.9",
+        pkg_root,
+        root_modules_dir: pkg_root,
+        init_cwd: pkg_root,
+        extra_bin_paths: &extra_bin_paths,
+        extra_env: &extra_env,
+        node_execpath: None,
+        npm_execpath: None,
+        node_gyp_path: None,
+        user_agent: None,
+        unsafe_perm: true,
+    };
+
+    let ran = run_postinstall_hooks::<SilentReporter>(opts).expect("postinstall");
+    assert!(ran);
+
+    unsafe {
+        std::env::remove_var("npm_config_should_be_stripped");
+    }
+
+    let dumped = fs::read_to_string(&dump_path).expect("read env dump");
+    let dump = &dumped;
+    dbg!(dump);
+
+    let expected_init_cwd = pkg_root.to_string_lossy();
+    let expected_pairs = [
+        ("stage", "postinstall"),
+        ("name", "stamp-target"),
+        ("ver", "9.9.9"),
+        ("config", "myValue"),
+        ("init_cwd", expected_init_cwd.as_ref()),
+        ("leak", ""), // stripped — child sees empty string
+    ];
+    for (k, v) in expected_pairs {
+        let line = format!("{k}={v}\n");
+        assert!(dump.contains(&line), "missing line {line:?} in dump:\n{dump}");
+    }
+    // `script=` line contains the actual script body; just check the
+    // key is there with the printf prefix.
+    assert!(dump.contains("script=printf"), "missing script= line in dump:\n{dump}");
 }
 
 /// Malformed `package.json` surfaces as a `ReadManifest` error wrapping
@@ -228,6 +330,11 @@ fn malformed_manifest_propagates_error() {
         init_cwd: pkg_root,
         extra_bin_paths: &extra_bin_paths,
         extra_env: &extra_env,
+        node_execpath: None,
+        npm_execpath: None,
+        node_gyp_path: None,
+        user_agent: None,
+        unsafe_perm: true,
     };
 
     let err = run_postinstall_hooks::<SilentReporter>(opts).expect_err("malformed JSON must fail");

--- a/crates/executor/src/lifecycle/tests.rs
+++ b/crates/executor/src/lifecycle/tests.rs
@@ -1,4 +1,5 @@
 use super::{LifecycleScriptError, RunPostinstallHooks, run_postinstall_hooks};
+use crate::extend_path::ScriptsPrependNodePath;
 use pacquet_package_manifest::PackageManifestError;
 use pacquet_reporter::{
     LifecycleMessage, LifecycleStdio, LogEvent, LogLevel, Reporter, SilentReporter,
@@ -45,6 +46,8 @@ fn lifecycle_emits_script_stdio_and_exit_in_order() {
         node_gyp_path: None,
         user_agent: None,
         unsafe_perm: true,
+        node_gyp_bin: None,
+        scripts_prepend_node_path: ScriptsPrependNodePath::Never,
     };
 
     let ran = run_postinstall_hooks::<RecordingReporter>(opts).expect("postinstall");
@@ -145,6 +148,8 @@ fn lifecycle_emits_exit_with_nonzero_code_on_failure() {
         node_gyp_path: None,
         user_agent: None,
         unsafe_perm: true,
+        node_gyp_bin: None,
+        scripts_prepend_node_path: ScriptsPrependNodePath::Never,
     };
 
     let err = run_postinstall_hooks::<RecordingReporter>(opts).expect_err("script must fail");
@@ -191,6 +196,8 @@ fn lifecycle_runs_under_silent_reporter() {
         node_gyp_path: None,
         user_agent: None,
         unsafe_perm: true,
+        node_gyp_bin: None,
+        scripts_prepend_node_path: ScriptsPrependNodePath::Never,
     };
 
     let ran = run_postinstall_hooks::<SilentReporter>(opts).expect("postinstall");
@@ -221,6 +228,8 @@ fn missing_manifest_returns_false() {
         node_gyp_path: None,
         user_agent: None,
         unsafe_perm: true,
+        node_gyp_bin: None,
+        scripts_prepend_node_path: ScriptsPrependNodePath::Never,
     };
 
     let ran = run_postinstall_hooks::<SilentReporter>(opts).expect("missing manifest is OK");
@@ -278,6 +287,8 @@ fn child_sees_stamped_npm_package_and_no_leaked_npm_config() {
         node_gyp_path: None,
         user_agent: None,
         unsafe_perm: true,
+        node_gyp_bin: None,
+        scripts_prepend_node_path: ScriptsPrependNodePath::Never,
     };
 
     let ran = run_postinstall_hooks::<SilentReporter>(opts).expect("postinstall");
@@ -335,6 +346,8 @@ fn malformed_manifest_propagates_error() {
         node_gyp_path: None,
         user_agent: None,
         unsafe_perm: true,
+        node_gyp_bin: None,
+        scripts_prepend_node_path: ScriptsPrependNodePath::Never,
     };
 
     let err = run_postinstall_hooks::<SilentReporter>(opts).expect_err("malformed JSON must fail");

--- a/crates/executor/src/make_env.rs
+++ b/crates/executor/src/make_env.rs
@@ -129,8 +129,16 @@ pub fn build_env(
 /// Keep PATH (handled by the caller) and everything that does not
 /// start with `npm_`; drop NODE / TMPDIR / INIT_CWD /
 /// PNPM_SCRIPT_SRC_DIR because we re-derive them.
+///
+/// On Windows the comparison is case-insensitive because Rust's
+/// `Command::env` treats env keys case-insensitively on that
+/// platform (see [`Command::env`] docs). Leaving e.g. `NPM_CONFIG_FOO`
+/// alongside our `npm_*` inserts would collapse at spawn time with
+/// an unpredictable winner.
+///
+/// [`Command::env`]: https://doc.rust-lang.org/std/process/struct.Command.html#method.env
 fn filter_parent_env(env: HashMap<String, String>) -> HashMap<String, String> {
-    env.into_iter().filter(|(k, _)| !is_stamping_key(k)).collect()
+    env.into_iter().filter(|(k, _)| !is_stamping_key(k, cfg!(windows))).collect()
 }
 
 /// Mirrors `!i.match(/^npm_/)` at index.js:359 plus the per-call
@@ -138,7 +146,19 @@ fn filter_parent_env(env: HashMap<String, String>) -> HashMap<String, String> {
 /// `PNPM_SCRIPT_SRC_DIR`). Only the `npm_*` prefix is stripped —
 /// `pnpm_*` keys (e.g. `PNPM_HOME`, feature flags) are upstream-
 /// preserved and pacquet does the same.
-fn is_stamping_key(key: &str) -> bool {
+///
+/// `is_windows` toggles case-insensitive matching so test code can
+/// drive both branches without `#[cfg(windows)]` gating the test
+/// bodies. Production callers pass `cfg!(windows)`.
+fn is_stamping_key(key: &str, is_windows: bool) -> bool {
+    if is_windows {
+        if key.len() >= 4 && key[..4].eq_ignore_ascii_case("npm_") {
+            return true;
+        }
+        return ["NODE", "TMPDIR", "INIT_CWD", "PNPM_SCRIPT_SRC_DIR"]
+            .iter()
+            .any(|n| key.eq_ignore_ascii_case(n));
+    }
     if key.starts_with("npm_") {
         return true;
     }

--- a/crates/executor/src/make_env.rs
+++ b/crates/executor/src/make_env.rs
@@ -152,7 +152,12 @@ fn filter_parent_env(env: HashMap<String, String>) -> HashMap<String, String> {
 /// bodies. Production callers pass `cfg!(windows)`.
 fn is_stamping_key(key: &str, is_windows: bool) -> bool {
     if is_windows {
-        if key.len() >= 4 && key[..4].eq_ignore_ascii_case("npm_") {
+        // Byte-level prefix check: `key[..4]` would panic if byte 4
+        // lands inside a multi-byte UTF-8 codepoint (e.g. a key
+        // containing `𐀀` whose first byte sits at index 0). Since
+        // the prefix we want is pure ASCII, comparing bytes
+        // sidesteps the UTF-8 boundary question entirely.
+        if key.as_bytes().get(..4).is_some_and(|b| b.eq_ignore_ascii_case(b"npm_")) {
             return true;
         }
         return ["NODE", "TMPDIR", "INIT_CWD", "PNPM_SCRIPT_SRC_DIR"]

--- a/crates/executor/src/make_env.rs
+++ b/crates/executor/src/make_env.rs
@@ -1,0 +1,213 @@
+use serde_json::Value;
+use std::{
+    collections::HashMap,
+    env,
+    path::{Path, PathBuf},
+};
+
+/// Inputs needed to build the env for a single lifecycle hook spawn.
+///
+/// Mirrors the union of `makeEnv` inputs and the per-call additions in
+/// `lifecycle()` from `@pnpm/npm-lifecycle@d2d8e790` at
+/// <https://github.com/pnpm/npm-lifecycle/blob/d2d8e790/index.js#L52-L113>
+/// plus the wrapper's `extraEnv` additions at
+/// <https://github.com/pnpm/pnpm/blob/b4f8f47ac2/exec/lifecycle/src/runLifecycleHook.ts#L119-L124>.
+pub struct EnvOptions<'a> {
+    pub stage: &'a str,
+    pub script: &'a str,
+    pub pkg_root: &'a Path,
+    pub init_cwd: &'a Path,
+    pub script_src_dir: &'a Path,
+    pub node_execpath: Option<&'a Path>,
+    pub npm_execpath: Option<&'a Path>,
+    pub node_gyp_path: Option<&'a Path>,
+    pub user_agent: Option<&'a str>,
+    pub unsafe_perm: bool,
+    pub extra_env: &'a HashMap<String, String>,
+}
+
+/// The product of [`build_env`]: a ready-to-spawn env map and the
+/// `TMPDIR` the caller must create when `unsafe_perm` is false (so
+/// the side effect stays out of this pure builder).
+pub struct EnvBuild {
+    pub env: HashMap<String, String>,
+    pub tmpdir: Option<PathBuf>,
+}
+
+/// Build the env for a lifecycle script spawn, given the parent
+/// process env to inherit from.
+///
+/// Ports `makeEnv` + the surrounding env block in `lifecycle()` from
+/// `@pnpm/npm-lifecycle@d2d8e790`:
+/// - `index.js:73-104` for the post-`makeEnv` stamping.
+/// - `index.js:354-414` for `makeEnv` itself (parent-env filter,
+///   `npm_package_*` recursion, multi-line escaping).
+///
+/// Plus the wrapper's `extraEnv` additions at
+/// `pnpm/exec/lifecycle/src/runLifecycleHook.ts:119-124`.
+///
+/// `parent_env` is taken by value so the production caller can pass
+/// `env::vars().collect()` and tests can pass a controlled fixture
+/// without racing on the global process env.
+pub fn build_env(
+    opts: &EnvOptions<'_>,
+    manifest: &Value,
+    parent_env: HashMap<String, String>,
+) -> EnvBuild {
+    // 1. Start from the parent env, stripping every `npm_*` /
+    //    `pnpm_config_*` / `NODE` / `TMPDIR` key so a wrapping
+    //    invocation cannot leak its stamp through. Mirrors the
+    //    `!i.match(/^npm_/)` filter at index.js:359.
+    let mut env = filter_parent_env(parent_env);
+
+    // 2. `npm_package_*` recursive stamp. Top-level keeps only
+    //    name/version/config/engines/bin; recursion below those
+    //    keeps everything. Mirrors index.js:377-411.
+    stamp_package(&mut env, "npm_package_", manifest);
+
+    // 3. Per-call stamping from `lifecycle()` body (index.js:74-87).
+    env.insert("npm_lifecycle_event".into(), opts.stage.to_string());
+
+    let node_execpath =
+        opts.node_execpath.map(Path::to_path_buf).or_else(find_node_in_path);
+    if let Some(node) = node_execpath {
+        let node_str = node.to_string_lossy().into_owned();
+        env.insert("npm_node_execpath".into(), node_str.clone());
+        env.insert("NODE".into(), node_str);
+    }
+
+    env.insert(
+        "npm_package_json".into(),
+        opts.pkg_root.join("package.json").to_string_lossy().into_owned(),
+    );
+
+    let npm_execpath = opts.npm_execpath.map(Path::to_path_buf).or_else(|| env::current_exe().ok());
+    if let Some(p) = npm_execpath {
+        env.insert("npm_execpath".into(), p.to_string_lossy().into_owned());
+    }
+
+    env.insert("INIT_CWD".into(), opts.init_cwd.to_string_lossy().into_owned());
+    env.insert(
+        "PNPM_SCRIPT_SRC_DIR".into(),
+        opts.script_src_dir.to_string_lossy().into_owned(),
+    );
+
+    if let Some(p) = opts.node_gyp_path {
+        env.insert("npm_config_node_gyp".into(), p.to_string_lossy().into_owned());
+    }
+    if let Some(ua) = opts.user_agent {
+        env.insert("npm_config_user_agent".into(), ua.to_string());
+    }
+
+    // 4. `extraEnv` is applied last among the makeEnv-area writes
+    //    (index.js:88-92), so it overrides anything stamped above.
+    for (k, v) in opts.extra_env {
+        env.insert(k.clone(), v.clone());
+    }
+
+    // 5. TMPDIR under <wd>/node_modules/.tmp when !unsafe_perm.
+    //    Mirrors index.js:94-104. The caller creates the dir; we
+    //    only record the path and pass it back.
+    let tmpdir = if opts.unsafe_perm {
+        None
+    } else {
+        let dir = opts.pkg_root.join("node_modules").join(".tmp");
+        env.insert("TMPDIR".into(), dir.to_string_lossy().into_owned());
+        Some(dir)
+    };
+
+    // 6. `npm_lifecycle_script` is set in `lifecycle_` after the
+    //    extraEnv overwrite (index.js:125), so the caller can never
+    //    clobber it.
+    env.insert("npm_lifecycle_script".into(), opts.script.to_string());
+
+    EnvBuild { env, tmpdir }
+}
+
+/// Keep PATH (handled by the caller) and everything that does not
+/// start with the npm/pnpm stamping prefixes; drop NODE and TMPDIR
+/// for the same reason — we re-derive them.
+fn filter_parent_env(env: HashMap<String, String>) -> HashMap<String, String> {
+    env.into_iter().filter(|(k, _)| !is_stamping_key(k)).collect()
+}
+
+fn is_stamping_key(key: &str) -> bool {
+    if key.starts_with("npm_") || key.starts_with("pnpm_") {
+        return true;
+    }
+    matches!(key, "NODE" | "TMPDIR" | "INIT_CWD" | "PNPM_SCRIPT_SRC_DIR")
+}
+
+fn find_node_in_path() -> Option<PathBuf> {
+    let path = env::var_os("PATH")?;
+    let node_name = if cfg!(windows) { "node.exe" } else { "node" };
+    env::split_paths(&path).find_map(|dir| {
+        let candidate = dir.join(node_name);
+        candidate.is_file().then_some(candidate)
+    })
+}
+
+/// `data[i]` recursion from `makeEnv`. JS arrays iterate as indexed
+/// keys; objects iterate as named keys. The top-level call uses
+/// prefix `npm_package_`; recursion appends `<sanitized-key>_`.
+///
+/// Filter at index.js:380-385: at the top level only
+/// name/version/config/engines/bin are kept; once recursed under
+/// one of those, everything is kept.
+fn stamp_package(env: &mut HashMap<String, String>, prefix: &str, value: &Value) {
+    let pairs: Vec<(String, &Value)> = match value {
+        Value::Object(map) => map.iter().map(|(k, v)| (k.clone(), v)).collect(),
+        Value::Array(arr) => arr.iter().enumerate().map(|(i, v)| (i.to_string(), v)).collect(),
+        _ => return,
+    };
+
+    for (key, v) in pairs {
+        if key.starts_with('_') {
+            continue;
+        }
+
+        let is_top_level_keep =
+            matches!(key.as_str(), "name" | "version" | "config" | "engines" | "bin");
+        let in_descent = prefix.starts_with("npm_package_config_")
+            || prefix.starts_with("npm_package_engines_")
+            || prefix.starts_with("npm_package_bin_");
+        if !is_top_level_keep && !in_descent {
+            continue;
+        }
+
+        let env_key = sanitize_env_key(&format!("{prefix}{key}"));
+        match v {
+            Value::Object(_) | Value::Array(_) => {
+                let child_prefix = format!("{env_key}_");
+                stamp_package(env, &child_prefix, v);
+            }
+            Value::String(s) => {
+                env.insert(env_key, escape_newlines(s));
+            }
+            Value::Number(n) => {
+                env.insert(env_key, n.to_string());
+            }
+            Value::Bool(b) => {
+                env.insert(env_key, b.to_string());
+            }
+            Value::Null => {
+                env.insert(env_key, String::new());
+            }
+        }
+    }
+}
+
+/// `(prefix + i).replace(/[^a-zA-Z0-9_]/g, '_')` from index.js:379.
+fn sanitize_env_key(raw: &str) -> String {
+    raw.chars().map(|c| if c.is_ascii_alphanumeric() || c == '_' { c } else { '_' }).collect()
+}
+
+/// `env[envKey].includes('\n') ? JSON.stringify(env[envKey]) : env[envKey]`
+/// from index.js:406-408. JSON-encode multi-line strings so child
+/// shells don't break on embedded newlines.
+fn escape_newlines(s: &str) -> String {
+    if s.contains('\n') { Value::String(s.to_string()).to_string() } else { s.to_string() }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/executor/src/make_env.rs
+++ b/crates/executor/src/make_env.rs
@@ -54,10 +54,12 @@ pub fn build_env(
     manifest: &Value,
     parent_env: HashMap<String, String>,
 ) -> EnvBuild {
-    // 1. Start from the parent env, stripping every `npm_*` /
-    //    `pnpm_config_*` / `NODE` / `TMPDIR` key so a wrapping
-    //    invocation cannot leak its stamp through. Mirrors the
-    //    `!i.match(/^npm_/)` filter at index.js:359.
+    // 1. Start from the parent env, stripping every `npm_*` key
+    //    plus the per-call stamps we re-derive (`NODE`, `TMPDIR`,
+    //    `INIT_CWD`, `PNPM_SCRIPT_SRC_DIR`). Mirrors the
+    //    `!i.match(/^npm_/)` filter at index.js:359 — `pnpm_*` keys
+    //    such as `PNPM_HOME` are intentionally NOT in the filter
+    //    (upstream doesn't strip them either).
     let mut env = filter_parent_env(parent_env);
 
     // 2. `npm_package_*` recursive stamp. Top-level keeps only
@@ -68,7 +70,11 @@ pub fn build_env(
     // 3. Per-call stamping from `lifecycle()` body (index.js:74-87).
     env.insert("npm_lifecycle_event".into(), opts.stage.to_string());
 
-    let node_execpath = opts.node_execpath.map(Path::to_path_buf).or_else(find_node_in_path);
+    let parent_path = path_value(&env);
+    let node_execpath = opts
+        .node_execpath
+        .map(Path::to_path_buf)
+        .or_else(|| find_node_in_path(parent_path.as_deref()));
     if let Some(node) = node_execpath {
         let node_str = node.to_string_lossy().into_owned();
         env.insert("npm_node_execpath".into(), node_str.clone());
@@ -121,23 +127,40 @@ pub fn build_env(
 }
 
 /// Keep PATH (handled by the caller) and everything that does not
-/// start with the npm/pnpm stamping prefixes; drop NODE and TMPDIR
-/// for the same reason — we re-derive them.
+/// start with `npm_`; drop NODE / TMPDIR / INIT_CWD /
+/// PNPM_SCRIPT_SRC_DIR because we re-derive them.
 fn filter_parent_env(env: HashMap<String, String>) -> HashMap<String, String> {
     env.into_iter().filter(|(k, _)| !is_stamping_key(k)).collect()
 }
 
+/// Mirrors `!i.match(/^npm_/)` at index.js:359 plus the per-call
+/// stamps we always re-derive (`NODE`, `TMPDIR`, `INIT_CWD`,
+/// `PNPM_SCRIPT_SRC_DIR`). Only the `npm_*` prefix is stripped —
+/// `pnpm_*` keys (e.g. `PNPM_HOME`, feature flags) are upstream-
+/// preserved and pacquet does the same.
 fn is_stamping_key(key: &str) -> bool {
-    if key.starts_with("npm_") || key.starts_with("pnpm_") {
+    if key.starts_with("npm_") {
         return true;
     }
     matches!(key, "NODE" | "TMPDIR" | "INIT_CWD" | "PNPM_SCRIPT_SRC_DIR")
 }
 
-fn find_node_in_path() -> Option<PathBuf> {
-    let path = env::var_os("PATH")?;
+/// Look up the `PATH` value from `env` case-insensitively. On
+/// Windows the system variable is typically `Path`, not `PATH`;
+/// returning the value here lets the rest of `build_env` stay
+/// independent of casing.
+pub(crate) fn path_value(env: &HashMap<String, String>) -> Option<String> {
+    env.iter().find_map(|(k, v)| k.eq_ignore_ascii_case("PATH").then(|| v.clone()))
+}
+
+/// Look up `node` along the supplied `PATH`. Driven by the filtered
+/// `parent_env`'s PATH (not the process-global env) so `build_env`
+/// stays deterministic given its inputs — matching the docstring
+/// contract.
+fn find_node_in_path(path: Option<&str>) -> Option<PathBuf> {
+    let path = path?;
     let node_name = if cfg!(windows) { "node.exe" } else { "node" };
-    env::split_paths(&path).find_map(|dir| {
+    env::split_paths(path).find_map(|dir| {
         let candidate = dir.join(node_name);
         candidate.is_file().then_some(candidate)
     })

--- a/crates/executor/src/make_env.rs
+++ b/crates/executor/src/make_env.rs
@@ -68,8 +68,7 @@ pub fn build_env(
     // 3. Per-call stamping from `lifecycle()` body (index.js:74-87).
     env.insert("npm_lifecycle_event".into(), opts.stage.to_string());
 
-    let node_execpath =
-        opts.node_execpath.map(Path::to_path_buf).or_else(find_node_in_path);
+    let node_execpath = opts.node_execpath.map(Path::to_path_buf).or_else(find_node_in_path);
     if let Some(node) = node_execpath {
         let node_str = node.to_string_lossy().into_owned();
         env.insert("npm_node_execpath".into(), node_str.clone());
@@ -87,10 +86,7 @@ pub fn build_env(
     }
 
     env.insert("INIT_CWD".into(), opts.init_cwd.to_string_lossy().into_owned());
-    env.insert(
-        "PNPM_SCRIPT_SRC_DIR".into(),
-        opts.script_src_dir.to_string_lossy().into_owned(),
-    );
+    env.insert("PNPM_SCRIPT_SRC_DIR".into(), opts.script_src_dir.to_string_lossy().into_owned());
 
     if let Some(p) = opts.node_gyp_path {
         env.insert("npm_config_node_gyp".into(), p.to_string_lossy().into_owned());

--- a/crates/executor/src/make_env/tests.rs
+++ b/crates/executor/src/make_env/tests.rs
@@ -1,4 +1,6 @@
-use super::{EnvOptions, build_env, escape_newlines, sanitize_env_key, stamp_package};
+use super::{
+    EnvOptions, build_env, escape_newlines, is_stamping_key, sanitize_env_key, stamp_package,
+};
 use pretty_assertions::assert_eq;
 use serde_json::json;
 use std::{collections::HashMap, path::Path};
@@ -247,6 +249,49 @@ fn sanitize_env_key_matches_upstream_regex() {
     assert_eq!(sanitize_env_key("npm_package_@scope/foo"), "npm_package__scope_foo");
     assert_eq!(sanitize_env_key("npm_package_a-b.c"), "npm_package_a_b_c");
     assert_eq!(sanitize_env_key("npm_package_já"), "npm_package_j_");
+}
+
+/// On POSIX, env keys are case-sensitive: `NPM_CONFIG_FOO` is a
+/// different variable than `npm_config_foo`, so only the lowercase
+/// `npm_` prefix matches — matching upstream's `/^npm_/` regex
+/// exactly.
+#[test]
+fn is_stamping_key_is_case_sensitive_on_posix() {
+    assert!(is_stamping_key("npm_config_user_agent", false));
+    assert!(!is_stamping_key("NPM_CONFIG_USER_AGENT", false));
+    assert!(!is_stamping_key("Npm_Lifecycle_Event", false));
+    assert!(is_stamping_key("NODE", false));
+    assert!(!is_stamping_key("Node", false));
+    assert!(!is_stamping_key("node", false));
+    assert!(is_stamping_key("TMPDIR", false));
+    assert!(is_stamping_key("INIT_CWD", false));
+    assert!(is_stamping_key("PNPM_SCRIPT_SRC_DIR", false));
+    // pnpm_* keys other than the well-known stamps survive.
+    assert!(!is_stamping_key("PNPM_HOME", false));
+}
+
+/// On Windows, Rust's `Command::env` treats env keys
+/// case-insensitively, so `NPM_CONFIG_FOO` and `npm_config_foo`
+/// refer to the same variable. We must strip the entire family
+/// case-insensitively or our `npm_*` inserts collide at spawn time
+/// with an unpredictable winner.
+#[test]
+fn is_stamping_key_is_case_insensitive_on_windows() {
+    assert!(is_stamping_key("npm_config_user_agent", true));
+    assert!(is_stamping_key("NPM_CONFIG_USER_AGENT", true));
+    assert!(is_stamping_key("Npm_Lifecycle_Event", true));
+    assert!(is_stamping_key("NODE", true));
+    assert!(is_stamping_key("Node", true));
+    assert!(is_stamping_key("node", true));
+    assert!(is_stamping_key("tmpdir", true));
+    assert!(is_stamping_key("init_cwd", true));
+    assert!(is_stamping_key("pnpm_script_src_dir", true));
+    // Edge: short keys shouldn't accidentally match `npm_`.
+    assert!(!is_stamping_key("NPM", true));
+    assert!(!is_stamping_key("npm", true));
+    // pnpm_* keys other than the well-known stamps still survive.
+    assert!(!is_stamping_key("PNPM_HOME", true));
+    assert!(!is_stamping_key("pnpm_home", true));
 }
 
 /// Multi-line strings get JSON-encoded so child shells don't see a

--- a/crates/executor/src/make_env/tests.rs
+++ b/crates/executor/src/make_env/tests.rs
@@ -270,6 +270,26 @@ fn is_stamping_key_is_case_sensitive_on_posix() {
     assert!(!is_stamping_key("PNPM_HOME", false));
 }
 
+/// Regression: the byte-level prefix check inside the Windows
+/// branch must not panic on non-ASCII keys whose UTF-8 byte
+/// representation crosses byte 4. Slicing `key[..4]` panics for
+/// e.g. `"x𐀀"` (1 ASCII byte + a 4-byte codepoint), since byte 4
+/// lands inside the codepoint.
+#[test]
+fn is_stamping_key_handles_non_ascii_keys_without_panicking() {
+    // 1 ASCII byte + 4-byte UTF-8 codepoint = 5 bytes; byte 4 is
+    // mid-char. Comparison must be byte-safe.
+    assert!(!is_stamping_key("x\u{10000}", true));
+    assert!(!is_stamping_key("x\u{10000}", false));
+    // 2-byte codepoint repeated: byte 4 IS a char boundary, but
+    // the leading bytes are not ASCII so the comparison must
+    // still return false.
+    assert!(!is_stamping_key("\u{0419}\u{0419}", true));
+    // 1-character ASCII (< 4 bytes): byte slice short-circuits.
+    assert!(!is_stamping_key("abc", true));
+    assert!(!is_stamping_key("", true));
+}
+
 /// On Windows, Rust's `Command::env` treats env keys
 /// case-insensitively, so `NPM_CONFIG_FOO` and `npm_config_foo`
 /// refer to the same variable. We must strip the entire family

--- a/crates/executor/src/make_env/tests.rs
+++ b/crates/executor/src/make_env/tests.rs
@@ -96,7 +96,9 @@ fn make_env_drops_non_keep_listed_top_level_keys() {
     let extra = empty_extra();
     let built = build_env(&base_opts(pkg_root, pkg_root, &extra), &manifest, HashMap::new());
 
-    for not_kept in ["npm_package_scripts_postinstall", "npm_package_dependencies_foo", "npm_package_homepage"] {
+    for not_kept in
+        ["npm_package_scripts_postinstall", "npm_package_dependencies_foo", "npm_package_homepage"]
+    {
         assert!(!built.env.contains_key(not_kept), "{not_kept} must be filtered out");
     }
 }
@@ -129,10 +131,7 @@ fn make_env_stamps_lifecycle_specific_keys() {
 
     assert_eq!(built.env.get("npm_lifecycle_event").map(String::as_str), Some("preinstall"));
     assert_eq!(built.env.get("npm_lifecycle_script").map(String::as_str), Some("node x.js"));
-    assert_eq!(
-        built.env.get("npm_package_json").map(String::as_str),
-        Some("/tmp/y/package.json"),
-    );
+    assert_eq!(built.env.get("npm_package_json").map(String::as_str), Some("/tmp/y/package.json"),);
     assert_eq!(built.env.get("INIT_CWD").map(String::as_str), Some("/tmp/projects/y"));
     assert_eq!(built.env.get("PNPM_SCRIPT_SRC_DIR").map(String::as_str), Some("/tmp/y"));
 }
@@ -154,10 +153,7 @@ fn make_env_tmpdir_gating_mirrors_unsafe_perm() {
     opts.unsafe_perm = false;
     let built = build_env(&opts, &json!({"name":"z","version":"0"}), HashMap::new());
     assert_eq!(built.tmpdir.as_deref(), Some(Path::new("/tmp/z/node_modules/.tmp")));
-    assert_eq!(
-        built.env.get("TMPDIR").map(String::as_str),
-        Some("/tmp/z/node_modules/.tmp"),
-    );
+    assert_eq!(built.env.get("TMPDIR").map(String::as_str), Some("/tmp/z/node_modules/.tmp"),);
 }
 
 /// `extra_env` is applied AFTER the lifecycle-area writes, so it can
@@ -217,10 +213,7 @@ fn stamp_package_recurses_into_kept_buckets() {
         "recursion must keep going beneath config/* — only the top-level filter restricts",
     );
     assert_eq!(env.get("npm_package_engines_node").map(String::as_str), Some(">=18"));
-    assert_eq!(
-        env.get("npm_package_bin_foo").map(String::as_str),
-        Some("./bin/foo.js"),
-    );
+    assert_eq!(env.get("npm_package_bin_foo").map(String::as_str), Some("./bin/foo.js"),);
 }
 
 /// Array indices become numeric keys (`bin[0]`, `bin[1]`, …) — JS
@@ -229,11 +222,7 @@ fn stamp_package_recurses_into_kept_buckets() {
 #[test]
 fn stamp_package_handles_arrays() {
     let mut env = HashMap::new();
-    stamp_package(
-        &mut env,
-        "npm_package_",
-        &json!({"name":"a","bin":["./a","./b"]}),
-    );
+    stamp_package(&mut env, "npm_package_", &json!({"name":"a","bin":["./a","./b"]}));
     assert_eq!(env.get("npm_package_bin_0").map(String::as_str), Some("./a"));
     assert_eq!(env.get("npm_package_bin_1").map(String::as_str), Some("./b"));
 }

--- a/crates/executor/src/make_env/tests.rs
+++ b/crates/executor/src/make_env/tests.rs
@@ -129,11 +129,19 @@ fn make_env_stamps_lifecycle_specific_keys() {
 
     let built = build_env(&opts, &json!({ "name": "y", "version": "1.0.0" }), HashMap::new());
 
+    // Compute expected paths through the same `join` so the
+    // assertions are correct on Windows (`\\` separator) as well as
+    // POSIX. Path-separator handling itself is `std`'s job — these
+    // tests verify build_env's mapping, not separator policy.
+    let expected_package_json = pkg_root.join("package.json").to_string_lossy().into_owned();
+    let expected_init_cwd = init_cwd.to_string_lossy().into_owned();
+    let expected_src_dir = pkg_root.to_string_lossy().into_owned();
+
     assert_eq!(built.env.get("npm_lifecycle_event").map(String::as_str), Some("preinstall"));
     assert_eq!(built.env.get("npm_lifecycle_script").map(String::as_str), Some("node x.js"));
-    assert_eq!(built.env.get("npm_package_json").map(String::as_str), Some("/tmp/y/package.json"));
-    assert_eq!(built.env.get("INIT_CWD").map(String::as_str), Some("/tmp/projects/y"));
-    assert_eq!(built.env.get("PNPM_SCRIPT_SRC_DIR").map(String::as_str), Some("/tmp/y"));
+    assert_eq!(built.env.get("npm_package_json"), Some(&expected_package_json));
+    assert_eq!(built.env.get("INIT_CWD"), Some(&expected_init_cwd));
+    assert_eq!(built.env.get("PNPM_SCRIPT_SRC_DIR"), Some(&expected_src_dir));
 }
 
 /// `unsafe_perm: true` skips both the TMPDIR creation and the env
@@ -152,8 +160,9 @@ fn make_env_tmpdir_gating_mirrors_unsafe_perm() {
 
     opts.unsafe_perm = false;
     let built = build_env(&opts, &json!({"name":"z","version":"0"}), HashMap::new());
-    assert_eq!(built.tmpdir.as_deref(), Some(Path::new("/tmp/z/node_modules/.tmp")));
-    assert_eq!(built.env.get("TMPDIR").map(String::as_str), Some("/tmp/z/node_modules/.tmp"));
+    let expected_tmpdir = pkg_root.join("node_modules").join(".tmp");
+    assert_eq!(built.tmpdir.as_deref(), Some(expected_tmpdir.as_path()));
+    assert_eq!(built.env.get("TMPDIR"), Some(&expected_tmpdir.to_string_lossy().into_owned()));
 }
 
 /// `extra_env` is applied AFTER the lifecycle-area writes, so it can

--- a/crates/executor/src/make_env/tests.rs
+++ b/crates/executor/src/make_env/tests.rs
@@ -1,0 +1,260 @@
+use super::{EnvOptions, build_env, escape_newlines, sanitize_env_key, stamp_package};
+use pretty_assertions::assert_eq;
+use serde_json::json;
+use std::{collections::HashMap, path::Path};
+
+fn empty_extra() -> HashMap<String, String> {
+    HashMap::new()
+}
+
+fn base_opts<'a>(
+    pkg_root: &'a Path,
+    init_cwd: &'a Path,
+    extra_env: &'a HashMap<String, String>,
+) -> EnvOptions<'a> {
+    EnvOptions {
+        stage: "postinstall",
+        script: "echo hi",
+        pkg_root,
+        init_cwd,
+        script_src_dir: pkg_root,
+        node_execpath: None,
+        npm_execpath: None,
+        node_gyp_path: None,
+        user_agent: None,
+        unsafe_perm: true,
+        extra_env,
+    }
+}
+
+/// Ports `test('makeEnv')` from
+/// <https://github.com/pnpm/npm-lifecycle/blob/d2d8e790/test/index.js#L97-L124>.
+///
+/// Three invariants we mirror:
+/// - top-level `npm_package_name` is set from the manifest's `name`,
+/// - package-local config like `_myPackage` keys are NOT promoted to
+///   `npm_package_config_*`,
+/// - `npm_config_*` keys leaked from the parent env are stripped.
+#[test]
+fn make_env_stamps_top_level_keys_and_strips_npm_config_leakage() {
+    let mut parent = HashMap::new();
+    parent.insert("PATH".into(), "/usr/bin".into());
+    parent.insert("npm_config_enteente".into(), "should-be-stripped".into());
+    parent.insert("pnpm_config_user_agent".into(), "should-also-go".into());
+    parent.insert("HOME".into(), "/home/me".into());
+
+    let manifest = json!({
+        "name": "@scope/pkg",
+        "version": "1.2.3",
+        "config": { "myKey": "myValue" },
+        "_myPackage": { "secret": "ignored" },
+        "scripts": { "postinstall": "noop" },
+    });
+
+    let pkg_root = Path::new("/tmp/pkg-x");
+    let extra = empty_extra();
+    let built = build_env(&base_opts(pkg_root, pkg_root, &extra), &manifest, parent);
+
+    assert_eq!(built.env.get("npm_package_name").map(String::as_str), Some("@scope/pkg"));
+    assert_eq!(built.env.get("npm_package_version").map(String::as_str), Some("1.2.3"));
+    assert_eq!(built.env.get("npm_package_config_myKey").map(String::as_str), Some("myValue"));
+    assert!(
+        !built.env.contains_key("npm_package__myPackage_secret"),
+        "underscore-prefixed manifest keys must be ignored",
+    );
+    assert!(
+        !built.env.contains_key("npm_config_enteente"),
+        "npm_config_* must be stripped from parent env: {:?}",
+        built.env,
+    );
+    assert!(
+        !built.env.contains_key("pnpm_config_user_agent"),
+        "pnpm_config_* must be stripped from parent env: {:?}",
+        built.env,
+    );
+    assert_eq!(
+        built.env.get("HOME").map(String::as_str),
+        Some("/home/me"),
+        "non-npm parent keys are preserved",
+    );
+}
+
+/// `scripts` is NOT in the top-level keep-list at index.js:381, so it
+/// must not become `npm_package_scripts_*`. Catches the most common
+/// way the filter could regress.
+#[test]
+fn make_env_drops_non_keep_listed_top_level_keys() {
+    let manifest = json!({
+        "name": "x",
+        "version": "0.1.0",
+        "scripts": { "postinstall": "echo hi", "test": "exit 1" },
+        "dependencies": { "foo": "1.0.0" },
+        "homepage": "https://example.com",
+    });
+
+    let pkg_root = Path::new("/tmp/x");
+    let extra = empty_extra();
+    let built = build_env(&base_opts(pkg_root, pkg_root, &extra), &manifest, HashMap::new());
+
+    for not_kept in ["npm_package_scripts_postinstall", "npm_package_dependencies_foo", "npm_package_homepage"] {
+        assert!(!built.env.contains_key(not_kept), "{not_kept} must be filtered out");
+    }
+}
+
+/// `npm_lifecycle_event`, `npm_lifecycle_script`, `npm_package_json`,
+/// `INIT_CWD`, and `PNPM_SCRIPT_SRC_DIR` all come from the lifecycle
+/// wrapper, not from the manifest. Mirrors index.js:74-86 + the pnpm
+/// wrapper at runLifecycleHook.ts:119-124.
+#[test]
+fn make_env_stamps_lifecycle_specific_keys() {
+    let pkg_root = Path::new("/tmp/y");
+    let init_cwd = Path::new("/tmp/projects/y");
+    let extra = empty_extra();
+
+    let opts = EnvOptions {
+        stage: "preinstall",
+        script: "node x.js",
+        pkg_root,
+        init_cwd,
+        script_src_dir: pkg_root,
+        node_execpath: None,
+        npm_execpath: None,
+        node_gyp_path: None,
+        user_agent: None,
+        unsafe_perm: true,
+        extra_env: &extra,
+    };
+
+    let built = build_env(&opts, &json!({ "name": "y", "version": "1.0.0" }), HashMap::new());
+
+    assert_eq!(built.env.get("npm_lifecycle_event").map(String::as_str), Some("preinstall"));
+    assert_eq!(built.env.get("npm_lifecycle_script").map(String::as_str), Some("node x.js"));
+    assert_eq!(
+        built.env.get("npm_package_json").map(String::as_str),
+        Some("/tmp/y/package.json"),
+    );
+    assert_eq!(built.env.get("INIT_CWD").map(String::as_str), Some("/tmp/projects/y"));
+    assert_eq!(built.env.get("PNPM_SCRIPT_SRC_DIR").map(String::as_str), Some("/tmp/y"));
+}
+
+/// `unsafe_perm: true` skips both the TMPDIR creation and the env
+/// stamp; `unsafe_perm: false` records the path but does NOT create
+/// the directory (that's the caller's job).
+#[test]
+fn make_env_tmpdir_gating_mirrors_unsafe_perm() {
+    let pkg_root = Path::new("/tmp/z");
+    let extra = empty_extra();
+
+    let mut opts = base_opts(pkg_root, pkg_root, &extra);
+    opts.unsafe_perm = true;
+    let built = build_env(&opts, &json!({"name":"z","version":"0"}), HashMap::new());
+    assert!(built.tmpdir.is_none());
+    assert!(!built.env.contains_key("TMPDIR"));
+
+    opts.unsafe_perm = false;
+    let built = build_env(&opts, &json!({"name":"z","version":"0"}), HashMap::new());
+    assert_eq!(built.tmpdir.as_deref(), Some(Path::new("/tmp/z/node_modules/.tmp")));
+    assert_eq!(
+        built.env.get("TMPDIR").map(String::as_str),
+        Some("/tmp/z/node_modules/.tmp"),
+    );
+}
+
+/// `extra_env` is applied AFTER the lifecycle-area writes, so it can
+/// override INIT_CWD etc. — matches index.js:88-92's `Object.entries(opts.extraEnv)`
+/// loop order. But `npm_lifecycle_script` is stamped *after* extraEnv
+/// (set in lifecycle_ at index.js:125), so the caller can never
+/// clobber it.
+#[test]
+fn extra_env_overrides_writes_except_lifecycle_script() {
+    let pkg_root = Path::new("/tmp/w");
+    let mut extra = HashMap::new();
+    extra.insert("INIT_CWD".into(), "/overridden".into());
+    extra.insert("npm_lifecycle_script".into(), "FAKE".into());
+    extra.insert("CUSTOM".into(), "hello".into());
+
+    let opts = EnvOptions {
+        stage: "postinstall",
+        script: "REAL",
+        pkg_root,
+        init_cwd: Path::new("/original"),
+        script_src_dir: pkg_root,
+        node_execpath: None,
+        npm_execpath: None,
+        node_gyp_path: None,
+        user_agent: None,
+        unsafe_perm: true,
+        extra_env: &extra,
+    };
+
+    let built = build_env(&opts, &json!({"name":"w","version":"0"}), HashMap::new());
+
+    assert_eq!(built.env.get("INIT_CWD").map(String::as_str), Some("/overridden"));
+    assert_eq!(built.env.get("npm_lifecycle_script").map(String::as_str), Some("REAL"));
+    assert_eq!(built.env.get("CUSTOM").map(String::as_str), Some("hello"));
+}
+
+/// Recursion goes one level into `config`, `engines`, `bin` but
+/// keeps everything inside them — including nested objects.
+#[test]
+fn stamp_package_recurses_into_kept_buckets() {
+    let mut env = HashMap::new();
+    stamp_package(
+        &mut env,
+        "npm_package_",
+        &json!({
+            "name": "pkg",
+            "config": { "port": 3000, "deep": { "nested": "value" } },
+            "engines": { "node": ">=18" },
+            "bin": { "foo": "./bin/foo.js" },
+        }),
+    );
+    assert_eq!(env.get("npm_package_name").map(String::as_str), Some("pkg"));
+    assert_eq!(env.get("npm_package_config_port").map(String::as_str), Some("3000"));
+    assert_eq!(
+        env.get("npm_package_config_deep_nested").map(String::as_str),
+        Some("value"),
+        "recursion must keep going beneath config/* — only the top-level filter restricts",
+    );
+    assert_eq!(env.get("npm_package_engines_node").map(String::as_str), Some(">=18"));
+    assert_eq!(
+        env.get("npm_package_bin_foo").map(String::as_str),
+        Some("./bin/foo.js"),
+    );
+}
+
+/// Array indices become numeric keys (`bin[0]`, `bin[1]`, …) — JS
+/// iterates `for (i in array)` as strings, and the recursion handles
+/// it the same way as object keys.
+#[test]
+fn stamp_package_handles_arrays() {
+    let mut env = HashMap::new();
+    stamp_package(
+        &mut env,
+        "npm_package_",
+        &json!({"name":"a","bin":["./a","./b"]}),
+    );
+    assert_eq!(env.get("npm_package_bin_0").map(String::as_str), Some("./a"));
+    assert_eq!(env.get("npm_package_bin_1").map(String::as_str), Some("./b"));
+}
+
+/// `(prefix + i).replace(/[^a-zA-Z0-9_]/g, '_')` from index.js:379.
+/// Scoped names, dashes, dots all collapse to `_`.
+#[test]
+fn sanitize_env_key_matches_upstream_regex() {
+    assert_eq!(sanitize_env_key("npm_package_name"), "npm_package_name");
+    assert_eq!(sanitize_env_key("npm_package_@scope/foo"), "npm_package__scope_foo");
+    assert_eq!(sanitize_env_key("npm_package_a-b.c"), "npm_package_a_b_c");
+    assert_eq!(sanitize_env_key("npm_package_já"), "npm_package_j_");
+}
+
+/// Multi-line strings get JSON-encoded so child shells don't see a
+/// literal newline. Mirrors index.js:406-408.
+#[test]
+fn escape_newlines_json_encodes_multi_line_only() {
+    assert_eq!(escape_newlines("plain"), "plain");
+    assert_eq!(escape_newlines("a\nb"), "\"a\\nb\"");
+    // Single-line strings with quotes/backslashes pass through verbatim
+    // — matches the JS `s.includes('\n') ? JSON.stringify(s) : s` exactly.
+    assert_eq!(escape_newlines("has \"quotes\""), "has \"quotes\"");
+}

--- a/crates/executor/src/make_env/tests.rs
+++ b/crates/executor/src/make_env/tests.rs
@@ -131,7 +131,7 @@ fn make_env_stamps_lifecycle_specific_keys() {
 
     assert_eq!(built.env.get("npm_lifecycle_event").map(String::as_str), Some("preinstall"));
     assert_eq!(built.env.get("npm_lifecycle_script").map(String::as_str), Some("node x.js"));
-    assert_eq!(built.env.get("npm_package_json").map(String::as_str), Some("/tmp/y/package.json"),);
+    assert_eq!(built.env.get("npm_package_json").map(String::as_str), Some("/tmp/y/package.json"));
     assert_eq!(built.env.get("INIT_CWD").map(String::as_str), Some("/tmp/projects/y"));
     assert_eq!(built.env.get("PNPM_SCRIPT_SRC_DIR").map(String::as_str), Some("/tmp/y"));
 }
@@ -153,7 +153,7 @@ fn make_env_tmpdir_gating_mirrors_unsafe_perm() {
     opts.unsafe_perm = false;
     let built = build_env(&opts, &json!({"name":"z","version":"0"}), HashMap::new());
     assert_eq!(built.tmpdir.as_deref(), Some(Path::new("/tmp/z/node_modules/.tmp")));
-    assert_eq!(built.env.get("TMPDIR").map(String::as_str), Some("/tmp/z/node_modules/.tmp"),);
+    assert_eq!(built.env.get("TMPDIR").map(String::as_str), Some("/tmp/z/node_modules/.tmp"));
 }
 
 /// `extra_env` is applied AFTER the lifecycle-area writes, so it can
@@ -213,7 +213,7 @@ fn stamp_package_recurses_into_kept_buckets() {
         "recursion must keep going beneath config/* — only the top-level filter restricts",
     );
     assert_eq!(env.get("npm_package_engines_node").map(String::as_str), Some(">=18"));
-    assert_eq!(env.get("npm_package_bin_foo").map(String::as_str), Some("./bin/foo.js"),);
+    assert_eq!(env.get("npm_package_bin_foo").map(String::as_str), Some("./bin/foo.js"));
 }
 
 /// Array indices become numeric keys (`bin[0]`, `bin[1]`, …) — JS

--- a/crates/executor/src/make_env/tests.rs
+++ b/crates/executor/src/make_env/tests.rs
@@ -30,17 +30,20 @@ fn base_opts<'a>(
 /// Ports `test('makeEnv')` from
 /// <https://github.com/pnpm/npm-lifecycle/blob/d2d8e790/test/index.js#L97-L124>.
 ///
-/// Three invariants we mirror:
+/// Four invariants we mirror:
 /// - top-level `npm_package_name` is set from the manifest's `name`,
 /// - package-local config like `_myPackage` keys are NOT promoted to
 ///   `npm_package_config_*`,
-/// - `npm_config_*` keys leaked from the parent env are stripped.
+/// - `npm_*` keys leaked from the parent env are stripped (upstream's
+///   `!i.match(/^npm_/)` filter at `index.js:359`),
+/// - everything else passes through — including `pnpm_*` keys like
+///   `PNPM_HOME`, which upstream does not filter.
 #[test]
 fn make_env_stamps_top_level_keys_and_strips_npm_config_leakage() {
     let mut parent = HashMap::new();
     parent.insert("PATH".into(), "/usr/bin".into());
     parent.insert("npm_config_enteente".into(), "should-be-stripped".into());
-    parent.insert("pnpm_config_user_agent".into(), "should-also-go".into());
+    parent.insert("PNPM_HOME".into(), "/opt/pnpm".into());
     parent.insert("HOME".into(), "/home/me".into());
 
     let manifest = json!({
@@ -67,10 +70,10 @@ fn make_env_stamps_top_level_keys_and_strips_npm_config_leakage() {
         "npm_config_* must be stripped from parent env: {:?}",
         built.env,
     );
-    assert!(
-        !built.env.contains_key("pnpm_config_user_agent"),
-        "pnpm_config_* must be stripped from parent env: {:?}",
-        built.env,
+    assert_eq!(
+        built.env.get("PNPM_HOME").map(String::as_str),
+        Some("/opt/pnpm"),
+        "pnpm_* (incl. PNPM_HOME) keys are NOT in upstream's strip filter — they must pass through",
     );
     assert_eq!(
         built.env.get("HOME").map(String::as_str),

--- a/crates/executor/src/shell.rs
+++ b/crates/executor/src/shell.rs
@@ -35,7 +35,9 @@ pub struct SelectedShell {
     pub args: Vec<OsString>,
     /// Whether Node's `windowsVerbatimArguments` flag would have
     /// fired for this combination. Used by the Windows caller to opt
-    /// into Rust's [`std::os::windows::process::CommandExt::raw_arg`].
+    /// into Rust's `std::os::windows::process::CommandExt::raw_arg`
+    /// (Windows-only API; not linked as an intra-doc reference
+    /// because rustdoc on non-Windows targets cannot resolve it).
     ///
     /// On non-Windows platforms the field is set but ignored —
     /// keeping the struct platform-independent simplifies tests.

--- a/crates/executor/src/shell.rs
+++ b/crates/executor/src/shell.rs
@@ -1,0 +1,110 @@
+use derive_more::{Display, Error};
+use miette::Diagnostic;
+use std::{
+    env,
+    ffi::OsString,
+    path::{Path, PathBuf},
+};
+
+/// Failure to pick a shell for a lifecycle hook. Ports the pnpm-side
+/// guard at <https://github.com/pnpm/pnpm/blob/b4f8f47ac2/exec/lifecycle/src/runLifecycleHook.ts#L63-L71>.
+#[derive(Debug, Display, Error, Diagnostic)]
+#[non_exhaustive]
+pub enum ScriptShellError {
+    /// Setting `scriptShell` to a `.bat` or `.cmd` file on Windows is
+    /// blocked because Node refuses to spawn batch files without
+    /// `shell: true`, and re-escaping arguments for a shell-wrapped
+    /// batch invocation is unsafe (cf. CVE-2024-27980 / CVE-2024-24576).
+    #[display(
+        "Cannot spawn .bat or .cmd as a script shell. \
+         The pnpm-workspace.yaml scriptShell option was configured to a .bat or .cmd file. \
+         These cannot be used as a script shell reliably. \
+         Please unset the scriptShell option, or configure it to a .exe instead. \
+         (scriptShell={path})"
+    )]
+    #[diagnostic(code(ERR_PNPM_INVALID_SCRIPT_SHELL_WINDOWS))]
+    BatchFileOnWindows { path: String },
+}
+
+/// The result of [`select_shell`]: a program path plus the leading
+/// flag arguments (`-c`, `/d /s /c`, etc.) that go before the script
+/// body when spawning.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SelectedShell {
+    pub program: PathBuf,
+    pub args: Vec<OsString>,
+    /// Whether Node's `windowsVerbatimArguments` flag would have
+    /// fired for this combination. Used by the Windows caller to opt
+    /// into Rust's [`std::os::windows::process::CommandExt::raw_arg`].
+    ///
+    /// On non-Windows platforms the field is set but ignored —
+    /// keeping the struct platform-independent simplifies tests.
+    pub windows_verbatim_args: bool,
+}
+
+/// Pick the shell to spawn a lifecycle script under.
+///
+/// Ports `runCmd_`'s shell-selection block from
+/// <https://github.com/pnpm/npm-lifecycle/blob/d2d8e790/index.js#L241-L252>,
+/// with the `.bat` / `.cmd` guard from `pnpm/exec/lifecycle/src/runLifecycleHook.ts:63-71`.
+///
+/// Priority:
+/// 1. If `script_shell` ends in `.bat` / `.cmd` on Windows, return
+///    [`ScriptShellError::BatchFileOnWindows`].
+/// 2. If `script_shell` is `Some`, use it with `-c`.
+/// 3. On Windows: `%ComSpec%` (or `cmd`) with `/d /s /c`, with
+///    `windows_verbatim_args` set.
+/// 4. Otherwise: `sh -c`.
+///
+/// `is_windows` lets tests drive both branches without `#[cfg(windows)]`
+/// gating the test bodies. Production callers pass `cfg!(windows)`.
+pub fn select_shell(
+    script_shell: Option<&Path>,
+    is_windows: bool,
+) -> Result<SelectedShell, ScriptShellError> {
+    if is_windows
+        && let Some(p) = script_shell
+        && is_windows_batch_file(p)
+    {
+        return Err(ScriptShellError::BatchFileOnWindows {
+            path: p.to_string_lossy().into_owned(),
+        });
+    }
+
+    if let Some(p) = script_shell {
+        return Ok(SelectedShell {
+            program: p.to_path_buf(),
+            args: vec![OsString::from("-c")],
+            windows_verbatim_args: false,
+        });
+    }
+
+    if is_windows {
+        let comspec = env::var_os("ComSpec")
+            .or_else(|| env::var_os("COMSPEC"))
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("cmd"));
+        return Ok(SelectedShell {
+            program: comspec,
+            args: vec![OsString::from("/d"), OsString::from("/s"), OsString::from("/c")],
+            windows_verbatim_args: true,
+        });
+    }
+
+    Ok(SelectedShell {
+        program: PathBuf::from("sh"),
+        args: vec![OsString::from("-c")],
+        windows_verbatim_args: false,
+    })
+}
+
+/// `.cmd` / `.bat` suffix check, case-insensitive on the suffix. The
+/// upstream `isWindowsBatchFile` also gates on `process.platform === 'win32'`;
+/// here we factor that out and let the caller pass `is_windows`.
+fn is_windows_batch_file(path: &Path) -> bool {
+    let lowered = path.to_string_lossy().to_ascii_lowercase();
+    lowered.ends_with(".cmd") || lowered.ends_with(".bat")
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/executor/src/shell/tests.rs
+++ b/crates/executor/src/shell/tests.rs
@@ -31,10 +31,7 @@ fn windows_default_uses_cmd_with_d_s_c_and_verbatim_args() {
     assert_eq!(shell.args, vec![os("/d"), os("/s"), os("/c")]);
     assert!(shell.windows_verbatim_args, "verbatim must be set for cmd.exe");
     let p = shell.program.to_string_lossy().to_ascii_lowercase();
-    assert!(
-        p == "cmd" || p.ends_with("cmd.exe"),
-        "expected cmd or *cmd.exe, got {p:?}",
-    );
+    assert!(p == "cmd" || p.ends_with("cmd.exe"), "expected cmd or *cmd.exe, got {p:?}",);
 }
 
 /// A custom `scriptShell` (e.g. `/usr/local/bin/bash`) wins on both

--- a/crates/executor/src/shell/tests.rs
+++ b/crates/executor/src/shell/tests.rs
@@ -1,0 +1,89 @@
+use super::{ScriptShellError, SelectedShell, select_shell};
+use pretty_assertions::assert_eq;
+use std::{ffi::OsString, path::Path};
+
+fn os(s: &str) -> OsString {
+    OsString::from(s)
+}
+
+/// Default on POSIX: `sh -c`, no verbatim args.
+#[test]
+fn posix_default_is_sh_minus_c() {
+    let shell = select_shell(None, false).expect("select_shell");
+    assert_eq!(
+        shell,
+        SelectedShell {
+            program: Path::new("sh").to_path_buf(),
+            args: vec![os("-c")],
+            windows_verbatim_args: false,
+        },
+    );
+}
+
+/// Default on Windows: `cmd /d /s /c` with verbatim args. When
+/// `ComSpec` / `COMSPEC` is set the env var wins; otherwise the
+/// literal string `cmd` is used. We do not assert the program path
+/// here because the runner env may or may not have ComSpec set —
+/// the args + verbatim flag are the load-bearing part.
+#[test]
+fn windows_default_uses_cmd_with_d_s_c_and_verbatim_args() {
+    let shell = select_shell(None, true).expect("select_shell");
+    assert_eq!(shell.args, vec![os("/d"), os("/s"), os("/c")]);
+    assert!(shell.windows_verbatim_args, "verbatim must be set for cmd.exe");
+    let p = shell.program.to_string_lossy().to_ascii_lowercase();
+    assert!(
+        p == "cmd" || p.ends_with("cmd.exe"),
+        "expected cmd or *cmd.exe, got {p:?}",
+    );
+}
+
+/// A custom `scriptShell` (e.g. `/usr/local/bin/bash`) wins on both
+/// platforms, with `-c`. This is the path exercised by upstream's
+/// `skipOnWindows('pnpm run with custom shell')` test from
+/// <https://github.com/pnpm/pnpm/blob/b4f8f47ac2/exec/commands/test/index.ts#L478-L508>.
+#[test]
+fn custom_script_shell_wins_on_both_platforms() {
+    let custom = Path::new("/usr/local/bin/bash");
+    for is_windows in [false, true] {
+        let shell = select_shell(Some(custom), is_windows).expect("select_shell");
+        assert_eq!(
+            shell,
+            SelectedShell {
+                program: custom.to_path_buf(),
+                args: vec![os("-c")],
+                windows_verbatim_args: false,
+            },
+            "is_windows={is_windows}",
+        );
+    }
+}
+
+/// `.cmd` / `.bat` `script_shell` on Windows surfaces as
+/// `ERR_PNPM_INVALID_SCRIPT_SHELL_WINDOWS`. Mirrors the upstream
+/// guard at
+/// <https://github.com/pnpm/pnpm/blob/b4f8f47ac2/exec/lifecycle/src/runLifecycleHook.ts#L63-L71>
+/// and ports the `onlyOnWindows('pnpm shows error if script-shell is .cmd')`
+/// test from `pnpm/exec/commands/test/index.ts:509-542`.
+#[test]
+fn batch_file_script_shell_rejected_on_windows() {
+    for ext in [".cmd", ".CMD", ".bat", ".BAT"] {
+        let path = format!("C:\\tools\\shell-mock{ext}");
+        let err = select_shell(Some(Path::new(&path)), true).expect_err("must reject");
+        match err {
+            ScriptShellError::BatchFileOnWindows { path: got } => {
+                assert_eq!(got, path, "error path must echo input");
+            }
+        }
+    }
+}
+
+/// Same `.cmd` path on POSIX is allowed — we only block on Windows.
+/// Upstream's `isWindowsBatchFile` gates on `process.platform === 'win32'`,
+/// so a Linux user pointing scriptShell at `something.cmd` is left
+/// alone (it'd fail elsewhere, but that's not this guard's job).
+#[test]
+fn batch_file_script_shell_allowed_on_posix() {
+    let path = Path::new("/tmp/weird.cmd");
+    let shell = select_shell(Some(path), false).expect("must accept on POSIX");
+    assert_eq!(shell.program, path);
+}

--- a/crates/executor/src/shell/tests.rs
+++ b/crates/executor/src/shell/tests.rs
@@ -31,7 +31,7 @@ fn windows_default_uses_cmd_with_d_s_c_and_verbatim_args() {
     assert_eq!(shell.args, vec![os("/d"), os("/s"), os("/c")]);
     assert!(shell.windows_verbatim_args, "verbatim must be set for cmd.exe");
     let p = shell.program.to_string_lossy().to_ascii_lowercase();
-    assert!(p == "cmd" || p.ends_with("cmd.exe"), "expected cmd or *cmd.exe, got {p:?}",);
+    assert!(p == "cmd" || p.ends_with("cmd.exe"), "expected cmd or *cmd.exe, got {p:?}");
 }
 
 /// A custom `scriptShell` (e.g. `/usr/local/bin/bash`) wins on both

--- a/crates/package-manager/src/build_modules.rs
+++ b/crates/package-manager/src/build_modules.rs
@@ -238,6 +238,10 @@ impl<'a> BuildModules<'a> {
                     // Item #15 in #397 will surface `scriptsPrependNodePath`
                     // from config; today the safe default is `Never`.
                     scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+                    // `scriptShell` / `shell-emulator` plumbing through the
+                    // package-manager config is its own follow-up — pass
+                    // `None` here to use the platform default.
+                    script_shell: None,
                 })
                 .map_err(BuildModulesError::LifecycleScript)?;
             }

--- a/crates/package-manager/src/build_modules.rs
+++ b/crates/package-manager/src/build_modules.rs
@@ -222,6 +222,15 @@ impl<'a> BuildModules<'a> {
                     init_cwd: lockfile_dir,
                     extra_bin_paths: &extra_bin_paths,
                     extra_env: &extra_env,
+                    node_execpath: None,
+                    npm_execpath: None,
+                    node_gyp_path: None,
+                    user_agent: None,
+                    // Item #14 will replace this with a config-driven
+                    // value once `unsafePerm` plumbing lands. Setting
+                    // true here keeps current behavior (no TMPDIR
+                    // creation, no uid/gid drop).
+                    unsafe_perm: true,
                 })
                 .map_err(BuildModulesError::LifecycleScript)?;
             }

--- a/crates/package-manager/src/build_modules.rs
+++ b/crates/package-manager/src/build_modules.rs
@@ -1,7 +1,9 @@
 use crate::build_sequence::build_sequence;
 use derive_more::{Display, Error};
 use miette::Diagnostic;
-use pacquet_executor::{LifecycleScriptError, RunPostinstallHooks, run_postinstall_hooks};
+use pacquet_executor::{
+    LifecycleScriptError, RunPostinstallHooks, ScriptsPrependNodePath, run_postinstall_hooks,
+};
 use pacquet_lockfile::{PackageKey, ProjectSnapshot, SnapshotEntry};
 use pacquet_package_manifest::pkg_requires_build;
 use pacquet_reporter::Reporter;
@@ -231,6 +233,11 @@ impl<'a> BuildModules<'a> {
                     // true here keeps current behavior (no TMPDIR
                     // creation, no uid/gid drop).
                     unsafe_perm: true,
+                    // Pacquet does not bundle a node-gyp shim yet.
+                    node_gyp_bin: None,
+                    // Item #15 in #397 will surface `scriptsPrependNodePath`
+                    // from config; today the safe default is `Never`.
+                    scripts_prepend_node_path: ScriptsPrependNodePath::Never,
                 })
                 .map_err(BuildModulesError::LifecycleScript)?;
             }

--- a/crates/package-manager/src/build_modules.rs
+++ b/crates/package-manager/src/build_modules.rs
@@ -228,19 +228,13 @@ impl<'a> BuildModules<'a> {
                     npm_execpath: None,
                     node_gyp_path: None,
                     user_agent: None,
-                    // Item #14 will replace this with a config-driven
-                    // value once `unsafePerm` plumbing lands. Setting
-                    // true here keeps current behavior (no TMPDIR
-                    // creation, no uid/gid drop).
+                    // Hard-coded until the `unsafe-perm` config knob
+                    // is plumbed through. `true` skips both the
+                    // TMPDIR creation and the uid/gid drop, matching
+                    // pacquet's behavior before any of this landed.
                     unsafe_perm: true,
-                    // Pacquet does not bundle a node-gyp shim yet.
                     node_gyp_bin: None,
-                    // Item #15 in #397 will surface `scriptsPrependNodePath`
-                    // from config; today the safe default is `Never`.
                     scripts_prepend_node_path: ScriptsPrependNodePath::Never,
-                    // `scriptShell` / `shell-emulator` plumbing through the
-                    // package-manager config is its own follow-up — pass
-                    // `None` here to use the platform default.
                     script_shell: None,
                 })
                 .map_err(BuildModulesError::LifecycleScript)?;


### PR DESCRIPTION
## Summary

Closes three of the critical items in #397 by porting the corresponding
behaviors from `@pnpm/npm-lifecycle@d2d8e790` and `pnpm/pnpm@b4f8f47ac2`:

- **#1 — Lifecycle env vars.** New `make_env` module ports `makeEnv` and
  the surrounding env block in `lifecycle()` ([npm-lifecycle/index.js:73-104](https://github.com/pnpm/npm-lifecycle/blob/d2d8e790/index.js#L73-L104), [:354-414](https://github.com/pnpm/npm-lifecycle/blob/d2d8e790/index.js#L354-L414)) plus the pnpm wrapper's `extraEnv` additions ([runLifecycleHook.ts:119-124](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/exec/lifecycle/src/runLifecycleHook.ts#L119-L124)). Lifecycle scripts now see `npm_lifecycle_event`, `npm_lifecycle_script`, `npm_node_execpath`/`NODE`, `npm_package_json`, `npm_execpath`, `npm_package_*` (`name`, `version`, and recursive `config`/`engines`/`bin`), `npm_config_node_gyp`, `npm_config_user_agent`, `INIT_CWD`, `PNPM_SCRIPT_SRC_DIR`, and `TMPDIR` (when `unsafe_perm` is false). The spawn now strips inherited env (`env_clear()`) so leftover `npm_*` keys from a wrapping invocation cannot leak through.
- **#2 — PATH ancestor walk.** New `extend_path` module ports `extendPath` ([npm-lifecycle/lib/extendPath.js:5-27](https://github.com/pnpm/npm-lifecycle/blob/d2d8e790/lib/extendPath.js#L5-L27)) plus the tri-state `scriptsPrependNodePath` gating ([:29-61](https://github.com/pnpm/npm-lifecycle/blob/d2d8e790/lib/extendPath.js#L29-L61)). For a dep at `<root>/node_modules/.pnpm/<slot>/node_modules/<pkg>`, `PATH` now contains the dep's own `.bin`, the `.pnpm` slot's `.bin`, the project root's `.bin`, the bundled `node-gyp-bin` (when supplied), `extra_bin_paths`, and finally the inherited PATH.
- **#4 — Shell selection.** New `shell` module ports the [shell-selection block](https://github.com/pnpm/npm-lifecycle/blob/d2d8e790/index.js#L241-L252) and the [pnpm-side `.bat`/`.cmd` guard](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/exec/lifecycle/src/runLifecycleHook.ts#L63-L71). `cmd /d /s /c` on Windows, custom `scriptShell` on either platform, otherwise `sh -c`. The Windows-batch-file `scriptShell` case surfaces as `ERR_PNPM_INVALID_SCRIPT_SHELL_WINDOWS` (matching upstream's error code).

`RunPostinstallHooks` grows seven new fields to surface these knobs; `BuildModules` passes safe defaults (`None` / `true` / `Never`) for all of them — full config plumbing for `user-agent`, `unsafe-perm`, `scripts-prepend-node-path`, `node-gyp` bundling, and `script-shell` are tracked as separate items in #397 (#14, #15) or follow-ups.

### Explicit non-goals in this PR

Three caveats called out in #397 that are deliberately deferred:

- `windowsVerbatimArguments` (Rust equivalent: `CommandExt::raw_arg`) is signalled by `SelectedShell.windows_verbatim_args` but not yet applied to the spawned `Command`.
- `@yarnpkg/shell` / `shellEmulator: true` has no clean Rust port; pacquet ignores the flag for now.
- `unsafe_perm` uid/gid drop (#14) — `BuildModules` passes `true`, which keeps current behavior (no TMPDIR creation, no privilege drop).

### Test parity

Per the project guide ("port the relevant pnpm tests too whenever they translate"), this branch ports:

- `test('makeEnv')` from [npm-lifecycle/test/index.js:97-124](https://github.com/pnpm/npm-lifecycle/blob/d2d8e790/test/index.js#L97-L124).
- The `extendPath` ordering test from [npm-lifecycle/test/extendPath.test.js:5-8](https://github.com/pnpm/npm-lifecycle/blob/d2d8e790/test/extendPath.test.js#L5-L8).
- `runLifecycleHook() does not set npm_config env vars` from [pnpm/exec/lifecycle/test/index.ts:65-77](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/exec/lifecycle/test/index.ts#L65-L77), adapted to a file-dump model so we don't need the IPC fixture.
- `onlyOnWindows('pnpm shows error if script-shell is .cmd')` from [pnpm/exec/commands/test/index.ts:509-542](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/exec/commands/test/index.ts#L509-L542) and the custom-shell case from [:478-508](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/exec/commands/test/index.ts#L478-L508).

Plus fills the gaps where upstream coverage is thin: tri-state `scriptsPrependNodePath`, two-level pnpm virtual-store PATH walks, `extra_bin_paths` ordering, TMPDIR gating on `unsafe_perm`, and `extra_env` precedence vs `npm_lifecycle_script`.

## Test plan

- [x] `just ready` (466 tests + clippy clean)
- [x] `taplo format --check` (clean — `just ready` doesn't run this, CI does)
- [x] CI green on Linux / macOS / Windows
- [ ] Verify against `alot7`-style real-install fixtures in a follow-up perf run if reviewers want to confirm no warm-install regression

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Improved lifecycle script execution: deterministic PATH ordering for tooling bins, optional inclusion of the node executable directory, configurable node-gyp placement, richer lifecycle environment stamping (npm_* vars, INIT_CWD, PNPM_SCRIPT_SRC_DIR), and platform-aware script-shell selection with safer defaults.
* **Tests**
  - Extensive unit and integration tests covering PATH ordering, environment stamping, TMPDIR behavior, and shell selection.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pacquet/pull/418)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->