### PR TITLE
feat(lockfile,store-dir): gitHosted on TarballResolution + pickStoreIndexKey (#436 §A)

### DIFF
--- a/crates/lockfile/src/resolution.rs
+++ b/crates/lockfile/src/resolution.rs
@@ -10,6 +10,19 @@ pub struct TarballResolution {
     pub tarball: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub integrity: Option<Integrity>,
+    /// `true` for tarballs sourced from a git host (codeload.github.com /
+    /// gitlab.com / bitbucket.org). Such tarballs need preparation
+    /// (preparePackage / packlist) on extraction, and their cached content
+    /// depends on whether build scripts ran, so they are addressed by a
+    /// git-hosted store-index key rather than the integrity-based key.
+    ///
+    /// The git resolver sets this when it produces the resolution; the
+    /// lockfile loader back-fills it on entries whose URL matches a known
+    /// git host for backward compatibility with lockfiles written before
+    /// this field existed. Mirrors pnpm's `TarballResolution.gitHosted`
+    /// at <https://github.com/pnpm/pnpm/blob/94240bc046/lockfile/types/src/index.ts#L88-L107>.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub git_hosted: Option<bool>,
 }
 
 /// For standard package specification, with package name and version range.
@@ -75,12 +88,33 @@ enum ResolutionSerde {
 impl From<ResolutionSerde> for LockfileResolution {
     fn from(value: ResolutionSerde) -> Self {
         match value {
-            ResolutionSerde::Tarball(resolution) => resolution.into(),
+            ResolutionSerde::Tarball(mut resolution) => {
+                // Back-fill `gitHosted` for entries written by older pnpm
+                // versions that lacked the field. Mirrors upstream's
+                // `enrichGitHostedFlag` at
+                // <https://github.com/pnpm/pnpm/blob/94240bc046/lockfile/fs/src/lockfileFormatConverters.ts#L158-L168>.
+                if resolution.git_hosted.is_none() && is_git_hosted_tarball_url(&resolution.tarball)
+                {
+                    resolution.git_hosted = Some(true);
+                }
+                resolution.into()
+            }
             ResolutionSerde::Registry(resolution) => resolution.into(),
             ResolutionSerde::Tagged(TaggedResolution::Directory(resolution)) => resolution.into(),
             ResolutionSerde::Tagged(TaggedResolution::Git(resolution)) => resolution.into(),
         }
     }
+}
+
+/// Best-effort URL-prefix check used to back-fill `gitHosted` on tarball
+/// resolutions written by older pnpm versions. Mirrors upstream's
+/// `isGitHostedTarballUrl` at
+/// <https://github.com/pnpm/pnpm/blob/94240bc046/lockfile/fs/src/lockfileFormatConverters.ts#L23-L29>.
+fn is_git_hosted_tarball_url(url: &str) -> bool {
+    (url.starts_with("https://codeload.github.com/")
+        || url.starts_with("https://bitbucket.org/")
+        || url.starts_with("https://gitlab.com/"))
+        && url.contains("tar.gz")
 }
 
 impl From<LockfileResolution> for ResolutionSerde {

--- a/crates/lockfile/src/resolution/tests.rs
+++ b/crates/lockfile/src/resolution/tests.rs
@@ -21,6 +21,7 @@ fn deserialize_tarball_resolution() {
     let expected = LockfileResolution::Tarball(TarballResolution {
         tarball: "file:ts-pipe-compose-0.2.1.tgz".to_string(),
         integrity: None,
+        git_hosted: None,
     });
     assert_eq!(received, expected);
 
@@ -33,7 +34,94 @@ fn deserialize_tarball_resolution() {
     dbg!(&received);
     let expected = LockfileResolution::Tarball(TarballResolution {
         tarball: "file:ts-pipe-compose-0.2.1.tgz".to_string(),
-        integrity: integrity("sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==").into()
+        integrity: integrity("sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==").into(),
+        git_hosted: None,
+    });
+    assert_eq!(received, expected);
+}
+
+#[test]
+fn deserialize_tarball_resolution_with_git_hosted() {
+    eprintln!("CASE: explicit gitHosted: true");
+    let yaml = text_block! {
+        "tarball: https://codeload.github.com/foo/bar/tar.gz/abc1234"
+        "gitHosted: true"
+    };
+    let received: LockfileResolution = serde_saphyr::from_str(yaml).unwrap();
+    dbg!(&received);
+    let expected = LockfileResolution::Tarball(TarballResolution {
+        tarball: "https://codeload.github.com/foo/bar/tar.gz/abc1234".to_string(),
+        integrity: None,
+        git_hosted: Some(true),
+    });
+    assert_eq!(received, expected);
+}
+
+#[test]
+fn deserialize_tarball_resolution_backfills_git_hosted() {
+    // Lockfiles written by older pnpm versions don't carry `gitHosted`; the
+    // loader back-fills it for entries whose URL matches a known git host.
+    // Mirrors upstream's `enrichGitHostedFlag`.
+    eprintln!("CASE: codeload.github.com");
+    let yaml = text_block! {
+        "tarball: https://codeload.github.com/foo/bar/tar.gz/abc1234"
+    };
+    let received: LockfileResolution = serde_saphyr::from_str(yaml).unwrap();
+    dbg!(&received);
+    let expected = LockfileResolution::Tarball(TarballResolution {
+        tarball: "https://codeload.github.com/foo/bar/tar.gz/abc1234".to_string(),
+        integrity: None,
+        git_hosted: Some(true),
+    });
+    assert_eq!(received, expected);
+
+    eprintln!("CASE: gitlab.com archive");
+    let yaml = text_block! {
+        "tarball: https://gitlab.com/foo/bar/-/archive/abc1234/bar-abc1234.tar.gz"
+    };
+    let received: LockfileResolution = serde_saphyr::from_str(yaml).unwrap();
+    let expected = LockfileResolution::Tarball(TarballResolution {
+        tarball: "https://gitlab.com/foo/bar/-/archive/abc1234/bar-abc1234.tar.gz".to_string(),
+        integrity: None,
+        git_hosted: Some(true),
+    });
+    assert_eq!(received, expected);
+
+    eprintln!("CASE: bitbucket.org archive");
+    let yaml = text_block! {
+        "tarball: https://bitbucket.org/foo/bar/get/abc1234.tar.gz"
+    };
+    let received: LockfileResolution = serde_saphyr::from_str(yaml).unwrap();
+    let expected = LockfileResolution::Tarball(TarballResolution {
+        tarball: "https://bitbucket.org/foo/bar/get/abc1234.tar.gz".to_string(),
+        integrity: None,
+        git_hosted: Some(true),
+    });
+    assert_eq!(received, expected);
+
+    eprintln!("CASE: registry URL (must not back-fill)");
+    let yaml = text_block! {
+        "tarball: https://registry.npmjs.org/foo/-/foo-1.0.0.tgz"
+    };
+    let received: LockfileResolution = serde_saphyr::from_str(yaml).unwrap();
+    let expected = LockfileResolution::Tarball(TarballResolution {
+        tarball: "https://registry.npmjs.org/foo/-/foo-1.0.0.tgz".to_string(),
+        integrity: None,
+        git_hosted: None,
+    });
+    assert_eq!(received, expected);
+
+    eprintln!("CASE: github.com without tar.gz (must not back-fill)");
+    // Upstream's prefix check requires both the host prefix *and* a `tar.gz`
+    // substring — release pages aren't tarballs.
+    let yaml = text_block! {
+        "tarball: https://codeload.github.com/foo/bar/zip/abc1234"
+    };
+    let received: LockfileResolution = serde_saphyr::from_str(yaml).unwrap();
+    let expected = LockfileResolution::Tarball(TarballResolution {
+        tarball: "https://codeload.github.com/foo/bar/zip/abc1234".to_string(),
+        integrity: None,
+        git_hosted: None,
     });
     assert_eq!(received, expected);
 }
@@ -44,6 +132,7 @@ fn serialize_tarball_resolution() {
     let resolution = LockfileResolution::Tarball(TarballResolution {
         tarball: "file:ts-pipe-compose-0.2.1.tgz".to_string(),
         integrity: None,
+        git_hosted: None,
     });
     let received = serialize_yaml::to_string(&resolution).unwrap();
     let received = received.trim();
@@ -56,7 +145,8 @@ fn serialize_tarball_resolution() {
     eprintln!("CASE: with integrity");
     let resolution = LockfileResolution::Tarball(TarballResolution {
         tarball: "file:ts-pipe-compose-0.2.1.tgz".to_string(),
-        integrity: integrity("sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==").into()
+        integrity: integrity("sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==").into(),
+        git_hosted: None,
     });
     let received = serialize_yaml::to_string(&resolution).unwrap();
     let received = received.trim();
@@ -64,6 +154,24 @@ fn serialize_tarball_resolution() {
     let expected = text_block! {
         "tarball: file:ts-pipe-compose-0.2.1.tgz"
         "integrity: sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg=="
+    };
+    assert_eq!(received, expected);
+}
+
+#[test]
+fn serialize_tarball_resolution_with_git_hosted() {
+    let resolution = LockfileResolution::Tarball(TarballResolution {
+        tarball: "https://codeload.github.com/foo/bar/tar.gz/abc1234".to_string(),
+        integrity: integrity("sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==").into(),
+        git_hosted: Some(true),
+    });
+    let received = serialize_yaml::to_string(&resolution).unwrap();
+    let received = received.trim();
+    eprintln!("RECEIVED:\n{received}");
+    let expected = text_block! {
+        "tarball: https://codeload.github.com/foo/bar/tar.gz/abc1234"
+        "integrity: sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg=="
+        "gitHosted: true"
     };
     assert_eq!(received, expected);
 }

--- a/crates/store-dir/src/store_index.rs
+++ b/crates/store-dir/src/store_index.rs
@@ -707,6 +707,42 @@ pub fn store_index_key(integrity: &str, pkg_id: &str) -> String {
     format!("{integrity}\t{pkg_id}")
 }
 
+/// Store-index key for git-hosted tarballs and bare `type: git` resolutions.
+/// Mirrors pnpm's `gitHostedStoreIndexKey` at
+/// <https://github.com/pnpm/pnpm/blob/94240bc046/store/index/src/index.ts#L65-L67>.
+///
+/// The cached content of a git-hosted package depends on whether build scripts
+/// ran during fetch (`preparePackage`), so `built` is part of the key. The
+/// integrity-only key would collapse the built/not-built variants into one
+/// slot.
+pub fn git_hosted_store_index_key(pkg_id: &str, built: bool) -> String {
+    store_index_key(pkg_id, if built { "built" } else { "not-built" })
+}
+
+/// Pick the store-index key for a tarball-shaped resolution.
+///
+/// Mirrors pnpm's `pickStoreIndexKey` at
+/// <https://github.com/pnpm/pnpm/blob/94240bc046/store/index/src/index.ts#L85-L94>:
+///
+/// - Tarballs flagged `git_hosted: true`, or any tarball entry missing
+///   integrity, use [`git_hosted_store_index_key`] — the cached content
+///   depends on whether the build ran.
+/// - All other integrity-carrying tarballs use [`store_index_key`].
+///
+/// The `built` flag must match the build decision the caller will make at
+/// fetch time (upstream sets it to `!opts.ignoreScripts`).
+pub fn pick_store_index_key(
+    integrity: Option<&str>,
+    git_hosted: bool,
+    pkg_id: &str,
+    built: bool,
+) -> String {
+    match integrity {
+        Some(integrity) if !git_hosted => store_index_key(integrity, pkg_id),
+        _ => git_hosted_store_index_key(pkg_id, built),
+    }
+}
+
 /// Per-instance record of what a tarball contributed to the CAFS. Stored as the
 /// value half of each `package_index` row.
 ///

--- a/crates/store-dir/src/store_index/tests.rs
+++ b/crates/store-dir/src/store_index/tests.rs
@@ -1,4 +1,7 @@
-use super::{CafsFileInfo, GET_MANY_CHUNK, PackageFilesIndex, StoreIndex, store_index_key};
+use super::{
+    CafsFileInfo, GET_MANY_CHUNK, PackageFilesIndex, StoreIndex, git_hosted_store_index_key,
+    pick_store_index_key, store_index_key,
+};
 use crate::StoreDir;
 use pretty_assertions::assert_eq;
 use std::collections::HashMap;
@@ -31,6 +34,46 @@ fn sample_index() -> PackageFilesIndex {
 #[test]
 fn key_format_is_integrity_tab_pkg_id() {
     assert_eq!(store_index_key("sha512-abc", "lodash@4.17.21"), "sha512-abc\tlodash@4.17.21");
+}
+
+#[test]
+fn git_hosted_key_uses_built_marker() {
+    // Mirrors upstream's `gitHostedStoreIndexKey(pkgId, { built })`.
+    assert_eq!(
+        git_hosted_store_index_key("github.com/foo/bar/abc1234", true),
+        "github.com/foo/bar/abc1234\tbuilt",
+    );
+    assert_eq!(
+        git_hosted_store_index_key("github.com/foo/bar/abc1234", false),
+        "github.com/foo/bar/abc1234\tnot-built",
+    );
+}
+
+#[test]
+fn pick_store_index_key_uses_integrity_for_plain_tarball() {
+    let key = pick_store_index_key(Some("sha512-abc"), false, "foo@1.0.0", true);
+    assert_eq!(key, "sha512-abc\tfoo@1.0.0");
+}
+
+#[test]
+fn pick_store_index_key_uses_git_hosted_for_flagged_tarball() {
+    // Even with integrity present, `git_hosted = true` routes to the
+    // built/not-built key — the built dimension is what disambiguates two
+    // cached variants of the same hosted tarball.
+    let key = pick_store_index_key(Some("sha512-abc"), true, "github.com/foo/bar/abc1234", true);
+    assert_eq!(key, "github.com/foo/bar/abc1234\tbuilt");
+
+    let key = pick_store_index_key(Some("sha512-abc"), true, "github.com/foo/bar/abc1234", false);
+    assert_eq!(key, "github.com/foo/bar/abc1234\tnot-built");
+}
+
+#[test]
+fn pick_store_index_key_uses_git_hosted_for_missing_integrity() {
+    // pnpm falls through to `gitHostedStoreIndexKey` for any resolution
+    // missing integrity — covers bare `type: git` resolutions and old
+    // lockfile entries that predate integrity for tarballs.
+    let key = pick_store_index_key(None, false, "github.com/foo/bar/abc1234", true);
+    assert_eq!(key, "github.com/foo/bar/abc1234\tbuilt");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Foundation for git-hosted package install (#436 Section A). Three small,
self-contained changes:

- **`TarballResolution.gitHosted: Option<bool>`** in `crates/lockfile`.
  Recent pnpm lockfiles ship this field on tarballs sourced from a git
  host. Without it, pacquet's `deny_unknown_fields` strictness rejected
  real lockfiles before the install dispatcher ran — a silent correctness
  gap independent of the rest of #436. Mirrors upstream's
  [`TarballResolution.gitHosted`](https://github.com/pnpm/pnpm/blob/94240bc046/lockfile/types/src/index.ts#L88-L107).

- **Back-fill on read.** When `gitHosted` is absent but the tarball URL
  prefix-matches a known git host (`codeload.github.com`, `gitlab.com`,
  `bitbucket.org`) with a `tar.gz` substring, set it to `true` during
  deserialize. Mirrors upstream's
  [`enrichGitHostedFlag`](https://github.com/pnpm/pnpm/blob/94240bc046/lockfile/fs/src/lockfileFormatConverters.ts#L158-L168)
  so every downstream reader can rely on the typed field instead of
  matching URL prefixes at each site.

- **`git_hosted_store_index_key` + `pick_store_index_key`** helpers in
  `pacquet-store-dir`. Git-hosted cache content depends on whether the
  build ran during fetch, so the cache key carries a `built` / `not-built`
  dimension that the integrity-only key would collapse. Mirrors
  upstream's
  [`gitHostedStoreIndexKey` / `pickStoreIndexKey`](https://github.com/pnpm/pnpm/blob/94240bc046/store/index/src/index.ts#L60-L94).
  No call sites switch yet — the dispatcher continues to error with
  `UnsupportedResolution { resolution_kind: "git" }` until the git fetcher
  lands.

## Out of scope (follow-ups for #436)

- Section B — `pacquet-git-fetcher` crate, `git_shallow_hosts` config,
  dispatcher wiring at `install_package_by_snapshot.rs:110-115` and
  `create_virtual_store.rs:513-520`.
- Section C — git-hosted tarball fetcher.
- Section D — `preparePackage` port wiring into the existing lifecycle
  runner.
- Section E — integration tests against a local git fixture.

## Test plan

- [x] `cargo nextest run -p pacquet-lockfile` — gitHosted round-trip,
      back-fill from codeload/gitlab/bitbucket URLs, no back-fill from
      registry URLs, no back-fill from a github URL without `tar.gz`.
- [x] `cargo nextest run -p pacquet-store-dir` — `built` / `not-built`
      key, route selection by `git_hosted` flag, route selection by
      missing integrity.
- [x] `just ready`
- [x] `taplo format --check`
- [x] `just dylint`

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and handling of git-hosted tarball dependencies in lockfiles, with automatic back-fill logic for legacy entries to ensure compatibility.

* **New Features**
  * Enhanced store indexing with new key-generation utilities to distinguish between different tarball source types and build states, aligning with upstream standards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pacquet/pull/440)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->