### PR TITLE
feat(package-manager): version unions in allowBuilds keys (#397 item 5 completion)

### DIFF
--- a/crates/package-manager/src/build_modules.rs
+++ b/crates/package-manager/src/build_modules.rs
@@ -1,4 +1,5 @@
 use crate::build_sequence::build_sequence;
+use crate::version_policy::{VersionPolicyError, expand_package_version_specs};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_config::Config;
@@ -13,7 +14,7 @@ use pacquet_reporter::{
     SkippedOptionalReason,
 };
 use std::{
-    collections::{BTreeSet, HashMap},
+    collections::{BTreeSet, HashMap, HashSet},
     path::{Path, PathBuf},
 };
 
@@ -47,24 +48,37 @@ pub enum BuildModulesError {
 /// Ports pnpm's `createAllowBuildFunction` from
 /// <https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/policy/src/index.ts>.
 ///
+/// The internal `expanded_allowed` and `expanded_disallowed` sets
+/// contain the result of running each `allowBuilds` key through
+/// [`expand_package_version_specs`], so a key like
+/// `foo@1.0.0 || 2.0.0` lands as two separate `foo@1.0.0` and
+/// `foo@2.0.0` entries that [`AllowBuildPolicy::check`] can match
+/// via `HashSet::contains`.
+///
 /// The tri-state return from [`AllowBuildPolicy::check`]:
 /// - `Some(true)`: explicitly allowed, run scripts
 /// - `Some(false)`: explicitly denied, silently skip
 /// - `None`: not in the list, skip and report as ignored
 #[derive(Debug, Default)]
 pub struct AllowBuildPolicy {
-    rules: HashMap<String, bool>,
+    expanded_allowed: HashSet<String>,
+    expanded_disallowed: HashSet<String>,
     dangerously_allow_all: bool,
 }
 
 impl AllowBuildPolicy {
-    /// Build a policy from already-parsed `allowBuilds` rules and
-    /// `dangerouslyAllowAllBuilds`. Pure constructor — no IO — so
-    /// the policy logic is tested directly with in-memory inputs
-    /// (mirrors upstream's `createAllowBuildFunction(opts)` in
+    /// Build a policy from already-expanded `allowed` and
+    /// `disallowed` sets and `dangerouslyAllowAllBuilds`. Pure
+    /// constructor — no IO — so the policy logic is tested
+    /// directly with in-memory inputs (mirrors upstream's
+    /// `createAllowBuildFunction(opts)` in
     /// <https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/policy/src/index.ts>).
-    pub fn new(rules: HashMap<String, bool>, dangerously_allow_all: bool) -> Self {
-        Self { rules, dangerously_allow_all }
+    pub fn new(
+        expanded_allowed: HashSet<String>,
+        expanded_disallowed: HashSet<String>,
+        dangerously_allow_all: bool,
+    ) -> Self {
+        Self { expanded_allowed, expanded_disallowed, dangerously_allow_all }
     }
 
     /// Build the policy from a resolved [`Config`]. Reads
@@ -72,8 +86,29 @@ impl AllowBuildPolicy {
     /// populated by [`pacquet_config::WorkspaceSettings::apply_to`]
     /// from `pnpm-workspace.yaml`. pnpm v11 stopped reading these
     /// from `package.json#pnpm` — see pnpm/pacquet#397 item 5.
-    pub fn from_config(config: &Config) -> Self {
-        Self::new(config.allow_builds.clone(), config.dangerously_allow_all_builds)
+    ///
+    /// Each `allow_builds` key is partitioned by its boolean value
+    /// into `allowed` / `disallowed` sets, then each set is
+    /// expanded through [`expand_package_version_specs`] so version
+    /// unions like `foo@1.0.0 || 2.0.0` become two literal
+    /// `foo@1.0.0` / `foo@2.0.0` entries. Errors from the expansion
+    /// (`ERR_PNPM_INVALID_VERSION_UNION` /
+    /// `ERR_PNPM_NAME_PATTERN_IN_VERSION_UNION`) surface to the
+    /// caller — mirrors upstream's behavior of throwing from
+    /// `expandPackageVersionSpecs` at config-load time.
+    pub fn from_config(config: &Config) -> Result<Self, VersionPolicyError> {
+        let mut allowed_specs: Vec<&str> = Vec::new();
+        let mut disallowed_specs: Vec<&str> = Vec::new();
+        for (spec, &value) in &config.allow_builds {
+            if value {
+                allowed_specs.push(spec);
+            } else {
+                disallowed_specs.push(spec);
+            }
+        }
+        let expanded_allowed = expand_package_version_specs(allowed_specs)?;
+        let expanded_disallowed = expand_package_version_specs(disallowed_specs)?;
+        Ok(Self::new(expanded_allowed, expanded_disallowed, config.dangerously_allow_all_builds))
     }
 
     /// Check whether a package is allowed to run build scripts.
@@ -82,18 +117,28 @@ impl AllowBuildPolicy {
     /// - `Some(true)`: explicitly allowed (or `dangerouslyAllowAllBuilds`)
     /// - `Some(false)`: explicitly denied, silently skip
     /// - `None`: not in the list, skip and report as ignored
+    ///
+    /// Mirrors upstream's
+    /// [`createAllowBuildFunction`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/policy/src/index.ts#L35-L44)
+    /// matching: `disallowed` checked first, then `allowed`, both
+    /// against `name` and `name@version`. The `HashSet::contains`
+    /// lookup means `*` wildcards in specs do NOT match real
+    /// package names — see [`expand_package_version_specs`] for
+    /// the rationale.
     pub fn check(&self, name: &str, version: &str) -> Option<bool> {
         if self.dangerously_allow_all {
             return Some(true);
         }
 
-        let exact_key = format!("{name}@{version}");
-        if let Some(&allowed) = self.rules.get(&exact_key) {
-            return Some(allowed);
+        let name_at_version = format!("{name}@{version}");
+        if self.expanded_disallowed.contains(name)
+            || self.expanded_disallowed.contains(&name_at_version)
+        {
+            return Some(false);
         }
-
-        if let Some(&allowed) = self.rules.get(name) {
-            return Some(allowed);
+        if self.expanded_allowed.contains(name) || self.expanded_allowed.contains(&name_at_version)
+        {
+            return Some(true);
         }
 
         None

--- a/crates/package-manager/src/build_modules/tests.rs
+++ b/crates/package-manager/src/build_modules/tests.rs
@@ -16,9 +16,29 @@ use std::{
 };
 use tempfile::tempdir;
 
-/// Build a rules map from a list of (name, allowed) pairs, for tests.
-fn rules<const N: usize>(entries: [(&str, bool); N]) -> HashMap<String, bool> {
-    entries.into_iter().map(|(k, v)| (k.to_string(), v)).collect()
+/// Build an [`AllowBuildPolicy`] from a list of `(spec, allowed)`
+/// pairs, mirroring how `pnpm-workspace.yaml`'s `allowBuilds` map
+/// would arrive at the policy. Each spec is parsed through
+/// [`crate::expand_package_version_specs`] so version unions
+/// (`foo@1.0.0 || 2.0.0`) work the same way they do at runtime.
+/// Panics on any parse failure — test inputs must be valid.
+fn policy_from_specs<const N: usize>(
+    entries: [(&str, bool); N],
+    dangerously_allow_all: bool,
+) -> AllowBuildPolicy {
+    use crate::expand_package_version_specs;
+    let mut allowed_specs: Vec<&str> = Vec::new();
+    let mut disallowed_specs: Vec<&str> = Vec::new();
+    for (spec, value) in entries {
+        if value {
+            allowed_specs.push(spec);
+        } else {
+            disallowed_specs.push(spec);
+        }
+    }
+    let expanded_allowed = expand_package_version_specs(allowed_specs).expect("valid specs");
+    let expanded_disallowed = expand_package_version_specs(disallowed_specs).expect("valid specs");
+    AllowBuildPolicy::new(expanded_allowed, expanded_disallowed, dangerously_allow_all)
 }
 
 #[test]
@@ -57,49 +77,115 @@ fn default_policy_denies_all() {
 
 #[test]
 fn explicit_allow() {
-    let policy = AllowBuildPolicy::new(rules([("@pnpm.e2e/install-script-example", true)]), false);
+    let policy = policy_from_specs([("@pnpm.e2e/install-script-example", true)], false);
     assert_eq!(policy.check("@pnpm.e2e/install-script-example", "1.0.0"), Some(true));
 }
 
 #[test]
 fn explicit_deny() {
-    let policy = AllowBuildPolicy::new(rules([("@pnpm.e2e/bad-package", false)]), false);
+    let policy = policy_from_specs([("@pnpm.e2e/bad-package", false)], false);
     assert_eq!(policy.check("@pnpm.e2e/bad-package", "1.0.0"), Some(false));
 }
 
 #[test]
 fn unlisted_returns_none() {
-    let policy = AllowBuildPolicy::new(rules([("@pnpm.e2e/allowed", true)]), false);
+    let policy = policy_from_specs([("@pnpm.e2e/allowed", true)], false);
     assert_eq!(policy.check("@pnpm.e2e/not-listed", "1.0.0"), None);
 }
 
+/// Upstream checks `expandedDisallowed` before `expandedAllowed`
+/// in [`createAllowBuildFunction`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/policy/src/index.ts#L36-L43),
+/// so a bare-name disallow wins over an exact-version allow.
+/// Pacquet matches that order — pre-#397-item-5, the matcher
+/// checked exact-version first, which diverged from upstream.
 #[test]
-fn exact_version_takes_precedence() {
-    let policy = AllowBuildPolicy::new(
-        rules([("@pnpm.e2e/pkg@1.0.0", true), ("@pnpm.e2e/pkg", false)]),
-        false,
-    );
-    assert_eq!(policy.check("@pnpm.e2e/pkg", "1.0.0"), Some(true));
+fn disallow_bare_name_wins_over_allow_exact_version() {
+    let policy =
+        policy_from_specs([("@pnpm.e2e/pkg@1.0.0", true), ("@pnpm.e2e/pkg", false)], false);
+    assert_eq!(policy.check("@pnpm.e2e/pkg", "1.0.0"), Some(false));
     assert_eq!(policy.check("@pnpm.e2e/pkg", "2.0.0"), Some(false));
+}
+
+/// The converse: a bare-name allow combined with an exact-version
+/// disallow → the disallow on `pkg@1.0.0` fires only for that
+/// version; other versions hit the bare-name allow.
+#[test]
+fn disallow_exact_version_with_allow_bare_name() {
+    let policy =
+        policy_from_specs([("@pnpm.e2e/pkg", true), ("@pnpm.e2e/pkg@1.0.0", false)], false);
+    assert_eq!(policy.check("@pnpm.e2e/pkg", "1.0.0"), Some(false));
+    assert_eq!(policy.check("@pnpm.e2e/pkg", "2.0.0"), Some(true));
 }
 
 #[test]
 fn empty_rules_denies_all() {
-    let policy = AllowBuildPolicy::new(HashMap::new(), false);
+    let policy = policy_from_specs([], false);
     assert_eq!(policy.check("any-package", "1.0.0"), None);
 }
 
 #[test]
 fn dangerously_allow_all_builds() {
-    let policy = AllowBuildPolicy::new(HashMap::new(), true);
+    let policy = policy_from_specs([], true);
     assert_eq!(policy.check("any-package", "1.0.0"), Some(true));
     assert_eq!(policy.check("other-package", "2.0.0"), Some(true));
 }
 
 #[test]
 fn dangerously_allow_all_overrides_deny() {
-    let policy = AllowBuildPolicy::new(rules([("@pnpm.e2e/pkg", false)]), true);
+    let policy = policy_from_specs([("@pnpm.e2e/pkg", false)], true);
     assert_eq!(policy.check("@pnpm.e2e/pkg", "1.0.0"), Some(true));
+}
+
+/// Mirrors upstream's
+/// [`'should allowBuilds with true value'`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/policy/test/index.ts#L5-L15)
+/// — version unions expand into separate exact-version allows.
+/// `qar@1.0.0 || 2.0.0` allows exactly those two versions, leaves
+/// other versions unlisted (`None`).
+#[test]
+fn allow_via_version_union() {
+    let policy = policy_from_specs([("foo", true), ("qar@1.0.0 || 2.0.0", true)], false);
+    assert_eq!(policy.check("foo", "1.0.0"), Some(true));
+    assert_eq!(policy.check("bar", "1.0.0"), None);
+    assert_eq!(policy.check("qar", "1.0.0"), Some(true));
+    assert_eq!(policy.check("qar", "2.0.0"), Some(true));
+    assert_eq!(policy.check("qar", "1.1.0"), None);
+}
+
+/// Mirrors upstream's
+/// [`'should not allow patterns in allowBuilds'`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/policy/test/index.ts#L28-L34)
+/// — wildcards in `allowBuilds` keys are accepted by the parser
+/// (they land as literal strings in the expanded set) but the
+/// `HashSet::contains` lookup means they never match a real
+/// package name. Use `dangerouslyAllowAllBuilds` for blanket
+/// allow.
+#[test]
+fn wildcard_name_in_allow_builds_does_not_match_real_package() {
+    let policy = policy_from_specs([("is-*", true)], false);
+    assert_eq!(policy.check("is-odd", "1.0.0"), None);
+    assert_eq!(policy.check("is-positive", "1.0.0"), None);
+}
+
+/// `from_config` propagates `expand_package_version_specs` errors —
+/// an invalid version union in `Config.allow_builds` surfaces as
+/// `ERR_PNPM_INVALID_VERSION_UNION` rather than silently dropping
+/// the rule.
+#[test]
+fn from_config_propagates_invalid_version_union() {
+    let mut config = Config::new();
+    config.allow_builds.insert("foo@not-a-version".to_string(), true);
+    let err = AllowBuildPolicy::from_config(&config).expect_err("must reject");
+    assert!(matches!(err, crate::VersionPolicyError::InvalidVersionUnion { .. }), "got: {err:?}");
+}
+
+#[test]
+fn from_config_propagates_name_pattern_in_version_union() {
+    let mut config = Config::new();
+    config.allow_builds.insert("foo*@1.0.0".to_string(), true);
+    let err = AllowBuildPolicy::from_config(&config).expect_err("must reject");
+    assert!(
+        matches!(err, crate::VersionPolicyError::NamePatternInVersionUnion { .. }),
+        "got: {err:?}",
+    );
 }
 
 // The next two tests exercise `from_config` end-to-end: an empty Config
@@ -110,7 +196,7 @@ fn dangerously_allow_all_overrides_deny() {
 
 #[test]
 fn empty_config_denies_all() {
-    let policy = AllowBuildPolicy::from_config(&Config::new());
+    let policy = AllowBuildPolicy::from_config(&Config::new()).expect("empty config never errors");
     assert_eq!(policy.check("anything", "1.0.0"), None);
 }
 
@@ -121,7 +207,7 @@ fn from_config_consumes_allow_builds_and_dangerously_allow_all_builds() {
     config.allow_builds.insert("@pnpm.e2e/install-script-example".to_string(), true);
     config.allow_builds.insert("@pnpm.e2e/bad-package".to_string(), false);
 
-    let policy = AllowBuildPolicy::from_config(&config);
+    let policy = AllowBuildPolicy::from_config(&config).expect("valid specs");
     assert_eq!(policy.check("@pnpm.e2e/install-script-example", "1.0.0"), Some(true));
     assert_eq!(policy.check("@pnpm.e2e/bad-package", "1.0.0"), Some(false));
     assert_eq!(policy.check("@pnpm.e2e/unrelated", "1.0.0"), None);
@@ -236,7 +322,7 @@ fn build_modules_excludes_explicit_deny_from_ignored() {
     ]);
     let importers = root_importers(&[("denied", "1.0.0"), ("ignored", "1.0.0")]);
 
-    let policy = AllowBuildPolicy::new(rules([("denied", false)]), false);
+    let policy = policy_from_specs([("denied", false)], false);
 
     let virtual_store_dir = tempdir().expect("create temp dir");
     let modules_dir = tempdir().expect("create temp dir");
@@ -311,7 +397,7 @@ fn do_not_fail_on_optional_dep_with_failing_postinstall() {
     // `dangerouslyAllowAllBuilds` so the policy lets the failing
     // script through to actually run — this test exercises the
     // build-failure path, not the policy gate.
-    let policy = AllowBuildPolicy::new(rules([]), true);
+    let policy = policy_from_specs([], true);
 
     let virtual_store_dir = tempdir().expect("create temp dir");
     let modules_dir = tempdir().expect("create temp dir");
@@ -411,7 +497,7 @@ fn using_side_effects_cache_skips_rebuild() {
             },
         )]);
     let importers = root_importers(&[("@pnpm.e2e/failing-postinstall", "1.0.0")]);
-    let policy = AllowBuildPolicy::new(rules([]), true);
+    let policy = policy_from_specs([], true);
 
     let virtual_store_dir = tempdir().expect("create temp dir");
     let modules_dir = tempdir().expect("create temp dir");
@@ -482,7 +568,7 @@ fn side_effects_cache_disabled_bypasses_the_gate() {
     let packages: HashMap<pacquet_lockfile::PackageKey, pacquet_lockfile::PackageMetadata> =
         HashMap::new();
     let importers = root_importers(&[("@pnpm.e2e/failing-postinstall", "1.0.0")]);
-    let policy = AllowBuildPolicy::new(rules([]), true);
+    let policy = policy_from_specs([], true);
 
     let virtual_store_dir = tempdir().expect("create temp dir");
     let modules_dir = tempdir().expect("create temp dir");
@@ -540,7 +626,7 @@ fn fail_when_failing_postinstall_is_required() {
     // ALL-paths-optional fold concluding the dep is required.
     let snapshots = HashMap::from([(pkg_key.clone(), SnapshotEntry::default())]);
     let importers = root_importers(&[("@pnpm.e2e/failing-postinstall", "1.0.0")]);
-    let policy = AllowBuildPolicy::new(rules([]), true);
+    let policy = policy_from_specs([], true);
 
     let virtual_store_dir = tempdir().expect("create temp dir");
     let modules_dir = tempdir().expect("create temp dir");
@@ -710,7 +796,7 @@ async fn write_path_populates_side_effects_row() {
             },
         )]);
     let importers = root_importers(&[("@pnpm/postinstall-modifies-source", "1.0.0")]);
-    let policy = AllowBuildPolicy::new(rules([]), true);
+    let policy = policy_from_specs([], true);
 
     let store_root = tempdir().expect("create store dir");
     let store_dir = StoreDir::from(store_root.path().to_path_buf());
@@ -850,7 +936,7 @@ async fn write_path_disabled_skips_upload() {
             },
         )]);
     let importers = root_importers(&[("@pnpm/postinstall-modifies-source", "1.0.0")]);
-    let policy = AllowBuildPolicy::new(rules([]), true);
+    let policy = policy_from_specs([], true);
 
     let store_root = tempdir().expect("create store dir");
     let store_dir = StoreDir::from(store_root.path().to_path_buf());
@@ -953,7 +1039,7 @@ async fn upload_error_does_not_interrupt_install() {
             },
         )]);
     let importers = root_importers(&[("@pnpm/postinstall-modifies-source", "1.0.0")]);
-    let policy = AllowBuildPolicy::new(rules([]), true);
+    let policy = policy_from_specs([], true);
 
     let store_root = tempdir().expect("create store dir");
     let store_dir = StoreDir::from(store_root.path().to_path_buf());
@@ -1122,7 +1208,7 @@ async fn write_path_cache_key_includes_patch_hash() {
             },
         )]);
     let importers = root_importers(&[("@pnpm/postinstall-modifies-source", "1.0.0")]);
-    let policy = AllowBuildPolicy::new(rules([]), true);
+    let policy = policy_from_specs([], true);
 
     let store_root = tempdir().expect("create store dir");
     let store_dir = StoreDir::from(store_root.path().to_path_buf());
@@ -1262,7 +1348,7 @@ async fn patch_only_snapshot_gets_patched_via_build_modules() {
     let pkg_key = key("is-positive", "1.0.0");
     let snapshots = HashMap::from([(pkg_key.clone(), SnapshotEntry::default())]);
     let importers = root_importers(&[("is-positive", "1.0.0")]);
-    let policy = AllowBuildPolicy::new(rules([]), true);
+    let policy = policy_from_specs([], true);
 
     let store_root = tempdir().expect("create store dir");
     let store_dir = StoreDir::from(store_root.path().to_path_buf());
@@ -1350,7 +1436,7 @@ async fn missing_patch_file_path_errors_with_diagnostic() {
     let pkg_key = key("is-positive", "1.0.0");
     let snapshots = HashMap::from([(pkg_key.clone(), SnapshotEntry::default())]);
     let importers = root_importers(&[("is-positive", "1.0.0")]);
-    let policy = AllowBuildPolicy::new(rules([]), true);
+    let policy = policy_from_specs([], true);
 
     let store_root = tempdir().expect("create store dir");
     let store_dir = StoreDir::from(store_root.path().to_path_buf());

--- a/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/crates/package-manager/src/install_frozen_lockfile.rs
@@ -1,7 +1,7 @@
 use crate::{
     AllowBuildPolicy, BuildModules, BuildModulesError, CreateVirtualStore, CreateVirtualStoreError,
     CreateVirtualStoreOutput, LinkVirtualStoreBins, LinkVirtualStoreBinsError,
-    SymlinkDirectDependencies, SymlinkDirectDependenciesError,
+    SymlinkDirectDependencies, SymlinkDirectDependenciesError, VersionPolicyError,
 };
 use derive_more::{Display, Error};
 use miette::Diagnostic;
@@ -68,6 +68,13 @@ pub enum InstallFrozenLockfileError {
     /// <https://github.com/pnpm/pnpm/blob/b4f8f47ac2/patching/config/src/getPatchInfo.ts#L5-L19>.
     #[diagnostic(transparent)]
     PatchKeyConflict(#[error(source)] PatchKeyConflictError),
+
+    /// Surfaces upstream's `ERR_PNPM_INVALID_VERSION_UNION` /
+    /// `ERR_PNPM_NAME_PATTERN_IN_VERSION_UNION` when an
+    /// `allowBuilds` key in `pnpm-workspace.yaml` can't be parsed.
+    /// See <https://github.com/pnpm/pnpm/blob/b4f8f47ac2/config/version-policy/src/index.ts#L60-L80>.
+    #[diagnostic(transparent)]
+    VersionPolicy(#[error(source)] VersionPolicyError),
 }
 
 impl<'a, DependencyGroupList> InstallFrozenLockfile<'a, DependencyGroupList>
@@ -167,7 +174,8 @@ where
         }));
 
         let manifest_dir = Path::new(requester);
-        let allow_build_policy = AllowBuildPolicy::from_config(config);
+        let allow_build_policy = AllowBuildPolicy::from_config(config)
+            .map_err(InstallFrozenLockfileError::VersionPolicy)?;
 
         // Resolve `pnpm-workspace.yaml`'s `patchedDependencies` once
         // per install. Yields `None` when nothing is configured (no

--- a/crates/package-manager/src/lib.rs
+++ b/crates/package-manager/src/lib.rs
@@ -19,6 +19,7 @@ mod retry_config;
 mod store_init;
 mod symlink_direct_dependencies;
 mod symlink_package;
+mod version_policy;
 
 pub use add::*;
 pub use build_modules::*;
@@ -39,3 +40,4 @@ pub use link_bins::*;
 pub use link_file::*;
 pub use symlink_direct_dependencies::*;
 pub use symlink_package::*;
+pub use version_policy::*;

--- a/crates/package-manager/src/version_policy.rs
+++ b/crates/package-manager/src/version_policy.rs
@@ -1,0 +1,157 @@
+//! Parse and expand `<name>[@<version>[||<version>...]]` specs from
+//! `pnpm-workspace.yaml`'s `allowBuilds` (and analogous policy keys).
+//!
+//! Ports the [`expandPackageVersionSpecs`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/config/version-policy/src/index.ts#L17-L29)
+//! half of upstream's `config/version-policy` crate, plus the
+//! `parseVersionPolicyRule` and `parseExactVersionsUnion` helpers
+//! it builds on
+//! ([`config/version-policy/src/index.ts:56-91`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/config/version-policy/src/index.ts#L56-L91)).
+//!
+//! What this supports:
+//!
+//! - Bare name → `foo`, `@scope/foo`.
+//! - Exact version → `foo@1.0.0`, `@scope/foo@1.0.0`.
+//! - Exact-version union → `foo@1.0.0 || 2.0.0`. Each version is
+//!   parsed strictly (the JS-side uses `semver.valid`); whitespace
+//!   around `||` and within versions is trimmed.
+//!
+//! What this does NOT support — matching upstream's
+//! [`'should not allow patterns in allowBuilds'`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/policy/test/index.ts#L28-L34)
+//! test:
+//!
+//! - Wildcards in the name (`is-*`, `@scope/*`). Upstream's
+//!   `createAllowBuildFunction` uses `.has()` on the expanded set,
+//!   so a `*` in the spec ends up as a literal `*` in the set and
+//!   never matches a real package name. Pacquet preserves that
+//!   semantics — `*` is allowed in the parsed name when there's no
+//!   version part (so the literal string lands in the output set),
+//!   but it does NOT match real packages. Combining `*` with a
+//!   version is explicitly rejected as
+//!   [`ERR_PNPM_NAME_PATTERN_IN_VERSION_UNION`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/config/version-policy/src/index.ts#L73-L75)
+//!   (the same diagnostic code upstream emits).
+//!
+//! Note: `createPackageVersionPolicy` (which DOES support
+//! wildcards via `Matcher`) is a separate upstream function used
+//! by `minimumReleaseAgeExclude` / `dlx` — pacquet doesn't have
+//! those features yet, so only `expand_package_version_specs` is
+//! ported.
+
+use derive_more::{Display, Error};
+use miette::Diagnostic;
+use node_semver::Version;
+use std::collections::HashSet;
+
+/// Error from [`expand_package_version_specs`].
+#[derive(Debug, Display, Error, Diagnostic)]
+pub enum VersionPolicyError {
+    /// One of the versions in a `||` union didn't parse as a valid
+    /// exact semver. Mirrors upstream's
+    /// [`ERR_PNPM_INVALID_VERSION_UNION`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/config/version-policy/src/index.ts#L67-L69).
+    #[display("Invalid versions union. Found: \"{pattern}\". Use exact versions only.")]
+    #[diagnostic(code(ERR_PNPM_INVALID_VERSION_UNION))]
+    InvalidVersionUnion {
+        #[error(not(source))]
+        pattern: String,
+    },
+
+    /// A `*` wildcard in the package name AND a version part were
+    /// combined. Upstream rejects this because the matcher built on
+    /// top of the expanded set is `.has()` — wildcards would be
+    /// non-functional. Mirrors
+    /// [`ERR_PNPM_NAME_PATTERN_IN_VERSION_UNION`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/config/version-policy/src/index.ts#L73-L75).
+    #[display("Name patterns are not allowed with version unions. Found: \"{pattern}\"")]
+    #[diagnostic(code(ERR_PNPM_NAME_PATTERN_IN_VERSION_UNION))]
+    NamePatternInVersionUnion {
+        #[error(not(source))]
+        pattern: String,
+    },
+}
+
+/// Expand each spec into one or more `name` / `name@version` literal
+/// strings.
+///
+/// Output shape:
+///
+/// - Bare `foo` → `{"foo"}`.
+/// - `foo@1.0.0` → `{"foo@1.0.0"}`.
+/// - `foo@1.0.0 || 2.0.0` → `{"foo@1.0.0", "foo@2.0.0"}`.
+/// - `@scope/foo@1.0.0` → `{"@scope/foo@1.0.0"}`.
+///
+/// Ports upstream's
+/// [`expandPackageVersionSpecs`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/config/version-policy/src/index.ts#L17-L29).
+/// Callers feed the result into a `HashSet::contains` check, so a
+/// pattern like `is-*` lands in the set as the literal string
+/// `"is-*"` and never matches a real package name (matches upstream
+/// behavior exactly — see `should not allow patterns in allowBuilds`
+/// in `building/policy/test/index.ts`).
+pub fn expand_package_version_specs<I, S>(specs: I) -> Result<HashSet<String>, VersionPolicyError>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut out: HashSet<String> = HashSet::new();
+    for spec in specs {
+        let parsed = parse_version_policy_rule(spec.as_ref())?;
+        if parsed.exact_versions.is_empty() {
+            out.insert(parsed.package_name.to_string());
+        } else {
+            for version in parsed.exact_versions {
+                out.insert(format!("{}@{}", parsed.package_name, version));
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Parsed `<name>[@<version-union>]` rule. Either `exact_versions`
+/// is empty (bare name) or it contains one or more concrete semver
+/// strings. Mixing a `*` wildcard in the name with a version part
+/// is rejected by the caller before this struct is returned.
+struct ParsedRule<'a> {
+    package_name: &'a str,
+    exact_versions: Vec<String>,
+}
+
+fn parse_version_policy_rule(pattern: &str) -> Result<ParsedRule<'_>, VersionPolicyError> {
+    // Scoped name (`@scope/foo`) starts with `@`, so the version
+    // separator is the *second* `@`. Otherwise the first.
+    let at_index = if pattern.starts_with('@') {
+        pattern.char_indices().skip(1).find_map(|(i, c)| (c == '@').then_some(i))
+    } else {
+        pattern.find('@')
+    };
+
+    let Some(at) = at_index else {
+        return Ok(ParsedRule { package_name: pattern, exact_versions: Vec::new() });
+    };
+
+    let package_name = &pattern[..at];
+    let versions_part = &pattern[at + 1..];
+
+    let exact_versions = parse_exact_versions_union(versions_part)
+        .ok_or_else(|| VersionPolicyError::InvalidVersionUnion { pattern: pattern.to_string() })?;
+
+    if package_name.contains('*') {
+        return Err(VersionPolicyError::NamePatternInVersionUnion { pattern: pattern.to_string() });
+    }
+
+    Ok(ParsedRule { package_name, exact_versions })
+}
+
+/// Parse `v1 || v2 || …` into a list of strict semver versions.
+/// Returns `None` if any component fails to parse — the caller
+/// surfaces that as `ERR_PNPM_INVALID_VERSION_UNION`. Whitespace
+/// around `||` and around each version is trimmed before parsing
+/// (matches Node-semver's `valid()` which trims internally).
+fn parse_exact_versions_union(versions_str: &str) -> Option<Vec<String>> {
+    let mut out: Vec<String> = Vec::new();
+    for raw in versions_str.split("||") {
+        let trimmed = raw.trim();
+        let version = Version::parse(trimmed).ok()?;
+        out.push(version.to_string());
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/package-manager/src/version_policy/tests.rs
+++ b/crates/package-manager/src/version_policy/tests.rs
@@ -1,0 +1,98 @@
+use crate::version_policy::{VersionPolicyError, expand_package_version_specs};
+use pretty_assertions::assert_eq;
+
+fn expand(specs: &[&str]) -> Vec<String> {
+    let mut out: Vec<String> =
+        expand_package_version_specs(specs.iter().copied()).unwrap().into_iter().collect();
+    out.sort();
+    out
+}
+
+#[test]
+fn bare_name_expands_verbatim() {
+    assert_eq!(expand(&["foo"]), vec!["foo".to_string()]);
+}
+
+#[test]
+fn scoped_bare_name_expands_verbatim() {
+    assert_eq!(expand(&["@scope/foo"]), vec!["@scope/foo".to_string()]);
+}
+
+#[test]
+fn name_at_exact_version_expands_to_one_literal() {
+    assert_eq!(expand(&["foo@1.0.0"]), vec!["foo@1.0.0".to_string()]);
+}
+
+#[test]
+fn scoped_name_at_exact_version_expands_to_one_literal() {
+    assert_eq!(expand(&["@scope/foo@1.2.3"]), vec!["@scope/foo@1.2.3".to_string()]);
+}
+
+/// Mirrors the upstream test case
+/// [`'should allowBuilds with true value'`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/policy/test/index.ts#L5-L15)
+/// — the spec `qar@1.0.0 || 2.0.0` expands into two literal
+/// `qar@1.0.0` and `qar@2.0.0` entries.
+#[test]
+fn version_union_expands_into_separate_literals() {
+    let result = expand(&["qar@1.0.0 || 2.0.0"]);
+    assert_eq!(result, vec!["qar@1.0.0".to_string(), "qar@2.0.0".to_string()]);
+}
+
+#[test]
+fn version_union_trims_whitespace_around_each_version() {
+    // Extra whitespace around `||` and around each version. Mirrors
+    // semver-js's `valid()` which trims internally before parsing.
+    let result = expand(&["foo@  1.0.0   ||  2.0.0  "]);
+    assert_eq!(result, vec!["foo@1.0.0".to_string(), "foo@2.0.0".to_string()]);
+}
+
+/// Mirrors upstream's
+/// [`'should not allow patterns in allowBuilds'`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/policy/test/index.ts#L28-L34)
+/// — a pattern with `*` in the name lands in the expanded set as
+/// the literal string `is-*`. Downstream callers use
+/// `HashSet::contains` (mirroring upstream's `.has()`), so a real
+/// package name like `is-odd` does NOT match `is-*`. The expansion
+/// itself doesn't error.
+#[test]
+fn name_with_wildcard_alone_is_kept_verbatim() {
+    assert_eq!(expand(&["is-*"]), vec!["is-*".to_string()]);
+}
+
+/// Combining a wildcard in the name with a version part is
+/// explicitly an error (`ERR_PNPM_NAME_PATTERN_IN_VERSION_UNION`).
+/// Mirrors upstream
+/// [`config/version-policy/src/index.ts:73-75`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/config/version-policy/src/index.ts#L73-L75).
+#[test]
+fn wildcard_name_with_version_errors() {
+    let err = expand_package_version_specs(["foo*@1.0.0"]).expect_err("must reject");
+    assert!(matches!(err, VersionPolicyError::NamePatternInVersionUnion { .. }), "got: {err:?}");
+}
+
+/// Mirrors upstream
+/// [`config/version-policy/src/index.ts:67-69`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/config/version-policy/src/index.ts#L67-L69)
+/// — a `||` member that isn't valid semver triggers
+/// `ERR_PNPM_INVALID_VERSION_UNION`.
+#[test]
+fn non_semver_version_in_union_errors() {
+    let err = expand_package_version_specs(["foo@not-a-version"]).expect_err("must reject");
+    assert!(matches!(err, VersionPolicyError::InvalidVersionUnion { .. }), "got: {err:?}");
+}
+
+#[test]
+fn mixed_valid_invalid_union_errors() {
+    let err =
+        expand_package_version_specs(["foo@1.0.0 || not-a-version"]).expect_err("must reject");
+    assert!(matches!(err, VersionPolicyError::InvalidVersionUnion { .. }), "got: {err:?}");
+}
+
+#[test]
+fn empty_input_yields_empty_set() {
+    let result = expand_package_version_specs::<_, &str>([]).unwrap();
+    assert!(result.is_empty());
+}
+
+#[test]
+fn duplicate_specs_collapse_in_set() {
+    let result = expand(&["foo", "foo", "foo@1.0.0 || 1.0.0"]);
+    assert_eq!(result, vec!["foo".to_string(), "foo@1.0.0".to_string()]);
+}


### PR DESCRIPTION
## Summary

Completes pnpm/pacquet#397 item 5. Slice A+B's PR #425 moved `AllowBuildPolicy` off `package.json` onto `pnpm-workspace.yaml`; this PR ports the second half of upstream's matcher — `expandPackageVersionSpecs` — so users can write keys like `foo@1.0.0 || 2.0.0` in their `allowBuilds` map.

## What this adds

New `pacquet_package_manager::version_policy` module porting [`config/version-policy/src/index.ts`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/config/version-policy/src/index.ts) at SHA `b4f8f47ac2`. `expand_package_version_specs` parses each `allowBuilds` key into one or more `name` / `name@version` literal strings:

- `foo` → `{"foo"}`
- `foo@1.0.0` → `{"foo@1.0.0"}`
- `foo@1.0.0 || 2.0.0` → `{"foo@1.0.0", "foo@2.0.0"}`
- `@scope/foo@1.0.0` → `{"@scope/foo@1.0.0"}`

Two error codes mirror upstream:

- `ERR_PNPM_INVALID_VERSION_UNION` when a `||` member isn't valid semver
- `ERR_PNPM_NAME_PATTERN_IN_VERSION_UNION` when a `*` wildcard in the name is combined with a version part

Whitespace around `||` and within each version is trimmed before parsing, matching Node-semver's `valid()`.

## What this does NOT add

Wildcards in the name (`is-*`, `@scope/*`) are accepted by the parser and land in the expanded set as literal strings, but `HashSet::contains` lookups mean they never match real package names. Mirrors upstream's [`'should not allow patterns in allowBuilds'`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/policy/test/index.ts#L28-L34) test — the original #397 audit incorrectly claimed `@scope/*` should work in `allowBuilds`; it doesn't, neither upstream nor here. `createPackageVersionPolicy` (which DOES support wildcards via `Matcher`) is a separate upstream function used by `minimumReleaseAgeExclude` / `dlx` — pacquet doesn't have those features yet.

## AllowBuildPolicy refactor

`AllowBuildPolicy`'s internal storage changes from `HashMap<String, bool>` to two `HashSet<String>` (`expanded_allowed` and `expanded_disallowed`), populated through `expand_package_version_specs`. The `check` function checks `disallowed` before `allowed`, both against bare `name` and `name@version`, mirroring upstream's order at [`building/policy/src/index.ts:35-44`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/policy/src/index.ts#L35-L44).

This fixes a pre-existing pacquet divergence: the old matcher checked exact-version first, then bare name. With upstream's order, a bare-name disallow now correctly wins over an exact-version allow. New `disallow_bare_name_wins_over_allow_exact_version` test pins the behavior; the old `exact_version_takes_precedence` test was removed (it asserted the divergent behavior).

`AllowBuildPolicy::new` now takes the expanded sets directly (pure constructor — no IO). `AllowBuildPolicy::from_config` returns `Result<Self, VersionPolicyError>` so spec-parse failures surface at install time instead of being silently dropped. New `InstallFrozenLockfileError::VersionPolicy` variant propagates the error.

## Test plan

- [x] 12 new tests in `version_policy::tests` covering: bare name, exact version, version union, scoped names, whitespace trimming in unions, name-with-wildcard-alone (literal), invalid version union (error), mixed valid/invalid (error), wildcard-with-version (error), empty input, duplicate collapse.
- [x] Ports of upstream's [`building/policy/test/index.ts`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/policy/test/index.ts) cases: `allow_via_version_union` (version-union allows), `wildcard_name_in_allow_builds_does_not_match_real_package` (wildcards inert), `disallow_bare_name_wins_over_allow_exact_version` (matcher order), `disallow_exact_version_with_allow_bare_name` (converse).
- [x] `from_config` error-propagation tests for both `VersionPolicyError` variants.
- [x] `just ready` clean — 598 tests pass.
- [x] `just dylint` (perfectionist) clean.
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace --document-private-items` clean.
- [x] `taplo format --check` clean.

---
Written by an agent (Claude Code, claude-opus-4-7).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for package build policy configuration with more structured diagnostics.

* **Refactor**
  * Enhanced build policy evaluation logic for more accurate allow/deny decision-making.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pacquet/pull/428)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->