### PR TITLE
feat: apply patchedDependencies before postinstall (#397 item 9)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,7 +387,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -589,6 +589,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
+name = "diffy"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05264ab2aab4fb952fc4b0f3f6eff1ddfb4563064053a4ea174d91537584a769"
+dependencies = [
+ "hashbrown 0.17.0",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -680,7 +689,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -966,6 +975,9 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -2102,6 +2114,7 @@ name = "pacquet-patching"
 version = "0.0.1"
 dependencies = [
  "derive_more",
+ "diffy",
  "indexmap",
  "miette 7.6.0",
  "node-semver",
@@ -2663,7 +2676,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3069,7 +3082,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3652,7 +3665,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ command-extra = { version = "1.0.0" }
 base64 = { version = "0.22.1" }
 dashmap = { version = "6.1.0" }
 derive_more = { version = "2.1.1", features = ["full"] }
+diffy = { version = "0.5.0" }
 dunce = { version = "1.0.5" }
 home = { version = "0.5.12" }
 httpdate = { version = "1.0.3" }

--- a/crates/package-manager/src/build_modules.rs
+++ b/crates/package-manager/src/build_modules.rs
@@ -7,6 +7,7 @@ use pacquet_executor::{
 };
 use pacquet_lockfile::{PackageKey, ProjectSnapshot, SnapshotEntry};
 use pacquet_package_manifest::pkg_requires_build;
+use pacquet_patching::{PatchApplyError, apply_patch_to_dir};
 use pacquet_reporter::{
     LogEvent, LogLevel, Reporter, SkippedOptionalDependencyLog, SkippedOptionalPackage,
     SkippedOptionalReason,
@@ -21,6 +22,23 @@ use std::{
 pub enum BuildModulesError {
     #[diagnostic(transparent)]
     LifecycleScript(#[error(source)] LifecycleScriptError),
+
+    #[diagnostic(transparent)]
+    PatchApply(#[error(source)] PatchApplyError),
+
+    /// Mirrors upstream's
+    /// [`ERR_PNPM_PATCH_FILE_PATH_MISSING`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/during-install/src/index.ts#L172-L176)
+    /// — fired when a snapshot's resolved patch carries a hash but
+    /// no `patch_file_path`. The hash-without-path shape can come
+    /// from the lockfile when no live config provides the path, so
+    /// the user must add an entry to `patchedDependencies` in
+    /// `pnpm-workspace.yaml` to bring the file back into scope.
+    #[display("Cannot apply patch for {dep_path}: patch file path is missing")]
+    #[diagnostic(
+        code(ERR_PNPM_PATCH_FILE_PATH_MISSING),
+        help("Ensure the package is listed in patchedDependencies configuration")
+    )]
+    PatchFilePathMissing { dep_path: String },
 }
 
 /// Build policy derived from `allowBuilds` and
@@ -135,10 +153,16 @@ pub struct BuildModules<'a> {
     /// [`pacquet_patching::get_patch_info`]. `None` when no
     /// `patchedDependencies` is configured.
     ///
-    /// Slice B uses this only for the side-effects-cache key
-    /// (`patch_file_hash` in [`pacquet_graph_hasher::CalcDepStateOptions`]).
-    /// The build trigger and actual patch application land in slice C
-    /// — see pnpm/pacquet#397 item 9.
+    /// Drives three things, mirroring upstream's
+    /// [`during-install`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/during-install/src/index.ts)
+    /// flow:
+    ///
+    /// 1. Build trigger — a snapshot with a patch entry becomes a
+    ///    build candidate even when `requires_build` is false.
+    /// 2. Side-effects-cache key — `patch_file_hash` carries the
+    ///    SHA-256 hex into [`pacquet_graph_hasher::CalcDepStateOptions`].
+    /// 3. Patch application — the patch is applied to the extracted
+    ///    package dir before postinstall hooks run.
     pub patches: Option<&'a HashMap<PackageKey, pacquet_patching::ExtendedPatchInfo>>,
 }
 
@@ -235,7 +259,7 @@ impl<'a> BuildModules<'a> {
         let mut deps_state_cache: pacquet_graph_hasher::DepsStateCache<PackageKey> =
             pacquet_graph_hasher::DepsStateCache::new();
 
-        let chunks = build_sequence(&requires_build_map, snapshots, importers);
+        let chunks = build_sequence(&requires_build_map, patches, snapshots, importers);
 
         // Collect peer-stripped keys so the final list is unique and
         // sorted lexicographically — matches `dedupePackageNamesFromIgnoredBuilds`.
@@ -243,24 +267,55 @@ impl<'a> BuildModules<'a> {
 
         for chunk in chunks {
             for snapshot_key in chunk {
-                // Ancestors-of-build packages are included in the sequence
-                // but only run scripts when they themselves require a build.
-                if !requires_build_map.get(&snapshot_key).copied().unwrap_or(false) {
+                let metadata_key = snapshot_key.without_peer();
+                // Look up against the peer-stripped key because
+                // patches are configured at the (name, version)
+                // granularity in `pnpm-workspace.yaml`, not per
+                // peer-resolution variant.
+                let patch = patches.and_then(|map| map.get(&metadata_key));
+                let has_patch = patch.is_some();
+                let requires_build =
+                    requires_build_map.get(&snapshot_key).copied().unwrap_or(false);
+
+                // Ancestors of a build/patch candidate are included
+                // in the sequence (so the topo order stays correct)
+                // but only run scripts / apply patches when they
+                // themselves are candidates. Mirrors upstream's
+                // chunk filter at
+                // <https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/during-install/src/index.ts#L73-L77>.
+                if !requires_build && !has_patch {
                     continue;
                 }
 
-                let metadata_key = snapshot_key.without_peer();
                 let (name, version) = parse_name_version_from_key(&metadata_key.to_string());
-                match allow_build_policy.check(&name, &version) {
-                    Some(false) => continue,
-                    None => {
-                        // "Not in allowBuilds" — surfaced as `pnpm:ignored-scripts`.
-                        // Explicit `false` is silently skipped (above), matching
-                        // upstream's switch in `building/during-install/src/index.ts:88-101`.
-                        ignored_builds.insert(metadata_key.to_string());
-                        continue;
+
+                // Mirrors upstream's `if (node.requiresBuild) { allowBuild(...) }`
+                // at lines 88-101: the allowBuilds gate only applies
+                // when the node has scripts to run. A patched-only
+                // package skips this check entirely and proceeds to
+                // patch application below.
+                //
+                // `false` / `None` from the policy set
+                // `should_run_scripts = false` (NOT `continue`), so
+                // the patch still gets applied even when scripts
+                // are disallowed. Matches upstream's `ignoreScripts
+                // = true; break` pattern.
+                let mut should_run_scripts = requires_build;
+                if requires_build {
+                    match allow_build_policy.check(&name, &version) {
+                        Some(false) => {
+                            should_run_scripts = false;
+                        }
+                        None => {
+                            // "Not in allowBuilds" — surfaced as
+                            // `pnpm:ignored-scripts`. Explicit
+                            // `false` is silently denied (above),
+                            // matching upstream's switch.
+                            ignored_builds.insert(metadata_key.to_string());
+                            should_run_scripts = false;
+                        }
+                        Some(true) => {}
                     }
-                    Some(true) => {}
                 }
 
                 // Compute the side-effects cache key once per
@@ -275,17 +330,6 @@ impl<'a> BuildModules<'a> {
                 // `None` when the cache gate can't fire (no engine,
                 // no graph, etc.); both downstream consumers
                 // short-circuit on `None`.
-                // Snapshot's resolved patch metadata, if any. Slice B
-                // uses this only for the side-effects-cache key —
-                // build trigger + actual patch application land in
-                // slice C of pnpm/pacquet#397 item 9.
-                //
-                // Look up against the peer-stripped key
-                // (`metadata_key`) because patches are configured at
-                // the (name, version) granularity in
-                // `pnpm-workspace.yaml`, not per peer-resolution
-                // variant.
-                let patch = patches.and_then(|map| map.get(&metadata_key));
                 let cache_key = (dep_graph.as_ref().zip(engine_name)).map(|(graph, engine)| {
                     pacquet_graph_hasher::calc_dep_state(
                         graph,
@@ -302,14 +346,14 @@ impl<'a> BuildModules<'a> {
                             // key entirely, matching upstream when
                             // `depNode.patch == null`.
                             patch_file_hash: patch.map(|p| p.hash.as_str()),
-                            // `hasSideEffects` upstream — for a
-                            // `requires_build = true` snapshot
-                            // that's reached this point, the only
-                            // way the script can have side effects
-                            // is to actually run, so the bit is
-                            // true. Matches
-                            // `building/during-install/src/index.ts:202`.
-                            include_dep_graph_hash: true,
+                            // Mirrors `includeDepGraphHash: hasSideEffects`
+                            // at upstream line 202. A patched-only
+                            // snapshot (no scripts will run) leaves
+                            // the deps-hash off so the cache key
+                            // stays stable across dep-graph changes
+                            // that don't affect this package's
+                            // patched output.
+                            include_dep_graph_hash: should_run_scripts,
                         },
                     )
                 });
@@ -345,64 +389,102 @@ impl<'a> BuildModules<'a> {
 
                 let optional = snapshots.get(&snapshot_key).is_some_and(|entry| entry.optional);
 
-                let result = run_postinstall_hooks::<R>(RunPostinstallHooks {
-                    dep_path: &snapshot_key.to_string(),
-                    pkg_root: &pkg_dir,
-                    root_modules_dir: modules_dir,
-                    init_cwd: lockfile_dir,
-                    extra_bin_paths: &extra_bin_paths,
-                    extra_env: &extra_env,
-                    node_execpath: None,
-                    npm_execpath: None,
-                    node_gyp_path: None,
-                    user_agent: None,
-                    // Hard-coded until the `unsafe-perm` config knob
-                    // is plumbed through. `true` skips both the
-                    // TMPDIR creation and the uid/gid drop, matching
-                    // pacquet's behavior before any of this landed.
-                    unsafe_perm: true,
-                    node_gyp_bin: None,
-                    scripts_prepend_node_path: ScriptsPrependNodePath::Never,
-                    script_shell: None,
-                    optional,
-                });
+                // Apply the patch before running postinstall hooks.
+                // Mirrors upstream at
+                // <https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/during-install/src/index.ts#L171-L178>:
+                // ```
+                // if (depNode.patch) {
+                //   if (!depNode.patch.patchFilePath) throw PATCH_FILE_PATH_MISSING
+                //   isPatched = applyPatchToDir(...)
+                // }
+                // ```
+                // `is_patched` feeds the cache-write gate below
+                // (`is_patched || has_side_effects`), matching
+                // upstream's line 199 condition.
+                let is_patched = if let Some(p) = patch {
+                    let patch_file_path = p.patch_file_path.as_deref().ok_or_else(|| {
+                        BuildModulesError::PatchFilePathMissing {
+                            dep_path: snapshot_key.to_string(),
+                        }
+                    })?;
+                    apply_patch_to_dir(&pkg_dir, patch_file_path)
+                        .map_err(BuildModulesError::PatchApply)?;
+                    true
+                } else {
+                    false
+                };
 
-                if let Err(err) = result {
-                    if optional {
-                        // Mirrors `building/during-install/src/index.ts:226-238`:
-                        // a build failure on an optional dep is logged
-                        // through the `pnpm:skipped-optional-dependency`
-                        // channel and swallowed so the install can
-                        // continue. The `package.id` field upstream is
-                        // `depNode.dir`; we use the same.
-                        R::emit(&LogEvent::SkippedOptionalDependency(
-                            SkippedOptionalDependencyLog {
-                                level: LogLevel::Debug,
-                                details: Some(err.to_string()),
-                                package: SkippedOptionalPackage {
-                                    id: pkg_dir.to_string_lossy().into_owned(),
-                                    name: name.clone(),
-                                    version: version.clone(),
-                                },
-                                prefix: lockfile_dir.to_string_lossy().into_owned(),
-                                reason: SkippedOptionalReason::BuildFailure,
-                            },
-                        ));
-                        continue;
+                let has_side_effects = if should_run_scripts {
+                    let result = run_postinstall_hooks::<R>(RunPostinstallHooks {
+                        dep_path: &snapshot_key.to_string(),
+                        pkg_root: &pkg_dir,
+                        root_modules_dir: modules_dir,
+                        init_cwd: lockfile_dir,
+                        extra_bin_paths: &extra_bin_paths,
+                        extra_env: &extra_env,
+                        node_execpath: None,
+                        npm_execpath: None,
+                        node_gyp_path: None,
+                        user_agent: None,
+                        // Hard-coded until the `unsafe-perm` config knob
+                        // is plumbed through. `true` skips both the
+                        // TMPDIR creation and the uid/gid drop, matching
+                        // pacquet's behavior before any of this landed.
+                        unsafe_perm: true,
+                        node_gyp_bin: None,
+                        scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+                        script_shell: None,
+                        optional,
+                    });
+
+                    match result {
+                        Ok(ran) => ran,
+                        Err(err) => {
+                            if optional {
+                                // Mirrors `building/during-install/src/index.ts:226-238`:
+                                // a build failure on an optional dep is logged
+                                // through the `pnpm:skipped-optional-dependency`
+                                // channel and swallowed so the install can
+                                // continue. The `package.id` field upstream is
+                                // `depNode.dir`; we use the same.
+                                R::emit(&LogEvent::SkippedOptionalDependency(
+                                    SkippedOptionalDependencyLog {
+                                        level: LogLevel::Debug,
+                                        details: Some(err.to_string()),
+                                        package: SkippedOptionalPackage {
+                                            id: pkg_dir.to_string_lossy().into_owned(),
+                                            name: name.clone(),
+                                            version: version.clone(),
+                                        },
+                                        prefix: lockfile_dir.to_string_lossy().into_owned(),
+                                        reason: SkippedOptionalReason::BuildFailure,
+                                    },
+                                ));
+                                continue;
+                            }
+                            return Err(BuildModulesError::LifecycleScript(err));
+                        }
                     }
-                    return Err(BuildModulesError::LifecycleScript(err));
-                }
+                } else {
+                    false
+                };
 
                 // Side-effects-cache WRITE path. Mirrors
-                // `<https://github.com/pnpm/pnpm/blob/7e3145f9fc/building/during-install/src/index.ts#L198-L216>`:
-                // after a successful `run_postinstall_hooks`,
+                // `<https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/during-install/src/index.ts#L198-L216>`:
+                // after a successful `run_postinstall_hooks` (or a
+                // patch application that mutated the dir),
                 // re-hash the package directory and queue a
                 // `PackageFilesIndex.sideEffects[cache_key] = diff`
                 // mutation so a future install can skip the
                 // rebuild.
                 //
-                // Gated on every precondition for a meaningful
-                // upload: write enabled, cache_key composable
+                // Upstream's gate is `(isPatched || hasSideEffects)
+                // && opts.sideEffectsCacheWrite`. Pacquet mirrors
+                // that — a patched-only snapshot still uploads its
+                // post-patch state so subsequent installs hit the
+                // cache.
+                //
+                // The other preconditions: cache_key composable
                 // (engine + graph present), `packages` map
                 // available for the integrity lookup, and the
                 // metadata row carries an integrity (registry /
@@ -414,7 +496,8 @@ impl<'a> BuildModules<'a> {
                 // logger.warn(...) }` at lines 208-215. A failed
                 // upload doesn't fail the install: the next install
                 // re-runs the build.
-                if side_effects_cache_write
+                if (is_patched || has_side_effects)
+                    && side_effects_cache_write
                     && let Some(writer) = store_index_writer
                     && let Some(store) = store_dir
                     && let Some(cache_key) = cache_key.as_deref()

--- a/crates/package-manager/src/build_modules/tests.rs
+++ b/crates/package-manager/src/build_modules/tests.rs
@@ -1078,10 +1078,9 @@ fn sha512_hex(buf: &[u8]) -> String {
     format!("{digest:x}")
 }
 
-/// Slice B of pacquet#397 item 9: when `BuildModules.patches`
-/// contains an entry for a snapshot, the side-effects-cache key
-/// computed for that snapshot must include the `;patch=<hash>`
-/// segment that
+/// When `BuildModules.patches` contains an entry for a snapshot,
+/// the side-effects-cache key computed for that snapshot must
+/// include the `;patch=<hash>` segment that
 /// [`pacquet_graph_hasher::CalcDepStateOptions::patch_file_hash`]
 /// appends.
 ///
@@ -1161,14 +1160,33 @@ async fn write_path_cache_key_includes_patch_hash() {
 
     let (writer, writer_task) = StoreIndexWriter::spawn(&store_dir);
 
-    // Build the patches map keyed by the same peer-stripped key
-    // `BuildModules::run` uses internally for the lookup.
+    // The applier runs against `pkg_dir` before the postinstall, so
+    // it needs a real patch file that succeeds. Touch a brand-new
+    // file rather than modifying `index.js` so the assertions on
+    // the diff map below stay simple — the patch adds
+    // `patched.txt`, the postinstall adds `generated.txt`, the
+    // pristine `index.js` stays at its base digest.
+    let patch_dir = tempdir().expect("create patch dir");
+    let patch_file = patch_dir.path().join("foo.patch");
+    fs::write(
+        &patch_file,
+        "\
+diff --git a/patched.txt b/patched.txt
+new file mode 100644
+--- /dev/null
++++ b/patched.txt
+@@ -0,0 +1 @@
++hello from the patch
+",
+    )
+    .expect("write patch");
+
     let patch_hash = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
     let patches: HashMap<PackageKey, ExtendedPatchInfo> = HashMap::from([(
         pkg_key.without_peer(),
         ExtendedPatchInfo {
             hash: patch_hash.to_string(),
-            patch_file_path: None,
+            patch_file_path: Some(patch_file.clone()),
             key: "@pnpm/postinstall-modifies-source@1.0.0".to_string(),
         },
     )]);
@@ -1222,4 +1240,165 @@ async fn write_path_cache_key_includes_patch_hash() {
          expected key {expected_cache_key_with_patch:?}, got keys {:?}",
         side_effects.keys().collect::<Vec<_>>(),
     );
+}
+
+/// A patch in the `patches` map gets applied to the extracted
+/// package dir before postinstall hooks run. Mirrors the upstream
+/// `simple-with-patch` fixture at
+/// <https://github.com/pnpm/pnpm/blob/b4f8f47ac2/installing/deps-restorer/test/fixtures/simple-with-patch/>
+/// at the unit level.
+///
+/// Drives `BuildModules` with a single `requires_build=false`
+/// snapshot (no postinstall scripts), `dangerouslyAllowAllBuilds: true`
+/// (irrelevant — no scripts to allow), and a patch that creates
+/// `patched.txt`. After the run, `patched.txt` must exist on disk
+/// with the patch body.
+#[cfg(unix)]
+#[tokio::test(flavor = "current_thread")]
+async fn patch_only_snapshot_gets_patched_via_build_modules() {
+    use pacquet_patching::ExtendedPatchInfo;
+    use pacquet_store_dir::{StoreDir, StoreIndexWriter};
+
+    let pkg_key = key("is-positive", "1.0.0");
+    let snapshots = HashMap::from([(pkg_key.clone(), SnapshotEntry::default())]);
+    let importers = root_importers(&[("is-positive", "1.0.0")]);
+    let policy = AllowBuildPolicy::new(rules([]), true);
+
+    let store_root = tempdir().expect("create store dir");
+    let store_dir = StoreDir::from(store_root.path().to_path_buf());
+    store_dir.init().expect("init store");
+    let virtual_store_dir = tempdir().expect("create vstore dir");
+    let modules_dir = tempdir().expect("create modules dir");
+    let lockfile_dir = tempdir().expect("create lockfile dir");
+
+    // Lay down a pristine `is-positive` package dir under the
+    // virtual store so the applier has a real target. No scripts,
+    // so `requires_build_map` for this snapshot stays false — the
+    // build trigger fires solely because of the patch entry.
+    let pkg_dir = virtual_store_dir.path().join("is-positive@1.0.0/node_modules/is-positive");
+    fs::create_dir_all(&pkg_dir).expect("create pkg dir");
+    fs::write(pkg_dir.join("package.json"), r#"{"name":"is-positive","version":"1.0.0"}"#)
+        .expect("write manifest");
+
+    // Patch that creates a brand-new file. Pure Create operation;
+    // diffy parses and applies it cleanly.
+    let patch_dir = tempdir().expect("create patch dir");
+    let patch_file = patch_dir.path().join("is-positive.patch");
+    fs::write(
+        &patch_file,
+        "\
+diff --git a/patched.txt b/patched.txt
+new file mode 100644
+--- /dev/null
++++ b/patched.txt
+@@ -0,0 +1 @@
++applied
+",
+    )
+    .expect("write patch");
+
+    let patches: HashMap<PackageKey, ExtendedPatchInfo> = HashMap::from([(
+        pkg_key.without_peer(),
+        ExtendedPatchInfo {
+            hash: "0".repeat(64),
+            patch_file_path: Some(patch_file.clone()),
+            key: "is-positive@1.0.0".to_string(),
+        },
+    )]);
+
+    let (writer, writer_task) = StoreIndexWriter::spawn(&store_dir);
+
+    BuildModules {
+        virtual_store_dir: virtual_store_dir.path(),
+        modules_dir: modules_dir.path(),
+        lockfile_dir: lockfile_dir.path(),
+        snapshots: Some(&snapshots),
+        packages: None,
+        importers: &importers,
+        allow_build_policy: &policy,
+        side_effects_maps_by_snapshot: None,
+        engine_name: None,
+        side_effects_cache: false,
+        side_effects_cache_write: false,
+        store_dir: Some(&store_dir),
+        store_index_writer: Some(&writer),
+        patches: Some(&patches),
+    }
+    .run::<SilentReporter>()
+    .expect("build modules must complete cleanly");
+
+    drop(writer);
+    writer_task.await.expect("await writer").expect("writer succeeds");
+
+    let patched = pkg_dir.join("patched.txt");
+    assert!(patched.exists(), "patch must have created {}", patched.display());
+    assert_eq!(fs::read_to_string(&patched).unwrap(), "applied\n");
+}
+
+/// When the resolved patch entry carries a hash but no
+/// `patch_file_path`, surfacing `ERR_PNPM_PATCH_FILE_PATH_MISSING`
+/// is the explicit signal the user should add the package to
+/// `patchedDependencies` in `pnpm-workspace.yaml`. Mirrors upstream's
+/// guard at
+/// <https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/during-install/src/index.ts#L172-L176>.
+#[cfg(unix)]
+#[tokio::test(flavor = "current_thread")]
+async fn missing_patch_file_path_errors_with_diagnostic() {
+    use pacquet_patching::ExtendedPatchInfo;
+    use pacquet_store_dir::{StoreDir, StoreIndexWriter};
+
+    let pkg_key = key("is-positive", "1.0.0");
+    let snapshots = HashMap::from([(pkg_key.clone(), SnapshotEntry::default())]);
+    let importers = root_importers(&[("is-positive", "1.0.0")]);
+    let policy = AllowBuildPolicy::new(rules([]), true);
+
+    let store_root = tempdir().expect("create store dir");
+    let store_dir = StoreDir::from(store_root.path().to_path_buf());
+    store_dir.init().expect("init store");
+    let virtual_store_dir = tempdir().expect("create vstore dir");
+    let modules_dir = tempdir().expect("create modules dir");
+    let lockfile_dir = tempdir().expect("create lockfile dir");
+
+    let pkg_dir = virtual_store_dir.path().join("is-positive@1.0.0/node_modules/is-positive");
+    fs::create_dir_all(&pkg_dir).expect("create pkg dir");
+    fs::write(pkg_dir.join("package.json"), r#"{"name":"is-positive","version":"1.0.0"}"#)
+        .expect("write manifest");
+
+    // `patch_file_path: None` — the lockfile-only shape where a hash
+    // is known but no live config provides a file. Must surface as
+    // `ERR_PNPM_PATCH_FILE_PATH_MISSING`.
+    let patches: HashMap<PackageKey, ExtendedPatchInfo> = HashMap::from([(
+        pkg_key.without_peer(),
+        ExtendedPatchInfo {
+            hash: "0".repeat(64),
+            patch_file_path: None,
+            key: "is-positive@1.0.0".to_string(),
+        },
+    )]);
+
+    let (writer, writer_task) = StoreIndexWriter::spawn(&store_dir);
+
+    let err = BuildModules {
+        virtual_store_dir: virtual_store_dir.path(),
+        modules_dir: modules_dir.path(),
+        lockfile_dir: lockfile_dir.path(),
+        snapshots: Some(&snapshots),
+        packages: None,
+        importers: &importers,
+        allow_build_policy: &policy,
+        side_effects_maps_by_snapshot: None,
+        engine_name: None,
+        side_effects_cache: false,
+        side_effects_cache_write: false,
+        store_dir: Some(&store_dir),
+        store_index_writer: Some(&writer),
+        patches: Some(&patches),
+    }
+    .run::<SilentReporter>()
+    .expect_err("missing patch_file_path must surface as PatchFilePathMissing");
+
+    drop(writer);
+    let _ = writer_task.await;
+
+    assert!(matches!(err, super::BuildModulesError::PatchFilePathMissing { .. }), "got: {err:?}");
 }

--- a/crates/package-manager/src/build_sequence.rs
+++ b/crates/package-manager/src/build_sequence.rs
@@ -22,11 +22,16 @@ use std::collections::{HashMap, HashSet};
 /// `binding.gyp` / `.hooks/`). Mirrors the role of `node.requiresBuild`
 /// upstream, which the worker computes from the extracted package contents.
 ///
-/// `patches` is the resolved [`pacquet_patching::PatchGroupRecord`]
-/// per-snapshot lookup map (keyed by peer-stripped [`PackageKey`]);
-/// presence of a key here mirrors upstream's `node.patch != null` and
-/// makes the snapshot a build candidate even when `requires_build`
-/// is false. Mirrors upstream's
+/// `patches` is the per-snapshot lookup map produced by
+/// `InstallFrozenLockfile::run` from
+/// [`pacquet_patching::resolve_and_group`] + per-snapshot
+/// [`pacquet_patching::get_patch_info`]: keys are peer-stripped
+/// [`PackageKey`]s, values are the matched
+/// [`pacquet_patching::ExtendedPatchInfo`]. `None` when no
+/// `patchedDependencies` is configured. Presence of a key here
+/// mirrors upstream's `node.patch != null` and makes the snapshot
+/// a build candidate even when `requires_build` is false. Mirrors
+/// upstream's
 /// [`getSubgraphToBuild`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/during-install/src/buildSequence.ts#L40-L67).
 pub fn build_sequence(
     requires_build: &HashMap<PackageKey, bool>,

--- a/crates/package-manager/src/build_sequence.rs
+++ b/crates/package-manager/src/build_sequence.rs
@@ -1,5 +1,6 @@
 use crate::graph_sequencer::{GraphSequencerResult, graph_sequencer};
 use pacquet_lockfile::{PackageKey, ProjectSnapshot, SnapshotEntry};
+use pacquet_patching::ExtendedPatchInfo;
 use std::collections::{HashMap, HashSet};
 
 /// Compute topologically ordered chunks of packages that need building.
@@ -20,8 +21,16 @@ use std::collections::{HashMap, HashSet};
 /// extraction (from each package's manifest scripts and presence of
 /// `binding.gyp` / `.hooks/`). Mirrors the role of `node.requiresBuild`
 /// upstream, which the worker computes from the extracted package contents.
+///
+/// `patches` is the resolved [`pacquet_patching::PatchGroupRecord`]
+/// per-snapshot lookup map (keyed by peer-stripped [`PackageKey`]);
+/// presence of a key here mirrors upstream's `node.patch != null` and
+/// makes the snapshot a build candidate even when `requires_build`
+/// is false. Mirrors upstream's
+/// [`getSubgraphToBuild`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/during-install/src/buildSequence.ts#L40-L67).
 pub fn build_sequence(
     requires_build: &HashMap<PackageKey, bool>,
+    patches: Option<&HashMap<PackageKey, ExtendedPatchInfo>>,
     snapshots: &HashMap<PackageKey, SnapshotEntry>,
     importers: &HashMap<String, ProjectSnapshot>,
 ) -> Vec<Vec<PackageKey>> {
@@ -35,6 +44,7 @@ pub fn build_sequence(
         &root_dep_paths,
         &children,
         requires_build,
+        patches,
         &mut nodes_to_build_set,
         &mut nodes_to_build,
         &mut walked,
@@ -133,13 +143,17 @@ fn collect_root_dep_paths(
 /// packages whose subtree (including themselves) contains a build candidate.
 ///
 /// Ports `getSubgraphToBuild` from
-/// `https://github.com/pnpm/pnpm/blob/80037699fb/building/during-install/src/buildSequence.ts`.
+/// `https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/during-install/src/buildSequence.ts`.
+/// A node is a candidate when `requires_build` is set OR when an entry
+/// for the peer-stripped key is present in `patches` (mirrors
+/// upstream's `node.requiresBuild || node.patch != null`).
 ///
 /// Returns whether *any* of the entry nodes (or their subtrees) needs to build.
 fn get_subgraph_to_build(
     entry_nodes: &[PackageKey],
     children: &HashMap<PackageKey, Vec<PackageKey>>,
     requires_build: &HashMap<PackageKey, bool>,
+    patches: Option<&HashMap<PackageKey, ExtendedPatchInfo>>,
     nodes_to_build_set: &mut HashSet<PackageKey>,
     nodes_to_build: &mut Vec<PackageKey>,
     walked: &mut HashSet<PackageKey>,
@@ -159,16 +173,16 @@ fn get_subgraph_to_build(
             &child_paths,
             children,
             requires_build,
+            patches,
             nodes_to_build_set,
             nodes_to_build,
             walked,
         );
 
         let needs_build = requires_build.get(dep_path).copied().unwrap_or(false);
-        // TODO: also trigger on `patch != null` when pacquet supports
-        // `patchedDependencies`.
+        let has_patch = patches.is_some_and(|p| p.contains_key(&dep_path.without_peer()));
 
-        if child_should_be_built || needs_build {
+        if child_should_be_built || needs_build || has_patch {
             if nodes_to_build_set.insert(dep_path.clone()) {
                 nodes_to_build.push(dep_path.clone());
             }

--- a/crates/package-manager/src/build_sequence/tests.rs
+++ b/crates/package-manager/src/build_sequence/tests.rs
@@ -61,7 +61,7 @@ fn root_importers(deps: &[(&str, &str)]) -> HashMap<String, ProjectSnapshot> {
 
 #[test]
 fn empty_inputs() {
-    let chunks = build_sequence(&HashMap::new(), &HashMap::new(), &HashMap::new());
+    let chunks = build_sequence(&HashMap::new(), None, &HashMap::new(), &HashMap::new());
     dbg!(&chunks);
     assert!(chunks.is_empty(), "empty inputs ⇒ no chunks: {chunks:?}");
 }
@@ -75,7 +75,7 @@ fn no_requires_build_yields_empty() {
     let requires_build = requires([(key("a", "1.0.0"), false), (key("b", "1.0.0"), false)]);
     let importers = root_importers(&[("a", "1.0.0")]);
 
-    let chunks = build_sequence(&requires_build, &snapshots, &importers);
+    let chunks = build_sequence(&requires_build, None, &snapshots, &importers);
     dbg!(&chunks);
     assert!(chunks.is_empty(), "no requires_build ⇒ no chunks: {chunks:?}");
 }
@@ -92,7 +92,7 @@ fn leaf_with_requires_build_runs_first() {
     let requires_build = requires([(key("a", "1.0.0"), false), (key("b", "1.0.0"), true)]);
     let importers = root_importers(&[("a", "1.0.0")]);
 
-    let chunks = build_sequence(&requires_build, &snapshots, &importers);
+    let chunks = build_sequence(&requires_build, None, &snapshots, &importers);
     assert_eq!(chunks, vec![vec![key("b", "1.0.0")], vec![key("a", "1.0.0")]]);
 }
 
@@ -111,7 +111,7 @@ fn deep_chain_orders_leaf_first() {
     ]);
     let importers = root_importers(&[("a", "1.0.0")]);
 
-    let chunks = build_sequence(&requires_build, &snapshots, &importers);
+    let chunks = build_sequence(&requires_build, None, &snapshots, &importers);
     assert_eq!(
         chunks,
         vec![vec![key("c", "1.0.0")], vec![key("b", "1.0.0")], vec![key("a", "1.0.0")]],
@@ -136,7 +136,7 @@ fn unrelated_subgraph_excluded() {
     ]);
     let importers = root_importers(&[("a", "1.0.0")]);
 
-    let chunks = build_sequence(&requires_build, &snapshots, &importers);
+    let chunks = build_sequence(&requires_build, None, &snapshots, &importers);
     let flat: Vec<_> = chunks.into_iter().flatten().collect();
     dbg!(&flat);
     assert!(flat.contains(&key("a", "1.0.0")), "ancestor of build leaf must appear: {flat:?}");
@@ -165,7 +165,7 @@ fn parallel_build_leaves_share_chunk() {
     ]);
     let importers = root_importers(&[("root", "1.0.0")]);
 
-    let chunks = build_sequence(&requires_build, &snapshots, &importers);
+    let chunks = build_sequence(&requires_build, None, &snapshots, &importers);
     assert_eq!(chunks.len(), 2);
     let mut leaves = chunks[0].clone();
     leaves.sort_by_key(|k| k.to_string());

--- a/crates/patching/Cargo.toml
+++ b/crates/patching/Cargo.toml
@@ -12,6 +12,7 @@ repository.workspace  = true
 
 [dependencies]
 derive_more = { workspace = true }
+diffy       = { workspace = true }
 indexmap    = { workspace = true }
 miette      = { workspace = true }
 node-semver = { workspace = true }

--- a/crates/patching/src/apply.rs
+++ b/crates/patching/src/apply.rs
@@ -1,7 +1,7 @@
 use derive_more::{Display, Error};
 use diffy::patch_set::{FileOperation, ParseOptions, PatchSet};
 use miette::Diagnostic;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::{fs, io};
 
 /// Error from [`apply_patch_to_dir`].
@@ -68,7 +68,18 @@ pub enum PatchApplyError {
 ///
 /// File paths in the patch are stripped one level
 /// (`diffy::FileOperation::strip_prefix(1)`) to drop the conventional
-/// `a/` and `b/` prefixes git uses.
+/// `a/` and `b/` prefixes git uses, then validated against
+/// `patched_dir`: absolute paths, `..` segments, and (on Windows)
+/// drive prefixes / root components are rejected as
+/// `ERR_PNPM_PATCH_FAILED`. A patch file is attacker-controlled
+/// data — an `a/../../outside` header would otherwise let it
+/// read, write, or delete outside the package directory.
+///
+/// `Create` refuses to overwrite an existing file (matches `patch`
+/// and `git apply` semantics for `--- /dev/null` hunks). `Delete`
+/// validates the hunks via `diffy::apply` and only unlinks when the
+/// result is empty — a stale patch would otherwise silently delete
+/// a file whose contents diverged from what the patch expects.
 pub fn apply_patch_to_dir(
     patched_dir: &Path,
     patch_file_path: &Path,
@@ -124,9 +135,25 @@ fn apply_one_file(
         message,
     };
 
+    // Reject patch paths that try to escape `patched_dir`: absolute
+    // paths, `..` segments, and (on Windows) drive-letter prefixes
+    // and root components. A patch is attacker-controlled data —
+    // an `a/../../outside` header could otherwise read, write, or
+    // delete files outside the package directory.
+    let resolve_target = |rel: &Path| -> Result<PathBuf, PatchApplyError> {
+        if rel.is_absolute()
+            || rel.components().any(|c| {
+                matches!(c, Component::ParentDir | Component::RootDir | Component::Prefix(_))
+            })
+        {
+            return Err(failed(format!("patch path escapes target dir: {}", rel.display(),)));
+        }
+        Ok(patched_dir.join(rel))
+    };
+
     match operation {
         FileOperation::Modify { modified, .. } => {
-            let target = patched_dir.join(modified.as_ref());
+            let target = resolve_target(Path::new(modified.as_ref()))?;
             let original = fs::read_to_string(&target)
                 .map_err(|source| failed(format!("read {}: {source}", target.display())))?;
             let text_patch = file_patch
@@ -139,7 +166,18 @@ fn apply_one_file(
                 .map_err(|source| failed(format!("write {}: {source}", target.display())))?;
         }
         FileOperation::Create(path) => {
-            let target = patched_dir.join(path.as_ref());
+            let target = resolve_target(Path::new(path.as_ref()))?;
+            // A "new file" patch (`--- /dev/null`) means upstream
+            // expects the target NOT to exist. Refusing to overwrite
+            // matches `patch`'s and `git apply`'s behavior — silently
+            // clobbering a real file would be a data-loss footgun if
+            // the patch was authored against the wrong base.
+            if target.try_exists().unwrap_or(false) {
+                return Err(failed(format!(
+                    "cannot create {}: target already exists",
+                    target.display(),
+                )));
+            }
             if let Some(parent) = target.parent() {
                 fs::create_dir_all(parent).map_err(|source| {
                     failed(format!("create parent of {}: {source}", target.display()))
@@ -155,14 +193,29 @@ fn apply_one_file(
                 .map_err(|source| failed(format!("write {}: {source}", target.display())))?;
         }
         FileOperation::Delete(path) => {
-            let target = patched_dir.join(path.as_ref());
-            match fs::remove_file(&target) {
-                Ok(()) => {}
-                Err(e) if e.kind() == io::ErrorKind::NotFound => {}
-                Err(source) => {
-                    return Err(failed(format!("delete {}: {source}", target.display())));
-                }
+            let target = resolve_target(Path::new(path.as_ref()))?;
+            // Validate that the existing file matches the patch
+            // before unlinking — a stale or wrong-target patch
+            // would otherwise silently delete the wrong file.
+            // diffy::apply on a delete patch produces the empty
+            // string when every hunk matches.
+            let original = fs::read_to_string(&target)
+                .map_err(|source| failed(format!("read {}: {source}", target.display())))?;
+            let text_patch = file_patch
+                .patch()
+                .as_text()
+                .ok_or_else(|| failed("binary patch is not supported".to_string()))?;
+            let after = diffy::apply(&original, text_patch)
+                .map_err(|source| failed(format!("apply to {}: {source}", target.display())))?;
+            if !after.is_empty() {
+                return Err(failed(format!(
+                    "delete patch left {} non-empty after apply ({} bytes remain)",
+                    target.display(),
+                    after.len(),
+                )));
             }
+            fs::remove_file(&target)
+                .map_err(|source| failed(format!("delete {}: {source}", target.display())))?;
         }
         FileOperation::Rename { .. } | FileOperation::Copy { .. } => {
             return Err(failed(

--- a/crates/patching/src/apply.rs
+++ b/crates/patching/src/apply.rs
@@ -1,0 +1,177 @@
+use derive_more::{Display, Error};
+use diffy::patch_set::{FileOperation, ParseOptions, PatchSet};
+use miette::Diagnostic;
+use std::path::{Path, PathBuf};
+use std::{fs, io};
+
+/// Error from [`apply_patch_to_dir`].
+///
+/// Mirrors the three diagnostic codes upstream's
+/// [`applyPatchToDir`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/patching/apply-patch/src/index.ts)
+/// surfaces:
+///
+/// - `ERR_PNPM_PATCH_NOT_FOUND` — the patch file is missing.
+/// - `ERR_PNPM_INVALID_PATCH` — the patch file can't be parsed.
+/// - `ERR_PNPM_PATCH_FAILED` — a hunk wouldn't apply, the target
+///   file is missing, or an IO error hit a target path.
+#[derive(Debug, Display, Error, Diagnostic)]
+pub enum PatchApplyError {
+    #[display("Patch file not found: {}", path.display())]
+    #[diagnostic(code(ERR_PNPM_PATCH_NOT_FOUND))]
+    PatchNotFound { path: PathBuf },
+
+    #[display("Failed to read patch file {}: {source}", path.display())]
+    #[diagnostic(code(ERR_PNPM_PATCH_NOT_FOUND))]
+    ReadPatchFile {
+        path: PathBuf,
+        #[error(source)]
+        source: io::Error,
+    },
+
+    #[display("Applying patch \"{}\" failed: {message}", patch_file_path.display())]
+    #[diagnostic(code(ERR_PNPM_INVALID_PATCH))]
+    InvalidPatch {
+        patch_file_path: PathBuf,
+        #[error(not(source))]
+        message: String,
+    },
+
+    #[display("Could not apply patch {} to {}: {message}", patch_file_path.display(), patched_dir.display())]
+    #[diagnostic(code(ERR_PNPM_PATCH_FAILED))]
+    PatchFailed {
+        patch_file_path: PathBuf,
+        patched_dir: PathBuf,
+        #[error(not(source))]
+        message: String,
+    },
+}
+
+/// Apply a unified-diff patch file to every modified/created/deleted
+/// file inside `patched_dir`.
+///
+/// Ports upstream's
+/// [`applyPatchToDir`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/patching/apply-patch/src/index.ts),
+/// which delegates to `@pnpm/patch-package`'s `applyPatch`. Pacquet
+/// uses [`diffy`] for parsing and applying — pure Rust, no
+/// subprocess, no Node, cross-platform. The upstream comment notes
+/// "Ideally, we would just run `patch` or `git apply`. However,
+/// `patch` is not available on Windows and `git apply` is hard to
+/// execute on a subdirectory of an existing repository", which is
+/// why pnpm vendored `patch-package`; pacquet sidesteps the same
+/// problem the same way (in-process applier, no subprocess).
+///
+/// Supported file operations: `Modify`, `Create`, `Delete`.
+/// `Rename`/`Copy` operations are reported as `ERR_PNPM_PATCH_FAILED`
+/// with a descriptive message — they don't appear in
+/// `patch-package`-style patches in practice, and the failure mode
+/// is at least loud rather than silent.
+///
+/// File paths in the patch are stripped one level
+/// (`diffy::FileOperation::strip_prefix(1)`) to drop the conventional
+/// `a/` and `b/` prefixes git uses.
+pub fn apply_patch_to_dir(
+    patched_dir: &Path,
+    patch_file_path: &Path,
+) -> Result<(), PatchApplyError> {
+    // Read the patch file. ENOENT becomes `ERR_PNPM_PATCH_NOT_FOUND`
+    // (mirrors upstream's `if (err.code === 'ENOENT') throw new
+    // PnpmError('PATCH_NOT_FOUND', ...)`). Every other IO error
+    // surfaces with the same diagnostic code but a different
+    // variant so the underlying `io::Error` chain is preserved.
+    let bytes = match fs::read(patch_file_path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            return Err(PatchApplyError::PatchNotFound { path: patch_file_path.to_path_buf() });
+        }
+        Err(source) => {
+            return Err(PatchApplyError::ReadPatchFile {
+                path: patch_file_path.to_path_buf(),
+                source,
+            });
+        }
+    };
+    // Lossy UTF-8 to match Node `fs.readFile(path, 'utf8')` (the
+    // same decoding [`create_hex_hash_from_file`] uses), so a patch
+    // file with stray bytes parses the same way upstream's reader
+    // would see it.
+    //
+    // [`create_hex_hash_from_file`]: crate::create_hex_hash_from_file
+    let text = String::from_utf8_lossy(&bytes);
+
+    let patches = PatchSet::parse(&text, ParseOptions::gitdiff());
+    for file_patch_result in patches {
+        let file_patch = file_patch_result.map_err(|source| PatchApplyError::InvalidPatch {
+            patch_file_path: patch_file_path.to_path_buf(),
+            message: source.to_string(),
+        })?;
+        apply_one_file(patched_dir, patch_file_path, &file_patch)?;
+    }
+    Ok(())
+}
+
+fn apply_one_file(
+    patched_dir: &Path,
+    patch_file_path: &Path,
+    file_patch: &diffy::patch_set::FilePatch<'_, str>,
+) -> Result<(), PatchApplyError> {
+    // Strip the conventional `a/` / `b/` prefix so the path inside
+    // the patch maps onto a relative path under `patched_dir`.
+    let operation = file_patch.operation().strip_prefix(1);
+
+    let failed = |message: String| PatchApplyError::PatchFailed {
+        patch_file_path: patch_file_path.to_path_buf(),
+        patched_dir: patched_dir.to_path_buf(),
+        message,
+    };
+
+    match operation {
+        FileOperation::Modify { modified, .. } => {
+            let target = patched_dir.join(modified.as_ref());
+            let original = fs::read_to_string(&target)
+                .map_err(|source| failed(format!("read {}: {source}", target.display())))?;
+            let text_patch = file_patch
+                .patch()
+                .as_text()
+                .ok_or_else(|| failed("binary patch is not supported".to_string()))?;
+            let updated = diffy::apply(&original, text_patch)
+                .map_err(|source| failed(format!("apply to {}: {source}", target.display())))?;
+            fs::write(&target, updated)
+                .map_err(|source| failed(format!("write {}: {source}", target.display())))?;
+        }
+        FileOperation::Create(path) => {
+            let target = patched_dir.join(path.as_ref());
+            if let Some(parent) = target.parent() {
+                fs::create_dir_all(parent).map_err(|source| {
+                    failed(format!("create parent of {}: {source}", target.display()))
+                })?;
+            }
+            let text_patch = file_patch
+                .patch()
+                .as_text()
+                .ok_or_else(|| failed("binary patch is not supported".to_string()))?;
+            let created = diffy::apply("", text_patch)
+                .map_err(|source| failed(format!("create {}: {source}", target.display())))?;
+            fs::write(&target, created)
+                .map_err(|source| failed(format!("write {}: {source}", target.display())))?;
+        }
+        FileOperation::Delete(path) => {
+            let target = patched_dir.join(path.as_ref());
+            match fs::remove_file(&target) {
+                Ok(()) => {}
+                Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+                Err(source) => {
+                    return Err(failed(format!("delete {}: {source}", target.display())));
+                }
+            }
+        }
+        FileOperation::Rename { .. } | FileOperation::Copy { .. } => {
+            return Err(failed(
+                "rename/copy operations in patches are not yet supported".to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/patching/src/apply.rs
+++ b/crates/patching/src/apply.rs
@@ -154,8 +154,14 @@ fn apply_one_file(
     match operation {
         FileOperation::Modify { modified, .. } => {
             let target = resolve_target(Path::new(modified.as_ref()))?;
-            let original = fs::read_to_string(&target)
+            // Read as bytes and lossy-decode so non-UTF-8 bytes
+            // turn into U+FFFD rather than failing the patch.
+            // Matches how the patch file itself is read (see
+            // [`apply_patch_to_dir`]) and Node `fs.readFile(..., 'utf8')`,
+            // which upstream's patch-package uses end-to-end.
+            let bytes = fs::read(&target)
                 .map_err(|source| failed(format!("read {}: {source}", target.display())))?;
+            let original = String::from_utf8_lossy(&bytes).into_owned();
             let text_patch = file_patch
                 .patch()
                 .as_text()
@@ -199,8 +205,13 @@ fn apply_one_file(
             // would otherwise silently delete the wrong file.
             // diffy::apply on a delete patch produces the empty
             // string when every hunk matches.
-            let original = fs::read_to_string(&target)
+            //
+            // Lossy UTF-8 decoding for the same reason as the
+            // `Modify` branch above: match the patch-file reader
+            // and Node's `fs.readFile(..., 'utf8')`.
+            let bytes = fs::read(&target)
                 .map_err(|source| failed(format!("read {}: {source}", target.display())))?;
+            let original = String::from_utf8_lossy(&bytes).into_owned();
             let text_patch = file_patch
                 .patch()
                 .as_text()

--- a/crates/patching/src/apply.rs
+++ b/crates/patching/src/apply.rs
@@ -146,7 +146,7 @@ fn apply_one_file(
                 matches!(c, Component::ParentDir | Component::RootDir | Component::Prefix(_))
             })
         {
-            return Err(failed(format!("patch path escapes target dir: {}", rel.display(),)));
+            return Err(failed(format!("patch path escapes target dir: {}", rel.display())));
         }
         Ok(patched_dir.join(rel))
     };

--- a/crates/patching/src/apply/tests.rs
+++ b/crates/patching/src/apply/tests.rs
@@ -1,0 +1,177 @@
+use crate::apply::{PatchApplyError, apply_patch_to_dir};
+use pretty_assertions::assert_eq;
+use std::fs;
+use tempfile::tempdir;
+
+/// Mirrors the upstream `is-positive` fixture at
+/// <https://github.com/pnpm/pnpm/blob/b4f8f47ac2/installing/deps-restorer/test/fixtures/simple-with-patch/patches/is-positive.patch>:
+/// a single-hunk Modify on `index.js`.
+const IS_POSITIVE_PATCH: &str = "\
+diff --git a/index.js b/index.js
+index 8e020cac3320e72cb40e66b4c4573cc51c55e1e4..8be55d95c50a2a28e021e586ce5b928d9fea140e 100644
+--- a/index.js
++++ b/index.js
+@@ -7,3 +7,5 @@ module.exports = function (n) {
+
+ \treturn n >= 0;
+ };
++
++// a change
+";
+
+/// The upstream `is-positive@1.0.0` `index.js` body the patch
+/// applies against. Six lines before the modified region, three
+/// lines of context. Indentation uses tabs because the file
+/// upstream's patch was authored against uses tabs.
+const IS_POSITIVE_INDEX_JS: &str = "\
+'use strict';
+module.exports = function (n) {
+\tif (typeof n !== 'number') {
+\t\tthrow new TypeError('Expected a number');
+\t}
+
+\treturn n >= 0;
+};
+";
+
+/// `is-positive`'s `index.js` after the upstream patch lands:
+/// trailing blank line plus a `// a change` comment.
+const IS_POSITIVE_INDEX_JS_PATCHED: &str = "\
+'use strict';
+module.exports = function (n) {
+\tif (typeof n !== 'number') {
+\t\tthrow new TypeError('Expected a number');
+\t}
+
+\treturn n >= 0;
+};
+
+// a change
+";
+
+fn write_patch(dir: &std::path::Path, body: &str) -> std::path::PathBuf {
+    let path = dir.join("patch.patch");
+    fs::write(&path, body).expect("write patch");
+    path
+}
+
+/// Happy path: applying the upstream is-positive patch over
+/// is-positive's actual `index.js` produces the expected output.
+/// Mirrors upstream's
+/// [`'install with patchedDependencies'`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/installing/deps-installer/test/install/patch.ts)
+/// happy-path coverage at the unit level.
+#[test]
+fn applies_modify_against_existing_file() {
+    let patched = tempdir().unwrap();
+    fs::write(patched.path().join("index.js"), IS_POSITIVE_INDEX_JS).unwrap();
+    let patch_dir = tempdir().unwrap();
+    let patch = write_patch(patch_dir.path(), IS_POSITIVE_PATCH);
+
+    apply_patch_to_dir(patched.path(), &patch).expect("apply must succeed");
+
+    let after = fs::read_to_string(patched.path().join("index.js")).unwrap();
+    assert_eq!(after, IS_POSITIVE_INDEX_JS_PATCHED);
+}
+
+/// `ERR_PNPM_PATCH_NOT_FOUND` for a missing patch file. Mirrors
+/// upstream's
+/// [`if (err.code === 'ENOENT') throw new PnpmError('PATCH_NOT_FOUND', ...)`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/patching/apply-patch/src/index.ts).
+#[test]
+fn missing_patch_file_errors_patch_not_found() {
+    let patched = tempdir().unwrap();
+    let missing = patched.path().join("does-not-exist.patch");
+    let err = apply_patch_to_dir(patched.path(), &missing).expect_err("must fail");
+    assert!(matches!(err, PatchApplyError::PatchNotFound { .. }), "got: {err:?}");
+}
+
+/// `ERR_PNPM_INVALID_PATCH` when the patch body can't be parsed —
+/// e.g. truncated hunk header. Mirrors upstream's `catch (err) ...
+/// throw new PnpmError('INVALID_PATCH', ...)` branch.
+#[test]
+fn malformed_patch_errors_invalid_patch() {
+    let patched = tempdir().unwrap();
+    fs::write(patched.path().join("file.txt"), "hello\n").unwrap();
+    let patch_dir = tempdir().unwrap();
+    let patch = write_patch(
+        patch_dir.path(),
+        "diff --git a/file.txt b/file.txt\n--- a/file.txt\n+++ b/file.txt\n@@ THIS IS NOT A HUNK HEADER\n",
+    );
+
+    let err = apply_patch_to_dir(patched.path(), &patch).expect_err("must fail");
+    assert!(matches!(err, PatchApplyError::InvalidPatch { .. }), "got: {err:?}");
+}
+
+/// `ERR_PNPM_PATCH_FAILED` when a hunk can't be applied — e.g. the
+/// context doesn't match the on-disk file. Mirrors upstream's
+/// `if (!success) throw new PnpmError('PATCH_FAILED', ...)`.
+#[test]
+fn unmatching_hunk_errors_patch_failed() {
+    let patched = tempdir().unwrap();
+    // Write a file whose contents diverge from the patch's context
+    // lines so diffy's apply can't locate the hunk.
+    fs::write(patched.path().join("index.js"), "totally different contents\n").unwrap();
+    let patch_dir = tempdir().unwrap();
+    let patch = write_patch(patch_dir.path(), IS_POSITIVE_PATCH);
+
+    let err = apply_patch_to_dir(patched.path(), &patch).expect_err("must fail");
+    assert!(matches!(err, PatchApplyError::PatchFailed { .. }), "got: {err:?}");
+}
+
+/// `ERR_PNPM_PATCH_FAILED` when the target file is missing. The
+/// patch refers to `index.js` but the patched dir is empty.
+#[test]
+fn missing_target_file_errors_patch_failed() {
+    let patched = tempdir().unwrap();
+    let patch_dir = tempdir().unwrap();
+    let patch = write_patch(patch_dir.path(), IS_POSITIVE_PATCH);
+
+    let err = apply_patch_to_dir(patched.path(), &patch).expect_err("must fail");
+    assert!(matches!(err, PatchApplyError::PatchFailed { .. }), "got: {err:?}");
+}
+
+/// File creation: a patch that adds a brand-new file (`--- /dev/null`).
+#[test]
+fn applies_create_for_new_file() {
+    let patched = tempdir().unwrap();
+    let patch_dir = tempdir().unwrap();
+    let patch = write_patch(
+        patch_dir.path(),
+        "\
+diff --git a/created.txt b/created.txt
+new file mode 100644
+--- /dev/null
++++ b/created.txt
+@@ -0,0 +1,2 @@
++first line
++second line
+",
+    );
+
+    apply_patch_to_dir(patched.path(), &patch).expect("apply must succeed");
+    let after = fs::read_to_string(patched.path().join("created.txt")).unwrap();
+    assert_eq!(after, "first line\nsecond line\n");
+}
+
+/// File deletion: a patch that removes an existing file
+/// (`+++ /dev/null`). The target is unlinked.
+#[test]
+fn applies_delete_for_removed_file() {
+    let patched = tempdir().unwrap();
+    let target = patched.path().join("to-delete.txt");
+    fs::write(&target, "going away\n").unwrap();
+    let patch_dir = tempdir().unwrap();
+    let patch = write_patch(
+        patch_dir.path(),
+        "\
+diff --git a/to-delete.txt b/to-delete.txt
+deleted file mode 100644
+--- a/to-delete.txt
++++ /dev/null
+@@ -1 +0,0 @@
+-going away
+",
+    );
+
+    apply_patch_to_dir(patched.path(), &patch).expect("apply must succeed");
+    assert!(!target.exists(), "deleted target must be gone");
+}

--- a/crates/patching/src/apply/tests.rs
+++ b/crates/patching/src/apply/tests.rs
@@ -152,6 +152,41 @@ new file mode 100644
     assert_eq!(after, "first line\nsecond line\n");
 }
 
+/// Target-file reads use lossy UTF-8 decoding, matching Node's
+/// `fs.readFile(..., 'utf8')` and the patch-file reader. A target
+/// file with stray non-UTF-8 bytes must NOT cause `Modify` to
+/// fail with `InvalidData` — those bytes round-trip through
+/// `String::from_utf8_lossy` as U+FFFD before
+/// [`diffy::apply`] sees them.
+///
+/// The patch context here is the U+FFFD chars themselves, so we
+/// can construct a real patch that applies cleanly against the
+/// lossy-decoded target. Flagged by Copilot during review of
+/// pacquet#427.
+#[test]
+fn modify_target_with_invalid_utf8_bytes_does_not_error() {
+    let patched = tempdir().unwrap();
+    // Three invalid UTF-8 bytes that lossy-decode to three U+FFFD
+    // chars (`\xEF\xBF\xBD` each).
+    fs::write(patched.path().join("blob.txt"), [0xffu8, 0xfeu8, 0xfdu8, b'\n']).unwrap();
+    let patch_dir = tempdir().unwrap();
+    let patch = write_patch(
+        patch_dir.path(),
+        "\
+diff --git a/blob.txt b/blob.txt
+--- a/blob.txt
++++ b/blob.txt
+@@ -1 +1,2 @@
+ \u{fffd}\u{fffd}\u{fffd}
++added line
+",
+    );
+
+    apply_patch_to_dir(patched.path(), &patch).expect("lossy decoding must allow apply");
+    let after = fs::read_to_string(patched.path().join("blob.txt")).unwrap();
+    assert!(after.contains("added line"), "got: {after:?}");
+}
+
 /// `..` in a patch path is rejected — a malicious or
 /// misconfigured patch must not be able to read/write/delete
 /// outside `patched_dir`. CodeRabbit flagged this as Critical

--- a/crates/patching/src/apply/tests.rs
+++ b/crates/patching/src/apply/tests.rs
@@ -152,6 +152,134 @@ new file mode 100644
     assert_eq!(after, "first line\nsecond line\n");
 }
 
+/// `..` in a patch path is rejected — a malicious or
+/// misconfigured patch must not be able to read/write/delete
+/// outside `patched_dir`. CodeRabbit flagged this as Critical
+/// during review of pacquet#427.
+#[test]
+fn parent_dir_segment_in_modify_errors() {
+    let patched = tempdir().unwrap();
+    let patch_dir = tempdir().unwrap();
+    let patch = write_patch(
+        patch_dir.path(),
+        "\
+diff --git a/../escape.txt b/../escape.txt
+--- a/../escape.txt
++++ b/../escape.txt
+@@ -1 +1 @@
+-existing
++modified
+",
+    );
+    let err = apply_patch_to_dir(patched.path(), &patch).expect_err("must reject ..");
+    let PatchApplyError::PatchFailed { message, .. } = err else {
+        panic!("expected PatchFailed, got: {err:?}");
+    };
+    assert!(message.contains("escapes target dir"), "got: {message}");
+}
+
+#[test]
+fn parent_dir_segment_in_create_errors() {
+    let patched = tempdir().unwrap();
+    let patch_dir = tempdir().unwrap();
+    let patch = write_patch(
+        patch_dir.path(),
+        "\
+diff --git a/../planted.txt b/../planted.txt
+new file mode 100644
+--- /dev/null
++++ b/../planted.txt
+@@ -0,0 +1 @@
++pwned
+",
+    );
+    let err = apply_patch_to_dir(patched.path(), &patch).expect_err("must reject ..");
+    let PatchApplyError::PatchFailed { message, .. } = err else {
+        panic!("expected PatchFailed, got: {err:?}");
+    };
+    assert!(message.contains("escapes target dir"), "got: {message}");
+}
+
+#[test]
+fn parent_dir_segment_in_delete_errors() {
+    let patched = tempdir().unwrap();
+    let patch_dir = tempdir().unwrap();
+    let patch = write_patch(
+        patch_dir.path(),
+        "\
+diff --git a/../victim.txt b/../victim.txt
+deleted file mode 100644
+--- a/../victim.txt
++++ /dev/null
+@@ -1 +0,0 @@
+-going away
+",
+    );
+    let err = apply_patch_to_dir(patched.path(), &patch).expect_err("must reject ..");
+    let PatchApplyError::PatchFailed { message, .. } = err else {
+        panic!("expected PatchFailed, got: {err:?}");
+    };
+    assert!(message.contains("escapes target dir"), "got: {message}");
+}
+
+/// `Create` refuses to overwrite an existing file. Matches `patch`
+/// and `git apply` semantics for `--- /dev/null` hunks. Flagged by
+/// Copilot during review of pacquet#427.
+#[test]
+fn create_on_existing_file_errors() {
+    let patched = tempdir().unwrap();
+    let target = patched.path().join("already-here.txt");
+    fs::write(&target, "i was here first\n").unwrap();
+    let patch_dir = tempdir().unwrap();
+    let patch = write_patch(
+        patch_dir.path(),
+        "\
+diff --git a/already-here.txt b/already-here.txt
+new file mode 100644
+--- /dev/null
++++ b/already-here.txt
+@@ -0,0 +1 @@
++overwriting
+",
+    );
+    let err = apply_patch_to_dir(patched.path(), &patch).expect_err("must refuse overwrite");
+    let PatchApplyError::PatchFailed { message, .. } = err else {
+        panic!("expected PatchFailed, got: {err:?}");
+    };
+    assert!(message.contains("already exists"), "got: {message}");
+    // The original file must be untouched.
+    assert_eq!(fs::read_to_string(&target).unwrap(), "i was here first\n");
+}
+
+/// `Delete` validates hunks before unlinking. A stale patch (one
+/// whose `-` lines don't match the actual file content) must NOT
+/// silently remove the file. Flagged by Copilot during review of
+/// pacquet#427.
+#[test]
+fn delete_with_mismatching_hunks_errors_without_unlinking() {
+    let patched = tempdir().unwrap();
+    let target = patched.path().join("to-delete.txt");
+    // The patch expects the file to contain "going away\n", but
+    // the actual file diverges. A correct implementation must
+    // refuse to delete.
+    fs::write(&target, "actually different content\n").unwrap();
+    let patch_dir = tempdir().unwrap();
+    let patch = write_patch(
+        patch_dir.path(),
+        "\
+diff --git a/to-delete.txt b/to-delete.txt
+deleted file mode 100644
+--- a/to-delete.txt
++++ /dev/null
+@@ -1 +0,0 @@
+-going away
+",
+    );
+    let err = apply_patch_to_dir(patched.path(), &patch).expect_err("must refuse mismatch");
+    assert!(matches!(err, PatchApplyError::PatchFailed { .. }), "got: {err:?}");
+    assert!(target.exists(), "file must NOT be unlinked when the patch doesn't match");
+}
+
 /// File deletion: a patch that removes an existing file
 /// (`+++ /dev/null`). The target is unlinked.
 #[test]

--- a/crates/patching/src/lib.rs
+++ b/crates/patching/src/lib.rs
@@ -1,31 +1,31 @@
-//! Configuration and matching logic for pnpm's `patchedDependencies`.
+//! Configuration, matching, and application logic for pnpm's
+//! `patchedDependencies` (pacquet#397 item 9).
 //!
-//! Ports the upstream `@pnpm/patching.types` and `@pnpm/patching.config`
+//! Ports the upstream `@pnpm/patching.types`,
+//! `@pnpm/patching.config`, and `@pnpm/patching.apply-patch`
 //! workspaces (commit
-//! [`b4f8f47ac2`](https://github.com/pnpm/pnpm/tree/b4f8f47ac2)) plus
-//! the patch-file hashing in `@pnpm/lockfile.settings-checker`'s
+//! [`b4f8f47ac2`](https://github.com/pnpm/pnpm/tree/b4f8f47ac2))
+//! plus the patch-file hashing in `@pnpm/lockfile.settings-checker`'s
 //! [`calcPatchHashes`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/lockfile/settings-checker/src/calcPatchHashes.ts).
 //!
-//! Pacquet's `patchedDependencies` work (pacquet#397 item 9) lands
-//! across multiple slices. This PR (slices A + B) covers everything
-//! up to threading the patch hash into the side-effects-cache key:
+//! The crate exposes:
 //!
 //! 1. Types, parser, grouping, matcher, verify, hashing, and the
-//!    workspace-dir-anchored [`resolve_and_group`] helper.
-//! 2. `pacquet-config` exposes
-//!    [`Config::resolved_patched_dependencies`][crate-config] and the
-//!    install pipeline (`InstallFrozenLockfile::run`) calls it once
-//!    per install, looks each snapshot up with [`get_patch_info()`],
-//!    and threads the resulting map into `BuildModules`.
-//! 3. `BuildModules` passes the per-snapshot
-//!    [`ExtendedPatchInfo::hash`] into
-//!    `pacquet_graph_hasher::CalcDepStateOptions::patch_file_hash`
-//!    so the cache key includes `;patch=<hash>` when a snapshot is
-//!    patched.
-//!
-//! Slice C will land the remaining pieces: the build-trigger update
-//! (`requires_build || patch.is_some()`) and the actual patch
-//! application to extracted package dirs before postinstall hooks.
+//!    workspace-dir-anchored [`resolve_and_group`] helper for going
+//!    from `pnpm-workspace.yaml`'s `patchedDependencies` map to a
+//!    [`PatchGroupRecord`].
+//! 2. [`get_patch_info()`] for looking up the matching patch for a
+//!    `(name, version)` pair (exact → unique range → wildcard) with
+//!    `ERR_PNPM_PATCH_KEY_CONFLICT` on ambiguity.
+//! 3. [`apply_patch_to_dir`] for applying a unified-diff patch
+//!    against an extracted package directory before postinstall
+//!    hooks run. Ports upstream's
+//!    [`applyPatchToDir`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/patching/apply-patch/src/index.ts)
+//!    using the pure-Rust [`diffy`] crate (the upstream `@pnpm/patch-package`
+//!    fork serves the same role with `git apply` and `patch` ruled out
+//!    for cross-platform reasons).
+//! 4. [`verify_patches`] for the `ERR_PNPM_UNUSED_PATCH` diagnostic
+//!    when configured patches don't match any installed dep.
 //!
 //! pnpm v11 reads `patchedDependencies` from `pnpm-workspace.yaml`,
 //! not from `package.json`'s `pnpm` field. [`resolve_and_group`]
@@ -33,9 +33,8 @@
 //! [`IndexMap`][indexmap::IndexMap] — the caller is responsible for
 //! surfacing the map (today: from yaml; in the lockfile-only path,
 //! from `pnpm-lock.yaml`'s top-level `patchedDependencies` field).
-//!
-//! [crate-config]: ../pacquet_config/struct.Config.html#method.resolved_patched_dependencies
 
+mod apply;
 mod get_patch_info;
 mod group;
 mod hash;
@@ -44,6 +43,7 @@ mod resolve;
 mod types;
 mod verify;
 
+pub use apply::{PatchApplyError, apply_patch_to_dir};
 pub use get_patch_info::{PatchKeyConflictError, get_patch_info};
 pub use group::{PatchInput, PatchNonSemverRangeError, group_patched_dependencies};
 pub use hash::{CalcPatchHashError, calc_patch_hashes, create_hex_hash_from_file};

--- a/crates/patching/src/resolve.rs
+++ b/crates/patching/src/resolve.rs
@@ -40,7 +40,7 @@ impl From<PatchNonSemverRangeError> for ResolvePatchedDependenciesError {
 /// the user wrote in yaml — matching pnpm's JS-object iteration
 /// behavior. [`IndexMap`] is required for that; a [`BTreeMap`]
 /// would sort the keys and reorder ranges alphabetically, which
-/// surfaced as a review comment from Copilot during slice A.
+/// surfaced as a review comment from Copilot on pacquet#425.
 ///
 /// Ports the workspace-dir-resolution + grouping half of upstream's
 /// [`getOptionsFromPnpmSettings`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/config/reader/src/getOptionsFromRootManifest.ts#L28-L46)

--- a/crates/patching/src/resolve/tests.rs
+++ b/crates/patching/src/resolve/tests.rs
@@ -104,7 +104,7 @@ fn mixed_entries_resolve_in_one_call() {
 /// `PatchGroup.range`. Switching back to BTreeMap (alphabetical)
 /// would silently break parity with upstream's JS-object iteration
 /// order and surface as different `PATCH_KEY_CONFLICT` diagnostics
-/// when multiple ranges match a version. Caught in review of slice A.
+/// when multiple ranges match a version.
 #[test]
 fn range_preserves_user_specified_order() {
     let workspace = tempdir().unwrap();

--- a/crates/patching/src/verify/tests.rs
+++ b/crates/patching/src/verify/tests.rs
@@ -24,8 +24,7 @@ fn entries(keys: &[&str]) -> Vec<(String, PatchInput)> {
 ///    then the wildcard.
 ///
 /// Assert the order directly rather than sorting — sorting would
-/// hide regressions in [`all_patch_keys`]. Flagged in slice A
-/// review.
+/// hide regressions in [`all_patch_keys`].
 #[test]
 fn all_keys_yields_every_configured_key() {
     let groups = group_patched_dependencies(entries(&[


### PR DESCRIPTION
## Summary

Completes pnpm/pacquet#397 item 9 (`patchedDependencies` support). Patches now actually land on disk: pacquet applies configured patches to extracted package directories before postinstall hooks run, includes patched-only packages in the build trigger, and surfaces the four upstream diagnostic codes.

Slices A + B (PR #425, merged) landed the foundation, Config plumbing, and the side-effects-cache key wiring. This PR wires the rest.

## Pure-Rust patch applier

`pacquet_patching::apply_patch_to_dir` ports upstream's [`applyPatchToDir`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/patching/apply-patch/src/index.ts) using the [`diffy`](https://crates.io/crates/diffy) crate (MIT OR Apache-2.0, pure Rust, no subprocess). Upstream's own comment notes that `patch` is unavailable on Windows and `git apply` is awkward inside an existing git repo — pnpm vendored `@pnpm/patch-package` for that reason; pacquet sidesteps it the same way with an in-process applier.

Supported `FileOperation`s: `Modify`, `Create`, `Delete`. `Rename` and `Copy` fall through to `ERR_PNPM_PATCH_FAILED` with a descriptive message — they don't appear in `patch-package`-style patches in practice.

## Build pipeline

- `build_sequence::get_subgraph_to_build` now considers `patch.is_some()` alongside `requires_build`. A patched-only package becomes a build candidate the same way upstream's filter at [`buildSequence.ts:47,60`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/during-install/src/buildSequence.ts#L40-L67) treats them.
- `BuildModules::run` per-snapshot loop refactored to mirror upstream's flow:
  - Inner build trigger becomes `requires_build || patch.is_some()`.
  - `allowBuilds` check only gates scripts (upstream's `if (node.requiresBuild)` at [`during-install/src/index.ts:88-101`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/during-install/src/index.ts#L82-L106)). Disallow / ignored sets `should_run_scripts = false` rather than `continue` — patches still apply.
  - `cache_key`'s `include_dep_graph_hash` is now `should_run_scripts` (was unconditionally `true`), so a patched-only snapshot's cache key omits the deps-hash, matching upstream's `includeDepGraphHash: hasSideEffects` at [line 202](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/during-install/src/index.ts#L199-L204).
  - Patch application happens before `run_postinstall_hooks`, mirroring [`during-install/src/index.ts:171-178`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/during-install/src/index.ts#L168-L191).
  - Cache-write gate becomes `(is_patched || has_side_effects) && side_effects_cache_write` (was just `side_effects_cache_write`), matching upstream's `(isPatched || hasSideEffects)` at line 199.

## Diagnostics

Four upstream codes surface via `BuildModulesError`:

- `ERR_PNPM_PATCH_NOT_FOUND` — patch file missing on disk
- `ERR_PNPM_INVALID_PATCH` — unified-diff parse error
- `ERR_PNPM_PATCH_FAILED` — hunk wouldn't apply, target missing, IO error on a target path
- `ERR_PNPM_PATCH_FILE_PATH_MISSING` — resolved patch entry has a hash but no path (lockfile-only shape with no live config); mirrors [`during-install/src/index.ts:172-176`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/during-install/src/index.ts#L172-L176)

## Dependency

New workspace dep: `diffy = "0.5.0"`. MIT OR Apache-2.0, both in the deny.toml allow-list. `cargo deny check licenses` ok.

## Test plan

- [x] `pacquet_patching::apply::tests` — 8 cases: happy-path Modify against the upstream `is-positive@1.0.0` body, Create, Delete, missing patch file (PATCH_NOT_FOUND), malformed patch (INVALID_PATCH), unmatching hunk (PATCH_FAILED), missing target file (PATCH_FAILED).
- [x] `patch_only_snapshot_gets_patched_via_build_modules` drives `BuildModules` with a patched no-scripts snapshot end-to-end and verifies the patch file lands on disk.
- [x] `missing_patch_file_path_errors_with_diagnostic` verifies `ERR_PNPM_PATCH_FILE_PATH_MISSING` propagates.
- [x] `write_path_cache_key_includes_patch_hash` (from slices A+B) updated to provide a real patch file the applier can succeed against.
- [x] `just ready` clean — 575 tests pass.
- [x] `just dylint` (perfectionist) clean.
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace --document-private-items` clean.
- [x] `taplo format --check` clean.
- [x] `cargo deny check licenses` ok.

## Out of scope

- E2E parity test with upstream's [`simple-with-patch`](https://github.com/pnpm/pnpm/tree/b4f8f47ac2/installing/deps-restorer/test/fixtures/simple-with-patch) fixture via `Install::run` through the live mock registry. Unit-level coverage of the same patched-package flow is in place above; the registry-mocked E2E mirrors the pattern from pacquet#419's optional-dep test and would fit a follow-up.
- `Rename` and `Copy` `FileOperation`s — they don't appear in `patch-package`-style patches; the applier surfaces them as `ERR_PNPM_PATCH_FAILED` with a clear message.

---
Written by an agent (Claude Code, claude-opus-4-7).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic patch application during build runs, including for packages without build scripts
  * In-process patch applier supporting Modify/Create/Delete operations with path-safety checks

* **Bug Fixes**
  * Improved validation and clearer errors for missing or malformed patch metadata
  * Side-effects cache now permits uploads when patching or postinstall scripts ran

* **Tests & Docs**
  * Extensive tests and updated crate documentation for patching/apply behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pacquet/pull/427)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->