### PR TITLE
feat(config): POSIX root auto-detect for unsafePerm (#397 §14 follow-up)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1912,6 +1912,7 @@ dependencies = [
  "derive_more",
  "home",
  "indexmap",
+ "libc",
  "miette 7.6.0",
  "pacquet-patching",
  "pacquet-store-dir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ num_cpus = { version = "1.17.0" }
 os_display = { version = "0.1.4" }
 reflink-copy = { version = "0.1.29" }
 junction = { version = "2.0.0" }
+libc = { version = "0.2.185" }
 reqwest = { version = "0.13", default-features = false, features = [
   "hickory-dns",
   "json",

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -23,7 +23,7 @@ serde         = { workspace = true }
 serde-saphyr  = { workspace = true }
 smart-default = { workspace = true }
 
-[target.'cfg(unix)'.dependencies]
+[target.'cfg(all(unix, not(target_os = "cygwin")))'.dependencies]
 libc = { workspace = true }
 
 [dev-dependencies]

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -23,6 +23,9 @@ serde         = { workspace = true }
 serde-saphyr  = { workspace = true }
 smart-default = { workspace = true }
 
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }
+
 [dev-dependencies]
 pretty_assertions = { workspace = true }
 tempfile          = { workspace = true }

--- a/crates/config/src/defaults.rs
+++ b/crates/config/src/defaults.rs
@@ -160,5 +160,78 @@ pub fn resolve_child_concurrency_with_parallelism(option: Option<i32>, paralleli
     }
 }
 
+/// Default `unsafePerm` matching upstream's
+/// [`extendBuildOptions`](https://github.com/pnpm/pnpm/blob/94240bc046/building/after-install/src/extendBuildOptions.ts#L83-L86):
+///
+/// ```ts
+/// unsafePerm: process.platform === 'win32' ||
+///   process.platform === 'cygwin' ||
+///   !process.setgid ||
+///   process.getuid?.() !== 0,
+/// ```
+///
+/// Truth table:
+/// - Windows (or Cygwin) → `true`. POSIX privilege drop doesn't
+///   apply; upstream's `process.platform === 'win32' ||
+///   process.platform === 'cygwin'` branch fires unconditionally.
+/// - POSIX, not running as root → `true`. Nothing to drop from.
+/// - POSIX, running as root → `false`. Lifecycle scripts will run
+///   under TMPDIR isolation to `node_modules/.tmp`.
+///
+/// Pacquet's executor doesn't currently consume `unsafe_perm` to
+/// actually drop uid/gid (upstream's own [`@pnpm/npm-lifecycle`
+/// implementation](https://github.com/pnpm/npm-lifecycle/blob/d2d8e790/index.js#L236-L239)
+/// is a no-op in practice because `opts.user` / `opts.group` are
+/// never populated), but the TMPDIR-isolation side of the flag is
+/// honored — see `pacquet_executor::make_env`.
+///
+/// Rust's `cfg!(windows)` covers Windows and Cygwin (Cygwin builds
+/// target `windows-gnu`), so the upstream `process.platform ===
+/// 'cygwin'` branch is implicitly handled. The `!process.setgid`
+/// branch in upstream is a Node-version compatibility check for
+/// older Node where `setgid` doesn't exist; it doesn't translate
+/// to Rust (libc's `setgid` is always available on POSIX hosts
+/// where libc compiles).
+pub fn default_unsafe_perm() -> bool {
+    if cfg!(windows) {
+        return true;
+    }
+    is_unsafe_perm_posix(unsafe { posix_getuid() })
+}
+
+/// Pure-logic helper exposed for tests so the POSIX branch can be
+/// exercised under both root and non-root uids without root
+/// privileges. Mirrors the POSIX half of [`default_unsafe_perm`].
+pub fn is_unsafe_perm_posix(uid: u32) -> bool {
+    // `unsafe_perm = true` means "do NOT drop privileges". Drop
+    // only when we *are* root (uid == 0).
+    uid != 0
+}
+
+/// POSIX `getuid()` wrapper. Returns 0 on Windows (the caller
+/// short-circuits on Windows before reaching this, but the stub
+/// keeps the function callable from non-Windows test code without
+/// `cfg` gating at every call site).
+///
+/// # Safety
+///
+/// `libc::getuid` is documented as always-safe (it reads a kernel
+/// field, has no side effects, and cannot fail). The `unsafe`
+/// marker here is the standard Rust FFI requirement, not a sign of
+/// per-call invariants.
+#[cfg(unix)]
+unsafe fn posix_getuid() -> u32 {
+    unsafe { libc::getuid() as u32 }
+}
+
+/// Stub for non-POSIX builds — `default_unsafe_perm` never
+/// reaches this branch on Windows because it short-circuits to
+/// `true` first. The stub exists so the function signature
+/// resolves on every target without `cfg` gating in the caller.
+#[cfg(not(unix))]
+unsafe fn posix_getuid() -> u32 {
+    0
+}
+
 #[cfg(test)]
 mod tests;

--- a/crates/config/src/defaults.rs
+++ b/crates/config/src/defaults.rs
@@ -171,12 +171,15 @@ pub fn resolve_child_concurrency_with_parallelism(option: Option<i32>, paralleli
 /// ```
 ///
 /// Truth table:
-/// - Windows (or Cygwin) → `true`. POSIX privilege drop doesn't
+/// - Windows or Cygwin → `true`. POSIX privilege drop doesn't
 ///   apply; upstream's `process.platform === 'win32' ||
 ///   process.platform === 'cygwin'` branch fires unconditionally.
-/// - POSIX, not running as root → `true`. Nothing to drop from.
+/// - POSIX (excluding Cygwin), not running as root → `true`. Nothing
+///   to drop from.
 /// - POSIX, running as root → `false`. Lifecycle scripts will run
 ///   under TMPDIR isolation to `node_modules/.tmp`.
+/// - Anything else (e.g. `wasm32-*`) → `true`. No POSIX privilege
+///   model to drop into; behave like upstream's Windows branch.
 ///
 /// Pacquet's executor doesn't currently consume `unsafe_perm` to
 /// actually drop uid/gid (upstream's own [`@pnpm/npm-lifecycle`
@@ -185,18 +188,41 @@ pub fn resolve_child_concurrency_with_parallelism(option: Option<i32>, paralleli
 /// never populated), but the TMPDIR-isolation side of the flag is
 /// honored — see `pacquet_executor::make_env`.
 ///
-/// Rust's `cfg!(windows)` covers Windows and Cygwin (Cygwin builds
-/// target `windows-gnu`), so the upstream `process.platform ===
-/// 'cygwin'` branch is implicitly handled. The `!process.setgid`
-/// branch in upstream is a Node-version compatibility check for
-/// older Node where `setgid` doesn't exist; it doesn't translate
-/// to Rust (libc's `setgid` is always available on POSIX hosts
-/// where libc compiles).
+/// Cygwin needs explicit handling because Rust's
+/// [`x86_64-pc-cygwin` target](https://doc.rust-lang.org/rustc/platform-support/x86_64-pc-cygwin.html)
+/// emits `target_os = "cygwin"` with `cfg!(unix)` set and
+/// `cfg!(windows)` *unset*, so a plain `cfg!(windows)` check would
+/// fall through to the uid logic and diverge from upstream's
+/// unconditional-true Cygwin behavior. The `!process.setgid` branch
+/// in upstream is a Node-version compatibility check for older Node
+/// where `setgid` doesn't exist; it doesn't translate to Rust
+/// (libc's `setgid` is always available on POSIX hosts where libc
+/// compiles).
 pub fn default_unsafe_perm() -> bool {
-    if cfg!(windows) {
-        return true;
-    }
-    is_unsafe_perm_posix(unsafe { posix_getuid() })
+    platform_unsafe_perm_default()
+}
+
+/// Windows / Cygwin branch — always `true` (no POSIX privilege
+/// drop applies).
+#[cfg(any(windows, target_os = "cygwin"))]
+fn platform_unsafe_perm_default() -> bool {
+    true
+}
+
+/// POSIX (excluding Cygwin) — drop privileges only when running
+/// as root.
+#[cfg(all(unix, not(target_os = "cygwin")))]
+fn platform_unsafe_perm_default() -> bool {
+    is_unsafe_perm_posix(posix_getuid())
+}
+
+/// Targets that are neither Windows, Cygwin, nor POSIX
+/// (`wasm32-*`, `redox`, etc.) have no `getuid()` and no privilege
+/// model to drop into. Default to `true` so lifecycle scripts
+/// behave the same as on Windows.
+#[cfg(not(any(windows, unix)))]
+fn platform_unsafe_perm_default() -> bool {
+    true
 }
 
 /// Pure-logic helper exposed for tests so the POSIX branch can be
@@ -208,29 +234,17 @@ pub fn is_unsafe_perm_posix(uid: u32) -> bool {
     uid != 0
 }
 
-/// POSIX `getuid()` wrapper. Returns 0 on Windows (the caller
-/// short-circuits on Windows before reaching this, but the stub
-/// keeps the function callable from non-Windows test code without
-/// `cfg` gating at every call site).
-///
-/// # Safety
-///
-/// `libc::getuid` is documented as always-safe (it reads a kernel
-/// field, has no side effects, and cannot fail). The `unsafe`
-/// marker here is the standard Rust FFI requirement, not a sign of
-/// per-call invariants.
-#[cfg(unix)]
-unsafe fn posix_getuid() -> u32 {
+/// Safe wrapper around `libc::getuid` — contains the `unsafe`
+/// FFI block internally so the caller doesn't need to propagate
+/// `unsafe`. `libc::getuid` is documented as always-safe: it
+/// reads a kernel field, has no side effects, and cannot fail.
+/// Only compiled on POSIX-excluding-Cygwin since that's the only
+/// branch that actually calls it.
+#[cfg(all(unix, not(target_os = "cygwin")))]
+fn posix_getuid() -> u32 {
+    // SAFETY: `libc::getuid` has no preconditions; it reads a
+    // kernel-owned uid field and cannot fail.
     unsafe { libc::getuid() as u32 }
-}
-
-/// Stub for non-POSIX builds — `default_unsafe_perm` never
-/// reaches this branch on Windows because it short-circuits to
-/// `true` first. The stub exists so the function signature
-/// resolves on every target without `cfg` gating in the caller.
-#[cfg(not(unix))]
-unsafe fn posix_getuid() -> u32 {
-    0
 }
 
 #[cfg(test)]

--- a/crates/config/src/defaults/tests.rs
+++ b/crates/config/src/defaults/tests.rs
@@ -164,17 +164,29 @@ fn default_unsafe_perm_on_windows_is_always_true() {
     assert!(default_unsafe_perm(), "Windows default must always be true");
 }
 
-/// On POSIX, [`default_unsafe_perm`] matches the host's runtime
-/// uid via [`is_unsafe_perm_posix`]. Test environments don't
-/// usually run as root, so this is `true` in practice; the
-/// `is_unsafe_perm_posix_truth_table` test above pins the
-/// per-uid logic without needing root privileges to run as.
-#[cfg(unix)]
+/// On POSIX (excluding Cygwin), [`default_unsafe_perm`] matches
+/// the host's runtime uid via [`is_unsafe_perm_posix`]. Test
+/// environments don't usually run as root, so this is `true` in
+/// practice; the `is_unsafe_perm_posix_truth_table` test above
+/// pins the per-uid logic without needing root privileges. Cygwin
+/// is excluded because `default_unsafe_perm` short-circuits to
+/// `true` on Cygwin regardless of uid (matching upstream's
+/// `process.platform === 'cygwin'` branch).
+#[cfg(all(unix, not(target_os = "cygwin")))]
 #[test]
 fn default_unsafe_perm_on_posix_matches_runtime_uid() {
     // SAFETY: `libc::getuid` is documented as always-safe.
     let uid = unsafe { libc::getuid() } as u32;
     assert_eq!(default_unsafe_perm(), is_unsafe_perm_posix(uid));
+}
+
+/// On Cygwin, [`default_unsafe_perm`] short-circuits to `true`
+/// without consulting the uid — same branch as Windows. Mirrors
+/// upstream's `process.platform === 'cygwin'` check.
+#[cfg(target_os = "cygwin")]
+#[test]
+fn default_unsafe_perm_on_cygwin_is_always_true() {
+    assert!(default_unsafe_perm(), "Cygwin default must always be true (matches upstream)");
 }
 
 #[cfg(windows)]

--- a/crates/config/src/defaults/tests.rs
+++ b/crates/config/src/defaults/tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    default_child_concurrency_with_parallelism, default_store_dir, resolve_child_concurrency,
-    resolve_child_concurrency_with_parallelism,
+    default_child_concurrency_with_parallelism, default_store_dir, default_unsafe_perm,
+    is_unsafe_perm_posix, resolve_child_concurrency, resolve_child_concurrency_with_parallelism,
 };
 use crate::test_env_guard::EnvGuard;
 use pacquet_store_dir::StoreDir;
@@ -137,6 +137,44 @@ fn resolve_child_concurrency_positive_amount() {
 fn resolve_child_concurrency_handles_i32_min() {
     let result = resolve_child_concurrency(Some(i32::MIN));
     assert_eq!(result, 1);
+}
+
+/// POSIX truth table for [`is_unsafe_perm_posix`] matching
+/// upstream's
+/// [`getuid?.() !== 0`](https://github.com/pnpm/pnpm/blob/94240bc046/building/after-install/src/extendBuildOptions.ts#L83-L86)
+/// branch:
+///
+/// - root (uid 0) → `false` (drop privileges)
+/// - non-root (any other uid) → `true` (no drop)
+#[test]
+fn is_unsafe_perm_posix_truth_table() {
+    assert!(!is_unsafe_perm_posix(0), "running as root → drop perms");
+    assert!(is_unsafe_perm_posix(1), "non-root uid 1 → no drop");
+    assert!(is_unsafe_perm_posix(501), "non-root uid 501 → no drop");
+    assert!(is_unsafe_perm_posix(65534), "non-root uid 65534 → no drop");
+}
+
+/// On Windows, [`default_unsafe_perm`] short-circuits to `true`
+/// without ever calling `getuid()`. Mirrors upstream's
+/// `process.platform === 'win32' || process.platform === 'cygwin'`
+/// branch.
+#[cfg(windows)]
+#[test]
+fn default_unsafe_perm_on_windows_is_always_true() {
+    assert!(default_unsafe_perm(), "Windows default must always be true");
+}
+
+/// On POSIX, [`default_unsafe_perm`] matches the host's runtime
+/// uid via [`is_unsafe_perm_posix`]. Test environments don't
+/// usually run as root, so this is `true` in practice; the
+/// `is_unsafe_perm_posix_truth_table` test above pins the
+/// per-uid logic without needing root privileges to run as.
+#[cfg(unix)]
+#[test]
+fn default_unsafe_perm_on_posix_matches_runtime_uid() {
+    // SAFETY: `libc::getuid` is documented as always-safe.
+    let uid = unsafe { libc::getuid() } as u32;
+    assert_eq!(default_unsafe_perm(), is_unsafe_perm_posix(uid));
 }
 
 #[cfg(windows)]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -12,7 +12,9 @@ use serde::Deserialize;
 use smart_default::SmartDefault;
 use std::{collections::HashMap, fs, path::PathBuf};
 
-pub use crate::defaults::{available_parallelism, resolve_child_concurrency};
+pub use crate::defaults::{
+    available_parallelism, default_unsafe_perm, is_unsafe_perm_posix, resolve_child_concurrency,
+};
 use crate::defaults::{
     default_child_concurrency, default_fetch_retries, default_fetch_retry_factor,
     default_fetch_retry_maxtimeout, default_fetch_retry_mintimeout, default_hoist_pattern,
@@ -346,27 +348,25 @@ pub struct Config {
     /// Yaml accepts `true` / `false` / `"warn-only"`.
     pub scripts_prepend_node_path: ScriptsPrependNodePath,
 
-    /// `unsafePerm` from `pnpm-workspace.yaml`. When `false`, pnpm
-    /// runs lifecycle scripts under a TMPDIR isolated to
+    /// `unsafePerm` from `pnpm-workspace.yaml`. When `false`,
+    /// pnpm runs lifecycle scripts under a TMPDIR isolated to
     /// `node_modules/.tmp` and (in upstream) drops uid/gid to a
-    /// non-root user. Default `true` here. Pacquet honors the
-    /// TMPDIR side of the upstream behavior (see
-    /// `pacquet_executor::make_env`); the uid/gid drop is a no-op
-    /// in practice because pnpm's npm-lifecycle fork never
-    /// populates `opts.user` / `opts.group`, so even upstream just
-    /// re-applies the current process's uid/gid.
+    /// non-root user. Pacquet honors the TMPDIR side of the
+    /// upstream behavior (see `pacquet_executor::make_env`); the
+    /// uid/gid drop is a no-op in practice because pnpm's
+    /// npm-lifecycle fork never populates `opts.user` /
+    /// `opts.group`, so even upstream just re-applies the current
+    /// process's uid/gid.
     ///
-    /// Pacquet's default deviates slightly from upstream's
-    /// [`StrictBuildOptions.unsafePerm`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/after-install/src/extendBuildOptions.ts#L83-L86)
-    /// which auto-detects root-on-POSIX (`getuid() === 0 && setgid`)
-    /// and flips to `false`. Adding the auto-detect requires `libc`
-    /// (not currently in `[workspace.dependencies]`); for now,
-    /// root-run CI must set `unsafePerm: false` in yaml explicitly.
-    /// On Windows, [`WorkspaceSettings::apply_to`] forces this to
-    /// `true` regardless of yaml — matching upstream's
-    /// `process.platform === 'win32'` override at
+    /// The default is auto-detected via [`default_unsafe_perm`] to
+    /// mirror upstream's [`StrictBuildOptions.unsafePerm`](https://github.com/pnpm/pnpm/blob/94240bc046/building/after-install/src/extendBuildOptions.ts#L83-L86):
+    /// `true` on Windows or POSIX-not-root; `false` when running
+    /// as root on POSIX. On Windows,
+    /// [`WorkspaceSettings::apply_to`] also force-overrides the
+    /// applied value to `true` regardless of yaml — matching
+    /// upstream's `process.platform === 'win32'` gate at
     /// [`@pnpm/npm-lifecycle/index.js:204-220`](https://github.com/pnpm/npm-lifecycle/blob/d2d8e790/index.js#L204-L220).
-    #[default = true]
+    #[default(_code = "default_unsafe_perm()")]
     pub unsafe_perm: bool,
 
     /// `childConcurrency` from `pnpm-workspace.yaml` — the maximum

--- a/crates/config/src/workspace_yaml/tests.rs
+++ b/crates/config/src/workspace_yaml/tests.rs
@@ -313,10 +313,12 @@ fn rejects_invalid_scripts_prepend_node_path() {
     serde_saphyr::from_str::<WorkspaceSettings>(yaml).expect_err("must reject");
 }
 
-/// `unsafePerm` from yaml flips the default-`true` field. Mirrors
-/// upstream's [`Config.unsafePerm: boolean`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/config/reader/src/Config.ts).
-/// Pacquet's auto-root-detect default is a follow-up — for now,
-/// yaml override is the only way to flip the flag on POSIX.
+/// `unsafePerm: false` from yaml propagates to `Config.unsafe_perm`
+/// on POSIX. Mirrors upstream's [`Config.unsafePerm: boolean`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/config/reader/src/Config.ts).
+/// The starting `Config::new()` value depends on the runtime uid
+/// (see [`default_unsafe_perm`]) — `true` for non-root, `false`
+/// for root. Either way, `apply_to` with `Some(false)` ends in
+/// `false`.
 #[test]
 fn parses_unsafe_perm_from_yaml_and_applies() {
     // POSIX-only: the Windows force-override below would mask this
@@ -329,7 +331,6 @@ fn parses_unsafe_perm_from_yaml_and_applies() {
     assert_eq!(settings.unsafe_perm, Some(false));
 
     let mut config = Config::new();
-    assert!(config.unsafe_perm, "default is true");
     settings.apply_to(&mut config, Path::new("/irrelevant"));
     assert!(!config.unsafe_perm, "yaml override wins on POSIX");
 }


### PR DESCRIPTION
## Summary

Closes the deferred follow-up from #397 §14 — the POSIX root auto-detect for `unsafePerm`. Adds `libc` to `[workspace.dependencies]` (Unix-only at the consuming crate via `[target.'cfg(unix)'.dependencies]`) and implements `default_unsafe_perm()` mirroring upstream's [`extendBuildOptions.ts:83-86`](https://github.com/pnpm/pnpm/blob/94240bc046/building/after-install/src/extendBuildOptions.ts#L83-L86):

```ts
unsafePerm: process.platform === 'win32' ||
  process.platform === 'cygwin' ||
  !process.setgid ||
  process.getuid?.() !== 0
```

Pacquet truth table:

| Platform | uid | `default_unsafe_perm()` |
|---|---|---|
| Windows (or Cygwin via `cfg!(windows)`) | any | `true` |
| POSIX | `0` (root) | `false` (drop privileges) |
| POSIX | non-root | `true` |

The `!process.setgid` upstream branch is a Node-version compatibility check that doesn't translate to Rust (libc's `setgid` is always available on POSIX hosts where libc compiles).

`Config.unsafe_perm`'s default switches from a hard-coded `true` to `default_unsafe_perm()`. The yaml override path and the Windows force-override in `WorkspaceSettings::apply_to` stay unchanged. `is_unsafe_perm_posix(uid)` is exposed for tests so the per-uid logic can be exercised without root privileges to run as.

## Test plan

- [x] `cargo nextest run` — 617 tests pass (was 614 before; +3 new).
- [x] `just ready` — typos, fmt, check, lint clean.
- [x] `just dylint` — perfectionist clean.
- [x] `cargo doc -D warnings --document-private-items` — clean.
- [x] `taplo format --check` — clean.
- [x] `is_unsafe_perm_posix_truth_table` — root (uid 0) → `false`; non-root uids 1/501/65534 → `true`.
- [x] `default_unsafe_perm_on_posix_matches_runtime_uid` (POSIX-gated) — agrees with `is_unsafe_perm_posix(libc::getuid())`.
- [x] `default_unsafe_perm_on_windows_is_always_true` (Windows-gated).
- [x] Existing `parses_unsafe_perm_from_yaml_and_applies` updated to drop the now-uid-dependent explicit default assertion.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `unsafePerm` now has platform-aware, runtime defaults: Windows and Cygwin default to enabled; POSIX systems auto-detect based on process UID (root vs non-root).

* **Tests**
  * Expanded unit tests to cover POSIX root/non-root logic and platform-specific `unsafePerm` behavior, and updated YAML-related tests to reflect runtime defaults.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pacquet/pull/430)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->