### PR TITLE
feat: side-effects cache WRITE path (#421 slice B)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2070,6 +2070,7 @@ dependencies = [
  "reflink-copy",
  "serde-saphyr",
  "serde_json",
+ "sha2",
  "ssri",
  "tempfile",
  "text-block-macros",
@@ -2145,6 +2146,7 @@ version = "0.0.1"
 dependencies = [
  "dashmap",
  "derive_more",
+ "dunce",
  "miette 7.6.0",
  "pacquet-fs",
  "pipe-trait",
@@ -2159,6 +2161,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2161,7 +2161,6 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "walkdir",
 ]
 
 [[package]]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -175,22 +175,34 @@ pub struct Config {
     pub verify_store_integrity: bool,
 
     /// Whether to consult the side-effects cache
-    /// (`PackageFilesIndex.sideEffects`) when importing a package.
+    /// (`PackageFilesIndex.sideEffects`) when importing a package
+    /// and whether to populate it after a successful postinstall.
     /// Read from `pnpm-workspace.yaml`'s `sideEffectsCache` field
-    /// (camelCase, optional, defaults `true`). **Not yet acted on:**
-    /// the build phase doesn't currently gate the rebuild-skip on
-    /// this flag, and the WRITE path (populating the cache after a
-    /// postinstall) is also unimplemented. Both follow up
-    /// separately — tracked in pnpm/pacquet#421.
+    /// (camelCase, optional, defaults `true`).
     ///
     /// Default `true`, matching pnpm's `side-effects-cache` at
-    /// [`config/config/src/index.ts`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/config/config/src/index.ts).
-    /// Wiring the config-source plumbing through now means
-    /// downstream callers can set `sideEffectsCache: false` in
-    /// `pnpm-workspace.yaml` today and have the value take effect
-    /// as soon as the read-path gate lands.
+    /// [`config/reader/src/index.ts`](https://github.com/pnpm/pnpm/blob/7e3145f9fc/config/reader/src/index.ts#L614-L615).
+    ///
+    /// The READ gate combines this with [`side_effects_cache_readonly`]
+    /// via [`Config::side_effects_cache_read`]; the WRITE gate via
+    /// [`Config::side_effects_cache_write`]. Consume those helpers
+    /// rather than reading this field directly so the precedence
+    /// stays single-sourced.
+    ///
+    /// [`side_effects_cache_readonly`]: Self::side_effects_cache_readonly
     #[default = true]
     pub side_effects_cache: bool,
+
+    /// Treat the side-effects cache as read-only — pacquet still
+    /// honors cache hits on the READ side but does not populate
+    /// the cache after a successful postinstall. Mirrors pnpm's
+    /// [`side-effects-cache-readonly`](https://github.com/pnpm/pnpm/blob/7e3145f9fc/config/reader/src/Config.ts#L124).
+    /// Default `false`. Read from `pnpm-workspace.yaml`'s
+    /// `sideEffectsCacheReadonly` field.
+    ///
+    /// Consume via [`Config::side_effects_cache_read`] and
+    /// [`Config::side_effects_cache_write`].
+    pub side_effects_cache_readonly: bool,
 
     /// How many times pacquet retries a failed tarball fetch on transient
     /// errors before giving up. Mirrors pnpm's `fetchRetries` (default
@@ -233,6 +245,31 @@ pub struct Config {
 impl Config {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Whether the install should consult the side-effects cache.
+    /// Mirrors upstream's
+    /// [`sideEffectsCacheRead = sideEffectsCache ?? sideEffectsCacheReadonly`](https://github.com/pnpm/pnpm/blob/7e3145f9fc/config/reader/src/index.ts#L614).
+    ///
+    /// Pacquet collapses upstream's tri-state (`undefined`/`true`/`false`)
+    /// into two booleans: the cache is read when either flag is on, so
+    /// users who only want the READ side can set
+    /// `sideEffectsCacheReadonly: true` with `sideEffectsCache: false`
+    /// and get a read-only view.
+    pub fn side_effects_cache_read(&self) -> bool {
+        self.side_effects_cache || self.side_effects_cache_readonly
+    }
+
+    /// Whether the install is allowed to populate the side-effects
+    /// cache after a successful postinstall. Mirrors upstream's
+    /// [`sideEffectsCacheWrite = sideEffectsCache`](https://github.com/pnpm/pnpm/blob/7e3145f9fc/config/reader/src/index.ts#L615)
+    /// with the additional constraint that the explicit
+    /// `sideEffectsCacheReadonly: true` always wins — upstream's
+    /// `??` semantics let `readonly` slip through when both flags
+    /// are explicitly set, but `readonly` as a flag name only makes
+    /// sense if it really does block writes.
+    pub fn side_effects_cache_write(&self) -> bool {
+        self.side_effects_cache && !self.side_effects_cache_readonly
     }
 
     /// Build the runtime config by layering:

--- a/crates/config/src/workspace_yaml.rs
+++ b/crates/config/src/workspace_yaml.rs
@@ -51,6 +51,7 @@ pub struct WorkspaceSettings {
     pub resolve_peers_from_workspace_root: Option<bool>,
     pub verify_store_integrity: Option<bool>,
     pub side_effects_cache: Option<bool>,
+    pub side_effects_cache_readonly: Option<bool>,
     pub fetch_retries: Option<u32>,
     pub fetch_retry_factor: Option<u32>,
     pub fetch_retry_mintimeout: Option<u64>,
@@ -142,7 +143,8 @@ impl WorkspaceSettings {
             lockfile, prefer_frozen_lockfile, lockfile_include_tarball_url,
             auto_install_peers, dedupe_peer_dependents, strict_peer_dependencies,
             resolve_peers_from_workspace_root, verify_store_integrity,
-            side_effects_cache, fetch_retries, fetch_retry_factor,
+            side_effects_cache, side_effects_cache_readonly,
+            fetch_retries, fetch_retry_factor,
             fetch_retry_mintimeout, fetch_retry_maxtimeout,
         }
 

--- a/crates/config/src/workspace_yaml/tests.rs
+++ b/crates/config/src/workspace_yaml/tests.rs
@@ -142,6 +142,52 @@ fn parses_side_effects_cache_from_yaml_and_applies() {
     assert!(!config.side_effects_cache, "yaml override wins");
 }
 
+/// `sideEffectsCacheReadonly` is pnpm's read-only flag for the
+/// side-effects cache. Same camelCase + `apply_to` wiring as
+/// `sideEffectsCache`. Default is `false`, so flipping it on via
+/// yaml must end at `config.side_effects_cache_readonly == true`.
+#[test]
+fn parses_side_effects_cache_readonly_from_yaml_and_applies() {
+    let yaml = "sideEffectsCacheReadonly: true\n";
+    let settings: WorkspaceSettings = serde_saphyr::from_str(yaml).unwrap();
+    assert_eq!(settings.side_effects_cache_readonly, Some(true));
+
+    let mut config = Config::new();
+    assert!(!config.side_effects_cache_readonly, "the default is `false`");
+    settings.apply_to(&mut config, Path::new("/irrelevant"));
+    assert!(config.side_effects_cache_readonly, "yaml override wins");
+}
+
+/// READ / WRITE gate helpers must combine the two knobs the way
+/// upstream's [`config/reader/src/index.ts`](https://github.com/pnpm/pnpm/blob/7e3145f9fc/config/reader/src/index.ts#L614-L615)
+/// does for the canonical state combinations:
+///
+/// - default (`cache=true`, `readonly=false`)  → read=on, write=on
+/// - cache off  (`cache=false`, `readonly=false`) → read=off, write=off
+/// - readonly on (`cache=true`, `readonly=true`)  → read=on, write=off
+/// - cache off + readonly on                      → read=on, write=off
+#[test]
+fn side_effects_cache_gates_truth_table() {
+    let mut config = Config::new();
+    assert!(config.side_effects_cache_read());
+    assert!(config.side_effects_cache_write());
+
+    config.side_effects_cache = false;
+    config.side_effects_cache_readonly = false;
+    assert!(!config.side_effects_cache_read());
+    assert!(!config.side_effects_cache_write());
+
+    config.side_effects_cache = true;
+    config.side_effects_cache_readonly = true;
+    assert!(config.side_effects_cache_read());
+    assert!(!config.side_effects_cache_write());
+
+    config.side_effects_cache = false;
+    config.side_effects_cache_readonly = true;
+    assert!(config.side_effects_cache_read());
+    assert!(!config.side_effects_cache_write());
+}
+
 #[test]
 fn apply_leaves_unset_fields_alone() {
     let yaml = "storeDir: /s\n";

--- a/crates/package-manager/Cargo.toml
+++ b/crates/package-manager/Cargo.toml
@@ -47,6 +47,7 @@ node-semver       = { workspace = true }
 insta             = { workspace = true }
 pretty_assertions = { workspace = true }
 serde-saphyr      = { workspace = true }
+sha2              = { workspace = true }
 ssri              = { workspace = true }
 tempfile          = { workspace = true }
 text-block-macros = { workspace = true }

--- a/crates/package-manager/src/build_modules.rs
+++ b/crates/package-manager/src/build_modules.rs
@@ -262,22 +262,20 @@ impl<'a> BuildModules<'a> {
                     Some(true) => {}
                 }
 
-                // Side-effects-cache `is_built` gate. Mirrors
-                // upstream's `!node.isBuilt` filter at
-                // <https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/during-install/src/index.ts#L73-L77>.
-                // We're already past the policy gate, so this
-                // snapshot would otherwise run its scripts — but if
-                // the prefetch surfaced a matching side-effects-cache
-                // entry, the build is already represented on disk
-                // (pnpm seeded it on a previous install) and we
-                // can skip.
-                if side_effects_cache
-                    && let Some(maps_by_snapshot) = side_effects_maps_by_snapshot
-                    && let Some(maps) = maps_by_snapshot.get(&snapshot_key)
-                    && let Some(graph) = dep_graph.as_ref()
-                    && let Some(engine) = engine_name
-                {
-                    let cache_key = pacquet_graph_hasher::calc_dep_state(
+                // Compute the side-effects cache key once per
+                // snapshot, before the `is_built` gate. The same
+                // value is later consumed by the WRITE-path upload
+                // call after `run_postinstall_hooks` succeeds, so
+                // recomputing it there would just duplicate work —
+                // `deps_state_cache` makes the second call free
+                // anyway, but routing through one `let` keeps the
+                // gate-side and write-side keys provably identical.
+                //
+                // `None` when the cache gate can't fire (no engine,
+                // no graph, etc.); both downstream consumers
+                // short-circuit on `None`.
+                let cache_key = (dep_graph.as_ref().zip(engine_name)).map(|(graph, engine)| {
+                    pacquet_graph_hasher::calc_dep_state(
                         graph,
                         &mut deps_state_cache,
                         &snapshot_key,
@@ -298,16 +296,31 @@ impl<'a> BuildModules<'a> {
                             // `building/during-install/src/index.ts:202`.
                             include_dep_graph_hash: true,
                         },
+                    )
+                });
+
+                // Side-effects-cache `is_built` gate. Mirrors
+                // upstream's `!node.isBuilt` filter at
+                // <https://github.com/pnpm/pnpm/blob/7e3145f9fc/building/during-install/src/index.ts#L73-L77>.
+                // We're already past the policy gate, so this
+                // snapshot would otherwise run its scripts — but if
+                // the prefetch surfaced a matching side-effects-cache
+                // entry, the build is already represented on disk
+                // (pnpm seeded it on a previous install) and we
+                // can skip.
+                if side_effects_cache
+                    && let Some(maps_by_snapshot) = side_effects_maps_by_snapshot
+                    && let Some(maps) = maps_by_snapshot.get(&snapshot_key)
+                    && let Some(key) = cache_key.as_deref()
+                    && maps.contains_key(key)
+                {
+                    tracing::debug!(
+                        target: "pacquet::build",
+                        ?snapshot_key,
+                        cache_key = key,
+                        "side-effects cache hit; skipping build",
                     );
-                    if maps.contains_key(&cache_key) {
-                        tracing::debug!(
-                            target: "pacquet::build",
-                            ?snapshot_key,
-                            cache_key,
-                            "side-effects cache hit; skipping build",
-                        );
-                        continue;
-                    }
+                    continue;
                 }
 
                 let pkg_dir = virtual_store_dir_for_key(virtual_store_dir, &snapshot_key);

--- a/crates/package-manager/src/build_modules.rs
+++ b/crates/package-manager/src/build_modules.rs
@@ -252,8 +252,10 @@ impl<'a> BuildModules<'a> {
         let read_gate_active = side_effects_cache
             && engine_name.is_some()
             && side_effects_maps_by_snapshot.is_some_and(|m| !m.is_empty());
-        let write_gate_active =
-            side_effects_cache_write && engine_name.is_some() && store_index_writer.is_some();
+        let write_gate_active = side_effects_cache_write
+            && engine_name.is_some()
+            && store_index_writer.is_some()
+            && store_dir.is_some();
         let cache_gate_active = (read_gate_active || write_gate_active) && packages.is_some();
         let dep_graph = cache_gate_active.then(|| {
             let roots = requires_build_map

--- a/crates/package-manager/src/build_modules.rs
+++ b/crates/package-manager/src/build_modules.rs
@@ -229,36 +229,45 @@ impl<'a> BuildModules<'a> {
         // either the READ side (prefetch surfaced cache rows) or
         // the WRITE side (the install will be populating new
         // cache entries after a successful build). When neither
-        // applies the O(|snapshots|) graph construction is dead
-        // work.
+        // applies the graph construction is dead work.
         //
-        // The WRITE side additionally requires at least one
-        // `requires_build` snapshot, because the upload site is
-        // gated on that bit per-snapshot — a pure-JS install
-        // with no postinstalls / no `binding.gyp` produces zero
-        // upload calls regardless of how `side_effects_cache_write`
-        // is set, and walking the graph for that case is dead work
-        // (the cold-install benchmark catches this — see the
-        // pnpm/pacquet#424 review).
+        // The graph is bounded to the *forward closure of
+        // `requires_build` snapshots* via `build_deps_subgraph`.
+        // The upload-site and gate-check loops only ever compute
+        // cache keys for `requires_build` snapshots (the
+        // `continue` at the top of the chunk loop), and
+        // `calc_dep_state` only recurses into a snapshot's own
+        // children, so the closure-bounded graph produces the
+        // exact same cache keys as the full graph for every
+        // root we'll query. Saves the O(|snapshots|) walk for
+        // pure-JS installs without postinstalls (#424 cold-install
+        // benchmark catches the unbounded cost).
         //
         // Mirrors upstream's per-install `DepsStateCache` at
         // <https://github.com/pnpm/pnpm/blob/7e3145f9fc/building/during-install/src/index.ts#L74>.
         // The cache memoizes per-node hash across diamond-shaped
         // subgraphs so the recursive walk stays linear in
-        // |snapshots| even when the same dep is reachable through
+        // |closure| even when the same dep is reachable through
         // many parents.
         let read_gate_active = side_effects_cache
             && engine_name.is_some()
             && side_effects_maps_by_snapshot.is_some_and(|m| !m.is_empty());
+        let any_requires_build = requires_build_map.values().any(|&v| v);
         let write_gate_active = side_effects_cache_write
             && engine_name.is_some()
             && store_index_writer.is_some()
-            && requires_build_map.values().any(|&v| v);
-        let cache_gate_active = (read_gate_active || write_gate_active) && packages.is_some();
+            && any_requires_build;
+        let cache_gate_active =
+            (read_gate_active || write_gate_active) && packages.is_some() && any_requires_build;
         let dep_graph = cache_gate_active.then(|| {
-            crate::build_deps_graph(
+            let roots = requires_build_map
+                .iter()
+                .filter(|&(_, &requires_build)| requires_build)
+                .map(|(key, _)| key.clone());
+            crate::build_deps_subgraph(
                 snapshots,
                 packages.expect("`cache_gate_active` requires packages: Some"),
+                roots,
             )
         });
         let mut deps_state_cache: pacquet_graph_hasher::DepsStateCache<PackageKey> =

--- a/crates/package-manager/src/build_modules.rs
+++ b/crates/package-manager/src/build_modules.rs
@@ -163,6 +163,20 @@ pub struct BuildModules<'a> {
     /// gate is bypassed entirely and every `requires_build`
     /// snapshot runs its scripts.
     pub side_effects_cache: bool,
+    /// Mirrors upstream's `sideEffectsCacheWrite` at
+    /// <https://github.com/pnpm/pnpm/blob/7e3145f9fc/config/reader/src/index.ts#L615>.
+    /// When `true`, a successful postinstall triggers a re-CAFS of
+    /// the built package directory and a queued mutation of the
+    /// matching `PackageFilesIndex.sideEffects` row.
+    pub side_effects_cache_write: bool,
+    /// Store-dir handle for the WRITE path's `add_files_from_dir`
+    /// call. `None` short-circuits the upload site entirely — used
+    /// by unit tests that don't set up a CAFS.
+    pub store_dir: Option<&'a pacquet_store_dir::StoreDir>,
+    /// Shared batched writer for the side-effects upload's
+    /// read-modify-write of the existing `PackageFilesIndex` row.
+    /// `None` short-circuits the upload site.
+    pub store_index_writer: Option<&'a std::sync::Arc<pacquet_store_dir::StoreIndexWriter>>,
 }
 
 impl<'a> BuildModules<'a> {
@@ -184,6 +198,9 @@ impl<'a> BuildModules<'a> {
             side_effects_maps_by_snapshot,
             engine_name,
             side_effects_cache,
+            side_effects_cache_write,
+            store_dir,
+            store_index_writer,
         } = self;
 
         let Some(snapshots) = snapshots else { return Ok(Vec::new()) };
@@ -208,23 +225,25 @@ impl<'a> BuildModules<'a> {
             .collect();
 
         // Build the dep graph + state cache only when the
-        // side-effects-cache gate has a chance of firing. Otherwise
-        // the O(|snapshots|) graph construction is dead work — when
-        // `config.side_effects_cache` is off, or no Node major was
-        // detected, or the prefetch surfaced no cache rows, the
-        // gate below short-circuits before ever consulting the
-        // graph.
+        // side-effects-cache gate has a chance of firing — on
+        // either the READ side (prefetch surfaced cache rows) or
+        // the WRITE side (the install will be populating new
+        // cache entries after a successful build). When neither
+        // applies the O(|snapshots|) graph construction is dead
+        // work.
         //
         // Mirrors upstream's per-install `DepsStateCache` at
-        // <https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/during-install/src/index.ts#L74>.
+        // <https://github.com/pnpm/pnpm/blob/7e3145f9fc/building/during-install/src/index.ts#L74>.
         // The cache memoizes per-node hash across diamond-shaped
         // subgraphs so the recursive walk stays linear in
         // |snapshots| even when the same dep is reachable through
         // many parents.
-        let cache_gate_active = side_effects_cache
+        let read_gate_active = side_effects_cache
             && engine_name.is_some()
-            && side_effects_maps_by_snapshot.is_some_and(|m| !m.is_empty())
-            && packages.is_some();
+            && side_effects_maps_by_snapshot.is_some_and(|m| !m.is_empty());
+        let write_gate_active =
+            side_effects_cache_write && engine_name.is_some() && store_index_writer.is_some();
+        let cache_gate_active = (read_gate_active || write_gate_active) && packages.is_some();
         let dep_graph = cache_gate_active.then(|| {
             crate::build_deps_graph(
                 snapshots,
@@ -376,6 +395,55 @@ impl<'a> BuildModules<'a> {
                         continue;
                     }
                     return Err(BuildModulesError::LifecycleScript(err));
+                }
+
+                // Side-effects-cache WRITE path. Mirrors
+                // `<https://github.com/pnpm/pnpm/blob/7e3145f9fc/building/during-install/src/index.ts#L198-L216>`:
+                // after a successful `run_postinstall_hooks`,
+                // re-hash the package directory and queue a
+                // `PackageFilesIndex.sideEffects[cache_key] = diff`
+                // mutation so a future install can skip the
+                // rebuild.
+                //
+                // Gated on every precondition for a meaningful
+                // upload: write enabled, cache_key composable
+                // (engine + graph present), `packages` map
+                // available for the integrity lookup, and the
+                // metadata row carries an integrity (registry /
+                // tarball resolutions — git / directory have no
+                // integrity and pnpm doesn't cache those either).
+                //
+                // All errors are swallowed with a `tracing::warn!`,
+                // matching upstream's `try { upload } catch (err) {
+                // logger.warn(...) }` at lines 208-215. A failed
+                // upload doesn't fail the install: the next install
+                // re-runs the build.
+                if side_effects_cache_write
+                    && let Some(writer) = store_index_writer
+                    && let Some(store) = store_dir
+                    && let Some(cache_key) = cache_key.as_deref()
+                    && let Some(packages) = packages
+                    && let Some(metadata) = packages.get(&metadata_key)
+                    && let Some(integrity) = metadata.resolution.integrity()
+                {
+                    let files_index_file = pacquet_store_dir::store_index_key(
+                        &integrity.to_string(),
+                        &metadata_key.to_string(),
+                    );
+                    if let Err(err) = pacquet_store_dir::upload(
+                        store,
+                        &pkg_dir,
+                        &files_index_file,
+                        cache_key,
+                        writer,
+                    ) {
+                        tracing::warn!(
+                            target: "pacquet::build",
+                            ?err,
+                            dep_path = %snapshot_key,
+                            "side-effects cache upload failed; build proceeds",
+                        );
+                    }
                 }
             }
         }

--- a/crates/package-manager/src/build_modules.rs
+++ b/crates/package-manager/src/build_modules.rs
@@ -232,6 +232,15 @@ impl<'a> BuildModules<'a> {
         // applies the O(|snapshots|) graph construction is dead
         // work.
         //
+        // The WRITE side additionally requires at least one
+        // `requires_build` snapshot, because the upload site is
+        // gated on that bit per-snapshot — a pure-JS install
+        // with no postinstalls / no `binding.gyp` produces zero
+        // upload calls regardless of how `side_effects_cache_write`
+        // is set, and walking the graph for that case is dead work
+        // (the cold-install benchmark catches this — see the
+        // pnpm/pacquet#424 review).
+        //
         // Mirrors upstream's per-install `DepsStateCache` at
         // <https://github.com/pnpm/pnpm/blob/7e3145f9fc/building/during-install/src/index.ts#L74>.
         // The cache memoizes per-node hash across diamond-shaped
@@ -241,8 +250,10 @@ impl<'a> BuildModules<'a> {
         let read_gate_active = side_effects_cache
             && engine_name.is_some()
             && side_effects_maps_by_snapshot.is_some_and(|m| !m.is_empty());
-        let write_gate_active =
-            side_effects_cache_write && engine_name.is_some() && store_index_writer.is_some();
+        let write_gate_active = side_effects_cache_write
+            && engine_name.is_some()
+            && store_index_writer.is_some()
+            && requires_build_map.values().any(|&v| v);
         let cache_gate_active = (read_gate_active || write_gate_active) && packages.is_some();
         let dep_graph = cache_gate_active.then(|| {
             crate::build_deps_graph(

--- a/crates/package-manager/src/build_modules.rs
+++ b/crates/package-manager/src/build_modules.rs
@@ -228,8 +228,7 @@ impl<'a> BuildModules<'a> {
         // side-effects-cache gate has a chance of firing — on
         // either the READ side (prefetch surfaced cache rows) or
         // the WRITE side (the install will be populating new
-        // cache entries after a successful build). When neither
-        // applies the graph construction is dead work.
+        // cache entries after a successful build).
         //
         // The graph is bounded to the *forward closure of
         // `requires_build` snapshots* via `build_deps_subgraph`.
@@ -239,9 +238,10 @@ impl<'a> BuildModules<'a> {
         // `calc_dep_state` only recurses into a snapshot's own
         // children, so the closure-bounded graph produces the
         // exact same cache keys as the full graph for every
-        // root we'll query. Saves the O(|snapshots|) walk for
-        // pure-JS installs without postinstalls (#424 cold-install
-        // benchmark catches the unbounded cost).
+        // root we'll query. A pure-JS install with no
+        // `requires_build` snapshots feeds in an empty root
+        // iterator and the function returns immediately —
+        // O(0) walk for that path.
         //
         // Mirrors upstream's per-install `DepsStateCache` at
         // <https://github.com/pnpm/pnpm/blob/7e3145f9fc/building/during-install/src/index.ts#L74>.
@@ -252,13 +252,9 @@ impl<'a> BuildModules<'a> {
         let read_gate_active = side_effects_cache
             && engine_name.is_some()
             && side_effects_maps_by_snapshot.is_some_and(|m| !m.is_empty());
-        let any_requires_build = requires_build_map.values().any(|&v| v);
-        let write_gate_active = side_effects_cache_write
-            && engine_name.is_some()
-            && store_index_writer.is_some()
-            && any_requires_build;
-        let cache_gate_active =
-            (read_gate_active || write_gate_active) && packages.is_some() && any_requires_build;
+        let write_gate_active =
+            side_effects_cache_write && engine_name.is_some() && store_index_writer.is_some();
+        let cache_gate_active = (read_gate_active || write_gate_active) && packages.is_some();
         let dep_graph = cache_gate_active.then(|| {
             let roots = requires_build_map
                 .iter()

--- a/crates/package-manager/src/build_modules/tests.rs
+++ b/crates/package-manager/src/build_modules/tests.rs
@@ -909,15 +909,15 @@ async fn write_path_disabled_skips_upload() {
 /// generated file is on disk) but the SQLite row's `side_effects`
 /// stays empty.
 ///
-/// Pacquet has no DI seam to stub `upload`, but we can reach the
-/// same property by handing `BuildModules` a `store_dir` that has
-/// no `index.db` yet. The WRITE-path's `StoreIndex::open_readonly_in`
-/// call returns an error (no `index.db` to read), `upload` surfaces
-/// it as `UploadError::OpenIndex`, `BuildModules` swallows it with
-/// a `tracing::warn!` (matching upstream's `try { … } catch { logger.warn }`),
-/// and the build completes. The postinstall-created file is on disk;
-/// no row has been written so there's nothing to assert "side_effects
-/// stays empty" on — the absence is the assertion.
+/// Pacquet has no DI seam for the upload, but the WRITE path's
+/// only failure point is `add_files_from_dir`, which surfaces as
+/// `UploadError::AddFilesFromDir`. We force that failure by having
+/// the postinstall script create a 0-permission file in the
+/// package directory: `add_files_from_dir` then fails to `fs::read`
+/// it, returning an error that `BuildModules` swallows with
+/// `tracing::warn!` (matching upstream's `try { … } catch { logger.warn }`).
+/// The install completes, the postinstall-generated artifact is on
+/// disk, and the build keeps going.
 #[cfg(unix)]
 #[tokio::test(flavor = "current_thread")]
 async fn upload_error_does_not_interrupt_install() {
@@ -950,16 +950,17 @@ async fn upload_error_does_not_interrupt_install() {
     let importers = root_importers(&[("@pnpm/postinstall-modifies-source", "1.0.0")]);
     let policy = AllowBuildPolicy::new(rules([]), true);
 
-    // Crucially: we do NOT call `store_dir.init()` and we do NOT
-    // seed an index row. The WRITE path's `StoreIndex::open_readonly_in`
-    // will fail because the file doesn't exist.
     let store_root = tempdir().expect("create store dir");
     let store_dir = StoreDir::from(store_root.path().to_path_buf());
+    store_dir.init().expect("init store");
     let virtual_store_dir = tempdir().expect("create vstore dir");
     let modules_dir = tempdir().expect("create modules dir");
     let lockfile_dir = tempdir().expect("create lockfile dir");
 
-    let pkg_dir = create_postinstall_modifies_source_fixture(virtual_store_dir.path(), &pkg_key);
+    // Fixture variant: postinstall produces a regular file (to
+    // prove the script ran end-to-end) AND a 0-permission file
+    // (to force `add_files_from_dir` to fail on `fs::read`).
+    let pkg_dir = create_postinstall_with_unreadable_fixture(virtual_store_dir.path(), &pkg_key);
     let (writer, writer_task) = StoreIndexWriter::spawn(&store_dir);
 
     BuildModules {
@@ -990,6 +991,43 @@ async fn upload_error_does_not_interrupt_install() {
         pkg_dir.join("generated.txt").exists(),
         "postinstall-created file must be present after a swallowed upload failure",
     );
+
+    // Restore perms so the tempdir cleanup can remove the file.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(pkg_dir.join("unreadable"), fs::Permissions::from_mode(0o644));
+    }
+}
+
+/// Variant of `create_postinstall_modifies_source_fixture` whose
+/// postinstall additionally produces a 0-permission file. The
+/// WRITE-path walker (`add_files_from_dir`) then fails on
+/// `fs::read("unreadable")` with `EACCES`, surfacing as
+/// `UploadError::AddFilesFromDir(ReadFile { … })` — a real upload
+/// error that `BuildModules` must swallow.
+#[cfg(unix)]
+fn create_postinstall_with_unreadable_fixture(
+    virtual_store_dir: &Path,
+    key: &PackageKey,
+) -> PathBuf {
+    let key_str = key.without_peer().to_string();
+    let name_version = key_str.strip_prefix('/').unwrap_or(&key_str);
+    let at_idx = name_version.rfind('@').unwrap_or(name_version.len());
+    let pkg_name = &name_version[..at_idx];
+    let store_name = name_version.replace('/', "+");
+    let pkg_dir = virtual_store_dir.join(&store_name).join("node_modules").join(pkg_name);
+    fs::create_dir_all(&pkg_dir).expect("create pkg dir");
+    fs::write(pkg_dir.join("index.js"), "module.exports = 'hi'\n").expect("write index.js");
+    let manifest = serde_json::json!({
+        "name": pkg_name,
+        "version": name_version[at_idx + 1..].to_string(),
+        "scripts": {
+            "postinstall": "echo touched > generated.txt && : > unreadable && chmod 000 unreadable"
+        },
+    });
+    fs::write(pkg_dir.join("package.json"), manifest.to_string()).expect("write manifest");
+    pkg_dir
 }
 
 /// sha-512 hex helper for fixture-building. Pacquet's `CafsFileInfo`

--- a/crates/package-manager/src/build_modules/tests.rs
+++ b/crates/package-manager/src/build_modules/tests.rs
@@ -214,6 +214,9 @@ fn build_modules_collects_ignored_builds() {
         side_effects_maps_by_snapshot: None,
         engine_name: None,
         side_effects_cache: true,
+        side_effects_cache_write: false,
+        store_dir: None,
+        store_index_writer: None,
     }
     .run::<SilentReporter>()
     .expect("run BuildModules");
@@ -257,6 +260,9 @@ fn build_modules_excludes_explicit_deny_from_ignored() {
         side_effects_maps_by_snapshot: None,
         engine_name: None,
         side_effects_cache: true,
+        side_effects_cache_write: false,
+        store_dir: None,
+        store_index_writer: None,
     }
     .run::<SilentReporter>()
     .expect("run BuildModules");
@@ -327,6 +333,9 @@ fn do_not_fail_on_optional_dep_with_failing_postinstall() {
         side_effects_maps_by_snapshot: None,
         engine_name: None,
         side_effects_cache: true,
+        side_effects_cache_write: false,
+        store_dir: None,
+        store_index_writer: None,
     }
     .run::<RecordingReporter>()
     .expect("optional build failure must NOT abort the install");
@@ -445,6 +454,9 @@ fn using_side_effects_cache_skips_rebuild() {
         side_effects_maps_by_snapshot: Some(&side_effects_maps),
         engine_name: Some(engine),
         side_effects_cache: true,
+        side_effects_cache_write: false,
+        store_dir: None,
+        store_index_writer: None,
     }
     .run::<RecordingReporter>()
     .expect("install must succeed when the cache hit skips the rebuild");
@@ -498,6 +510,9 @@ fn side_effects_cache_disabled_bypasses_the_gate() {
         side_effects_maps_by_snapshot: Some(&side_effects_maps),
         engine_name: Some("darwin;arm64;node20"),
         side_effects_cache: false,
+        side_effects_cache_write: false,
+        store_dir: None,
+        store_index_writer: None,
     }
     .run::<SilentReporter>()
     .expect_err("with cache disabled, the failing postinstall must run and the install must fail");
@@ -544,6 +559,9 @@ fn fail_when_failing_postinstall_is_required() {
         side_effects_maps_by_snapshot: None,
         engine_name: None,
         side_effects_cache: true,
+        side_effects_cache_write: false,
+        store_dir: None,
+        store_index_writer: None,
     }
     .run::<SilentReporter>()
     .expect_err("required build failure must propagate");
@@ -609,4 +627,286 @@ fn ignored_scripts_event_carries_returned_names() {
         ),
         "captured: {captured:?}",
     );
+}
+
+/// Materialize a package fixture whose postinstall touches a
+/// marker file. After the script runs, the package directory has
+/// a file (`generated.txt`) that the original tarball didn't, so
+/// the WRITE-path diff produces a non-empty `added` entry under
+/// the snapshot's cache key.
+#[cfg(unix)]
+fn create_postinstall_modifies_source_fixture(
+    virtual_store_dir: &Path,
+    key: &PackageKey,
+) -> PathBuf {
+    let key_str = key.without_peer().to_string();
+    let name_version = key_str.strip_prefix('/').unwrap_or(&key_str);
+    let at_idx = name_version.rfind('@').unwrap_or(name_version.len());
+    let pkg_name = &name_version[..at_idx];
+    let store_name = name_version.replace('/', "+");
+    let pkg_dir = virtual_store_dir.join(&store_name).join("node_modules").join(pkg_name);
+    fs::create_dir_all(&pkg_dir).expect("create pkg dir");
+    // Bake the pristine `index.js` into the directory before the
+    // postinstall runs. The WRITE-path diff compares the
+    // post-build directory against the pre-seeded `files` map,
+    // so this file must appear in both — the postinstall only
+    // adds `generated.txt` on top.
+    fs::write(pkg_dir.join("index.js"), "module.exports = 'hi'\n").expect("write index.js");
+    let manifest = serde_json::json!({
+        "name": pkg_name,
+        "version": name_version[at_idx + 1..].to_string(),
+        "scripts": { "postinstall": "echo touched > generated.txt" },
+    });
+    fs::write(pkg_dir.join("package.json"), manifest.to_string()).expect("write manifest");
+    pkg_dir
+}
+
+/// Mirrors upstream's `'a postinstall script does not modify the
+/// original sources added to the store'` at
+/// <https://github.com/pnpm/pnpm/blob/7e3145f9fc/installing/deps-installer/test/install/sideEffects.ts#L189-L223>.
+///
+/// After a successful postinstall, `BuildModules` re-CAFS the
+/// built directory, diffs against the pristine `PackageFilesIndex.files`
+/// row pre-seeded in the store, and queues a mutation so the row's
+/// `side_effects[cache_key]` carries the post-build files that
+/// differ from the base. The base CAS blob is left untouched — the
+/// digest the store-index row holds for `index.js` matches the
+/// pristine content, not the post-build content.
+///
+/// Unix-gated because the fixture uses `sh -c` semantics for the
+/// `postinstall` script. Windows shell selection is exercised
+/// separately by `pacquet_executor::select_shell`.
+#[cfg(unix)]
+#[tokio::test(flavor = "current_thread")]
+async fn write_path_populates_side_effects_row() {
+    use pacquet_store_dir::{
+        CafsFileInfo, HASH_ALGORITHM, PackageFilesIndex, StoreDir, StoreIndex, StoreIndexWriter,
+        store_index_key,
+    };
+
+    let pkg_key = key("@pnpm/postinstall-modifies-source", "1.0.0");
+    let integrity_str = "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    let snapshots = HashMap::from([(pkg_key.clone(), SnapshotEntry::default())]);
+    let packages: HashMap<pacquet_lockfile::PackageKey, pacquet_lockfile::PackageMetadata> =
+        HashMap::from([(
+            pkg_key.without_peer(),
+            pacquet_lockfile::PackageMetadata {
+                resolution: pacquet_lockfile::LockfileResolution::Registry(
+                    pacquet_lockfile::RegistryResolution {
+                        integrity: integrity_str.parse().expect("parse integrity"),
+                    },
+                ),
+                engines: None,
+                cpu: None,
+                os: None,
+                libc: None,
+                deprecated: None,
+                has_bin: None,
+                prepare: None,
+                bundled_dependencies: None,
+                peer_dependencies: None,
+                peer_dependencies_meta: None,
+            },
+        )]);
+    let importers = root_importers(&[("@pnpm/postinstall-modifies-source", "1.0.0")]);
+    let policy = AllowBuildPolicy::new(rules([]), true);
+
+    let store_root = tempdir().expect("create store dir");
+    let store_dir = StoreDir::from(store_root.path().to_path_buf());
+    store_dir.init().expect("init store");
+    let virtual_store_dir = tempdir().expect("create vstore dir");
+    let modules_dir = tempdir().expect("create modules dir");
+    let lockfile_dir = tempdir().expect("create lockfile dir");
+
+    create_postinstall_modifies_source_fixture(virtual_store_dir.path(), &pkg_key);
+
+    // Pre-seed the base PackageFilesIndex row that the WRITE
+    // path will mutate. The base captures only `index.js`; the
+    // postinstall creates `generated.txt` on top, so the diff's
+    // `added` map should have exactly the `generated.txt` entry.
+    let files_index_file = store_index_key(integrity_str, &pkg_key.without_peer().to_string());
+    let mut base_files = HashMap::new();
+    base_files.insert(
+        "index.js".to_string(),
+        CafsFileInfo {
+            // The pristine content's actual digest is irrelevant
+            // for this test — the WRITE path doesn't compare it
+            // against on-disk CAS, just against the post-build
+            // hashes from `add_files_from_dir`. So long as it
+            // matches what `add_files_from_dir` will compute for
+            // `module.exports = 'hi'\n`, the diff for `index.js`
+            // stays empty (= no spurious entry in `added`).
+            digest: sha512_hex(b"module.exports = 'hi'\n"),
+            mode: 0o644,
+            size: b"module.exports = 'hi'\n".len() as u64,
+            checked_at: None,
+        },
+    );
+    let base_row = PackageFilesIndex {
+        manifest: None,
+        requires_build: Some(true),
+        algo: HASH_ALGORITHM.to_string(),
+        files: base_files,
+        side_effects: None,
+    };
+    {
+        let mut index = StoreIndex::open_in(&store_dir).expect("open index for seed");
+        index
+            .set_many(std::iter::once((files_index_file.clone(), base_row)))
+            .expect("seed base row");
+    }
+
+    // Spawn the writer task once we've seeded the base row, so
+    // the seed and the WRITE-path mutation don't race.
+    let (writer, writer_task) = StoreIndexWriter::spawn(&store_dir);
+
+    let engine = "darwin;arm64;node20";
+    let dep_graph = crate::build_deps_graph(&snapshots, &packages);
+    let mut state_cache = pacquet_graph_hasher::DepsStateCache::new();
+    let expected_cache_key = pacquet_graph_hasher::calc_dep_state(
+        &dep_graph,
+        &mut state_cache,
+        &pkg_key,
+        &pacquet_graph_hasher::CalcDepStateOptions {
+            engine_name: engine,
+            patch_file_hash: None,
+            include_dep_graph_hash: true,
+        },
+    );
+
+    BuildModules {
+        virtual_store_dir: virtual_store_dir.path(),
+        modules_dir: modules_dir.path(),
+        lockfile_dir: lockfile_dir.path(),
+        snapshots: Some(&snapshots),
+        packages: Some(&packages),
+        importers: &importers,
+        allow_build_policy: &policy,
+        side_effects_maps_by_snapshot: None,
+        engine_name: Some(engine),
+        side_effects_cache: true,
+        side_effects_cache_write: true,
+        store_dir: Some(&store_dir),
+        store_index_writer: Some(&writer),
+    }
+    .run::<SilentReporter>()
+    .expect("build modules must complete cleanly");
+
+    // Drop our writer handle and wait for the task to flush the
+    // queued WRITE-path mutation before reading the row back.
+    drop(writer);
+    writer_task.await.expect("await writer").expect("writer succeeds");
+
+    let index = StoreIndex::open_readonly_in(&store_dir).expect("open index for read");
+    let row = index.get(&files_index_file).expect("get row").expect("row present");
+    let side_effects = row.side_effects.expect("side_effects populated");
+    let diff = side_effects.get(&expected_cache_key).expect("entry for cache key");
+    let added = diff.added.as_ref().expect("added present");
+    assert!(
+        added.contains_key("generated.txt"),
+        "added map should record the postinstall-created file: {added:?}",
+    );
+    assert!(
+        !added.contains_key("index.js"),
+        "pristine index.js must NOT appear in `added` (its digest matches base): {added:?}",
+    );
+}
+
+/// Counterpart of the WRITE-path test: with `side_effects_cache_write
+/// = false`, the same fixture's row must come out of `BuildModules`
+/// with `side_effects = None`. Mirrors upstream's gate on
+/// `opts.sideEffectsCacheWrite` at `building/during-install/src/index.ts:198`.
+#[cfg(unix)]
+#[tokio::test(flavor = "current_thread")]
+async fn write_path_disabled_skips_upload() {
+    use pacquet_store_dir::{
+        HASH_ALGORITHM, PackageFilesIndex, StoreDir, StoreIndex, StoreIndexWriter, store_index_key,
+    };
+
+    let pkg_key = key("@pnpm/postinstall-modifies-source", "1.0.0");
+    let integrity_str = "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    let snapshots = HashMap::from([(pkg_key.clone(), SnapshotEntry::default())]);
+    let packages: HashMap<pacquet_lockfile::PackageKey, pacquet_lockfile::PackageMetadata> =
+        HashMap::from([(
+            pkg_key.without_peer(),
+            pacquet_lockfile::PackageMetadata {
+                resolution: pacquet_lockfile::LockfileResolution::Registry(
+                    pacquet_lockfile::RegistryResolution {
+                        integrity: integrity_str.parse().expect("parse integrity"),
+                    },
+                ),
+                engines: None,
+                cpu: None,
+                os: None,
+                libc: None,
+                deprecated: None,
+                has_bin: None,
+                prepare: None,
+                bundled_dependencies: None,
+                peer_dependencies: None,
+                peer_dependencies_meta: None,
+            },
+        )]);
+    let importers = root_importers(&[("@pnpm/postinstall-modifies-source", "1.0.0")]);
+    let policy = AllowBuildPolicy::new(rules([]), true);
+
+    let store_root = tempdir().expect("create store dir");
+    let store_dir = StoreDir::from(store_root.path().to_path_buf());
+    store_dir.init().expect("init store");
+    let virtual_store_dir = tempdir().expect("create vstore dir");
+    let modules_dir = tempdir().expect("create modules dir");
+    let lockfile_dir = tempdir().expect("create lockfile dir");
+
+    create_postinstall_modifies_source_fixture(virtual_store_dir.path(), &pkg_key);
+
+    let files_index_file = store_index_key(integrity_str, &pkg_key.without_peer().to_string());
+    let base_row = PackageFilesIndex {
+        manifest: None,
+        requires_build: Some(true),
+        algo: HASH_ALGORITHM.to_string(),
+        files: HashMap::new(),
+        side_effects: None,
+    };
+    {
+        let mut index = StoreIndex::open_in(&store_dir).expect("open index for seed");
+        index
+            .set_many(std::iter::once((files_index_file.clone(), base_row)))
+            .expect("seed base row");
+    }
+    let (writer, writer_task) = StoreIndexWriter::spawn(&store_dir);
+
+    BuildModules {
+        virtual_store_dir: virtual_store_dir.path(),
+        modules_dir: modules_dir.path(),
+        lockfile_dir: lockfile_dir.path(),
+        snapshots: Some(&snapshots),
+        packages: Some(&packages),
+        importers: &importers,
+        allow_build_policy: &policy,
+        side_effects_maps_by_snapshot: None,
+        engine_name: Some("darwin;arm64;node20"),
+        side_effects_cache: true,
+        side_effects_cache_write: false,
+        store_dir: Some(&store_dir),
+        store_index_writer: Some(&writer),
+    }
+    .run::<SilentReporter>()
+    .expect("build modules must complete cleanly");
+
+    drop(writer);
+    writer_task.await.expect("await writer").expect("writer succeeds");
+
+    let index = StoreIndex::open_readonly_in(&store_dir).expect("open index for read");
+    let row = index.get(&files_index_file).expect("get row").expect("row present");
+    assert!(row.side_effects.is_none(), "write disabled must NOT populate side_effects");
+}
+
+/// sha-512 hex helper for fixture-building. Pacquet's `CafsFileInfo`
+/// stores digests as raw hex (no `sha512-` prefix); using the same
+/// shape here keeps the test's pre-seeded base row in lockstep with
+/// what `add_files_from_dir` will compute.
+fn sha512_hex(buf: &[u8]) -> String {
+    use sha2::{Digest, Sha512};
+    let digest = Sha512::digest(buf);
+    format!("{digest:x}")
 }

--- a/crates/package-manager/src/build_modules/tests.rs
+++ b/crates/package-manager/src/build_modules/tests.rs
@@ -921,7 +921,9 @@ async fn write_path_disabled_skips_upload() {
 #[cfg(unix)]
 #[tokio::test(flavor = "current_thread")]
 async fn upload_error_does_not_interrupt_install() {
-    use pacquet_store_dir::{StoreDir, StoreIndexWriter};
+    use pacquet_store_dir::{
+        HASH_ALGORITHM, PackageFilesIndex, StoreDir, StoreIndex, StoreIndexWriter, store_index_key,
+    };
 
     let pkg_key = key("@pnpm/postinstall-modifies-source", "1.0.0");
     let integrity_str = "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
@@ -961,6 +963,26 @@ async fn upload_error_does_not_interrupt_install() {
     // prove the script ran end-to-end) AND a 0-permission file
     // (to force `add_files_from_dir` to fail on `fs::read`).
     let pkg_dir = create_postinstall_with_unreadable_fixture(virtual_store_dir.path(), &pkg_key);
+
+    // Pre-seed a base row so we can assert that the swallowed
+    // upload error leaves the row's `side_effects` field
+    // untouched — matches upstream's `filesIndex2.sideEffects
+    // toBeFalsy()` at sideEffects.ts:186.
+    let files_index_file = store_index_key(integrity_str, &pkg_key.without_peer().to_string());
+    let base_row = PackageFilesIndex {
+        manifest: None,
+        requires_build: Some(true),
+        algo: HASH_ALGORITHM.to_string(),
+        files: HashMap::new(),
+        side_effects: None,
+    };
+    {
+        let mut index = StoreIndex::open_in(&store_dir).expect("open index for seed");
+        index
+            .set_many(std::iter::once((files_index_file.clone(), base_row)))
+            .expect("seed base row");
+    }
+
     let (writer, writer_task) = StoreIndexWriter::spawn(&store_dir);
 
     BuildModules {
@@ -990,6 +1012,18 @@ async fn upload_error_does_not_interrupt_install() {
     assert!(
         pkg_dir.join("generated.txt").exists(),
         "postinstall-created file must be present after a swallowed upload failure",
+    );
+
+    // The base row stays untouched: the `add_files_from_dir`
+    // error fired before `queue_side_effects_upload` ran, so the
+    // writer task never saw a `SideEffectsUpload` for this row.
+    // Mirrors upstream's `filesIndex2.sideEffects toBeFalsy()` at
+    // sideEffects.ts:186.
+    let index = StoreIndex::open_readonly_in(&store_dir).expect("open index for read");
+    let row = index.get(&files_index_file).expect("get row").expect("base row present");
+    assert!(
+        row.side_effects.is_none(),
+        "swallowed upload error must leave `side_effects` unmodified",
     );
 
     // Restore perms so the tempdir cleanup can remove the file.

--- a/crates/package-manager/src/build_modules/tests.rs
+++ b/crates/package-manager/src/build_modules/tests.rs
@@ -901,6 +901,97 @@ async fn write_path_disabled_skips_upload() {
     assert!(row.side_effects.is_none(), "write disabled must NOT populate side_effects");
 }
 
+/// Mirrors upstream's `'uploading errors do not interrupt
+/// installation'` at <https://github.com/pnpm/pnpm/blob/7e3145f9fc/installing/deps-installer/test/install/sideEffects.ts#L166-L186>.
+///
+/// Upstream stubs `opts.storeController.upload` to throw and
+/// asserts the install completes (the postinstall ran, the
+/// generated file is on disk) but the SQLite row's `side_effects`
+/// stays empty.
+///
+/// Pacquet has no DI seam to stub `upload`, but we can reach the
+/// same property by handing `BuildModules` a `store_dir` that has
+/// no `index.db` yet. The WRITE-path's `StoreIndex::open_readonly_in`
+/// call returns an error (no `index.db` to read), `upload` surfaces
+/// it as `UploadError::OpenIndex`, `BuildModules` swallows it with
+/// a `tracing::warn!` (matching upstream's `try { … } catch { logger.warn }`),
+/// and the build completes. The postinstall-created file is on disk;
+/// no row has been written so there's nothing to assert "side_effects
+/// stays empty" on — the absence is the assertion.
+#[cfg(unix)]
+#[tokio::test(flavor = "current_thread")]
+async fn upload_error_does_not_interrupt_install() {
+    use pacquet_store_dir::{StoreDir, StoreIndexWriter};
+
+    let pkg_key = key("@pnpm/postinstall-modifies-source", "1.0.0");
+    let integrity_str = "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    let snapshots = HashMap::from([(pkg_key.clone(), SnapshotEntry::default())]);
+    let packages: HashMap<pacquet_lockfile::PackageKey, pacquet_lockfile::PackageMetadata> =
+        HashMap::from([(
+            pkg_key.without_peer(),
+            pacquet_lockfile::PackageMetadata {
+                resolution: pacquet_lockfile::LockfileResolution::Registry(
+                    pacquet_lockfile::RegistryResolution {
+                        integrity: integrity_str.parse().expect("parse integrity"),
+                    },
+                ),
+                engines: None,
+                cpu: None,
+                os: None,
+                libc: None,
+                deprecated: None,
+                has_bin: None,
+                prepare: None,
+                bundled_dependencies: None,
+                peer_dependencies: None,
+                peer_dependencies_meta: None,
+            },
+        )]);
+    let importers = root_importers(&[("@pnpm/postinstall-modifies-source", "1.0.0")]);
+    let policy = AllowBuildPolicy::new(rules([]), true);
+
+    // Crucially: we do NOT call `store_dir.init()` and we do NOT
+    // seed an index row. The WRITE path's `StoreIndex::open_readonly_in`
+    // will fail because the file doesn't exist.
+    let store_root = tempdir().expect("create store dir");
+    let store_dir = StoreDir::from(store_root.path().to_path_buf());
+    let virtual_store_dir = tempdir().expect("create vstore dir");
+    let modules_dir = tempdir().expect("create modules dir");
+    let lockfile_dir = tempdir().expect("create lockfile dir");
+
+    let pkg_dir = create_postinstall_modifies_source_fixture(virtual_store_dir.path(), &pkg_key);
+    let (writer, writer_task) = StoreIndexWriter::spawn(&store_dir);
+
+    BuildModules {
+        virtual_store_dir: virtual_store_dir.path(),
+        modules_dir: modules_dir.path(),
+        lockfile_dir: lockfile_dir.path(),
+        snapshots: Some(&snapshots),
+        packages: Some(&packages),
+        importers: &importers,
+        allow_build_policy: &policy,
+        side_effects_maps_by_snapshot: None,
+        engine_name: Some("darwin;arm64;node20"),
+        side_effects_cache: true,
+        side_effects_cache_write: true,
+        store_dir: Some(&store_dir),
+        store_index_writer: Some(&writer),
+    }
+    .run::<SilentReporter>()
+    .expect("upload failure must not propagate; install continues");
+
+    drop(writer);
+    writer_task.await.expect("await writer").expect("writer succeeds");
+
+    // The postinstall-generated artifact is on disk — proves the
+    // build ran end-to-end and the swallowed upload error didn't
+    // short-circuit the loop.
+    assert!(
+        pkg_dir.join("generated.txt").exists(),
+        "postinstall-created file must be present after a swallowed upload failure",
+    );
+}
+
 /// sha-512 hex helper for fixture-building. Pacquet's `CafsFileInfo`
 /// stores digests as raw hex (no `sha512-` prefix); using the same
 /// shape here keeps the test's pre-seeded base row in lockstep with

--- a/crates/package-manager/src/create_virtual_store.rs
+++ b/crates/package-manager/src/create_virtual_store.rs
@@ -74,6 +74,11 @@ pub struct CreateVirtualStore<'a> {
     pub logged_methods: &'a AtomicU8,
     /// Install root, threaded into reporter `requester` fields.
     pub requester: &'a str,
+    /// Shared store-index writer for the install. Owned by
+    /// `InstallFrozenLockfile`, threaded down here for the cold-batch
+    /// download path's `InstallPackageBySnapshot` and also reused by
+    /// `BuildModules` for the side-effects-cache WRITE path.
+    pub store_index_writer: &'a std::sync::Arc<StoreIndexWriter>,
 }
 
 /// Error type of [`CreateVirtualStore`].
@@ -110,6 +115,7 @@ impl<'a> CreateVirtualStore<'a> {
             snapshots,
             logged_methods,
             requester,
+            store_index_writer,
         } = self;
 
         let Some(snapshots) = snapshots else {
@@ -199,24 +205,18 @@ impl<'a> CreateVirtualStore<'a> {
             };
         let store_index_ref = store_index.as_ref();
 
-        // Spawn the batched store-index writer. A single `spawn_blocking`
-        // task owns the writable SQLite connection for the whole install;
-        // every successfully extracted tarball just sends a row to it and
-        // the task flushes them in batched transactions. The old per-
-        // tarball `StoreIndex::open` + solo-INSERT pattern dominated
-        // install wall time on slow-metadata filesystems (#263) because
-        // each open is ~15 ms of metadata work on APFS and tokio's
-        // blocking pool grew to 500+ threads to service them.
+        // The batched store-index writer is now owned by the caller
+        // (`InstallFrozenLockfile::run`) so it survives past
+        // `CreateVirtualStore::run` and gets reused by the build
+        // phase's side-effects-cache WRITE path. Pacquet's original
+        // pattern was to spawn it here and drain it before returning,
+        // but the build phase needs to queue rows after the install
+        // path finishes — see pnpm/pnpm@7e3145f9fc:building/during-install/src/index.ts:198-216.
         //
-        // We drop our own copy of the `Arc<StoreIndexWriter>` after the
-        // `try_join_all` below so the channel can close once every tarball
-        // task has dropped its clone; then `.await` on the join handle
-        // waits for the final batch to flush before returning. A writer-
-        // side `JoinError` or open failure is surfaced at `warn!` and
-        // degraded to "no writer" — the install still succeeds, missing
-        // rows just force a re-download on the next install.
-        let (store_index_writer, writer_task) = StoreIndexWriter::spawn(store_dir);
-        let store_index_writer_ref = Some(&store_index_writer);
+        // The cold-batch download path uses the same writer through
+        // `InstallPackageBySnapshot.store_index_writer`, so the design
+        // is unchanged from the writer's perspective.
+        let store_index_writer_ref = Some(store_index_writer);
 
         // Install-scoped `verifiedFilesCache`. One `Arc<DashSet>` lives
         // for the duration of the install; every per-snapshot fetch
@@ -444,24 +444,11 @@ impl<'a> CreateVirtualStore<'a> {
                 .await?;
         }
 
-        // Drop the orchestration's sender so the channel closes once every
-        // per-tarball clone has also dropped; then wait for the writer task
-        // to flush its final batch. Swallow any error with `warn!` — we've
-        // already done the install and cache-miss degradation is fine.
-        drop(store_index_writer);
-        match writer_task.await {
-            Ok(Ok(())) => {}
-            Ok(Err(error)) => tracing::warn!(
-                target: "pacquet::install",
-                ?error,
-                "store-index writer task returned an error; some rows may not be persisted",
-            ),
-            Err(error) => tracing::warn!(
-                target: "pacquet::install",
-                ?error,
-                "store-index writer task panicked; some rows may not be persisted",
-            ),
-        }
+        // The writer is owned by the caller now. They drop their
+        // sender and await the join handle after the build phase
+        // finishes, so the final batch flushes after every queued
+        // row from both the download path and the WRITE-path
+        // upload.
 
         Ok(CreateVirtualStoreOutput { package_manifests, side_effects_maps_by_snapshot })
     }

--- a/crates/package-manager/src/deps_graph.rs
+++ b/crates/package-manager/src/deps_graph.rs
@@ -39,15 +39,70 @@ pub fn build_deps_graph(
 ) -> HashMap<PackageKey, DepsGraphNode<PackageKey>> {
     let mut graph = HashMap::with_capacity(snapshots.len());
     for (snapshot_key, snapshot) in snapshots {
-        let metadata_key = snapshot_key.without_peer();
-        let Some(metadata) = packages.get(&metadata_key) else {
-            continue;
-        };
-        let full_pkg_id = full_pkg_id_for(&metadata_key, &metadata.resolution);
-        let children = build_children(snapshot);
-        graph.insert(snapshot_key.clone(), DepsGraphNode { full_pkg_id, children });
+        if let Some(node) = build_node(snapshot_key, snapshot, packages) {
+            graph.insert(snapshot_key.clone(), node);
+        }
     }
     graph
+}
+
+/// Build the `DepsGraph` for only the forward closure of `roots`
+/// — the union of every snapshot transitively reachable through
+/// `dependencies` + `optional_dependencies` starting from any root.
+///
+/// `BuildModules` uses this for the side-effects cache READ /
+/// WRITE gates so the O(|snapshots|) walk doesn't run on the
+/// pure-JS install case where no snapshot is `requires_build`.
+/// `calc_dep_state` only ever recurses into a node's own
+/// closure, so the bounded graph produces the exact same cache
+/// keys as the full graph for every root — observable behavior
+/// matches [`build_deps_graph`] for the inputs we care about.
+///
+/// Upstream's [`lockfileToDepGraph`](https://github.com/pnpm/pnpm/blob/7e3145f9fc/deps/graph-builder/src/lockfileToDepGraph.ts#L123-L170)
+/// always builds the full graph because its consumers extend
+/// beyond cache hashing (hierarchy + hoisting + direct-deps map +
+/// bin linking). Pacquet only uses the graph for cache hashing
+/// today, so the trimmed walk is sound here — same cache keys,
+/// fewer cycles spent.
+pub fn build_deps_subgraph<I>(
+    snapshots: &HashMap<PackageKey, SnapshotEntry>,
+    packages: &HashMap<PackageKey, PackageMetadata>,
+    roots: I,
+) -> HashMap<PackageKey, DepsGraphNode<PackageKey>>
+where
+    I: IntoIterator<Item = PackageKey>,
+{
+    let mut graph: HashMap<PackageKey, DepsGraphNode<PackageKey>> = HashMap::new();
+    let mut queue: std::collections::VecDeque<PackageKey> = roots.into_iter().collect();
+    while let Some(key) = queue.pop_front() {
+        if graph.contains_key(&key) {
+            continue;
+        }
+        let Some(snapshot) = snapshots.get(&key) else { continue };
+        let Some(node) = build_node(&key, snapshot, packages) else { continue };
+        // Enqueue every child the new node points at. Repeat-enqueues
+        // are cheap — the `graph.contains_key` guard at the top of
+        // the loop discards them.
+        for child_key in node.children.values() {
+            if !graph.contains_key(child_key) {
+                queue.push_back(child_key.clone());
+            }
+        }
+        graph.insert(key, node);
+    }
+    graph
+}
+
+fn build_node(
+    snapshot_key: &PackageKey,
+    snapshot: &SnapshotEntry,
+    packages: &HashMap<PackageKey, PackageMetadata>,
+) -> Option<DepsGraphNode<PackageKey>> {
+    let metadata_key = snapshot_key.without_peer();
+    let metadata = packages.get(&metadata_key)?;
+    let full_pkg_id = full_pkg_id_for(&metadata_key, &metadata.resolution);
+    let children = build_children(snapshot);
+    Some(DepsGraphNode { full_pkg_id, children })
 }
 
 /// Mirrors [`createFullPkgId`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/deps/graph-hasher/src/index.ts#L263-L292).

--- a/crates/package-manager/src/deps_graph/tests.rs
+++ b/crates/package-manager/src/deps_graph/tests.rs
@@ -1,4 +1,4 @@
-use super::build_deps_graph;
+use super::{build_deps_graph, build_deps_subgraph};
 use pacquet_lockfile::{
     LockfileResolution, PackageKey, PackageMetadata, PkgName, PkgVerPeer, RegistryResolution,
     SnapshotDepRef, SnapshotEntry,
@@ -134,4 +134,78 @@ fn snapshot_without_metadata_is_skipped() {
 
     let graph = build_deps_graph(&snapshots, &packages);
     assert!(graph.is_empty(), "orphan snapshot must not produce a graph node");
+}
+
+/// `build_deps_subgraph` with empty roots produces an empty graph
+/// — the pure-JS install case where no snapshot is `requires_build`.
+#[test]
+fn subgraph_with_empty_roots_is_empty() {
+    let parent_key = key("a", "1.0.0");
+    let child_key = key("b", "1.0.0");
+    let deps = HashMap::from([(name("b"), SnapshotDepRef::Plain(ver("1.0.0")))]);
+    let snapshots = HashMap::from([
+        (parent_key, SnapshotEntry { dependencies: Some(deps), ..Default::default() }),
+        (child_key, SnapshotEntry::default()),
+    ]);
+    let packages = HashMap::from([
+        (key("a", "1.0.0"), registry_metadata()),
+        (key("b", "1.0.0"), registry_metadata()),
+    ]);
+
+    let graph = build_deps_subgraph(&snapshots, &packages, std::iter::empty());
+    assert!(graph.is_empty(), "empty roots must produce an empty graph");
+}
+
+/// `build_deps_subgraph` walks the forward closure of each root.
+/// For `a -> b -> c` with `a` as the only root, all three nodes
+/// land in the graph; `d` (unrelated) does not. Mirrors the
+/// `calc_dep_state` recursion's reach.
+#[test]
+fn subgraph_walks_forward_closure() {
+    let a = key("a", "1.0.0");
+    let b = key("b", "1.0.0");
+    let c = key("c", "1.0.0");
+    let d = key("d", "1.0.0"); // unrelated
+    let a_deps = HashMap::from([(name("b"), SnapshotDepRef::Plain(ver("1.0.0")))]);
+    let b_deps = HashMap::from([(name("c"), SnapshotDepRef::Plain(ver("1.0.0")))]);
+    let snapshots = HashMap::from([
+        (a.clone(), SnapshotEntry { dependencies: Some(a_deps), ..Default::default() }),
+        (b.clone(), SnapshotEntry { dependencies: Some(b_deps), ..Default::default() }),
+        (c.clone(), SnapshotEntry::default()),
+        (d.clone(), SnapshotEntry::default()),
+    ]);
+    let packages = HashMap::from([
+        (a.clone(), registry_metadata()),
+        (b.clone(), registry_metadata()),
+        (c.clone(), registry_metadata()),
+        (d.clone(), registry_metadata()),
+    ]);
+
+    let graph = build_deps_subgraph(&snapshots, &packages, std::iter::once(a.clone()));
+    assert!(graph.contains_key(&a));
+    assert!(graph.contains_key(&b), "b is in a's closure");
+    assert!(graph.contains_key(&c), "c is in a's closure via b");
+    assert!(!graph.contains_key(&d), "d is unrelated; must not be included");
+}
+
+/// `build_deps_subgraph` terminates on a dependency cycle —
+/// `a -> b -> a` enqueues `a` and `b` once each, then bails on
+/// re-visits.
+#[test]
+fn subgraph_terminates_on_cycle() {
+    let a = key("a", "1.0.0");
+    let b = key("b", "1.0.0");
+    let a_deps = HashMap::from([(name("b"), SnapshotDepRef::Plain(ver("1.0.0")))]);
+    let b_deps = HashMap::from([(name("a"), SnapshotDepRef::Plain(ver("1.0.0")))]);
+    let snapshots = HashMap::from([
+        (a.clone(), SnapshotEntry { dependencies: Some(a_deps), ..Default::default() }),
+        (b.clone(), SnapshotEntry { dependencies: Some(b_deps), ..Default::default() }),
+    ]);
+    let packages =
+        HashMap::from([(a.clone(), registry_metadata()), (b.clone(), registry_metadata())]);
+
+    let graph = build_deps_subgraph(&snapshots, &packages, std::iter::once(a.clone()));
+    assert_eq!(graph.len(), 2);
+    assert!(graph.contains_key(&a));
+    assert!(graph.contains_key(&b));
 }

--- a/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/crates/package-manager/src/install_frozen_lockfile.rs
@@ -165,7 +165,7 @@ where
             allow_build_policy: &allow_build_policy,
             side_effects_maps_by_snapshot: Some(&side_effects_maps_by_snapshot),
             engine_name: engine_name.as_deref(),
-            side_effects_cache: config.side_effects_cache,
+            side_effects_cache: config.side_effects_cache_read(),
             side_effects_cache_write: config.side_effects_cache_write(),
             store_dir: Some(&config.store_dir),
             store_index_writer: Some(&store_index_writer),

--- a/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/crates/package-manager/src/install_frozen_lockfile.rs
@@ -152,6 +152,12 @@ where
             side_effects_maps_by_snapshot: Some(&side_effects_maps_by_snapshot),
             engine_name: engine_name.as_deref(),
             side_effects_cache: config.side_effects_cache,
+            side_effects_cache_write: config.side_effects_cache_write(),
+            // Threading the actual `StoreDir` + `StoreIndexWriter`
+            // here lands in the follow-up commit that hoists the
+            // writer out of `CreateVirtualStore`.
+            store_dir: None,
+            store_index_writer: None,
         }
         .run::<R>()
         .map_err(InstallFrozenLockfileError::BuildModules)?;

--- a/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/crates/package-manager/src/install_frozen_lockfile.rs
@@ -10,6 +10,7 @@ use pacquet_lockfile::{PackageKey, PackageMetadata, ProjectSnapshot, SnapshotEnt
 use pacquet_network::ThrottledClient;
 use pacquet_package_manifest::DependencyGroup;
 use pacquet_reporter::{IgnoredScriptsLog, LogEvent, LogLevel, Reporter, Stage, StageLog};
+use pacquet_store_dir::StoreIndexWriter;
 use std::{collections::HashMap, path::Path, sync::atomic::AtomicU8};
 
 /// This subroutine installs dependencies from a frozen lockfile.
@@ -74,6 +75,18 @@ where
 
         // TODO: check if the lockfile is out-of-date
 
+        // Spawn the batched store-index writer here so it lives
+        // across both the prefetch/download phase (consumers in
+        // `CreateVirtualStore`) and the build phase (the new
+        // side-effects-cache WRITE-path upload site in
+        // `BuildModules`). We drop the orchestrator's clone and
+        // await the join handle at the end of `run`, so the final
+        // batch flushes once every queued row from both phases has
+        // been processed. A writer open / task failure is degraded
+        // to a `warn!` and the install still succeeds — pacquet's
+        // existing best-effort stance on cache writes.
+        let (store_index_writer, writer_task) = StoreIndexWriter::spawn(&config.store_dir);
+
         let CreateVirtualStoreOutput { package_manifests, side_effects_maps_by_snapshot } =
             CreateVirtualStore {
                 http_client,
@@ -82,6 +95,7 @@ where
                 snapshots,
                 logged_methods,
                 requester,
+                store_index_writer: &store_index_writer,
             }
             .run::<R>()
             .await
@@ -153,11 +167,8 @@ where
             engine_name: engine_name.as_deref(),
             side_effects_cache: config.side_effects_cache,
             side_effects_cache_write: config.side_effects_cache_write(),
-            // Threading the actual `StoreDir` + `StoreIndexWriter`
-            // here lands in the follow-up commit that hoists the
-            // writer out of `CreateVirtualStore`.
-            store_dir: None,
-            store_index_writer: None,
+            store_dir: Some(&config.store_dir),
+            store_index_writer: Some(&store_index_writer),
         }
         .run::<R>()
         .map_err(InstallFrozenLockfileError::BuildModules)?;
@@ -170,6 +181,27 @@ where
             level: LogLevel::Debug,
             package_names: ignored_builds,
         }));
+
+        // Drop the orchestrator's clone of the writer so the channel
+        // closes once every per-snapshot clone has also been dropped;
+        // then await the task so the final batch flushes before
+        // returning. Swallow any error with `warn!` — the install is
+        // complete and a missed cache write just forces a re-fetch
+        // on the next install.
+        drop(store_index_writer);
+        match writer_task.await {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => tracing::warn!(
+                target: "pacquet::install",
+                ?error,
+                "store-index writer task returned an error; some rows may not be persisted",
+            ),
+            Err(error) => tracing::warn!(
+                target: "pacquet::install",
+                ?error,
+                "store-index writer task panicked; some rows may not be persisted",
+            ),
+        }
 
         Ok(())
     }

--- a/crates/package-manager/src/install_package_from_registry/tests.rs
+++ b/crates/package-manager/src/install_package_from_registry/tests.rs
@@ -37,6 +37,7 @@ fn create_config(store_dir: &Path, modules_dir: &Path, virtual_store_dir: &Path)
         resolve_peers_from_workspace_root: false,
         verify_store_integrity: true,
         side_effects_cache: true,
+        side_effects_cache_readonly: false,
         fetch_retries: 2,
         fetch_retry_factor: 10,
         fetch_retry_mintimeout: 10_000,

--- a/crates/store-dir/Cargo.toml
+++ b/crates/store-dir/Cargo.toml
@@ -26,7 +26,6 @@ smart-default = { workspace = true }
 ssri          = { workspace = true }
 tokio         = { workspace = true, features = ["sync"] }
 tracing       = { workspace = true }
-walkdir       = { workspace = true }
 
 # Enable `sha2`'s `asm` feature on non-MSVC targets only. The feature
 # activates the `sha2-asm` crate (hand-written `.S` assembly files for

--- a/crates/store-dir/Cargo.toml
+++ b/crates/store-dir/Cargo.toml
@@ -15,6 +15,7 @@ pacquet-fs = { workspace = true }
 
 dashmap       = { workspace = true }
 derive_more   = { workspace = true }
+dunce         = { workspace = true }
 miette        = { workspace = true }
 rmp-serde     = { workspace = true }
 rusqlite      = { workspace = true }
@@ -25,6 +26,7 @@ smart-default = { workspace = true }
 ssri          = { workspace = true }
 tokio         = { workspace = true, features = ["sync"] }
 tracing       = { workspace = true }
+walkdir       = { workspace = true }
 
 # Enable `sha2`'s `asm` feature on non-MSVC targets only. The feature
 # activates the `sha2-asm` crate (hand-written `.S` assembly files for

--- a/crates/store-dir/src/add_files_from_dir.rs
+++ b/crates/store-dir/src/add_files_from_dir.rs
@@ -123,6 +123,14 @@ fn walk(
             .map_err(|source| AddFilesFromDirError::Stat { path: absolute.clone(), source })?;
 
         let mut next_real_dir: Option<PathBuf> = None;
+        // Path to use for the read/stat after this branch:
+        // - regular file or directory: the original entry path.
+        // - symlink to a file: the *resolved* target path. Reading
+        //   from the resolved path closes a TOCTOU where the
+        //   symlink could be retargeted between the containment
+        //   check and the read, otherwise letting us ingest data
+        //   from outside `pkg_root`.
+        let mut read_path = absolute.clone();
         let mut symlink_target_meta: Option<fs::Metadata> = None;
 
         if file_type.is_symlink() {
@@ -143,6 +151,7 @@ fn walk(
                 next_real_dir = Some(real);
             } else {
                 symlink_target_meta = Some(meta);
+                read_path = real;
             }
         } else if file_type.is_dir() {
             next_real_dir = Some(current_real_path.join(&*name));
@@ -160,21 +169,25 @@ fn walk(
                 continue;
             }
             ctx.visited.insert(real_dir.clone());
-            walk(ctx, &absolute, &relative_subpath, &real_dir)?;
+            // Recurse via the resolved directory so a symlinked
+            // sub-directory's contents are walked from the canonical
+            // path. Matches the TOCTOU rationale above for file
+            // reads.
+            walk(ctx, &real_dir, &relative_subpath, &real_dir)?;
             ctx.visited.remove(&real_dir);
             continue;
         }
 
         let meta = match symlink_target_meta {
             Some(m) => m,
-            None => fs::metadata(&absolute)
-                .map_err(|source| AddFilesFromDirError::Stat { path: absolute.clone(), source })?,
+            None => fs::metadata(&read_path)
+                .map_err(|source| AddFilesFromDirError::Stat { path: read_path.clone(), source })?,
         };
         if !meta.is_file() {
             continue;
         }
-        let buffer = fs::read(&absolute)
-            .map_err(|source| AddFilesFromDirError::ReadFile { path: absolute.clone(), source })?;
+        let buffer = fs::read(&read_path)
+            .map_err(|source| AddFilesFromDirError::ReadFile { path: read_path.clone(), source })?;
         let mode = file_mode_from(&meta);
         let executable = is_executable(mode);
         let (_path, hash) = ctx

--- a/crates/store-dir/src/add_files_from_dir.rs
+++ b/crates/store-dir/src/add_files_from_dir.rs
@@ -1,0 +1,213 @@
+//! Re-CAFS an already-extracted package directory: walks the tree,
+//! writes each file into the content-addressed store, and returns
+//! the resulting `path → file metadata` map.
+//!
+//! Ports pnpm's
+//! [`addFilesFromDir`](https://github.com/pnpm/pnpm/blob/7e3145f9fc/store/cafs/src/addFilesFromDir.ts)
+//! and the surrounding worker-side glue at
+//! [`worker/src/start.ts:312-383`](https://github.com/pnpm/pnpm/blob/7e3145f9fc/worker/src/start.ts#L312-L383).
+//! Used by the side-effects-cache WRITE path: after a postinstall
+//! script modifies the package directory, this function rehashes
+//! the directory so [`upload`](crate::upload) can diff it against
+//! the pristine `PackageFilesIndex.files` row and seed the cache.
+
+use crate::{CafsFileInfo, StoreDir, WriteCasFileError};
+use derive_more::{Display, Error};
+use miette::Diagnostic;
+use pacquet_fs::file_mode::is_executable;
+use std::{
+    collections::{HashMap, HashSet},
+    fs, io,
+    path::{Path, PathBuf},
+};
+
+/// Result of [`add_files_from_dir`]. The map's key is the file's
+/// path *relative to `pkg_root`*, with forward-slash separators —
+/// matching upstream's `${relativeDir}/${file.name}` shape so the
+/// resulting `FilesIndex` round-trips through pnpm without
+/// renormalisation.
+#[derive(Debug)]
+pub struct AddedFiles {
+    pub files: HashMap<String, CafsFileInfo>,
+}
+
+/// Error type of [`add_files_from_dir`].
+#[derive(Debug, Display, Error, Diagnostic)]
+#[non_exhaustive]
+pub enum AddFilesFromDirError {
+    #[display("Failed to canonicalize package root {}: {source}", root.display())]
+    CanonicalizeRoot {
+        root: PathBuf,
+        #[error(source)]
+        source: io::Error,
+    },
+    #[display("Failed to read directory {}: {source}", dir.display())]
+    ReadDir {
+        dir: PathBuf,
+        #[error(source)]
+        source: io::Error,
+    },
+    #[display("Failed to stat {}: {source}", path.display())]
+    Stat {
+        path: PathBuf,
+        #[error(source)]
+        source: io::Error,
+    },
+    #[display("Failed to read file {}: {source}", path.display())]
+    ReadFile {
+        path: PathBuf,
+        #[error(source)]
+        source: io::Error,
+    },
+    #[diagnostic(transparent)]
+    WriteCas(#[error(source)] WriteCasFileError),
+}
+
+/// Walk `pkg_root` and write every regular file into `store_dir`'s
+/// CAFS, producing an `AddedFiles { files }` map. Symlinks are
+/// followed only when they resolve inside `pkg_root` (mirrors
+/// upstream's `isSubdir(rootDir, realPath)` containment check at
+/// [`addFilesFromDir.ts:112`](https://github.com/pnpm/pnpm/blob/7e3145f9fc/store/cafs/src/addFilesFromDir.ts#L112));
+/// out-of-root targets are silently skipped. A top-level
+/// `node_modules` directory is skipped unconditionally (upstream's
+/// `includeNodeModules` defaults to `false` and pacquet has no
+/// caller that flips it).
+///
+/// Cycle-safe: traversal carries the set of canonical directory
+/// paths already visited, mirroring upstream's `ctx.visited`.
+pub fn add_files_from_dir(
+    store_dir: &StoreDir,
+    pkg_root: &Path,
+) -> Result<AddedFiles, AddFilesFromDirError> {
+    let canonical_root = dunce::canonicalize(pkg_root).map_err(|source| {
+        AddFilesFromDirError::CanonicalizeRoot { root: pkg_root.to_path_buf(), source }
+    })?;
+    let mut ctx = WalkCtx {
+        files: HashMap::new(),
+        canonical_root: canonical_root.clone(),
+        visited: HashSet::from([canonical_root.clone()]),
+        store_dir,
+    };
+    walk(&mut ctx, pkg_root, "", &canonical_root)?;
+    Ok(AddedFiles { files: ctx.files })
+}
+
+struct WalkCtx<'a> {
+    files: HashMap<String, CafsFileInfo>,
+    canonical_root: PathBuf,
+    visited: HashSet<PathBuf>,
+    store_dir: &'a StoreDir,
+}
+
+fn walk(
+    ctx: &mut WalkCtx<'_>,
+    dir: &Path,
+    relative_dir: &str,
+    current_real_path: &Path,
+) -> Result<(), AddFilesFromDirError> {
+    let entries = fs::read_dir(dir)
+        .map_err(|source| AddFilesFromDirError::ReadDir { dir: dir.to_path_buf(), source })?;
+    for entry in entries {
+        let entry = entry
+            .map_err(|source| AddFilesFromDirError::ReadDir { dir: dir.to_path_buf(), source })?;
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        let relative_subpath = if relative_dir.is_empty() {
+            name.to_string()
+        } else {
+            format!("{relative_dir}/{name}")
+        };
+        let absolute = entry.path();
+        let file_type = entry
+            .file_type()
+            .map_err(|source| AddFilesFromDirError::Stat { path: absolute.clone(), source })?;
+
+        let mut next_real_dir: Option<PathBuf> = None;
+        let mut symlink_target_meta: Option<fs::Metadata> = None;
+
+        if file_type.is_symlink() {
+            // Upstream's `getSymlinkStatIfContained`: realpath the
+            // symlink and validate it resolves inside the package
+            // root. Broken or out-of-root symlinks are skipped
+            // silently.
+            let real = match dunce::canonicalize(&absolute) {
+                Ok(p) => p,
+                Err(_) => continue,
+            };
+            if !real.starts_with(&ctx.canonical_root) {
+                continue;
+            }
+            let meta = fs::metadata(&real)
+                .map_err(|source| AddFilesFromDirError::Stat { path: real.clone(), source })?;
+            if meta.is_dir() {
+                next_real_dir = Some(real);
+            } else {
+                symlink_target_meta = Some(meta);
+            }
+        } else if file_type.is_dir() {
+            next_real_dir = Some(current_real_path.join(&*name));
+        }
+
+        if let Some(real_dir) = next_real_dir {
+            if ctx.visited.contains(&real_dir) {
+                continue;
+            }
+            // Mirror upstream's top-level-only `node_modules` skip
+            // (`relativeDir !== '' || file.name !== 'node_modules'`).
+            // Pacquet's `includeNodeModules` is implicitly `false`
+            // because no caller has needed it yet.
+            if relative_dir.is_empty() && name == "node_modules" {
+                continue;
+            }
+            ctx.visited.insert(real_dir.clone());
+            walk(ctx, &absolute, &relative_subpath, &real_dir)?;
+            ctx.visited.remove(&real_dir);
+            continue;
+        }
+
+        let meta = match symlink_target_meta {
+            Some(m) => m,
+            None => fs::metadata(&absolute)
+                .map_err(|source| AddFilesFromDirError::Stat { path: absolute.clone(), source })?,
+        };
+        if !meta.is_file() {
+            continue;
+        }
+        let buffer = fs::read(&absolute)
+            .map_err(|source| AddFilesFromDirError::ReadFile { path: absolute.clone(), source })?;
+        let mode = file_mode_from(&meta);
+        let executable = is_executable(mode);
+        let (_path, hash) = ctx
+            .store_dir
+            .write_cas_file(&buffer, executable)
+            .map_err(AddFilesFromDirError::WriteCas)?;
+        ctx.files.insert(
+            relative_subpath,
+            CafsFileInfo {
+                digest: format!("{hash:x}"),
+                mode,
+                size: buffer.len() as u64,
+                checked_at: None,
+            },
+        );
+    }
+    Ok(())
+}
+
+/// Return the file mode bits in pnpm's canonical form.
+/// On Unix this is `metadata.mode() & 0o777`; on Windows there is
+/// no analog so a fixed `0o644` is reported (matches what pnpm
+/// itself writes for tarball entries on Windows hosts).
+#[cfg(unix)]
+fn file_mode_from(meta: &fs::Metadata) -> u32 {
+    use std::os::unix::fs::PermissionsExt;
+    meta.permissions().mode() & 0o777
+}
+
+#[cfg(not(unix))]
+fn file_mode_from(_meta: &fs::Metadata) -> u32 {
+    0o644
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/store-dir/src/add_files_from_dir.rs
+++ b/crates/store-dir/src/add_files_from_dir.rs
@@ -73,8 +73,16 @@ pub enum AddFilesFromDirError {
 /// `includeNodeModules` defaults to `false` and pacquet has no
 /// caller that flips it).
 ///
-/// Cycle-safe: traversal carries the set of canonical directory
-/// paths already visited, mirroring upstream's `ctx.visited`.
+/// Cycle-safe: `WalkCtx.visited` is a *recursion-stack* set —
+/// each canonical directory path is inserted when we descend
+/// into it and removed when we return. A symlink pointing back
+/// at an ancestor of the current branch finds the ancestor's
+/// canonical path in `visited` and bails. Mirrors upstream's
+/// [`ctx.visited`](https://github.com/pnpm/pnpm/blob/7e3145f9fc/store/cafs/src/addFilesFromDir.ts#L121-L173)
+/// semantics: same directory can be visited twice if reached
+/// through two distinct paths (e.g. a shared subgraph), but
+/// cycles still terminate because the path-to-root is never
+/// re-entered.
 pub fn add_files_from_dir(
     store_dir: &StoreDir,
     pkg_root: &Path,

--- a/crates/store-dir/src/add_files_from_dir.rs
+++ b/crates/store-dir/src/add_files_from_dir.rs
@@ -8,7 +8,7 @@
 //! [`worker/src/start.ts:312-383`](https://github.com/pnpm/pnpm/blob/7e3145f9fc/worker/src/start.ts#L312-L383).
 //! Used by the side-effects-cache WRITE path: after a postinstall
 //! script modifies the package directory, this function rehashes
-//! the directory so [`upload`](crate::upload) can diff it against
+//! the directory so [`upload`](crate::upload()) can diff it against
 //! the pristine `PackageFilesIndex.files` row and seed the cache.
 
 use crate::{CafsFileInfo, StoreDir, WriteCasFileError};
@@ -21,7 +21,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-/// Result of [`add_files_from_dir`]. The map's key is the file's
+/// Result of [`add_files_from_dir()`]. The map's key is the file's
 /// path *relative to `pkg_root`*, with forward-slash separators —
 /// matching upstream's `${relativeDir}/${file.name}` shape so the
 /// resulting `FilesIndex` round-trips through pnpm without
@@ -31,7 +31,7 @@ pub struct AddedFiles {
     pub files: HashMap<String, CafsFileInfo>,
 }
 
-/// Error type of [`add_files_from_dir`].
+/// Error type of [`add_files_from_dir()`].
 #[derive(Debug, Display, Error, Diagnostic)]
 #[non_exhaustive]
 pub enum AddFilesFromDirError {

--- a/crates/store-dir/src/add_files_from_dir/tests.rs
+++ b/crates/store-dir/src/add_files_from_dir/tests.rs
@@ -164,10 +164,14 @@ fn directory_cycle_terminates() {
 }
 
 /// Walking a missing root surfaces a structured error rather than
-/// silently returning an empty map.
+/// silently returning an empty map. Use a tempdir subpath so the
+/// "missing" assertion works on every platform (Windows would not
+/// guarantee `/this/does/not/exist/anywhere` is missing).
 #[test]
 fn missing_root_errors() {
     let (_tmp, store_dir) = make_store();
-    let err = add_files_from_dir(&store_dir, Path::new("/this/does/not/exist/anywhere"));
+    let parent = tempdir().expect("create tempdir");
+    let missing = parent.path().join("does-not-exist");
+    let err = add_files_from_dir(&store_dir, &missing);
     assert!(matches!(err, Err(AddFilesFromDirError::CanonicalizeRoot { .. })));
 }

--- a/crates/store-dir/src/add_files_from_dir/tests.rs
+++ b/crates/store-dir/src/add_files_from_dir/tests.rs
@@ -1,0 +1,173 @@
+use super::{AddFilesFromDirError, add_files_from_dir};
+use crate::StoreDir;
+use pretty_assertions::assert_eq;
+#[cfg(unix)]
+use std::os::unix::fs as unix_fs;
+use std::{fs, path::Path};
+use tempfile::tempdir;
+
+fn make_store() -> (tempfile::TempDir, StoreDir) {
+    let tmp = tempdir().expect("create temp dir");
+    let store_dir = StoreDir::from(tmp.path().to_path_buf());
+    store_dir.init().expect("init store dir");
+    (tmp, store_dir)
+}
+
+fn write(path: &Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create parent dir");
+    }
+    fs::write(path, contents).expect("write file");
+}
+
+/// A directory with two regular files at the top level lands both
+/// in the returned map under their basenames. The CAFS-side blob
+/// hash matches `Sha512(contents)`.
+#[test]
+fn captures_top_level_files() {
+    let (_tmp, store_dir) = make_store();
+    let pkg_dir = tempdir().expect("create pkg dir");
+    write(&pkg_dir.path().join("index.js"), "console.log('hi')\n");
+    write(&pkg_dir.path().join("package.json"), "{\"name\":\"x\"}\n");
+
+    let added = add_files_from_dir(&store_dir, pkg_dir.path()).expect("walk");
+    let keys: Vec<_> = added.files.keys().cloned().collect();
+    let mut keys = keys;
+    keys.sort();
+    assert_eq!(keys, vec!["index.js".to_string(), "package.json".to_string()]);
+
+    let pkg = added.files.get("package.json").unwrap();
+    assert_eq!(pkg.size, b"{\"name\":\"x\"}\n".len() as u64);
+}
+
+/// Nested files use forward-slash relative paths regardless of
+/// host separator — required so the resulting `FilesIndex`
+/// round-trips through pnpm without renormalisation.
+#[test]
+fn nested_paths_use_forward_slashes() {
+    let (_tmp, store_dir) = make_store();
+    let pkg_dir = tempdir().expect("create pkg dir");
+    write(&pkg_dir.path().join("lib/inner/deep.js"), "deep\n");
+
+    let added = add_files_from_dir(&store_dir, pkg_dir.path()).expect("walk");
+    assert!(added.files.contains_key("lib/inner/deep.js"), "got keys: {:?}", added.files.keys());
+}
+
+/// An executable script (`0o755`) lands in the CAFS as `-exec`.
+/// Reading the same digest back via `cas_file_path_by_mode` with
+/// the recorded mode must resolve to that exact path.
+#[cfg(unix)]
+#[test]
+fn executable_files_get_exec_suffix() {
+    use std::os::unix::fs::PermissionsExt;
+    let (_tmp, store_dir) = make_store();
+    let pkg_dir = tempdir().expect("create pkg dir");
+    let bin = pkg_dir.path().join("bin/run");
+    write(&bin, "#!/bin/sh\necho hi\n");
+    fs::set_permissions(&bin, fs::Permissions::from_mode(0o755)).expect("chmod");
+
+    let added = add_files_from_dir(&store_dir, pkg_dir.path()).expect("walk");
+    let info = added.files.get("bin/run").expect("entry for bin/run");
+    assert_eq!(info.mode & 0o111, 0o111);
+
+    let on_disk = store_dir.cas_file_path_by_mode(&info.digest, info.mode).unwrap();
+    let path_str = on_disk.to_string_lossy();
+    assert!(path_str.ends_with("-exec"), "expected -exec suffix, got `{path_str}`");
+}
+
+/// A top-level `node_modules` directory is silently skipped —
+/// matches upstream's `includeNodeModules` default of `false`.
+#[test]
+fn top_level_node_modules_is_skipped() {
+    let (_tmp, store_dir) = make_store();
+    let pkg_dir = tempdir().expect("create pkg dir");
+    write(&pkg_dir.path().join("index.js"), "x\n");
+    write(&pkg_dir.path().join("node_modules/dep/index.js"), "y\n");
+
+    let added = add_files_from_dir(&store_dir, pkg_dir.path()).expect("walk");
+    let keys: Vec<_> = added.files.keys().cloned().collect();
+    assert_eq!(keys, vec!["index.js".to_string()]);
+}
+
+/// A nested `node_modules` (not at depth 0) is treated like any
+/// other directory and walked. Mirrors upstream's
+/// `relativeDir !== '' || file.name !== 'node_modules'` guard.
+#[test]
+fn nested_node_modules_is_walked() {
+    let (_tmp, store_dir) = make_store();
+    let pkg_dir = tempdir().expect("create pkg dir");
+    write(&pkg_dir.path().join("lib/node_modules/inner.js"), "i\n");
+
+    let added = add_files_from_dir(&store_dir, pkg_dir.path()).expect("walk");
+    assert!(
+        added.files.contains_key("lib/node_modules/inner.js"),
+        "got keys: {:?}",
+        added.files.keys(),
+    );
+}
+
+/// A symlink whose target resolves outside the package root is
+/// dropped. Mirrors upstream's `isSubdir(rootDir, realPath)` check.
+#[cfg(unix)]
+#[test]
+fn symlinks_pointing_outside_root_are_skipped() {
+    let (_tmp, store_dir) = make_store();
+    let outside = tempdir().expect("create outside dir");
+    write(&outside.path().join("secret"), "leaked\n");
+
+    let pkg_dir = tempdir().expect("create pkg dir");
+    write(&pkg_dir.path().join("index.js"), "x\n");
+    unix_fs::symlink(outside.path().join("secret"), pkg_dir.path().join("leak"))
+        .expect("create symlink");
+
+    let added = add_files_from_dir(&store_dir, pkg_dir.path()).expect("walk");
+    let mut keys: Vec<_> = added.files.keys().cloned().collect();
+    keys.sort();
+    assert_eq!(keys, vec!["index.js".to_string()]);
+}
+
+/// A symlink pointing at a sibling file within the same root is
+/// followed and captured under the link's name.
+#[cfg(unix)]
+#[test]
+fn symlinks_within_root_are_followed() {
+    let (_tmp, store_dir) = make_store();
+    let pkg_dir = tempdir().expect("create pkg dir");
+    write(&pkg_dir.path().join("target.js"), "ok\n");
+    unix_fs::symlink("target.js", pkg_dir.path().join("alias.js")).expect("create symlink");
+
+    let added = add_files_from_dir(&store_dir, pkg_dir.path()).expect("walk");
+    let info_target = added.files.get("target.js").expect("target.js");
+    let info_alias = added.files.get("alias.js").expect("alias.js");
+    assert_eq!(
+        info_target.digest, info_alias.digest,
+        "alias must hash to the same digest as its target",
+    );
+}
+
+/// A directory symlink that loops back to a parent must not infinite-
+/// recurse. The `visited` set carrying canonical paths is the defense.
+#[cfg(unix)]
+#[test]
+fn directory_cycle_terminates() {
+    let (_tmp, store_dir) = make_store();
+    let pkg_dir = tempdir().expect("create pkg dir");
+    let sub = pkg_dir.path().join("sub");
+    fs::create_dir_all(&sub).expect("mkdir sub");
+    write(&sub.join("file.txt"), "f\n");
+    unix_fs::symlink("..", sub.join("up")).expect("create dir symlink loop");
+
+    let added = add_files_from_dir(&store_dir, pkg_dir.path()).expect("walk");
+    // Must contain sub/file.txt; absence would be a bug, infinite
+    // recursion would have hung this test.
+    assert!(added.files.contains_key("sub/file.txt"), "got keys: {:?}", added.files.keys());
+}
+
+/// Walking a missing root surfaces a structured error rather than
+/// silently returning an empty map.
+#[test]
+fn missing_root_errors() {
+    let (_tmp, store_dir) = make_store();
+    let err = add_files_from_dir(&store_dir, Path::new("/this/does/not/exist/anywhere"));
+    assert!(matches!(err, Err(AddFilesFromDirError::CanonicalizeRoot { .. })));
+}

--- a/crates/store-dir/src/lib.rs
+++ b/crates/store-dir/src/lib.rs
@@ -1,3 +1,4 @@
+mod add_files_from_dir;
 mod cas_file;
 mod check_pkg_files_integrity;
 mod msgpackr_records;
@@ -5,6 +6,7 @@ mod prune;
 mod store_dir;
 mod store_index;
 
+pub use add_files_from_dir::*;
 pub use cas_file::*;
 pub use check_pkg_files_integrity::*;
 pub use msgpackr_records::*;

--- a/crates/store-dir/src/lib.rs
+++ b/crates/store-dir/src/lib.rs
@@ -5,6 +5,7 @@ mod msgpackr_records;
 mod prune;
 mod store_dir;
 mod store_index;
+mod upload;
 
 pub use add_files_from_dir::*;
 pub use cas_file::*;
@@ -13,3 +14,4 @@ pub use msgpackr_records::*;
 pub use prune::*;
 pub use store_dir::*;
 pub use store_index::*;
+pub use upload::*;

--- a/crates/store-dir/src/msgpackr_records.rs
+++ b/crates/store-dir/src/msgpackr_records.rs
@@ -769,20 +769,40 @@ fn encode_pkg_files_index_value(
     if let Some(manifest) = &idx.manifest {
         encode_json_value(w, state, manifest)?;
     }
+    // Iterate the file map in sorted-key order so the emitted
+    // msgpack bytes are byte-stable across runs. `HashMap`'s
+    // iteration is randomised, which would make every row pacquet
+    // writes appear "changed" on byte-diff even when the logical
+    // content is identical. Sorting here matches what msgpackr-on-
+    // JS effectively delivers via `Object` insertion order on
+    // deterministic input (npm tarballs walk files in directory
+    // order, which is sorted on most filesystems).
     write_map_header(w, idx.files.len());
-    for (name, info) in &idx.files {
+    for (name, info) in sorted_by_key(&idx.files) {
         write_str(w, name);
         encode_cafs_file_info(w, state, info)?;
     }
     if let Some(se) = &idx.side_effects {
         write_map_header(w, se.len());
-        for (platform, diff) in se {
+        for (platform, diff) in sorted_by_key(se) {
             write_str(w, platform);
             encode_side_effects_diff(w, state, diff)?;
         }
     }
 
     Ok(())
+}
+
+/// Sort a `HashMap` by key into a `Vec` of `(key, value)`
+/// references. Used by the msgpackr-records encoder so every map
+/// it writes — `PackageFilesIndex.files`, `…side_effects`,
+/// `SideEffectsDiff.added` — comes out in lexicographic key
+/// order. Without this the row payload depends on
+/// `HashMap`'s randomised iteration and isn't reproducible.
+fn sorted_by_key<V>(map: &HashMap<String, V>) -> Vec<(&String, &V)> {
+    let mut entries: Vec<(&String, &V)> = map.iter().collect();
+    entries.sort_by(|a, b| a.0.cmp(b.0));
+    entries
 }
 
 /// Emit one JSON value as msgpack inside an active records stream.
@@ -941,7 +961,7 @@ fn encode_side_effects_diff(
 
     if let Some(added) = &diff.added {
         write_map_header(w, added.len());
-        for (name, info) in added {
+        for (name, info) in sorted_by_key(added) {
             write_str(w, name);
             encode_cafs_file_info(w, state, info)?;
         }

--- a/crates/store-dir/src/store_index.rs
+++ b/crates/store-dir/src/store_index.rs
@@ -73,7 +73,7 @@ enum WriteMsg {
     /// from SQLite), compute the diff between `current_files` and
     /// the row's `files`, insert `(cache_key → diff)` into
     /// `side_effects`, and re-queue the row. Used by
-    /// [`crate::upload`] to seed the side-effects cache after a
+    /// [`crate::upload()`] to seed the side-effects cache after a
     /// successful postinstall.
     ///
     /// Routing R/M/W through the writer task is the simplest way

--- a/crates/store-dir/src/store_index.rs
+++ b/crates/store-dir/src/store_index.rs
@@ -4,7 +4,7 @@ use miette::Diagnostic;
 use rusqlite::{Connection, OpenFlags};
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     path::{Path, PathBuf},
     sync::{
         Arc, Mutex,
@@ -696,9 +696,16 @@ pub struct PackageFilesIndex {
     /// Map of in-tarball path → CAFS file metadata.
     pub files: HashMap<String, CafsFileInfo>,
 
-    /// Side-effect overlays applied after post-install scripts. Populated by
-    /// the build-side-effects cache; pacquet does not yet write this.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Side-effect overlays applied after post-install scripts. Populated
+    /// by the build-side-effects cache (WRITE path).
+    ///
+    /// Serialized through [`serialize_sorted_map`] so the msgpack
+    /// bytes are stable across runs even though the field's type is
+    /// `HashMap`. Without that, two installs that produce the same
+    /// logical overlay can produce two different row payloads,
+    /// which prevents byte-identical store-index files from being
+    /// reproduced and makes diff-debugging harder.
+    #[serde(skip_serializing_if = "Option::is_none", serialize_with = "serialize_sorted_map_opt")]
     pub side_effects: Option<HashMap<String, SideEffectsDiff>>,
 }
 
@@ -746,13 +753,40 @@ fn serialize_checked_at<S: serde::Serializer>(
 }
 
 /// Value of [`PackageFilesIndex::side_effects`].
+///
+/// `added` round-trips through [`serialize_sorted_map`] so the
+/// msgpack bytes are stable for the same logical overlay — same
+/// rationale as the parent struct's `side_effects` field.
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SideEffectsDiff {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", serialize_with = "serialize_sorted_map_opt")]
     pub added: Option<HashMap<String, CafsFileInfo>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deleted: Option<Vec<String>>,
+}
+
+/// `serialize_with` helper for `Option<HashMap<String, V>>` —
+/// converts the map to a `BTreeMap` (sorted by key) before
+/// emitting. Used on the WRITE-path side-effects fields so the
+/// resulting msgpack payload is byte-stable for the same logical
+/// overlay.
+fn serialize_sorted_map_opt<S, V>(
+    value: &Option<HashMap<String, V>>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+    V: serde::Serialize,
+{
+    use serde::Serialize;
+    match value {
+        Some(map) => {
+            let sorted: BTreeMap<&String, &V> = map.iter().collect();
+            sorted.serialize(serializer)
+        }
+        None => serializer.serialize_none(),
+    }
 }
 
 #[cfg(test)]

--- a/crates/store-dir/src/store_index.rs
+++ b/crates/store-dir/src/store_index.rs
@@ -699,7 +699,7 @@ pub struct PackageFilesIndex {
     /// Side-effect overlays applied after post-install scripts. Populated
     /// by the build-side-effects cache (WRITE path).
     ///
-    /// Serialized through [`serialize_sorted_map`] so the msgpack
+    /// Serialized through `serialize_sorted_map_opt` so the msgpack
     /// bytes are stable across runs even though the field's type is
     /// `HashMap`. Without that, two installs that produce the same
     /// logical overlay can produce two different row payloads,
@@ -754,7 +754,7 @@ fn serialize_checked_at<S: serde::Serializer>(
 
 /// Value of [`PackageFilesIndex::side_effects`].
 ///
-/// `added` round-trips through [`serialize_sorted_map`] so the
+/// `added` round-trips through `serialize_sorted_map_opt` so the
 /// msgpack bytes are stable for the same logical overlay — same
 /// rationale as the parent struct's `side_effects` field.
 #[derive(Debug, PartialEq, Serialize, Deserialize)]

--- a/crates/store-dir/src/store_index.rs
+++ b/crates/store-dir/src/store_index.rs
@@ -48,7 +48,7 @@ pub type SharedReadonlyStoreIndex = Arc<Mutex<StoreIndex>>;
 /// commit fsync across the batch, and leaves tokio's blocking pool alone
 /// (one writer thread, not one per tarball).
 pub struct StoreIndexWriter {
-    tx: tokio::sync::mpsc::UnboundedSender<(String, PackageFilesIndex)>,
+    tx: tokio::sync::mpsc::UnboundedSender<WriteMsg>,
     /// One-shot log guard for the "channel closed" case in [`Self::queue`].
     /// A dead writer (task panicked, [`StoreIndex::open`] failed) means
     /// every subsequent `queue` call fails — without this guard that
@@ -57,6 +57,37 @@ pub struct StoreIndexWriter {
     /// subsequent installs will still observe the missing index rows
     /// and re-download, which is the only actionable signal anyway.
     warn_on_send_failure: AtomicBool,
+}
+
+/// Messages the writer task processes in arrival order. Coalesced
+/// per-`key` inside each batch so multiple mutations to the same
+/// store-index row apply against the same in-memory `PackageFilesIndex`
+/// before the batch's `INSERT OR REPLACE` flush.
+enum WriteMsg {
+    /// Wholesale replace the row at `key`. Used by the prefetch /
+    /// download path that already has the full `PackageFilesIndex`
+    /// in hand.
+    Replace { key: String, value: PackageFilesIndex },
+    /// Read-modify-write the row at `key`: load the existing row
+    /// (from the same writer task's pending state or, on a miss,
+    /// from SQLite), compute the diff between `current_files` and
+    /// the row's `files`, insert `(cache_key → diff)` into
+    /// `side_effects`, and re-queue the row. Used by
+    /// [`crate::upload`] to seed the side-effects cache after a
+    /// successful postinstall.
+    ///
+    /// Routing R/M/W through the writer task is the simplest way
+    /// to make multi-snapshot uploads against the same row
+    /// commutative — every read happens after every previously-
+    /// queued write for the same key (committed in this batch or
+    /// in a prior one). Doing it on the caller thread with a
+    /// readonly handle would let a second upload re-read the
+    /// pre-mutation state and overwrite the first.
+    SideEffectsUpload {
+        key: String,
+        cache_key: String,
+        current_files: HashMap<String, CafsFileInfo>,
+    },
 }
 
 /// Batch cap for [`StoreIndexWriter`]. Big enough that a 1352-snapshot
@@ -90,10 +121,10 @@ impl StoreIndexWriter {
         store_dir: &StoreDir,
     ) -> (Arc<StoreIndexWriter>, tokio::task::JoinHandle<Result<(), StoreIndexError>>) {
         let v11_dir = store_dir.v11();
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<(String, PackageFilesIndex)>();
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<WriteMsg>();
         let handle = tokio::task::spawn_blocking(move || -> Result<(), StoreIndexError> {
             let mut index = StoreIndex::open(&v11_dir)?;
-            let mut batch: Vec<(String, PackageFilesIndex)> = Vec::with_capacity(MAX_BATCH_SIZE);
+            let mut batch: Vec<WriteMsg> = Vec::with_capacity(MAX_BATCH_SIZE);
             while let Some(first) = rx.blocking_recv() {
                 batch.push(first);
                 // Drain whatever else is already queued to maximize batch
@@ -112,7 +143,66 @@ impl StoreIndexWriter {
                         Err(_) => break,
                     }
                 }
-                if let Err(error) = index.set_many(batch.drain(..)) {
+                // Coalesce the batch by key. Multiple writes for the
+                // same store-index row arriving in the same batch get
+                // applied in order against a single in-memory
+                // `PackageFilesIndex` value, which then flushes once.
+                // This is what makes two `SideEffectsUpload`s for the
+                // same row commutative: each builds on the previous
+                // one's mutation rather than re-reading the pre-batch
+                // state from SQLite.
+                let mut pending: HashMap<String, PackageFilesIndex> =
+                    HashMap::with_capacity(batch.len());
+                for msg in batch.drain(..) {
+                    match msg {
+                        WriteMsg::Replace { key, value } => {
+                            pending.insert(key, value);
+                        }
+                        WriteMsg::SideEffectsUpload { key, cache_key, current_files } => {
+                            // Load from this batch's pending state
+                            // first; fall back to SQLite for the row's
+                            // first sighting in this batch.
+                            let mut row = match pending.remove(&key) {
+                                Some(r) => r,
+                                None => match index.get(&key) {
+                                    Ok(Some(r)) => r,
+                                    Ok(None) => {
+                                        tracing::debug!(
+                                            target: "pacquet::store_index",
+                                            key = %key,
+                                            "no base row for side-effects upload; skip",
+                                        );
+                                        continue;
+                                    }
+                                    Err(error) => {
+                                        tracing::warn!(
+                                            target: "pacquet::store_index",
+                                            ?error,
+                                            key = %key,
+                                            "failed to read base row for side-effects upload",
+                                        );
+                                        continue;
+                                    }
+                                },
+                            };
+                            if row.algo != crate::upload::HASH_ALGORITHM {
+                                tracing::warn!(
+                                    target: "pacquet::store_index",
+                                    key = %key,
+                                    row_algo = %row.algo,
+                                    "algo mismatch on base row; skip side-effects upload",
+                                );
+                                continue;
+                            }
+                            let diff = crate::upload::calculate_diff(&row.files, &current_files);
+                            row.side_effects
+                                .get_or_insert_with(HashMap::new)
+                                .insert(cache_key, diff);
+                            pending.insert(key, row);
+                        }
+                    }
+                }
+                if let Err(error) = index.set_many(pending.drain()) {
                     // Drop the batch and keep going. One failed flush
                     // (e.g. a disk-full hiccup) shouldn't silently drop
                     // the rest of the install's entries; the next install
@@ -124,7 +214,6 @@ impl StoreIndexWriter {
                         ?error,
                         "batched store-index write failed; dropping this batch and continuing",
                     );
-                    batch.clear();
                 }
             }
             Ok(())
@@ -143,7 +232,32 @@ impl StoreIndexWriter {
     /// snapshot install that's a thousand identical warnings drowning
     /// out real diagnostics.
     pub fn queue(&self, key: String, value: PackageFilesIndex) {
-        if let Err(error) = self.tx.send((key, value))
+        self.send_msg(WriteMsg::Replace { key, value });
+    }
+
+    /// Queue a side-effects R/M/W: the writer task loads the row,
+    /// computes [`crate::calculate_diff`] against the existing
+    /// `files`, inserts `(cache_key → diff)` into the row's
+    /// `side_effects` map, and re-flushes. Routing this through
+    /// the writer's batch loop is what keeps multiple uploads for
+    /// the same row commutative — see the doc-comment on the
+    /// `WriteMsg::SideEffectsUpload` variant for the rationale.
+    ///
+    /// If no base row exists at `key`, the upload is silently
+    /// skipped (matches upstream's
+    /// [`if (!existingFilesIndex) return`](https://github.com/pnpm/pnpm/blob/7e3145f9fc/worker/src/start.ts#L344-L353)
+    /// bail-out at the same gate).
+    pub fn queue_side_effects_upload(
+        &self,
+        key: String,
+        cache_key: String,
+        current_files: HashMap<String, CafsFileInfo>,
+    ) {
+        self.send_msg(WriteMsg::SideEffectsUpload { key, cache_key, current_files });
+    }
+
+    fn send_msg(&self, msg: WriteMsg) {
+        if let Err(error) = self.tx.send(msg)
             && self.warn_on_send_failure.swap(false, Ordering::Relaxed)
         {
             tracing::warn!(

--- a/crates/store-dir/src/store_index.rs
+++ b/crates/store-dir/src/store_index.rs
@@ -159,13 +159,21 @@ impl StoreIndexWriter {
                             pending.insert(key, value);
                         }
                         WriteMsg::SideEffectsUpload { key, cache_key, current_files } => {
-                            // Load from this batch's pending state
-                            // first; fall back to SQLite for the row's
-                            // first sighting in this batch.
-                            let mut row = match pending.remove(&key) {
-                                Some(r) => r,
-                                None => match index.get(&key) {
-                                    Ok(Some(r)) => r,
+                            // Use a `entry()` flow so the row stays
+                            // in `pending` across every short-circuit
+                            // branch — a same-batch `Replace` for
+                            // this same key still needs to land
+                            // regardless of whether the side-effects
+                            // mutation runs.
+                            use std::collections::hash_map::Entry;
+                            let entry = pending.entry(key.clone());
+                            // `or_insert_with` populates from SQLite
+                            // when this is the row's first sighting
+                            // in the batch.
+                            let row = match entry {
+                                Entry::Occupied(o) => o.into_mut(),
+                                Entry::Vacant(v) => match index.get(&key) {
+                                    Ok(Some(r)) => v.insert(r),
                                     Ok(None) => {
                                         tracing::debug!(
                                             target: "pacquet::store_index",
@@ -192,13 +200,15 @@ impl StoreIndexWriter {
                                     row_algo = %row.algo,
                                     "algo mismatch on base row; skip side-effects upload",
                                 );
+                                // Row stays in `pending` for the
+                                // flush — only the side-effects
+                                // mutation is suppressed.
                                 continue;
                             }
                             let diff = crate::upload::calculate_diff(&row.files, &current_files);
                             row.side_effects
                                 .get_or_insert_with(HashMap::new)
                                 .insert(cache_key, diff);
-                            pending.insert(key, row);
                         }
                     }
                 }

--- a/crates/store-dir/src/store_index.rs
+++ b/crates/store-dir/src/store_index.rs
@@ -4,7 +4,7 @@ use miette::Diagnostic;
 use rusqlite::{Connection, OpenFlags};
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::HashMap,
     path::{Path, PathBuf},
     sync::{
         Arc, Mutex,
@@ -154,63 +154,7 @@ impl StoreIndexWriter {
                 let mut pending: HashMap<String, PackageFilesIndex> =
                     HashMap::with_capacity(batch.len());
                 for msg in batch.drain(..) {
-                    match msg {
-                        WriteMsg::Replace { key, value } => {
-                            pending.insert(key, value);
-                        }
-                        WriteMsg::SideEffectsUpload { key, cache_key, current_files } => {
-                            // Use a `entry()` flow so the row stays
-                            // in `pending` across every short-circuit
-                            // branch — a same-batch `Replace` for
-                            // this same key still needs to land
-                            // regardless of whether the side-effects
-                            // mutation runs.
-                            use std::collections::hash_map::Entry;
-                            let entry = pending.entry(key.clone());
-                            // `or_insert_with` populates from SQLite
-                            // when this is the row's first sighting
-                            // in the batch.
-                            let row = match entry {
-                                Entry::Occupied(o) => o.into_mut(),
-                                Entry::Vacant(v) => match index.get(&key) {
-                                    Ok(Some(r)) => v.insert(r),
-                                    Ok(None) => {
-                                        tracing::debug!(
-                                            target: "pacquet::store_index",
-                                            key = %key,
-                                            "no base row for side-effects upload; skip",
-                                        );
-                                        continue;
-                                    }
-                                    Err(error) => {
-                                        tracing::warn!(
-                                            target: "pacquet::store_index",
-                                            ?error,
-                                            key = %key,
-                                            "failed to read base row for side-effects upload",
-                                        );
-                                        continue;
-                                    }
-                                },
-                            };
-                            if row.algo != crate::upload::HASH_ALGORITHM {
-                                tracing::warn!(
-                                    target: "pacquet::store_index",
-                                    key = %key,
-                                    row_algo = %row.algo,
-                                    "algo mismatch on base row; skip side-effects upload",
-                                );
-                                // Row stays in `pending` for the
-                                // flush — only the side-effects
-                                // mutation is suppressed.
-                                continue;
-                            }
-                            let diff = crate::upload::calculate_diff(&row.files, &current_files);
-                            row.side_effects
-                                .get_or_insert_with(HashMap::new)
-                                .insert(cache_key, diff);
-                        }
-                    }
+                    apply_write_msg(&mut index, &mut pending, msg);
                 }
                 if let Err(error) = index.set_many(pending.drain()) {
                     // Drop the batch and keep going. One failed flush
@@ -230,7 +174,87 @@ impl StoreIndexWriter {
         });
         (Arc::new(StoreIndexWriter { tx, warn_on_send_failure: AtomicBool::new(true) }), handle)
     }
+}
 
+/// Fold one queued `WriteMsg` into the batch's in-flight
+/// `pending` map. Pure function on `(&mut StoreIndex, &mut
+/// HashMap, WriteMsg)` so the writer-task closure stays a thin
+/// drain loop; correctness of each variant lives here.
+///
+/// `Replace` is a straight overwrite. `SideEffectsUpload` does
+/// the read-modify-write: it loads the row from `pending` (if a
+/// prior message in this batch already touched it) or from
+/// SQLite, then layers the diff on top. Three short-circuit
+/// branches log and skip without removing the row from
+/// `pending`, so a same-batch `Replace` for the same key still
+/// flushes — see the docs on
+/// [`WriteMsg::SideEffectsUpload`].
+fn apply_write_msg(
+    index: &mut StoreIndex,
+    pending: &mut HashMap<String, PackageFilesIndex>,
+    msg: WriteMsg,
+) {
+    match msg {
+        WriteMsg::Replace { key, value } => {
+            pending.insert(key, value);
+        }
+        WriteMsg::SideEffectsUpload { key, cache_key, current_files } => {
+            let Some(row) = load_pending_row(index, pending, &key) else { return };
+            if row.algo != crate::upload::HASH_ALGORITHM {
+                tracing::warn!(
+                    target: "pacquet::store_index",
+                    key = %key,
+                    row_algo = %row.algo,
+                    "algo mismatch on base row; skip side-effects upload",
+                );
+                // Row stays in `pending` for the flush — only
+                // the side-effects mutation is suppressed.
+                return;
+            }
+            let diff = crate::upload::calculate_diff(&row.files, &current_files);
+            row.side_effects.get_or_insert_with(HashMap::new).insert(cache_key, diff);
+        }
+    }
+}
+
+/// Return a mutable reference to the `PackageFilesIndex` row for
+/// `key`, loading from SQLite when this is the row's first
+/// sighting in the batch. Returns `None` (and logs at `debug!` /
+/// `warn!` as appropriate) when no base row exists or the SQLite
+/// read fails — both cases mean the caller should skip the
+/// side-effects mutation without disturbing `pending`.
+fn load_pending_row<'a>(
+    index: &mut StoreIndex,
+    pending: &'a mut HashMap<String, PackageFilesIndex>,
+    key: &str,
+) -> Option<&'a mut PackageFilesIndex> {
+    use std::collections::hash_map::Entry;
+    match pending.entry(key.to_string()) {
+        Entry::Occupied(o) => Some(o.into_mut()),
+        Entry::Vacant(v) => match index.get(key) {
+            Ok(Some(r)) => Some(v.insert(r)),
+            Ok(None) => {
+                tracing::debug!(
+                    target: "pacquet::store_index",
+                    key = %key,
+                    "no base row for side-effects upload; skip",
+                );
+                None
+            }
+            Err(error) => {
+                tracing::warn!(
+                    target: "pacquet::store_index",
+                    ?error,
+                    key = %key,
+                    "failed to read base row for side-effects upload",
+                );
+                None
+            }
+        },
+    }
+}
+
+impl StoreIndexWriter {
     /// Queue one `(key, value)` to be flushed in the next transaction.
     ///
     /// Silently drops the entry if the writer task has exited (closed
@@ -709,13 +733,15 @@ pub struct PackageFilesIndex {
     /// Side-effect overlays applied after post-install scripts. Populated
     /// by the build-side-effects cache (WRITE path).
     ///
-    /// Serialized through `serialize_sorted_map_opt` so the msgpack
-    /// bytes are stable across runs even though the field's type is
-    /// `HashMap`. Without that, two installs that produce the same
-    /// logical overlay can produce two different row payloads,
-    /// which prevents byte-identical store-index files from being
-    /// reproduced and makes diff-debugging harder.
-    #[serde(skip_serializing_if = "Option::is_none", serialize_with = "serialize_sorted_map_opt")]
+    /// Pacquet's on-disk byte stability for this field comes from
+    /// the msgpackr-records encoder
+    /// (`crate::msgpackr_records::encode_package_files_index`),
+    /// which iterates the map in sorted-key order before emitting.
+    /// The serde `Serialize` impl below is never reached on the
+    /// write path — `StoreIndex::set_many` always routes through
+    /// the bespoke encoder — but is kept for the read path's
+    /// round-trip through `rmp_serde::from_slice`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub side_effects: Option<HashMap<String, SideEffectsDiff>>,
 }
 
@@ -764,39 +790,17 @@ fn serialize_checked_at<S: serde::Serializer>(
 
 /// Value of [`PackageFilesIndex::side_effects`].
 ///
-/// `added` round-trips through `serialize_sorted_map_opt` so the
-/// msgpack bytes are stable for the same logical overlay — same
-/// rationale as the parent struct's `side_effects` field.
+/// Byte stability of the `added` field on the wire is provided by
+/// the bespoke encoder in `msgpackr_records.rs` (it iterates the
+/// map in sorted-key order). The derived serde `Serialize` impl
+/// is unused on the write path.
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SideEffectsDiff {
-    #[serde(skip_serializing_if = "Option::is_none", serialize_with = "serialize_sorted_map_opt")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub added: Option<HashMap<String, CafsFileInfo>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deleted: Option<Vec<String>>,
-}
-
-/// `serialize_with` helper for `Option<HashMap<String, V>>` —
-/// converts the map to a `BTreeMap` (sorted by key) before
-/// emitting. Used on the WRITE-path side-effects fields so the
-/// resulting msgpack payload is byte-stable for the same logical
-/// overlay.
-fn serialize_sorted_map_opt<S, V>(
-    value: &Option<HashMap<String, V>>,
-    serializer: S,
-) -> Result<S::Ok, S::Error>
-where
-    S: serde::Serializer,
-    V: serde::Serialize,
-{
-    use serde::Serialize;
-    match value {
-        Some(map) => {
-            let sorted: BTreeMap<&String, &V> = map.iter().collect();
-            sorted.serialize(serializer)
-        }
-        None => serializer.serialize_none(),
-    }
 }
 
 #[cfg(test)]

--- a/crates/store-dir/src/upload.rs
+++ b/crates/store-dir/src/upload.rs
@@ -9,13 +9,13 @@
 //! [`worker/src/start.ts:312-383`](https://github.com/pnpm/pnpm/blob/7e3145f9fc/worker/src/start.ts#L312-L383).
 
 use crate::{
-    AddFilesFromDirError, CafsFileInfo, SideEffectsDiff, StoreDir, StoreIndex, StoreIndexError,
-    StoreIndexWriter, add_files_from_dir,
+    AddFilesFromDirError, CafsFileInfo, SideEffectsDiff, StoreDir, StoreIndexWriter,
+    add_files_from_dir,
 };
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeSet, HashMap},
     path::Path,
     sync::Arc,
 };
@@ -26,18 +26,6 @@ use std::{
 pub enum UploadError {
     #[diagnostic(transparent)]
     AddFilesFromDir(#[error(source)] AddFilesFromDirError),
-
-    #[diagnostic(transparent)]
-    OpenIndex(#[error(source)] StoreIndexError),
-
-    #[diagnostic(transparent)]
-    ReadIndex(#[error(source)] StoreIndexError),
-
-    #[display(
-        "side-effects cache digest algorithm mismatch: row has {row_algo:?}, want {expected:?}"
-    )]
-    #[diagnostic(code(pacquet_store_dir::upload::algo_mismatch))]
-    AlgoMismatch { row_algo: String, expected: String },
 }
 
 /// Digest algorithm pacquet writes into `PackageFilesIndex.algo`.
@@ -47,27 +35,27 @@ pub enum UploadError {
 /// guard.
 pub const HASH_ALGORITHM: &str = "sha512";
 
-/// Re-hash the built package directory, compute the diff against
-/// the existing `PackageFilesIndex.files`, and re-queue the row
-/// with `side_effects[side_effects_cache_key] = diff`.
+/// Re-hash the built package directory and queue a side-effects
+/// R/M/W against the row at `files_index_file`.
 ///
-/// Behaviour mirrors `pnpm/pnpm@7e3145f9fc:worker/src/start.ts:342-371`:
+/// The actual load-existing → apply-diff → write-back happens
+/// inside the writer task ([`StoreIndexWriter::queue_side_effects_upload`])
+/// so concurrent uploads for the same row stay commutative — a
+/// second upload to the same row builds on the first's mutation
+/// rather than racing against a stale read.
 ///
-/// - If no existing row is found under `files_index_file`, returns
-///   `Ok(())` without writing — upstream's `if (!existingFilesIndex) return`
-///   bail-out. The base row will be populated by some other code path
-///   (or never, if the package was already in CAFS); the next install
-///   re-runs the build.
-/// - If the existing row's `algo` differs from the constant
-///   [`HASH_ALGORITHM`], returns `Err(UploadError::AlgoMismatch)`.
-/// - Otherwise inserts `(side_effects_cache_key → diff)` into the
-///   row's `side_effects` map (creating the map if absent) and
-///   re-queues the row via `writer.queue`.
+/// Behaviour at the writer side mirrors `pnpm/pnpm@7e3145f9fc:worker/src/start.ts:342-371`:
 ///
-/// `requires_build` is left as-is on the existing row.  Upstream
-/// recomputes it from `(manifest, filesMap)` when the field is
-/// `None`; pacquet's row already carries a real value from the
-/// download path so this is a no-op for the typical case.
+/// - No base row at `files_index_file` → silent skip (upstream's
+///   `if (!existingFilesIndex) return`).
+/// - Existing row's `algo` differs from [`HASH_ALGORITHM`] → log
+///   at `warn!` and skip (upstream's `ALGO_MISMATCH` error,
+///   demoted to a warning here because at this point in the
+///   install we've already done the build and the cache write is
+///   best-effort).
+/// - Otherwise the row's `side_effects[side_effects_cache_key] =
+///   diff` is set and the mutated row gets re-queued for the
+///   batch flush.
 pub fn upload(
     store_dir: &StoreDir,
     built_pkg_location: &Path,
@@ -77,31 +65,11 @@ pub fn upload(
 ) -> Result<(), UploadError> {
     let added =
         add_files_from_dir(store_dir, built_pkg_location).map_err(UploadError::AddFilesFromDir)?;
-
-    let index = StoreIndex::open_readonly_in(store_dir).map_err(UploadError::OpenIndex)?;
-    let Some(mut existing) = index.get(files_index_file).map_err(UploadError::ReadIndex)? else {
-        tracing::debug!(
-            target: "pacquet::upload",
-            files_index_file,
-            "no existing package_index row; skipping side-effects upload",
-        );
-        return Ok(());
-    };
-
-    if existing.algo != HASH_ALGORITHM {
-        return Err(UploadError::AlgoMismatch {
-            row_algo: existing.algo.clone(),
-            expected: HASH_ALGORITHM.to_string(),
-        });
-    }
-
-    let diff = calculate_diff(&existing.files, &added.files);
-    existing
-        .side_effects
-        .get_or_insert_with(HashMap::new)
-        .insert(side_effects_cache_key.to_string(), diff);
-
-    writer.queue(files_index_file.to_string(), existing);
+    writer.queue_side_effects_upload(
+        files_index_file.to_string(),
+        side_effects_cache_key.to_string(),
+        added.files,
+    );
     Ok(())
 }
 
@@ -124,7 +92,11 @@ pub fn calculate_diff(
 ) -> SideEffectsDiff {
     let mut added: HashMap<String, CafsFileInfo> = HashMap::new();
     let mut deleted: Vec<String> = Vec::new();
-    let all_files: HashSet<&str> = base.keys().chain(current.keys()).map(String::as_str).collect();
+    // `BTreeSet` so iteration order is deterministic — `deleted`
+    // ends up sorted lexicographically and `added`, while still a
+    // `HashMap`, gets built in a stable order which makes the
+    // resulting msgpack payload byte-stable for the same input.
+    let all_files: BTreeSet<&str> = base.keys().chain(current.keys()).map(String::as_str).collect();
     for file in all_files {
         match (base.get(file), current.get(file)) {
             (Some(_), None) => deleted.push(file.to_string()),

--- a/crates/store-dir/src/upload.rs
+++ b/crates/store-dir/src/upload.rs
@@ -20,7 +20,7 @@ use std::{
     sync::Arc,
 };
 
-/// Error type of [`upload`].
+/// Error type of [`upload()`].
 #[derive(Debug, Display, Error, Diagnostic)]
 #[non_exhaustive]
 pub enum UploadError {
@@ -109,7 +109,7 @@ pub fn upload(
 /// `pnpm/pnpm@7e3145f9fc:worker/src/start.ts:411-434`.
 ///
 /// `base`     — the pristine `PackageFilesIndex.files` map (pre-build).
-/// `current`  — the rehashed map produced by [`add_files_from_dir`].
+/// `current`  — the rehashed map produced by [`add_files_from_dir()`].
 ///
 /// Returns a [`SideEffectsDiff`] whose `added` entry covers files
 /// present in `current` that either don't appear in `base` or whose

--- a/crates/store-dir/src/upload.rs
+++ b/crates/store-dir/src/upload.rs
@@ -1,0 +1,156 @@
+//! WRITE-path orchestrator: re-CAFS a post-build package directory,
+//! diff it against the pristine `PackageFilesIndex.files` row, and
+//! seed the side-effects cache by re-queueing the mutated row through
+//! [`StoreIndexWriter`].
+//!
+//! Ports pnpm's
+//! [`storeController.upload`](https://github.com/pnpm/pnpm/blob/7e3145f9fc/store/controller/src/storeController/index.ts#L90-L99)
+//! and the worker-side body at
+//! [`worker/src/start.ts:312-383`](https://github.com/pnpm/pnpm/blob/7e3145f9fc/worker/src/start.ts#L312-L383).
+
+use crate::{
+    AddFilesFromDirError, CafsFileInfo, SideEffectsDiff, StoreDir, StoreIndex, StoreIndexError,
+    StoreIndexWriter, add_files_from_dir,
+};
+use derive_more::{Display, Error};
+use miette::Diagnostic;
+use std::{
+    collections::{HashMap, HashSet},
+    path::Path,
+    sync::Arc,
+};
+
+/// Error type of [`upload`].
+#[derive(Debug, Display, Error, Diagnostic)]
+#[non_exhaustive]
+pub enum UploadError {
+    #[diagnostic(transparent)]
+    AddFilesFromDir(#[error(source)] AddFilesFromDirError),
+
+    #[diagnostic(transparent)]
+    OpenIndex(#[error(source)] StoreIndexError),
+
+    #[diagnostic(transparent)]
+    ReadIndex(#[error(source)] StoreIndexError),
+
+    #[display(
+        "side-effects cache digest algorithm mismatch: row has {row_algo:?}, want {expected:?}"
+    )]
+    #[diagnostic(code(pacquet_store_dir::upload::algo_mismatch))]
+    AlgoMismatch { row_algo: String, expected: String },
+}
+
+/// Digest algorithm pacquet writes into `PackageFilesIndex.algo`.
+/// Held as a constant so the read-modify-write path can check the
+/// existing row's algorithm before appending a side-effects diff,
+/// matching upstream's [`ALGO_MISMATCH`](https://github.com/pnpm/pnpm/blob/7e3145f9fc/worker/src/start.ts#L358-L364)
+/// guard.
+pub const HASH_ALGORITHM: &str = "sha512";
+
+/// Re-hash the built package directory, compute the diff against
+/// the existing `PackageFilesIndex.files`, and re-queue the row
+/// with `side_effects[side_effects_cache_key] = diff`.
+///
+/// Behaviour mirrors `pnpm/pnpm@7e3145f9fc:worker/src/start.ts:342-371`:
+///
+/// - If no existing row is found under `files_index_file`, returns
+///   `Ok(())` without writing — upstream's `if (!existingFilesIndex) return`
+///   bail-out. The base row will be populated by some other code path
+///   (or never, if the package was already in CAFS); the next install
+///   re-runs the build.
+/// - If the existing row's `algo` differs from the constant
+///   [`HASH_ALGORITHM`], returns `Err(UploadError::AlgoMismatch)`.
+/// - Otherwise inserts `(side_effects_cache_key → diff)` into the
+///   row's `side_effects` map (creating the map if absent) and
+///   re-queues the row via `writer.queue`.
+///
+/// `requires_build` is left as-is on the existing row.  Upstream
+/// recomputes it from `(manifest, filesMap)` when the field is
+/// `None`; pacquet's row already carries a real value from the
+/// download path so this is a no-op for the typical case.
+pub fn upload(
+    store_dir: &StoreDir,
+    built_pkg_location: &Path,
+    files_index_file: &str,
+    side_effects_cache_key: &str,
+    writer: &Arc<StoreIndexWriter>,
+) -> Result<(), UploadError> {
+    let added =
+        add_files_from_dir(store_dir, built_pkg_location).map_err(UploadError::AddFilesFromDir)?;
+
+    let index = StoreIndex::open_readonly_in(store_dir).map_err(UploadError::OpenIndex)?;
+    let Some(mut existing) = index.get(files_index_file).map_err(UploadError::ReadIndex)? else {
+        tracing::debug!(
+            target: "pacquet::upload",
+            files_index_file,
+            "no existing package_index row; skipping side-effects upload",
+        );
+        return Ok(());
+    };
+
+    if existing.algo != HASH_ALGORITHM {
+        return Err(UploadError::AlgoMismatch {
+            row_algo: existing.algo.clone(),
+            expected: HASH_ALGORITHM.to_string(),
+        });
+    }
+
+    let diff = calculate_diff(&existing.files, &added.files);
+    existing
+        .side_effects
+        .get_or_insert_with(HashMap::new)
+        .insert(side_effects_cache_key.to_string(), diff);
+
+    writer.queue(files_index_file.to_string(), existing);
+    Ok(())
+}
+
+/// Set-difference over file digests + modes.  Mirrors
+/// `pnpm/pnpm@7e3145f9fc:worker/src/start.ts:411-434`.
+///
+/// `base`     — the pristine `PackageFilesIndex.files` map (pre-build).
+/// `current`  — the rehashed map produced by [`add_files_from_dir`].
+///
+/// Returns a [`SideEffectsDiff`] whose `added` entry covers files
+/// present in `current` that either don't appear in `base` or whose
+/// `digest`/`mode` differ from the base, and whose `deleted` entry
+/// lists files present in `base` but absent in `current`. Both
+/// fields use `Option<…>` with `skip_serializing_if = is_none`
+/// (see `SideEffectsDiff`), so an empty side of the diff
+/// round-trips through msgpack the same way pnpm's does.
+pub fn calculate_diff(
+    base: &HashMap<String, CafsFileInfo>,
+    current: &HashMap<String, CafsFileInfo>,
+) -> SideEffectsDiff {
+    let mut added: HashMap<String, CafsFileInfo> = HashMap::new();
+    let mut deleted: Vec<String> = Vec::new();
+    let all_files: HashSet<&str> = base.keys().chain(current.keys()).map(String::as_str).collect();
+    for file in all_files {
+        match (base.get(file), current.get(file)) {
+            (Some(_), None) => deleted.push(file.to_string()),
+            (None, Some(now)) => {
+                added.insert(file.to_string(), clone_info(now));
+            }
+            (Some(before), Some(now)) if before.digest != now.digest || before.mode != now.mode => {
+                added.insert(file.to_string(), clone_info(now));
+            }
+            _ => {}
+        }
+    }
+    SideEffectsDiff {
+        added: (!added.is_empty()).then_some(added),
+        deleted: (!deleted.is_empty()).then_some(deleted),
+    }
+}
+
+fn clone_info(info: &CafsFileInfo) -> CafsFileInfo {
+    CafsFileInfo {
+        digest: info.digest.clone(),
+        mode: info.mode,
+        size: info.size,
+        checked_at: info.checked_at,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/store-dir/src/upload.rs
+++ b/crates/store-dir/src/upload.rs
@@ -92,10 +92,12 @@ pub fn calculate_diff(
 ) -> SideEffectsDiff {
     let mut added: HashMap<String, CafsFileInfo> = HashMap::new();
     let mut deleted: Vec<String> = Vec::new();
-    // `BTreeSet` so iteration order is deterministic — `deleted`
-    // ends up sorted lexicographically and `added`, while still a
-    // `HashMap`, gets built in a stable order which makes the
-    // resulting msgpack payload byte-stable for the same input.
+    // `BTreeSet` so iteration order is deterministic. The returned
+    // `deleted` vector ends up sorted lexicographically; byte-
+    // stability of the eventual msgpack payload is provided
+    // separately by `SideEffectsDiff.added`'s sorted-map
+    // serializer (see `serialize_sorted_map_opt` in `store_index.rs`),
+    // since `HashMap` iteration on its own remains unordered.
     let all_files: BTreeSet<&str> = base.keys().chain(current.keys()).map(String::as_str).collect();
     for file in all_files {
         match (base.get(file), current.get(file)) {

--- a/crates/store-dir/src/upload/tests.rs
+++ b/crates/store-dir/src/upload/tests.rs
@@ -1,0 +1,107 @@
+use super::calculate_diff;
+use crate::CafsFileInfo;
+use pretty_assertions::assert_eq;
+use std::collections::HashMap;
+
+fn info(digest: &str, mode: u32, size: u64) -> CafsFileInfo {
+    CafsFileInfo { digest: digest.to_string(), mode, size, checked_at: None }
+}
+
+fn map(entries: &[(&str, CafsFileInfo)]) -> HashMap<String, CafsFileInfo> {
+    entries
+        .iter()
+        .map(|(k, v)| {
+            (
+                (*k).to_string(),
+                CafsFileInfo {
+                    digest: v.digest.clone(),
+                    mode: v.mode,
+                    size: v.size,
+                    checked_at: v.checked_at,
+                },
+            )
+        })
+        .collect()
+}
+
+/// Identical maps produce an empty diff. The `added` and `deleted`
+/// fields stay `None` (not `Some(empty)`) so the msgpack payload
+/// elides them entirely — matches the `if (deleted.length > 0)` /
+/// `if (added.size > 0)` guards upstream.
+#[test]
+fn identical_maps_yield_no_diff() {
+    let m = map(&[("a", info("d-a", 0o644, 1))]);
+    let diff = calculate_diff(&m, &m);
+    assert_eq!(diff.added, None);
+    assert_eq!(diff.deleted, None);
+}
+
+/// New file present only in `current` lands under `added`.
+#[test]
+fn added_only() {
+    let base = HashMap::new();
+    let current = map(&[("new", info("d-new", 0o644, 1))]);
+    let diff = calculate_diff(&base, &current);
+    assert_eq!(diff.deleted, None);
+    let added = diff.added.expect("added present");
+    assert!(added.contains_key("new"));
+}
+
+/// File present in `base` and missing in `current` lands under
+/// `deleted` (file removed by the postinstall).
+#[test]
+fn deleted_only() {
+    let base = map(&[("gone", info("d-gone", 0o644, 1))]);
+    let current = HashMap::new();
+    let diff = calculate_diff(&base, &current);
+    assert_eq!(diff.added, None);
+    let deleted = diff.deleted.expect("deleted present");
+    assert_eq!(deleted, vec!["gone".to_string()]);
+}
+
+/// Digest change at the same path appears under `added`, not `deleted`.
+/// Mirrors the `baseFiles.get(file)!.digest !== sideEffectsFiles.get(file)!.digest`
+/// branch at upstream's calculateDiff:418-421.
+#[test]
+fn digest_change_appears_in_added() {
+    let base = map(&[("f.txt", info("d-old", 0o644, 1))]);
+    let current = map(&[("f.txt", info("d-new", 0o644, 1))]);
+    let diff = calculate_diff(&base, &current);
+    assert_eq!(diff.deleted, None);
+    let added = diff.added.expect("added present");
+    assert_eq!(added.get("f.txt").unwrap().digest, "d-new");
+}
+
+/// Mode change at the same path (and same digest) appears under
+/// `added` — upstream catches this via the `baseFiles.get(file)!.mode
+/// !== sideEffectsFiles.get(file)!.mode` branch.
+#[test]
+fn mode_change_appears_in_added() {
+    let base = map(&[("f.sh", info("d", 0o644, 1))]);
+    let current = map(&[("f.sh", info("d", 0o755, 1))]);
+    let diff = calculate_diff(&base, &current);
+    assert_eq!(diff.deleted, None);
+    let added = diff.added.expect("added present");
+    assert_eq!(added.get("f.sh").unwrap().mode, 0o755);
+}
+
+/// Mixed: one delete, one add, one mod, one unchanged.
+#[test]
+fn mixed_changes() {
+    let base = map(&[
+        ("keep", info("d-keep", 0o644, 1)),
+        ("gone", info("d-gone", 0o644, 1)),
+        ("changed", info("d-old", 0o644, 1)),
+    ]);
+    let current = map(&[
+        ("keep", info("d-keep", 0o644, 1)),
+        ("changed", info("d-new", 0o644, 1)),
+        ("fresh", info("d-fresh", 0o644, 1)),
+    ]);
+    let diff = calculate_diff(&base, &current);
+    let added = diff.added.expect("added present");
+    let mut added_keys: Vec<_> = added.keys().cloned().collect();
+    added_keys.sort();
+    assert_eq!(added_keys, vec!["changed".to_string(), "fresh".to_string()]);
+    assert_eq!(diff.deleted, Some(vec!["gone".to_string()]));
+}


### PR DESCRIPTION
## Summary

Implements slice (B) of #421 — the WRITE path for pnpm's side-effects cache. With this PR, a successful postinstall now re-CAFSes the built package directory, diffs against the pristine `PackageFilesIndex.files` row, and mutates the row's `side_effects` map so a future install (pacquet *or* pnpm) can skip the rebuild via the READ path landed in #423.

User-visible behavior: lifecycle scripts that produce build artifacts (`node-gyp` outputs, generated source files, etc.) get cached the first time the install runs; subsequent installs against the same lockfile + Node major skip the script and reuse the cached overlay.

## What lands

- **`pacquet_store_dir::add_files_from_dir`** — directory walker that re-CAFSes a post-build package directory. Mirrors pnpm/pnpm@`7e3145f9fc`:`store/cafs/src/addFilesFromDir.ts:16-194` + `worker/src/start.ts:312-383`. Containment: `dunce::canonicalize` each symlink target, drop if out of root; read/recurse via the resolved canonical path so retargeting a symlink between containment check and read can't smuggle out-of-root data into CAFS. Skips top-level `node_modules` (matches upstream `includeNodeModules: false`). Cycle-safe via a recursion-stack `visited: HashSet<PathBuf>` (entries inserted on descend, removed on return).
- **`pacquet_store_dir::upload` + `calculate_diff`** — `upload(store_dir, built_pkg_location, files_index_file, cache_key, writer)` walks the package via `add_files_from_dir` and queues a `WriteMsg::SideEffectsUpload { key, cache_key, current_files }` to the writer task. The actual R/M/W of the existing `PackageFilesIndex` row happens inside the writer task (see below), so concurrent uploads to the same row stay commutative.
- **`StoreIndexWriter` now drives a `WriteMsg` enum** (`Replace` vs `SideEffectsUpload`). The batch loop coalesces per-key updates into one `PackageFilesIndex` value before flushing — multiple side-effects uploads for the same row apply in arrival order against a single in-memory state instead of racing against a stale read on a separate readonly handle. The R/M/W (load existing row → check `algo == HASH_ALGORITHM = "sha512"` → `calculate_diff` → insert into `side_effects` map) happens inside the writer's transaction. Loading short-circuits with a `debug!` / `warn!` when the base row is missing or unreadable, matching upstream's `if (!existingFilesIndex) return` / `ALGO_MISMATCH` bail-outs at `pnpm/pnpm@7e3145f9fc:worker/src/start.ts:342-371`.
- **`Config.side_effects_cache_readonly: bool`** (default `false`) — mirrors pnpm's `sideEffectsCacheReadonly`. Two derived helpers consolidate the gate semantics so precedence stays single-sourced:
  - `Config::side_effects_cache_read()` = `cache || readonly`
  - `Config::side_effects_cache_write()` = `cache && !readonly`
- **`BuildModules` WRITE-path call site** — after `run_postinstall_hooks` returns `Ok`, if `side_effects_cache_write` is on and `StoreIndexWriter` + `StoreDir` are both threaded in, calls `pacquet_store_dir::upload(...)` with the snapshot's `store_index_key(integrity, pkg_id)` and the `calc_dep_state` cache key. All upload errors are swallowed with `tracing::warn!`, mirroring upstream's `try { upload } catch { logger.warn }` at `pnpm/pnpm@7e3145f9fc:building/during-install/src/index.ts:208-215`.
- **`build_deps_subgraph`** — the cache-hashing dep graph is now bounded to the forward closure of `requires_build` snapshots. Pure-JS installs feed in an empty root iterator and the function returns immediately; installs with buildable deps walk only what `calc_dep_state` will actually traverse. Upstream's `lockfileToDepGraph` builds the full graph because its consumers extend beyond cache hashing; pacquet's graph is consumed only by `calc_dep_state` today, so the closure-bounded walk produces byte-identical cache keys with strictly less work. Restored the cold-install benchmark to parity with `main`.
- **`StoreIndexWriter` hoisted up to `InstallFrozenLockfile::run`** — previously spawned + drained inside `CreateVirtualStore::run`; now it spans both the prefetch/download phase and the build phase so the WRITE-path upload can queue through it. The final batch flushes after `BuildModules::run` returns.
- **Byte-stable msgpack encoding** — `encode_package_files_index` now iterates `files`, `side_effects`, and `SideEffectsDiff.added` in sorted-key order so two pacquet writes of the same logical row produce identical bytes. Was prompted by a review on PR #424 pointing out that `HashMap` iteration randomization would otherwise make every row look "changed" on byte-diff even when content was identical.
- **`cache_key` refactor in `BuildModules`** — `calc_dep_state` now fires once per snapshot (before the gate check) so both the READ gate and the new WRITE site read the same value.

## Tests

- **`add_files_from_dir::tests`** (9 cases): top-level files, nested forward-slash paths, exec-bit propagation, top-level-vs-nested `node_modules`, symlink-out-of-root drop, symlink-in-root follow, directory-cycle termination, missing-root error.
- **`upload::tests`** (6 cases): identical / added-only / deleted-only / digest change / mode change / mixed — covers every branch of upstream's `calculateDiff`.
- **`deps_graph::tests`** (new for slice B): empty-roots → empty subgraph; forward-closure inclusion + exclusion; cycle termination.
- **`workspace_yaml::tests`**: `sideEffectsCacheReadonly` parses + applies; the 4-state truth table for `side_effects_cache_read()` / `side_effects_cache_write()`.
- **`build_modules::tests`** (new):
  - `write_path_populates_side_effects_row` — full WRITE-path: pre-seed a base row, run a postinstall that creates `generated.txt`, drain the writer task, assert `side_effects[cache_key].added` contains `generated.txt` and NOT pristine `index.js`. Mirrors the spirit of upstream's `'a postinstall script does not modify the original sources added to the store'` at `pnpm/pnpm@7e3145f9fc:sideEffects.ts:189-223`.
  - `write_path_disabled_skips_upload` — same scenario with `side_effects_cache_write: false` → row's `side_effects` stays `None`. Counterpart of upstream's gate on `sideEffectsCacheWrite`.
  - `upload_error_does_not_interrupt_install` — postinstall produces a 0-permission file in the package dir; the walker fails on `fs::read` with `EACCES`, surfacing as `UploadError::AddFilesFromDir(_)` which `BuildModules` swallows with `tracing::warn!`. Asserts (a) the postinstall-created `generated.txt` is on disk and (b) the pre-seeded base row's `side_effects` stays `None`. Mirrors `'uploading errors do not interrupt installation'` at `pnpm/pnpm@7e3145f9fc:sideEffects.ts:166-187`.

## Out of scope

- **Patch-file hash in cache key** — depends on `patchedDependencies` (#397 item 9). Today's WRITE side stamps `patch_file_hash: None`; same as the existing READ side.
- **`requires_build` recompute** in the R/M/W path. Upstream recomputes from `(manifest, filesMap)` when the existing row's field is `None`; pacquet leaves the field as-is (cold-batch downloads already populate it with a real value).
- **GVS / hoisted-node-linker** variants of the upstream tests.

## Test plan

- [x] `just ready` (clippy clean, all tests pass)
- [x] `taplo format --check` (clean — `just ready` doesn't run this, CI does)
- [x] CI green on Linux / macOS / Windows

---
Written by an agent (Claude Code, claude-opus-4-7).