### PR TITLE
feat: partial install with --frozen-lockfile (#433)

### DIFF
--- a/crates/lockfile/src/lib.rs
+++ b/crates/lockfile/src/lib.rs
@@ -75,11 +75,35 @@ impl Lockfile {
     /// Base file name of the lockfile.
     pub const FILE_NAME: &str = "pnpm-lock.yaml";
 
+    /// Base file name of the *current* lockfile written under the
+    /// virtual store. Mirrors upstream pnpm's `lock.yaml` (the file
+    /// that records what was actually materialized in
+    /// `node_modules/.pnpm`, as opposed to what the wanted lockfile
+    /// asks for).
+    ///
+    /// Upstream: <https://github.com/pnpm/pnpm/blob/94240bc046/lockfile/fs/src/write.ts#L41-L51>.
+    pub const CURRENT_FILE_NAME: &str = "lock.yaml";
+
     /// The key used to refer to the root project inside `importers`.
     pub const ROOT_IMPORTER_KEY: &str = ".";
 
     /// Convenience accessor for the root project's snapshot.
     pub fn root_project(&self) -> Option<&'_ ProjectSnapshot> {
         self.importers.get(Lockfile::ROOT_IMPORTER_KEY)
+    }
+
+    /// `true` when no importer in this lockfile has either specifiers
+    /// or dependencies recorded. Mirrors upstream's `isEmptyLockfile`
+    /// at <https://github.com/pnpm/pnpm/blob/94240bc046/lockfile/fs/src/write.ts#L83-L85>;
+    /// upstream uses the result to suppress writing
+    /// `node_modules/.pnpm/lock.yaml` for an install that resolved to
+    /// zero packages. Only `specifiers` and `dependencies` participate
+    /// in the check — `devDependencies` and `optionalDependencies`
+    /// are ignored to match upstream exactly.
+    pub fn is_empty(&self) -> bool {
+        self.importers.values().all(|importer| {
+            importer.specifiers.as_ref().is_none_or(HashMap::is_empty)
+                && importer.dependencies.as_ref().is_none_or(HashMap::is_empty)
+        })
     }
 }

--- a/crates/lockfile/src/load_lockfile.rs
+++ b/crates/lockfile/src/load_lockfile.rs
@@ -5,6 +5,7 @@ use pipe_trait::Pipe;
 use std::{
     env, fs,
     io::{self, ErrorKind},
+    path::Path,
 };
 
 /// Error when reading lockfile the filesystem.
@@ -29,6 +30,30 @@ impl Lockfile {
     pub fn load_from_current_dir() -> Result<Option<Self>, LoadLockfileError> {
         let file_path =
             env::current_dir().map_err(LoadLockfileError::CurrentDir)?.join(Lockfile::FILE_NAME);
+        Self::load_from_path(&file_path)
+    }
+
+    /// Load the *current* lockfile from
+    /// `<virtual_store_dir>/lock.yaml`. Mirrors upstream's
+    /// `readCurrentLockfile` at
+    /// <https://github.com/pnpm/pnpm/blob/94240bc046/lockfile/fs/src/read.ts#L29-L37>:
+    /// the file records what pacquet actually materialized on the
+    /// previous install and is diffed against the wanted lockfile to
+    /// decide which snapshots can be skipped.
+    ///
+    /// Returns `Ok(None)` when the file is absent (a fresh install
+    /// against an empty `node_modules`), matching upstream's
+    /// ENOENT-as-`null` semantics. Same parse / version-check path as
+    /// the wanted lockfile, so a major-version mismatch surfaces as a
+    /// parse error rather than silently dropping the file.
+    pub fn load_current_from_virtual_store_dir(
+        virtual_store_dir: &Path,
+    ) -> Result<Option<Self>, LoadLockfileError> {
+        let file_path = virtual_store_dir.join(Lockfile::CURRENT_FILE_NAME);
+        Self::load_from_path(&file_path)
+    }
+
+    fn load_from_path(file_path: &Path) -> Result<Option<Self>, LoadLockfileError> {
         let content = match fs::read_to_string(file_path) {
             Ok(content) => content,
             Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),

--- a/crates/lockfile/src/save_lockfile.rs
+++ b/crates/lockfile/src/save_lockfile.rs
@@ -2,7 +2,9 @@ use crate::{Lockfile, serialize_yaml};
 use derive_more::{Display, Error};
 use pacquet_diagnostics::miette::{self, Diagnostic};
 use std::{
-    env, fs, io,
+    env,
+    fs::{self, OpenOptions},
+    io::{self, Write},
     path::{Path, PathBuf},
     sync::atomic::{AtomicU64, Ordering},
 };
@@ -102,25 +104,73 @@ impl Lockfile {
 /// Write `content` to `target` via a temp file in the same directory
 /// followed by `rename`. The rename is atomic on Unix and replaces
 /// in-place on Windows, so an observer never sees a torn file.
+///
+/// The temp file is opened with `O_CREAT | O_EXCL` (`create_new(true)`)
+/// rather than `create + truncate`, so we never follow a symlink or
+/// truncate a file an attacker (or a crashed prior install) pre-seeded
+/// at our predicted temp path. On `AlreadyExists` we advance the
+/// counter and try again, up to `MAX_TEMP_ATTEMPTS` times — matching
+/// the hardening already in `pacquet_fs::ensure_file::write_atomic`
+/// (per-call review on #442).
 fn write_atomic(target: &Path, content: &[u8]) -> Result<(), SaveLockfileError> {
-    static COUNTER: AtomicU64 = AtomicU64::new(0);
-    let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
-    let pid = std::process::id();
+    /// Sixteen fresh counter values is plenty — under benign
+    /// conditions we never collide; under shared-store-across-
+    /// containers the chance of 16 consecutive same-pid same-counter
+    /// collisions is negligible.
+    const MAX_TEMP_ATTEMPTS: usize = 16;
 
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let pid = std::process::id();
     let parent = target.parent().unwrap_or_else(|| Path::new("."));
     let file_name = target
         .file_name()
         .map(|s| s.to_string_lossy().into_owned())
         .unwrap_or_else(|| String::from("lock.yaml"));
-    let tmp = parent.join(format!(".{file_name}.{pid}.{counter}.tmp"));
 
-    fs::write(&tmp, content).map_err(SaveLockfileError::WriteFile)?;
-    fs::rename(&tmp, target).map_err(|error| {
-        // Best-effort cleanup so a failed rename doesn't leak temp
-        // files in the virtual store.
-        let _ = fs::remove_file(&tmp);
-        SaveLockfileError::RenameFile { tmp, target: target.to_path_buf(), error }
-    })
+    let mut last_already_exists: Option<io::Error> = None;
+    for _ in 0..MAX_TEMP_ATTEMPTS {
+        let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let tmp = parent.join(format!(".{file_name}.{pid}.{counter}.tmp"));
+
+        let mut file = match OpenOptions::new().write(true).create_new(true).open(&tmp) {
+            Ok(file) => file,
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                // Stale temp file or adversarial / concurrent pre-seed
+                // at the colliding path. Don't touch whatever is there;
+                // retry with a fresh counter.
+                last_already_exists = Some(error);
+                continue;
+            }
+            Err(error) => return Err(SaveLockfileError::WriteFile(error)),
+        };
+
+        if let Err(error) = file.write_all(content) {
+            drop(file);
+            let _ = fs::remove_file(&tmp);
+            return Err(SaveLockfileError::WriteFile(error));
+        }
+        // Close the handle before `rename`. Windows `MoveFileEx` over
+        // an open source file can fail with sharing-violation; on Unix
+        // an early `close` lets the kernel commit dirty buffers before
+        // the rename commits the dirent change.
+        drop(file);
+
+        return fs::rename(&tmp, target).map_err(|error| {
+            // Best-effort cleanup so a failed rename doesn't leak temp
+            // files in the virtual store.
+            let _ = fs::remove_file(&tmp);
+            SaveLockfileError::RenameFile { tmp, target: target.to_path_buf(), error }
+        });
+    }
+
+    // Ran out of temp-name attempts. Surface the last `AlreadyExists`
+    // so the operator can see what happened.
+    Err(SaveLockfileError::WriteFile(last_already_exists.unwrap_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "exhausted temp-path attempts for atomic lockfile write",
+        )
+    })))
 }
 
 #[cfg(test)]

--- a/crates/lockfile/src/save_lockfile.rs
+++ b/crates/lockfile/src/save_lockfile.rs
@@ -1,7 +1,11 @@
 use crate::{Lockfile, serialize_yaml};
 use derive_more::{Display, Error};
 use pacquet_diagnostics::miette::{self, Diagnostic};
-use std::{env, fs, io, path::Path};
+use std::{
+    env, fs, io,
+    path::{Path, PathBuf},
+    sync::atomic::{AtomicU64, Ordering},
+};
 
 /// Error when writing the lockfile to the filesystem.
 #[derive(Debug, Display, Error, Diagnostic)]
@@ -18,6 +22,31 @@ pub enum SaveLockfileError {
     #[display("Failed to write lockfile content: {_0}")]
     #[diagnostic(code(pacquet_lockfile::write_file))]
     WriteFile(io::Error),
+
+    #[display("Failed to create virtual-store directory {dir:?}: {error}")]
+    #[diagnostic(code(pacquet_lockfile::create_dir))]
+    CreateDir {
+        dir: PathBuf,
+        #[error(source)]
+        error: io::Error,
+    },
+
+    #[display("Failed to remove existing current-lockfile at {path:?}: {error}")]
+    #[diagnostic(code(pacquet_lockfile::remove_file))]
+    RemoveFile {
+        path: PathBuf,
+        #[error(source)]
+        error: io::Error,
+    },
+
+    #[display("Failed to rename temp file {tmp:?} over {target:?}: {error}")]
+    #[diagnostic(code(pacquet_lockfile::rename_file))]
+    RenameFile {
+        tmp: PathBuf,
+        target: PathBuf,
+        #[error(source)]
+        error: io::Error,
+    },
 }
 
 impl Lockfile {
@@ -33,6 +62,65 @@ impl Lockfile {
             env::current_dir().map_err(SaveLockfileError::CurrentDir)?.join(Lockfile::FILE_NAME);
         self.save_to_path(&file_path)
     }
+
+    /// Save the *current* lockfile under
+    /// `<virtual_store_dir>/lock.yaml` at end-of-install. Mirrors
+    /// upstream's `writeCurrentLockfile` at
+    /// <https://github.com/pnpm/pnpm/blob/94240bc046/lockfile/fs/src/write.ts#L41-L51>:
+    ///
+    /// - When the lockfile is empty ([`Lockfile::is_empty`]) the
+    ///   existing file is removed and no new content is written.
+    ///   Mirrors upstream's `rimraf` short-circuit so an empty install
+    ///   doesn't leave stale state behind.
+    /// - Otherwise the directory is created if missing and the file
+    ///   is written atomically: serialize → write next-to + rename.
+    ///   The rename is the only step an observer can race against,
+    ///   so a partial install will never leave a torn lockfile.
+    pub fn save_current_to_virtual_store_dir(
+        &self,
+        virtual_store_dir: &Path,
+    ) -> Result<(), SaveLockfileError> {
+        let target = virtual_store_dir.join(Lockfile::CURRENT_FILE_NAME);
+
+        if self.is_empty() {
+            match fs::remove_file(&target) {
+                Ok(()) => Ok(()),
+                Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+                Err(error) => Err(SaveLockfileError::RemoveFile { path: target, error }),
+            }
+        } else {
+            fs::create_dir_all(virtual_store_dir).map_err(|error| {
+                SaveLockfileError::CreateDir { dir: virtual_store_dir.to_path_buf(), error }
+            })?;
+            let content =
+                serialize_yaml::to_string(self).map_err(SaveLockfileError::SerializeYaml)?;
+            write_atomic(&target, content.as_bytes())
+        }
+    }
+}
+
+/// Write `content` to `target` via a temp file in the same directory
+/// followed by `rename`. The rename is atomic on Unix and replaces
+/// in-place on Windows, so an observer never sees a torn file.
+fn write_atomic(target: &Path, content: &[u8]) -> Result<(), SaveLockfileError> {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+
+    let parent = target.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = target
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| String::from("lock.yaml"));
+    let tmp = parent.join(format!(".{file_name}.{pid}.{counter}.tmp"));
+
+    fs::write(&tmp, content).map_err(SaveLockfileError::WriteFile)?;
+    fs::rename(&tmp, target).map_err(|error| {
+        // Best-effort cleanup so a failed rename doesn't leak temp
+        // files in the virtual store.
+        let _ = fs::remove_file(&tmp);
+        SaveLockfileError::RenameFile { tmp, target: target.to_path_buf(), error }
+    })
 }
 
 #[cfg(test)]

--- a/crates/lockfile/src/save_lockfile/tests.rs
+++ b/crates/lockfile/src/save_lockfile/tests.rs
@@ -98,3 +98,78 @@ fn save_fails_with_wrapped_io_error_when_path_is_invalid() {
         "expected SaveLockfileError::WriteFile(_), got: {err:?}",
     );
 }
+
+/// `write_current` creates the virtual-store directory if needed and
+/// reading it back yields the same lockfile. Verifies the read/write
+/// round-trip across the new `lock.yaml` path.
+#[test]
+fn write_current_round_trips_through_read_current() {
+    let original: Lockfile = serde_saphyr::from_str(LOCKFILE_YAML).expect("parse fixture lockfile");
+
+    let tmp = tempdir().expect("create tempdir");
+    let virtual_store_dir = tmp.path().join("node_modules").join(".pacquet");
+
+    original.save_current_to_virtual_store_dir(&virtual_store_dir).expect("write current lockfile");
+
+    let lock_path = virtual_store_dir.join(Lockfile::CURRENT_FILE_NAME);
+    assert!(lock_path.exists(), "lock.yaml should be created");
+
+    let loaded = Lockfile::load_current_from_virtual_store_dir(&virtual_store_dir)
+        .expect("read current lockfile")
+        .expect("current lockfile should be present");
+
+    assert_eq!(original, loaded);
+}
+
+/// `load_current_from_virtual_store_dir` returns `Ok(None)` when the
+/// file does not exist — mirrors upstream's ENOENT-as-null contract
+/// for first-time installs.
+#[test]
+fn read_current_returns_none_when_file_missing() {
+    let tmp = tempdir().expect("create tempdir");
+    let virtual_store_dir = tmp.path().join("node_modules").join(".pacquet");
+
+    let result = Lockfile::load_current_from_virtual_store_dir(&virtual_store_dir)
+        .expect("missing file should not error");
+    assert!(result.is_none(), "expected None for missing lock.yaml, got: {result:?}");
+}
+
+/// Empty-lockfile writes delete any existing `lock.yaml` rather than
+/// rewriting it. Mirrors upstream's `rimraf` short-circuit at
+/// <https://github.com/pnpm/pnpm/blob/94240bc046/lockfile/fs/src/write.ts#L45-L47>.
+#[test]
+fn write_current_deletes_file_when_lockfile_is_empty() {
+    let tmp = tempdir().expect("create tempdir");
+    let virtual_store_dir = tmp.path().join("node_modules").join(".pacquet");
+    std::fs::create_dir_all(&virtual_store_dir).unwrap();
+    let lock_path = virtual_store_dir.join(Lockfile::CURRENT_FILE_NAME);
+
+    // Pre-seed the file so we can observe the delete.
+    std::fs::write(&lock_path, "stale: true\n").unwrap();
+    assert!(lock_path.exists());
+
+    let empty: Lockfile =
+        serde_saphyr::from_str("lockfileVersion: '9.0'\n").expect("parse empty lockfile");
+    assert!(empty.is_empty(), "fixture should be considered empty");
+
+    empty
+        .save_current_to_virtual_store_dir(&virtual_store_dir)
+        .expect("write should succeed for empty lockfile");
+
+    assert!(!lock_path.exists(), "lock.yaml should be removed for empty lockfile");
+}
+
+/// Empty-lockfile writes are a no-op when the file was already
+/// absent. Mirrors `rimraf`'s ENOENT-as-OK behavior.
+#[test]
+fn write_current_is_a_noop_for_empty_lockfile_with_no_existing_file() {
+    let tmp = tempdir().expect("create tempdir");
+    let virtual_store_dir = tmp.path().join("node_modules").join(".pacquet");
+
+    let empty: Lockfile =
+        serde_saphyr::from_str("lockfileVersion: '9.0'\n").expect("parse empty lockfile");
+    empty
+        .save_current_to_virtual_store_dir(&virtual_store_dir)
+        .expect("write should succeed when target is missing");
+    assert!(!virtual_store_dir.join(Lockfile::CURRENT_FILE_NAME).exists());
+}

--- a/crates/package-manager/src/create_virtual_store.rs
+++ b/crates/package-manager/src/create_virtual_store.rs
@@ -10,7 +10,8 @@ use pacquet_lockfile::{
 };
 use pacquet_network::ThrottledClient;
 use pacquet_reporter::{
-    LogEvent, LogLevel, ProgressLog, ProgressMessage, Reporter, StatsLog, StatsMessage,
+    BrokenModulesLog, LogEvent, LogLevel, ProgressLog, ProgressMessage, Reporter, StatsLog,
+    StatsMessage,
 };
 use pacquet_store_dir::{SharedVerifiedFilesCache, StoreIndex, StoreIndexWriter, store_index_key};
 use pacquet_tarball::{PrefetchResult, prefetch_cas_paths};
@@ -69,6 +70,14 @@ pub struct CreateVirtualStore<'a> {
     pub config: &'static Config,
     pub packages: Option<&'a HashMap<PackageKey, PackageMetadata>>,
     pub snapshots: Option<&'a HashMap<PackageKey, SnapshotEntry>>,
+    /// Snapshots and per-version metadata recorded by the previous
+    /// install, parsed from `<virtual_store_dir>/lock.yaml`. `None`
+    /// on a first install (the file doesn't exist). When present,
+    /// per-snapshot lookups against this drive the
+    /// `lockfileToDepGraph`-equivalent skip decision — see
+    /// [`CreateVirtualStore::run`].
+    pub current_snapshots: Option<&'a HashMap<PackageKey, SnapshotEntry>>,
+    pub current_packages: Option<&'a HashMap<PackageKey, PackageMetadata>>,
     /// Install-scoped dedupe state for `pnpm:package-import-method`.
     /// See `link_file::log_method_once`.
     pub logged_methods: &'a AtomicU8,
@@ -113,6 +122,8 @@ impl<'a> CreateVirtualStore<'a> {
             config,
             packages,
             snapshots,
+            current_snapshots,
+            current_packages,
             logged_methods,
             requester,
             store_index_writer,
@@ -128,36 +139,6 @@ impl<'a> CreateVirtualStore<'a> {
             });
         };
         let packages = packages.ok_or(CreateVirtualStoreError::MissingPackagesSection)?;
-
-        // `pnpm:stats added` mirrors pnpm's emit at
-        // <https://github.com/pnpm/pnpm/blob/086c5e91e8/installing/deps-installer/src/install/link.ts#L363>:
-        // one event per project once the orchestrator has decided
-        // how many packages will land in the virtual store. Pnpm
-        // reports `newDepPathsSet.size` (the *delta* between current
-        // and wanted lockfile); pacquet has no current-lockfile
-        // tracking yet, so every install looks like a fresh install
-        // and `added` ends up as the total snapshot count. Once the
-        // current-lockfile path lands the count will narrow to the
-        // diff, matching pnpm exactly.
-        //
-        // `pnpm:stats removed: 0` mirrors the no-current-lockfile
-        // branch of
-        // <https://github.com/pnpm/pnpm/blob/086c5e91e8/installing/deps-restorer/src/index.ts#L290>:
-        // pnpm emits a placeholder `0` when there's nothing to prune
-        // so consumers don't render a stale "removed" count from a
-        // previous install. Pacquet has no pruning pipeline yet, so
-        // the placeholder is the truthful value today.
-        R::emit(&LogEvent::Stats(StatsLog {
-            level: LogLevel::Debug,
-            message: StatsMessage::Added {
-                prefix: requester.to_owned(),
-                added: snapshots.len() as u64,
-            },
-        }));
-        R::emit(&LogEvent::Stats(StatsLog {
-            level: LogLevel::Debug,
-            message: StatsMessage::Removed { prefix: requester.to_owned(), removed: 0 },
-        }));
 
         // Open the read-only SQLite index once for the whole run instead of
         // per snapshot. Every `InstallPackageBySnapshot` performs a cache
@@ -268,12 +249,87 @@ impl<'a> CreateVirtualStore<'a> {
         // batch, which meant the warm rayon batch ran to completion
         // (~6 s on `alot7`) before the actual error fired.
         type SnapshotWithCacheKey<'a> = (&'a PackageKey, &'a SnapshotEntry, Option<String>);
-        let snapshot_entries: Vec<SnapshotWithCacheKey<'_>> = snapshots
+        let all_snapshot_entries: Vec<SnapshotWithCacheKey<'_>> = snapshots
             .iter()
             .map(|(snapshot_key, snapshot)| {
                 snapshot_cache_key(snapshot_key, packages).map(|key| (snapshot_key, snapshot, key))
             })
             .collect::<Result<_, _>>()?;
+
+        // Per-snapshot skip pass: for every snapshot the previous
+        // install also installed (`current_snapshots`) with the same
+        // dependency wiring + integrity, *and* whose virtual-store
+        // slot still exists on disk, drop it entirely from the install
+        // graph. The current-lockfile write at end-of-install captures
+        // the full wanted graph regardless, so the next install sees
+        // the same skip surface even after partial graph deltas.
+        //
+        // Mirrors upstream's gate at
+        // <https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-builder/src/lockfileToDepGraph.ts#L246-L260>.
+        // When the cache key matches but the directory is gone (user
+        // ran `rm -rf node_modules/.pnpm/...`, antivirus quarantine,
+        // etc.) we emit the `_broken_node_modules` debug event and
+        // fall through to the full install path for that snapshot.
+        let virtual_store_dir = &config.virtual_store_dir;
+        let snapshot_entries: Vec<SnapshotWithCacheKey<'_>> = all_snapshot_entries
+            .into_iter()
+            .filter(|(snapshot_key, snapshot, _)| {
+                let Some(current_snapshots) = current_snapshots else { return true };
+                let Some(current_snapshot) = current_snapshots.get(snapshot_key) else {
+                    return true;
+                };
+                if !snapshot_deps_equal(current_snapshot, snapshot) {
+                    return true;
+                }
+                let current_metadata =
+                    current_packages.and_then(|p| p.get(&snapshot_key.without_peer()));
+                let wanted_metadata = packages.get(&snapshot_key.without_peer());
+                if !integrity_equal(current_metadata, wanted_metadata) {
+                    return true;
+                }
+                let dir = virtual_store_dir
+                    .join(snapshot_key.to_virtual_store_name())
+                    .join("node_modules")
+                    .join(snapshot_key.name.to_string());
+                if dir.is_dir() {
+                    false
+                } else {
+                    R::emit(&LogEvent::BrokenModules(BrokenModulesLog {
+                        level: LogLevel::Debug,
+                        missing: dir.to_string_lossy().into_owned(),
+                    }));
+                    true
+                }
+            })
+            .collect();
+        // `pnpm:stats added` mirrors pnpm's emit at
+        // <https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/src/install/link.ts#L363>:
+        // one event per project once the orchestrator has decided
+        // how many packages will land in the virtual store. Upstream
+        // reports `newDepPathsSet.size`, the *delta* between current
+        // and wanted lockfile; pacquet computes the same delta as the
+        // post-skip-filter snapshot count so a warm reinstall against
+        // an unchanged lockfile reports `added: 0`.
+        //
+        // `pnpm:stats removed: 0` mirrors the no-current-lockfile
+        // branch of
+        // <https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-restorer/src/index.ts#L290>:
+        // pnpm emits a placeholder `0` when there's nothing to prune
+        // so consumers don't render a stale "removed" count from a
+        // previous install. Pacquet has no pruning pipeline yet, so
+        // the placeholder is the truthful value today.
+        R::emit(&LogEvent::Stats(StatsLog {
+            level: LogLevel::Debug,
+            message: StatsMessage::Added {
+                prefix: requester.to_owned(),
+                added: snapshot_entries.len() as u64,
+            },
+        }));
+        R::emit(&LogEvent::Stats(StatsLog {
+            level: LogLevel::Debug,
+            message: StatsMessage::Removed { prefix: requester.to_owned(), removed: 0 },
+        }));
+
         let mut cache_key_refs: Vec<&str> =
             snapshot_entries.iter().filter_map(|(_, _, k)| k.as_deref()).collect();
         cache_key_refs.sort_unstable();
@@ -521,6 +577,43 @@ fn snapshot_cache_key(
     };
     let pkg_id = metadata_key.to_string();
     Ok(Some(store_index_key(&integrity, &pkg_id)))
+}
+
+/// Two snapshots agree on dependency wiring when both their
+/// `dependencies` and `optionalDependencies` maps are equal in
+/// upstream's sense — an absent map and an empty map are equivalent
+/// (`equals({}, undefined)` and `isEmpty({}) === isEmpty(undefined)`
+/// both hold in Ramda). Mirrors the AND-pair in
+/// <https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-builder/src/lockfileToDepGraph.ts#L246-L260>:
+/// the deps check is the `depIsPresent && equals(...)` arm and the
+/// optional-deps check is the `isEmpty(...) && isEmpty(...) ||
+/// equals(...)` arm folded together.
+fn snapshot_deps_equal(current: &SnapshotEntry, wanted: &SnapshotEntry) -> bool {
+    fn maps_equal<K, V>(a: Option<&HashMap<K, V>>, b: Option<&HashMap<K, V>>) -> bool
+    where
+        K: std::cmp::Eq + std::hash::Hash,
+        V: PartialEq,
+    {
+        match (a, b) {
+            (None, None) => true,
+            (Some(m), None) | (None, Some(m)) => m.is_empty(),
+            (Some(x), Some(y)) => x == y,
+        }
+    }
+    maps_equal(current.dependencies.as_ref(), wanted.dependencies.as_ref())
+        && maps_equal(current.optional_dependencies.as_ref(), wanted.optional_dependencies.as_ref())
+}
+
+/// Compare the `integrity` field on two `packages:` entries. Mirrors
+/// upstream's `isIntegrityEqual` helper at
+/// <https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-builder/src/lockfileToDepGraph.ts#L366>:
+/// only the tarball/registry-style integrity participates in the
+/// check; directory and git resolutions yield `None` on both sides,
+/// which we treat as "unchanged" so the existing slot is reused.
+fn integrity_equal(current: Option<&PackageMetadata>, wanted: Option<&PackageMetadata>) -> bool {
+    let current_integrity = current.and_then(|m| m.resolution.integrity());
+    let wanted_integrity = wanted.and_then(|m| m.resolution.integrity());
+    current_integrity == wanted_integrity
 }
 
 /// `pnpm:progress` `resolved` + `found_in_store` for a frozen-lockfile

--- a/crates/package-manager/src/create_virtual_store.rs
+++ b/crates/package-manager/src/create_virtual_store.rs
@@ -252,7 +252,7 @@ impl<'a> CreateVirtualStore<'a> {
         // Mirrors upstream's gate at
         // <https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-builder/src/lockfileToDepGraph.ts#L246-L260>.
         // When the cache key matches but the directory is gone (user
-        // ran `rm -rf node_modules/.pnpm/...`, antivirus quarantine,
+        // ran `rm -rf <virtual_store_dir>/...`, antivirus quarantine,
         // etc.) we emit the `_broken_node_modules` debug event and
         // fall through to the full install path for that snapshot.
         //

--- a/crates/package-manager/src/create_virtual_store.rs
+++ b/crates/package-manager/src/create_virtual_store.rs
@@ -241,21 +241,6 @@ impl<'a> CreateVirtualStore<'a> {
         // Sort + dedup the prefetch input so `prefetch_cas_paths`
         // doesn't redo identical SELECT + integrity-check work for
         // every peer variant.
-        // Validate every snapshot upfront so a malformed lockfile
-        // (missing metadata, missing tarball integrity, currently-
-        // unsupported directory / git resolution) errors out *before*
-        // we start the warm batch. Previously we collapsed those
-        // cases into `None` and let them fall through to the cold
-        // batch, which meant the warm rayon batch ran to completion
-        // (~6 s on `alot7`) before the actual error fired.
-        type SnapshotWithCacheKey<'a> = (&'a PackageKey, &'a SnapshotEntry, Option<String>);
-        let all_snapshot_entries: Vec<SnapshotWithCacheKey<'_>> = snapshots
-            .iter()
-            .map(|(snapshot_key, snapshot)| {
-                snapshot_cache_key(snapshot_key, packages).map(|key| (snapshot_key, snapshot, key))
-            })
-            .collect::<Result<_, _>>()?;
-
         // Per-snapshot skip pass: for every snapshot the previous
         // install also installed (`current_snapshots`) with the same
         // dependency wiring + integrity, *and* whose virtual-store
@@ -270,12 +255,20 @@ impl<'a> CreateVirtualStore<'a> {
         // ran `rm -rf node_modules/.pnpm/...`, antivirus quarantine,
         // etc.) we emit the `_broken_node_modules` debug event and
         // fall through to the full install path for that snapshot.
+        //
+        // Run this *before* deriving cache keys so unchanged
+        // directory-backed snapshots aren't tripped by
+        // `snapshot_cache_key`'s `UnsupportedResolution`. Once
+        // directory / git resolutions land they'll still survive the
+        // skip (their slot existing on disk is all the check needs)
+        // and the cache-key step won't see them either (review on
+        // #442).
         let virtual_store_dir = &config.virtual_store_dir;
-        let snapshot_entries: Vec<SnapshotWithCacheKey<'_>> = all_snapshot_entries
-            .into_iter()
-            .filter(|(snapshot_key, snapshot, _)| {
+        let survivors: Vec<(&PackageKey, &SnapshotEntry)> = snapshots
+            .iter()
+            .filter(|(snapshot_key, snapshot)| {
                 let Some(current_snapshots) = current_snapshots else { return true };
-                let Some(current_snapshot) = current_snapshots.get(snapshot_key) else {
+                let Some(current_snapshot) = current_snapshots.get(*snapshot_key) else {
                     return true;
                 };
                 if !snapshot_deps_equal(current_snapshot, snapshot) {
@@ -302,6 +295,21 @@ impl<'a> CreateVirtualStore<'a> {
                 }
             })
             .collect();
+
+        // Validate every surviving snapshot upfront so a malformed
+        // lockfile (missing metadata, missing tarball integrity,
+        // currently-unsupported directory / git resolution) errors
+        // out *before* we start the warm batch. Previously we
+        // collapsed those cases into `None` and let them fall through
+        // to the cold batch, which meant the warm rayon batch ran to
+        // completion (~6 s on `alot7`) before the actual error fired.
+        type SnapshotWithCacheKey<'a> = (&'a PackageKey, &'a SnapshotEntry, Option<String>);
+        let snapshot_entries: Vec<SnapshotWithCacheKey<'_>> = survivors
+            .into_iter()
+            .map(|(snapshot_key, snapshot)| {
+                snapshot_cache_key(snapshot_key, packages).map(|key| (snapshot_key, snapshot, key))
+            })
+            .collect::<Result<_, _>>()?;
         // `pnpm:stats added` mirrors pnpm's emit at
         // <https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/src/install/link.ts#L363>:
         // one event per project once the orchestrator has decided

--- a/crates/package-manager/src/create_virtual_store.rs
+++ b/crates/package-manager/src/create_virtual_store.rs
@@ -303,6 +303,22 @@ impl<'a> CreateVirtualStore<'a> {
         // collapsed those cases into `None` and let them fall through
         // to the cold batch, which meant the warm rayon batch ran to
         // completion (~6 s on `alot7`) before the actual error fired.
+        //
+        // Cache-key derivation runs in two passes:
+        //
+        // - *Survivors* go through the strict path (this `?`). Their
+        //   resolutions have to be valid because the install will
+        //   actually fetch + link them.
+        // - *Skipped* snapshots get a lenient pass below: cache keys
+        //   are derived if possible, and any per-snapshot error is
+        //   swallowed. Reason: skipped snapshots aren't being
+        //   re-installed, but their store-index rows still need to
+        //   land in `side_effects_maps_by_snapshot` so
+        //   [`crate::BuildModules`]'s `is_built` gate can skip
+        //   re-running build scripts on warm reinstalls (review on
+        //   #442 — without this, allowed-build packages re-execute
+        //   their scripts every install, costing seconds on the
+        //   warm-reinstall path).
         type SnapshotWithCacheKey<'a> = (&'a PackageKey, &'a SnapshotEntry, Option<String>);
         let snapshot_entries: Vec<SnapshotWithCacheKey<'_>> = survivors
             .into_iter()
@@ -310,6 +326,27 @@ impl<'a> CreateVirtualStore<'a> {
                 snapshot_cache_key(snapshot_key, packages).map(|key| (snapshot_key, snapshot, key))
             })
             .collect::<Result<_, _>>()?;
+
+        // Cache keys for the *skipped* snapshots (i.e. snapshots
+        // present in `snapshots` but absent from `snapshot_entries`).
+        // Derived leniently so an unsupported / malformed skipped
+        // entry doesn't fail the install — it just contributes no
+        // prefetch row, which is the same outcome as if the skip
+        // filter had not engaged. Built as a parallel `Vec` so the
+        // downstream `package_manifests` /
+        // `side_effects_maps_by_snapshot` loop sees the full snapshot
+        // set, not just survivors.
+        let survivor_keys: std::collections::HashSet<&PackageKey> =
+            snapshot_entries.iter().map(|(k, _, _)| *k).collect();
+        let skipped_entries: Vec<SnapshotWithCacheKey<'_>> = snapshots
+            .iter()
+            .filter(|(snapshot_key, _)| !survivor_keys.contains(snapshot_key))
+            .map(|(snapshot_key, snapshot)| {
+                let cache_key = snapshot_cache_key(snapshot_key, packages).ok().flatten();
+                (snapshot_key, snapshot, cache_key)
+            })
+            .collect();
+
         // `pnpm:stats added` mirrors pnpm's emit at
         // <https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/src/install/link.ts#L363>:
         // one event per project once the orchestrator has decided
@@ -338,8 +375,15 @@ impl<'a> CreateVirtualStore<'a> {
             message: StatsMessage::Removed { prefix: requester.to_owned(), removed: 0 },
         }));
 
-        let mut cache_key_refs: Vec<&str> =
-            snapshot_entries.iter().filter_map(|(_, _, k)| k.as_deref()).collect();
+        // Union the cache keys from survivors and skipped snapshots
+        // so the prefetch covers everyone the build phase might need
+        // to gate on. Sorted + deduplicated to avoid redundant SQL
+        // queries in `prefetch_cas_paths`.
+        let mut cache_key_refs: Vec<&str> = snapshot_entries
+            .iter()
+            .chain(skipped_entries.iter())
+            .filter_map(|(_, _, k)| k.as_deref())
+            .collect();
         cache_key_refs.sort_unstable();
         cache_key_refs.dedup();
         let cache_keys: Vec<String> = cache_key_refs.into_iter().map(String::from).collect();
@@ -402,6 +446,33 @@ impl<'a> CreateVirtualStore<'a> {
             HashMap::with_capacity(prefetched_manifests.len());
         let mut side_effects_maps_by_snapshot: SideEffectsMapsBySnapshot =
             HashMap::with_capacity(prefetched_side_effects.len());
+
+        // First pass: process *skipped* snapshots into the bin-
+        // manifest cache and the side-effects map. They don't enter
+        // the warm/cold partition (no link work to do), but their
+        // store-index rows are needed downstream so
+        // [`crate::BuildModules`]'s `is_built` gate can fire — without
+        // these entries, packages with `allowBuilds: true` would
+        // re-execute their lifecycle scripts on every warm reinstall.
+        for (snapshot_key, _snapshot, cache_key) in &skipped_entries {
+            if let Some(cache_key) = cache_key.as_deref()
+                && let Some(manifest) = prefetched_manifests.get(cache_key)
+            {
+                package_manifests
+                    .entry(snapshot_key.without_peer())
+                    .or_insert_with(|| std::sync::Arc::clone(manifest));
+            }
+            if let Some(cache_key) = cache_key.as_deref()
+                && let Some(maps) = prefetched_side_effects.get(cache_key)
+            {
+                side_effects_maps_by_snapshot
+                    .insert((*snapshot_key).clone(), std::sync::Arc::clone(maps));
+            }
+        }
+
+        // Second pass: survivors. Same loop as above plus the
+        // warm/cold partition that decides which snapshots run the
+        // link work.
         for (snapshot_key, snapshot, cache_key) in &snapshot_entries {
             if let Some(cache_key) = cache_key.as_deref()
                 && let Some(manifest) = prefetched_manifests.get(cache_key)

--- a/crates/package-manager/src/create_virtual_store/tests.rs
+++ b/crates/package-manager/src/create_virtual_store/tests.rs
@@ -1,6 +1,39 @@
-use super::emit_warm_snapshot_progress;
+use super::{emit_warm_snapshot_progress, integrity_equal, snapshot_deps_equal};
+use pacquet_lockfile::{
+    LockfileResolution, PackageMetadata, PkgName, RegistryResolution, SnapshotDepRef, SnapshotEntry,
+};
 use pacquet_reporter::{LogEvent, ProgressMessage, Reporter};
-use std::sync::Mutex;
+use std::{collections::HashMap, sync::Mutex};
+
+fn name(s: &str) -> PkgName {
+    PkgName::parse(s).expect("parse pkg name")
+}
+
+fn metadata_with_integrity(integrity: &str) -> PackageMetadata {
+    PackageMetadata {
+        resolution: LockfileResolution::Registry(RegistryResolution {
+            integrity: integrity.parse().expect("parse integrity"),
+        }),
+        engines: None,
+        cpu: None,
+        os: None,
+        libc: None,
+        deprecated: None,
+        has_bin: None,
+        prepare: None,
+        bundled_dependencies: None,
+        peer_dependencies: None,
+        peer_dependencies_meta: None,
+    }
+}
+
+fn snapshot_with_dep(child: &str, ref_str: &str) -> SnapshotEntry {
+    let dep_ref: SnapshotDepRef = ref_str.parse().expect("parse SnapshotDepRef");
+    SnapshotEntry {
+        dependencies: Some(HashMap::from([(name(child), dep_ref)])),
+        ..Default::default()
+    }
+}
 
 /// `emit_warm_snapshot_progress` fires `resolved` then
 /// `found_in_store` in that order for one (package_id, requester)
@@ -40,4 +73,96 @@ fn emits_resolved_then_found_in_store_with_matching_identifiers() {
         ),
         "warm-snapshot pair must be (Resolved, FoundInStore) with matching identifiers; got {captured:?}",
     );
+}
+
+/// `snapshot_deps_equal` is `true` when both `dependencies` and
+/// `optionalDependencies` agree — matching upstream's `equals(...)`
+/// pair. An absent map matches an empty map: pnpm canonicalises both
+/// to `{}` via Ramda's `isEmpty`, so pacquet must too or warm
+/// reinstalls would loop pointlessly when the lockfile drops the
+/// optional-deps key.
+#[test]
+fn snapshot_deps_equal_treats_absent_and_empty_alike() {
+    let absent = SnapshotEntry::default();
+    let empty = SnapshotEntry {
+        dependencies: Some(HashMap::new()),
+        optional_dependencies: Some(HashMap::new()),
+        ..Default::default()
+    };
+    assert!(snapshot_deps_equal(&absent, &empty));
+    assert!(snapshot_deps_equal(&empty, &absent));
+}
+
+/// A real diff on `dependencies` flips the result to `false`. Upstream
+/// gates the skip on this comparison; if pacquet treated mismatched
+/// child-version edges as "no change", a warm reinstall would silently
+/// keep an outdated symlink layout when the lockfile bumped a
+/// transitive.
+#[test]
+fn snapshot_deps_equal_distinguishes_different_dependency_values() {
+    let a = snapshot_with_dep("react", "17.0.2");
+    let b = snapshot_with_dep("react", "18.0.0");
+    assert!(!snapshot_deps_equal(&a, &b));
+}
+
+/// `optionalDependencies` participate in the comparison the same way
+/// `dependencies` do — both upstream `equals` calls have to agree
+/// before the skip fires.
+#[test]
+fn snapshot_deps_equal_distinguishes_different_optional_dependency_values() {
+    let dep_ref: SnapshotDepRef = "1.0.0".parse().expect("parse dep ref");
+    let a = SnapshotEntry {
+        optional_dependencies: Some(HashMap::from([(name("react"), dep_ref.clone())])),
+        ..Default::default()
+    };
+    let b = SnapshotEntry {
+        optional_dependencies: Some(HashMap::from([(name("react-dom"), dep_ref)])),
+        ..Default::default()
+    };
+    assert!(!snapshot_deps_equal(&a, &b));
+}
+
+/// `integrity_equal` mirrors upstream's `isIntegrityEqual` —
+/// identical `integrity` strings on both sides means the cached
+/// tarball is still valid, mismatched (or one-sided) integrities
+/// force a re-fetch.
+#[test]
+fn integrity_equal_matches_when_integrities_agree() {
+    let a = metadata_with_integrity(
+        "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    );
+    let b = metadata_with_integrity(
+        "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    );
+    assert!(integrity_equal(Some(&a), Some(&b)));
+}
+
+#[test]
+fn integrity_equal_distinguishes_changed_integrities() {
+    let a = metadata_with_integrity(
+        "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    );
+    let b = metadata_with_integrity(
+        "sha512-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+    );
+    assert!(!integrity_equal(Some(&a), Some(&b)));
+}
+
+/// Missing metadata on either side (a malformed lockfile, or the
+/// snapshot referring to a `packages:` entry that was dropped)
+/// collapses to `None` on the integrity lookup. Both sides `None`
+/// stays "equal" so a directory/git resolution pair (whose integrity
+/// is `None`) doesn't trip a spurious re-fetch.
+#[test]
+fn integrity_equal_treats_none_pair_as_equal() {
+    assert!(integrity_equal(None, None));
+}
+
+#[test]
+fn integrity_equal_treats_one_sided_missing_as_unequal() {
+    let with_integrity = metadata_with_integrity(
+        "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    );
+    assert!(!integrity_equal(None, Some(&with_integrity)));
+    assert!(!integrity_equal(Some(&with_integrity), None));
 }

--- a/crates/package-manager/src/install.rs
+++ b/crates/package-manager/src/install.rs
@@ -139,10 +139,12 @@ where
         // install actually materialized in `<virtual_store_dir>/lock.yaml`.
         // The frozen-lockfile path diffs each wanted snapshot against
         // this on a per-`PackageKey` basis to decide whether the
-        // already-installed slot is still usable. `None` on a first
-        // install (the file doesn't exist yet); also `None` if the
-        // file is corrupted in a way the parser surfaces — see
-        // `current_lockfile_load_error` below for the propagation.
+        // already-installed slot is still usable. `Ok(None)` on a
+        // first install (the file doesn't exist yet). A corrupted /
+        // version-incompatible file surfaces as `LoadCurrentLockfile`
+        // and fails the install — matching upstream's
+        // `ignoreIncompatible: false` posture at the deps-restorer
+        // call site rather than silently dropping the optimization.
         //
         // Mirrors upstream's `readCurrentLockfile` call at
         // <https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-restorer/src/index.ts#L226-L227>.
@@ -241,21 +243,6 @@ where
         // progress display has closed. Mirrors upstream's emit point in
         // <https://github.com/pnpm/pnpm/blob/80037699fb/installing/deps-installer/src/install/link.ts#L167>.
 
-        // Write `<virtual_store_dir>/lock.yaml`. Mirrors upstream's
-        // `writeCurrentLockfile` call at
-        // <https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/src/install/index.ts#L1597>:
-        // captures what was actually materialized so the next install
-        // can diff each snapshot against it and skip the unchanged
-        // slots. Today pacquet writes the wanted lockfile unchanged
-        // because there's only one importer to filter to; once
-        // workspace install (#431) lands this needs to narrow to the
-        // *filtered* lockfile (selected importers × engine filter).
-        if frozen_lockfile && let Some(lockfile) = lockfile {
-            lockfile
-                .save_current_to_virtual_store_dir(&config.virtual_store_dir)
-                .map_err(InstallError::SaveCurrentLockfile)?;
-        }
-
         // Write `node_modules/.modules.yaml`. Mirrors upstream's
         // `writeModulesManifest` call at
         // <https://github.com/pnpm/pnpm/blob/086c5e91e8/installing/deps-installer/src/install/index.ts#L1608-L1630>,
@@ -269,6 +256,26 @@ where
             build_modules_manifest(config, included),
         )
         .map_err(InstallError::WriteModules)?;
+
+        // Write `<virtual_store_dir>/lock.yaml`. Mirrors upstream's
+        // `writeCurrentLockfile` call at
+        // <https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/src/install/index.ts#L1597>:
+        // captures what was actually materialized so the next install
+        // can diff each snapshot against it and skip the unchanged
+        // slots. Persist *after* `write_modules_manifest` succeeds so
+        // a manifest failure can't leave a fresh current-lockfile
+        // pointing at incomplete install state — the next frozen
+        // reinstall would otherwise diff against a graph that never
+        // finished committing (review on #442). Today pacquet writes
+        // the wanted lockfile unchanged because there's only one
+        // importer to filter to; once workspace install (#431) lands
+        // this needs to narrow to the *filtered* lockfile (selected
+        // importers × engine filter).
+        if frozen_lockfile && let Some(lockfile) = lockfile {
+            lockfile
+                .save_current_to_virtual_store_dir(&config.virtual_store_dir)
+                .map_err(InstallError::SaveCurrentLockfile)?;
+        }
 
         // `pnpm:summary` closes the install and lets the reporter render
         // the accumulated `pnpm:root` events as a "+N -M" block. Must

--- a/crates/package-manager/src/install.rs
+++ b/crates/package-manager/src/install.rs
@@ -7,7 +7,7 @@ use crate::{
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_config::{Config, NodeLinker};
-use pacquet_lockfile::Lockfile;
+use pacquet_lockfile::{LoadLockfileError, Lockfile, SaveLockfileError};
 use pacquet_modules_yaml::{
     DEFAULT_VIRTUAL_STORE_DIR_MAX_LENGTH, IncludedDependencies, LayoutVersion, Modules,
     NodeLinker as ModulesNodeLinker, RealApi, WriteModulesError, write_modules_manifest,
@@ -59,6 +59,20 @@ pub enum InstallError {
 
     #[diagnostic(transparent)]
     WriteModules(#[error(source)] WriteModulesError),
+
+    /// Surfaces a corrupted `<virtual_store_dir>/lock.yaml` rather
+    /// than silently skipping the optimization. Mirrors upstream's
+    /// `ignoreIncompatible: false` posture at
+    /// <https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-restorer/src/index.ts#L226-L227>.
+    #[diagnostic(transparent)]
+    LoadCurrentLockfile(#[error(source)] LoadLockfileError),
+
+    /// Surfaces a failure to persist the current lockfile so the next
+    /// install can diff against it. A best-effort warn would let
+    /// silent disk-full or permission issues compound across installs;
+    /// fail the install instead.
+    #[diagnostic(transparent)]
+    SaveCurrentLockfile(#[error(source)] SaveLockfileError),
 }
 
 impl<'a, DependencyGroupList> Install<'a, DependencyGroupList>
@@ -121,15 +135,29 @@ where
             },
         }));
 
+        // Load the *current* lockfile that records what the previous
+        // install actually materialized in `<virtual_store_dir>/lock.yaml`.
+        // The frozen-lockfile path diffs each wanted snapshot against
+        // this on a per-`PackageKey` basis to decide whether the
+        // already-installed slot is still usable. `None` on a first
+        // install (the file doesn't exist yet); also `None` if the
+        // file is corrupted in a way the parser surfaces — see
+        // `current_lockfile_load_error` below for the propagation.
+        //
+        // Mirrors upstream's `readCurrentLockfile` call at
+        // <https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-restorer/src/index.ts#L226-L227>.
+        let current_lockfile =
+            Lockfile::load_current_from_virtual_store_dir(&config.virtual_store_dir)
+                .map_err(InstallError::LoadCurrentLockfile)?;
+
         // `pnpm:context` carries the directories pnpm's reporter prints
-        // in the install header. `currentLockfileExists` reflects
-        // `node_modules/.pnpm/lock.yaml` upstream; pacquet doesn't yet
-        // read or write that file, so it's always `false` today.
-        // TODO: flip when the current-lockfile path lands.
-        // Upstream: <https://github.com/pnpm/pnpm/blob/086c5e91e8/installing/context/src/index.ts#L196>.
+        // in the install header. `currentLockfileExists` mirrors
+        // upstream's <https://github.com/pnpm/pnpm/blob/94240bc046/installing/context/src/index.ts#L196>:
+        // `true` once a previous install has written
+        // `<virtual_store_dir>/lock.yaml`.
         R::emit(&LogEvent::Context(ContextLog {
             level: LogLevel::Debug,
-            current_lockfile_exists: false,
+            current_lockfile_exists: current_lockfile.is_some(),
             store_dir: config.store_dir.display().to_string(),
             virtual_store_dir: config.virtual_store_dir.to_string_lossy().into_owned(),
         }));
@@ -177,6 +205,8 @@ where
                 importers,
                 packages: packages.as_ref(),
                 snapshots: snapshots.as_ref(),
+                current_snapshots: current_lockfile.as_ref().and_then(|l| l.snapshots.as_ref()),
+                current_packages: current_lockfile.as_ref().and_then(|l| l.packages.as_ref()),
                 dependency_groups,
                 logged_methods: &logged_methods,
                 requester: &prefix,
@@ -210,6 +240,21 @@ where
         // subsequent `pnpm:lifecycle` events render after the import
         // progress display has closed. Mirrors upstream's emit point in
         // <https://github.com/pnpm/pnpm/blob/80037699fb/installing/deps-installer/src/install/link.ts#L167>.
+
+        // Write `<virtual_store_dir>/lock.yaml`. Mirrors upstream's
+        // `writeCurrentLockfile` call at
+        // <https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/src/install/index.ts#L1597>:
+        // captures what was actually materialized so the next install
+        // can diff each snapshot against it and skip the unchanged
+        // slots. Today pacquet writes the wanted lockfile unchanged
+        // because there's only one importer to filter to; once
+        // workspace install (#431) lands this needs to narrow to the
+        // *filtered* lockfile (selected importers × engine filter).
+        if frozen_lockfile && let Some(lockfile) = lockfile {
+            lockfile
+                .save_current_to_virtual_store_dir(&config.virtual_store_dir)
+                .map_err(InstallError::SaveCurrentLockfile)?;
+        }
 
         // Write `node_modules/.modules.yaml`. Mirrors upstream's
         // `writeModulesManifest` call at

--- a/crates/package-manager/src/install/tests.rs
+++ b/crates/package-manager/src/install/tests.rs
@@ -8,8 +8,9 @@ use pacquet_modules_yaml::{
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_registry_mock::AutoMockInstance;
 use pacquet_reporter::{
-    ContextLog, IgnoredScriptsLog, LogEvent, PackageManifestLog, PackageManifestMessage, Reporter,
-    SilentReporter, Stage, StageLog, StatsLog, StatsMessage, SummaryLog,
+    BrokenModulesLog, ContextLog, IgnoredScriptsLog, LogEvent, PackageManifestLog,
+    PackageManifestMessage, ProgressLog, ProgressMessage, Reporter, SilentReporter, Stage,
+    StageLog, StatsLog, StatsMessage, SummaryLog,
 };
 use pacquet_testing_utils::fs::{get_all_folders, is_symlink_or_junction};
 use pipe_trait::Pipe;
@@ -532,7 +533,9 @@ async fn install_emits_pnpm_event_sequence() {
 
     // Spot-check the context payload: pacquet's directories must
     // round-trip through the wire shape, and `currentLockfileExists`
-    // is the hard-coded `false` documented in `Install::run`.
+    // is `false` on this first install because no `lock.yaml` exists
+    // in the (just-created) virtual store yet — pacquet writes the
+    // file at end-of-install, so the next install would see `true`.
     let LogEvent::Context(ContextLog {
         current_lockfile_exists,
         store_dir: emitted_store_dir,
@@ -724,4 +727,331 @@ async fn install_optional_failing_postinstall_dep_via_registry_mock_succeeds() {
     );
 
     drop((dir, mock_instance));
+}
+
+/// A v9 lockfile fixture pinned to a placeholder package whose
+/// integrity is bogus on purpose. Pacquet enforces tarball integrity
+/// on the install path, so any test that lets the install reach the
+/// fetch site would fail — meaning a successful install with this
+/// fixture is *proof* that the per-snapshot skip path (issue #433
+/// section B) short-circuited the fetch entirely.
+const PARTIAL_INSTALL_LOCKFILE: &str = text_block! {
+    "lockfileVersion: '9.0'"
+    "importers:"
+    "  .:"
+    "    dependencies:"
+    "      placeholder:"
+    "        specifier: 1.0.0"
+    "        version: 1.0.0"
+    "packages:"
+    "  placeholder@1.0.0:"
+    "    resolution: {integrity: sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA, tarball: 'http://invalid.local/placeholder.tgz'}"
+    "snapshots:"
+    "  placeholder@1.0.0: {}"
+};
+
+/// Pre-populate the virtual-store slot that `PARTIAL_INSTALL_LOCKFILE`
+/// describes so the skip path has a directory to point at. Just the
+/// `<virtual_store_dir>/placeholder@1.0.0/node_modules/placeholder`
+/// dirent is enough — the skip check only stats the directory, it
+/// doesn't read CAS contents.
+fn seed_placeholder_virtual_store_slot(virtual_store_dir: &std::path::Path) {
+    let slot = virtual_store_dir.join("placeholder@1.0.0").join("node_modules").join("placeholder");
+    std::fs::create_dir_all(&slot).expect("create placeholder virtual-store slot");
+}
+
+/// Section B of pnpm/pacquet#433: a snapshot whose wiring and
+/// integrity match the current lockfile *and* whose virtual-store
+/// slot exists on disk is dropped from the install graph entirely.
+/// We prove this by pointing the lockfile at a bogus tarball URL —
+/// any code path that reaches the fetch site would fail, so a
+/// successful install demonstrates the skip path took over.
+#[tokio::test]
+async fn warm_reinstall_skips_snapshot_when_current_lockfile_matches() {
+    let dir = tempdir().unwrap();
+    let store_dir = dir.path().join("pacquet-store");
+    let project_root = dir.path().join("project");
+    let modules_dir = project_root.join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pacquet");
+
+    let manifest_path = dir.path().join("package.json");
+    let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
+
+    let mut config = Config::new();
+    config.store_dir = store_dir.into();
+    config.modules_dir = modules_dir.clone();
+    config.virtual_store_dir = virtual_store_dir.clone();
+    let config = config.leak();
+
+    let lockfile: Lockfile = serde_saphyr::from_str(PARTIAL_INSTALL_LOCKFILE)
+        .expect("parse partial-install fixture lockfile");
+
+    // Pre-seed the previous-install state: write the current lockfile
+    // identical to the wanted lockfile, and materialize the virtual-
+    // store slot the skip check stats against.
+    std::fs::create_dir_all(&virtual_store_dir).unwrap();
+    lockfile.save_current_to_virtual_store_dir(&virtual_store_dir).expect("seed current lockfile");
+    seed_placeholder_virtual_store_slot(&virtual_store_dir);
+
+    Install {
+        tarball_mem_cache: &Default::default(),
+        http_client: &Default::default(),
+        config,
+        manifest: &manifest,
+        lockfile: Some(&lockfile),
+        dependency_groups: [DependencyGroup::Prod],
+        frozen_lockfile: true,
+        resolved_packages: &Default::default(),
+    }
+    .run::<SilentReporter>()
+    .await
+    .expect(
+        "skip path must short-circuit the fetch for the placeholder snapshot \
+         (bogus integrity + URL would otherwise fail the install)",
+    );
+
+    // `lock.yaml` survives the install — the end-of-install write
+    // persists the wanted lockfile back to disk.
+    let written = Lockfile::load_current_from_virtual_store_dir(&virtual_store_dir)
+        .expect("read written current lockfile")
+        .expect("current lockfile should be written");
+    assert_eq!(written.snapshots.as_ref().map(|s| s.len()), Some(1));
+
+    drop(dir);
+}
+
+/// When the cached directory is gone but the cache key still matches,
+/// pacquet emits `pnpm:_broken_node_modules` (mirroring upstream's
+/// debug emit at `lockfileToDepGraph.ts:258`) and falls through to the
+/// full install path for that snapshot.
+#[tokio::test]
+async fn warm_reinstall_emits_broken_modules_when_dir_is_missing() {
+    static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
+    EVENTS.lock().unwrap().clear();
+
+    struct RecordingReporter;
+    impl Reporter for RecordingReporter {
+        fn emit(event: &LogEvent) {
+            EVENTS.lock().unwrap().push(event.clone());
+        }
+    }
+
+    let dir = tempdir().unwrap();
+    let store_dir = dir.path().join("pacquet-store");
+    let project_root = dir.path().join("project");
+    let modules_dir = project_root.join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pacquet");
+
+    let manifest_path = dir.path().join("package.json");
+    let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
+
+    let mut config = Config::new();
+    config.store_dir = store_dir.into();
+    config.modules_dir = modules_dir.clone();
+    config.virtual_store_dir = virtual_store_dir.clone();
+    // Skip fetch retries entirely — the install is expected to fail
+    // after emitting `_broken_node_modules`, so any retry budget is
+    // pure waste here.
+    config.fetch_retries = 0;
+    config.fetch_retry_mintimeout = 1;
+    config.fetch_retry_maxtimeout = 1;
+    let config = config.leak();
+
+    let lockfile: Lockfile = serde_saphyr::from_str(PARTIAL_INSTALL_LOCKFILE)
+        .expect("parse partial-install fixture lockfile");
+
+    // Pre-seed the current lockfile but deliberately *not* the
+    // virtual-store slot — the cache key matches but the directory is
+    // gone (the `rm -rf node_modules/.pnpm/<slot>` scenario).
+    std::fs::create_dir_all(&virtual_store_dir).unwrap();
+    lockfile.save_current_to_virtual_store_dir(&virtual_store_dir).expect("seed current lockfile");
+
+    // The install will attempt to fetch the placeholder (bogus URL),
+    // which fails — what we're testing is that the broken-modules
+    // signal fires *before* the fetch happens. So we look for the
+    // event in the captured set regardless of the final install
+    // result.
+    let _ = Install {
+        tarball_mem_cache: &Default::default(),
+        http_client: &Default::default(),
+        config,
+        manifest: &manifest,
+        lockfile: Some(&lockfile),
+        dependency_groups: [DependencyGroup::Prod],
+        frozen_lockfile: true,
+        resolved_packages: &Default::default(),
+    }
+    .run::<RecordingReporter>()
+    .await;
+
+    let captured = EVENTS.lock().unwrap();
+    let broken: Vec<&BrokenModulesLog> = captured
+        .iter()
+        .filter_map(|e| match e {
+            LogEvent::BrokenModules(b) => Some(b),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        broken.len(),
+        1,
+        "expected exactly one pnpm:_broken_node_modules emit; got: {captured:?}",
+    );
+    assert!(
+        broken[0].missing.contains("placeholder@1.0.0"),
+        "broken-modules `missing` path must name the affected slot; got: {missing}",
+        missing = broken[0].missing,
+    );
+
+    drop(dir);
+}
+
+/// Section A + D of pnpm/pacquet#433: a second install observes
+/// `pnpm:context.currentLockfileExists: true` once the first install
+/// has written `<virtual_store_dir>/lock.yaml`. Drives the read site
+/// (`Install::run` → `load_current_from_virtual_store_dir`) on real
+/// disk state produced by the matching write site.
+#[tokio::test]
+async fn context_log_reflects_current_lockfile_after_first_install() {
+    static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
+    EVENTS.lock().unwrap().clear();
+
+    struct RecordingReporter;
+    impl Reporter for RecordingReporter {
+        fn emit(event: &LogEvent) {
+            EVENTS.lock().unwrap().push(event.clone());
+        }
+    }
+
+    let dir = tempdir().unwrap();
+    let store_dir = dir.path().join("pacquet-store");
+    let project_root = dir.path().join("project");
+    let modules_dir = project_root.join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pacquet");
+
+    let manifest_path = dir.path().join("package.json");
+    let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
+
+    let mut config = Config::new();
+    config.store_dir = store_dir.into();
+    config.modules_dir = modules_dir.clone();
+    config.virtual_store_dir = virtual_store_dir.clone();
+    let config = config.leak();
+
+    // Empty lockfile keeps the install cheap and avoids needing the
+    // mock registry. `is_empty` is false here because we explicitly
+    // record an importer with deps — the test focuses on the
+    // read-after-write loop, not on the file-deletion edge case
+    // (covered in the lockfile crate's own tests).
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "importers:"
+        "  .:"
+        "    dependencies: {}"
+        "packages: {}"
+        "snapshots: {}"
+    })
+    .expect("parse minimal v9 lockfile");
+
+    // First install: `lock.yaml` does not exist yet.
+    EVENTS.lock().unwrap().clear();
+    Install {
+        tarball_mem_cache: &Default::default(),
+        http_client: &Default::default(),
+        config,
+        manifest: &manifest,
+        lockfile: Some(&lockfile),
+        dependency_groups: [DependencyGroup::Prod],
+        frozen_lockfile: true,
+        resolved_packages: &Default::default(),
+    }
+    .run::<RecordingReporter>()
+    .await
+    .expect("first install should succeed");
+
+    let first_context = EVENTS
+        .lock()
+        .unwrap()
+        .iter()
+        .find_map(|e| match e {
+            LogEvent::Context(c) => Some(c.clone()),
+            _ => None,
+        })
+        .expect("first install emitted a context event");
+    assert!(!first_context.current_lockfile_exists);
+
+    // The empty lockfile causes the end-of-install write to *delete*
+    // any stale `lock.yaml`. To exercise the read-after-write loop
+    // we need a non-empty wanted lockfile — swap to the partial-
+    // install fixture, pre-seed the matching directory so the install
+    // skips the fetch, and run a second install.
+    let partial: Lockfile = serde_saphyr::from_str(PARTIAL_INSTALL_LOCKFILE)
+        .expect("parse partial-install fixture lockfile");
+    seed_placeholder_virtual_store_slot(&virtual_store_dir);
+    partial.save_current_to_virtual_store_dir(&virtual_store_dir).expect("seed current lockfile");
+
+    EVENTS.lock().unwrap().clear();
+    Install {
+        tarball_mem_cache: &Default::default(),
+        http_client: &Default::default(),
+        config,
+        manifest: &manifest,
+        lockfile: Some(&partial),
+        dependency_groups: [DependencyGroup::Prod],
+        frozen_lockfile: true,
+        resolved_packages: &Default::default(),
+    }
+    .run::<RecordingReporter>()
+    .await
+    .expect("second install should succeed via the skip path");
+
+    let second_context = EVENTS
+        .lock()
+        .unwrap()
+        .iter()
+        .find_map(|e| match e {
+            LogEvent::Context(c) => Some(c.clone()),
+            _ => None,
+        })
+        .expect("second install emitted a context event");
+    assert!(
+        second_context.current_lockfile_exists,
+        "context.currentLockfileExists must flip to true once lock.yaml is on disk",
+    );
+
+    // Stats reports `added: 0` — the only snapshot is the one that
+    // got skipped.
+    let added: Vec<u64> = EVENTS
+        .lock()
+        .unwrap()
+        .iter()
+        .filter_map(|e| match e {
+            LogEvent::Stats(StatsLog { message: StatsMessage::Added { added, .. }, .. }) => {
+                Some(*added)
+            }
+            _ => None,
+        })
+        .collect();
+    assert_eq!(added, vec![0], "warm reinstall must report added: 0; got {added:?}");
+
+    // The warm install must not emit any per-snapshot `imported`
+    // progress event — the skip path removes the snapshot from both
+    // warm and cold batches.
+    let imported_count = EVENTS
+        .lock()
+        .unwrap()
+        .iter()
+        .filter(|e| {
+            matches!(
+                e,
+                LogEvent::Progress(ProgressLog { message: ProgressMessage::Imported { .. }, .. }),
+            )
+        })
+        .count();
+    assert_eq!(
+        imported_count, 0,
+        "skip path must suppress `pnpm:progress imported` for skipped snapshots",
+    );
+
+    drop(dir);
 }

--- a/crates/package-manager/src/install/tests.rs
+++ b/crates/package-manager/src/install/tests.rs
@@ -938,20 +938,28 @@ async fn context_log_reflects_current_lockfile_after_first_install() {
     config.virtual_store_dir = virtual_store_dir.clone();
     let config = config.leak();
 
-    // Empty lockfile keeps the install cheap and avoids needing the
-    // mock registry. `is_empty` is false here because we explicitly
-    // record an importer with deps — the test focuses on the
-    // read-after-write loop, not on the file-deletion edge case
-    // (covered in the lockfile crate's own tests).
+    // Non-empty lockfile with no snapshots: the root importer lists
+    // one dependency so `Lockfile::is_empty` returns `false` (and
+    // the end-of-install write persists the file rather than
+    // deleting it), but the empty `snapshots:` map means
+    // `CreateVirtualStore::run` has no fetches to attempt. The
+    // dangling symlink that `SymlinkDirectDependencies` creates is
+    // fine — `link_direct_dep_bins` swallows `NotFound` on the
+    // target's `package.json`. This keeps the test off the mock
+    // registry while still driving the read-after-write loop.
     let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
         "lockfileVersion: '9.0'"
         "importers:"
         "  .:"
-        "    dependencies: {}"
+        "    dependencies:"
+        "      placeholder:"
+        "        specifier: 1.0.0"
+        "        version: 1.0.0"
         "packages: {}"
         "snapshots: {}"
     })
     .expect("parse minimal v9 lockfile");
+    assert!(!lockfile.is_empty(), "fixture must be non-empty so the write path persists it");
 
     // First install: `lock.yaml` does not exist yet.
     EVENTS.lock().unwrap().clear();
@@ -980,30 +988,35 @@ async fn context_log_reflects_current_lockfile_after_first_install() {
         .expect("first install emitted a context event");
     assert!(!first_context.current_lockfile_exists);
 
-    // The empty lockfile causes the end-of-install write to *delete*
-    // any stale `lock.yaml`. To exercise the read-after-write loop
-    // we need a non-empty wanted lockfile — swap to the partial-
-    // install fixture, pre-seed the matching directory so the install
-    // skips the fetch, and run a second install.
-    let partial: Lockfile = serde_saphyr::from_str(PARTIAL_INSTALL_LOCKFILE)
-        .expect("parse partial-install fixture lockfile");
-    seed_placeholder_virtual_store_slot(&virtual_store_dir);
-    partial.save_current_to_virtual_store_dir(&virtual_store_dir).expect("seed current lockfile");
+    // The first install must have persisted the lockfile under the
+    // virtual store. If `save_current_to_virtual_store_dir` regressed
+    // for non-empty lockfiles, this check fails — and so does the
+    // false→true assertion below, which is the whole point of pinning
+    // the read-after-write loop.
+    let lock_yaml = virtual_store_dir.join(Lockfile::CURRENT_FILE_NAME);
+    assert!(
+        lock_yaml.is_file(),
+        "non-empty wanted lockfile must be persisted under <virtual_store_dir>/lock.yaml; found nothing at {lock_yaml:?}",
+    );
 
+    // Second install: identical inputs. The skip filter has nothing
+    // to skip (no snapshots), but the read-after-write loop still
+    // fires `current_lockfile_exists: true` because the first
+    // install's `lock.yaml` is now on disk.
     EVENTS.lock().unwrap().clear();
     Install {
         tarball_mem_cache: &Default::default(),
         http_client: &Default::default(),
         config,
         manifest: &manifest,
-        lockfile: Some(&partial),
+        lockfile: Some(&lockfile),
         dependency_groups: [DependencyGroup::Prod],
         frozen_lockfile: true,
         resolved_packages: &Default::default(),
     }
     .run::<RecordingReporter>()
     .await
-    .expect("second install should succeed via the skip path");
+    .expect("second install should succeed");
 
     let second_context = EVENTS
         .lock()
@@ -1018,6 +1031,65 @@ async fn context_log_reflects_current_lockfile_after_first_install() {
         second_context.current_lockfile_exists,
         "context.currentLockfileExists must flip to true once lock.yaml is on disk",
     );
+
+    drop(dir);
+}
+
+/// The skip path drops the snapshot from both the warm and cold
+/// batches, so a warm reinstall must report `added: 0` and emit
+/// zero `pnpm:progress imported` events. Pre-seeds `lock.yaml` and
+/// the virtual-store slot manually here — the
+/// [`context_log_reflects_current_lockfile_after_first_install`]
+/// test covers the read-after-write loop on its own, so this one
+/// can focus on the skip's reporter-visible effect.
+#[tokio::test]
+async fn warm_reinstall_reports_added_zero_and_emits_no_imported_events() {
+    static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
+    EVENTS.lock().unwrap().clear();
+
+    struct RecordingReporter;
+    impl Reporter for RecordingReporter {
+        fn emit(event: &LogEvent) {
+            EVENTS.lock().unwrap().push(event.clone());
+        }
+    }
+
+    let dir = tempdir().unwrap();
+    let store_dir = dir.path().join("pacquet-store");
+    let project_root = dir.path().join("project");
+    let modules_dir = project_root.join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pacquet");
+
+    let manifest_path = dir.path().join("package.json");
+    let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
+
+    let mut config = Config::new();
+    config.store_dir = store_dir.into();
+    config.modules_dir = modules_dir.clone();
+    config.virtual_store_dir = virtual_store_dir.clone();
+    let config = config.leak();
+
+    let lockfile: Lockfile = serde_saphyr::from_str(PARTIAL_INSTALL_LOCKFILE)
+        .expect("parse partial-install fixture lockfile");
+
+    std::fs::create_dir_all(&virtual_store_dir).unwrap();
+    lockfile.save_current_to_virtual_store_dir(&virtual_store_dir).expect("seed current lockfile");
+    seed_placeholder_virtual_store_slot(&virtual_store_dir);
+
+    EVENTS.lock().unwrap().clear();
+    Install {
+        tarball_mem_cache: &Default::default(),
+        http_client: &Default::default(),
+        config,
+        manifest: &manifest,
+        lockfile: Some(&lockfile),
+        dependency_groups: [DependencyGroup::Prod],
+        frozen_lockfile: true,
+        resolved_packages: &Default::default(),
+    }
+    .run::<RecordingReporter>()
+    .await
+    .expect("warm reinstall should succeed via the skip path");
 
     // Stats reports `added: 0` — the only snapshot is the one that
     // got skipped.
@@ -1034,9 +1106,8 @@ async fn context_log_reflects_current_lockfile_after_first_install() {
         .collect();
     assert_eq!(added, vec![0], "warm reinstall must report added: 0; got {added:?}");
 
-    // The warm install must not emit any per-snapshot `imported`
-    // progress event — the skip path removes the snapshot from both
-    // warm and cold batches.
+    // No per-snapshot `imported` progress event — the skip path
+    // removes the snapshot from both warm and cold batches.
     let imported_count = EVENTS
         .lock()
         .unwrap()

--- a/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/crates/package-manager/src/install_frozen_lockfile.rs
@@ -36,6 +36,14 @@ where
     pub importers: &'a HashMap<String, ProjectSnapshot>,
     pub packages: Option<&'a HashMap<PackageKey, PackageMetadata>>,
     pub snapshots: Option<&'a HashMap<PackageKey, SnapshotEntry>>,
+    /// Snapshots from the previous install's `lock.yaml`, if present.
+    /// Threaded through to [`crate::CreateVirtualStore`] to drive the
+    /// per-snapshot skip decision (a snapshot whose wiring and
+    /// integrity haven't changed and whose virtual-store slot still
+    /// exists on disk is dropped from the install graph). `None` on a
+    /// first install — the current-lockfile file doesn't exist yet.
+    pub current_snapshots: Option<&'a HashMap<PackageKey, SnapshotEntry>>,
+    pub current_packages: Option<&'a HashMap<PackageKey, PackageMetadata>>,
     pub dependency_groups: DependencyGroupList,
     /// Install-scoped dedupe state for `pnpm:package-import-method`.
     /// See `link_file::log_method_once`.
@@ -90,6 +98,8 @@ where
             importers,
             packages,
             snapshots,
+            current_snapshots,
+            current_packages,
             dependency_groups,
             logged_methods,
             requester,
@@ -115,6 +125,8 @@ where
                 config,
                 packages,
                 snapshots,
+                current_snapshots,
+                current_packages,
                 logged_methods,
                 requester,
                 store_index_writer: &store_index_writer,

--- a/crates/reporter/src/lib.rs
+++ b/crates/reporter/src/lib.rs
@@ -163,11 +163,11 @@ pub enum LogEvent {
     #[serde(rename = "pnpm:skipped-optional-dependency")]
     SkippedOptionalDependency(SkippedOptionalDependencyLog),
 
-    /// One per snapshot whose `node_modules/.pnpm/...` directory has
-    /// gone missing on disk even though the current lockfile records
-    /// it as installed (`pnpm:_broken_node_modules`). The frozen-
-    /// lockfile path emits one of these per missing slot before
-    /// falling through to a full re-install of that snapshot.
+    /// One per snapshot whose `<virtual_store_dir>/...` directory
+    /// has gone missing on disk even though the current lockfile
+    /// records it as installed (`pnpm:_broken_node_modules`). The
+    /// frozen-lockfile path emits one of these per missing slot
+    /// before falling through to a full re-install of that snapshot.
     ///
     /// Upstream: <https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-builder/src/lockfileToDepGraph.ts#L37>
     /// (channel declaration) and

--- a/crates/reporter/src/lib.rs
+++ b/crates/reporter/src/lib.rs
@@ -162,6 +162,19 @@ pub enum LogEvent {
     /// Emit site (build_failure): <https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/during-install/src/index.ts#L218-L240>.
     #[serde(rename = "pnpm:skipped-optional-dependency")]
     SkippedOptionalDependency(SkippedOptionalDependencyLog),
+
+    /// One per snapshot whose `node_modules/.pnpm/...` directory has
+    /// gone missing on disk even though the current lockfile records
+    /// it as installed (`pnpm:_broken_node_modules`). The frozen-
+    /// lockfile path emits one of these per missing slot before
+    /// falling through to a full re-install of that snapshot.
+    ///
+    /// Upstream: <https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-builder/src/lockfileToDepGraph.ts#L37>
+    /// (channel declaration) and
+    /// <https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-builder/src/lockfileToDepGraph.ts#L258>
+    /// (per-snapshot emit site).
+    #[serde(rename = "pnpm:_broken_node_modules")]
+    BrokenModules(BrokenModulesLog),
 }
 
 /// `pnpm:context` payload.
@@ -582,6 +595,16 @@ pub enum SkippedOptionalReason {
     UnsupportedEngine,
     UnsupportedPlatform,
     ResolutionFailure,
+}
+
+/// `pnpm:_broken_node_modules` payload. `missing` is the absolute
+/// path to the snapshot's `node_modules/<pkg>` slot that the current-
+/// lockfile lookup expected on disk but didn't find. Mirrors the
+/// payload upstream emits at <https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-builder/src/lockfileToDepGraph.ts#L258>.
+#[derive(Debug, Clone, Serialize)]
+pub struct BrokenModulesLog {
+    pub level: LogLevel,
+    pub missing: String,
 }
 
 /// Severity level on the [bunyan]-shaped envelope.

--- a/crates/reporter/src/tests.rs
+++ b/crates/reporter/src/tests.rs
@@ -5,11 +5,11 @@ use pretty_assertions::assert_eq;
 use serde_json::Value;
 
 use crate::{
-    AddedRoot, ContextLog, DependencyType, Envelope, FetchingProgressLog, FetchingProgressMessage,
-    GetHostName, IgnoredScriptsLog, LifecycleLog, LifecycleMessage, LifecycleStdio, LogEvent,
-    LogLevel, PackageImportMethod, PackageImportMethodLog, PackageManifestLog,
-    PackageManifestMessage, ProgressLog, ProgressMessage, RealApi, RemovedRoot, Reporter,
-    RequestRetryError, RequestRetryLog, RootLog, RootMessage, SilentReporter,
+    AddedRoot, BrokenModulesLog, ContextLog, DependencyType, Envelope, FetchingProgressLog,
+    FetchingProgressMessage, GetHostName, IgnoredScriptsLog, LifecycleLog, LifecycleMessage,
+    LifecycleStdio, LogEvent, LogLevel, PackageImportMethod, PackageImportMethodLog,
+    PackageManifestLog, PackageManifestMessage, ProgressLog, ProgressMessage, RealApi, RemovedRoot,
+    Reporter, RequestRetryError, RequestRetryLog, RootLog, RootMessage, SilentReporter,
     SkippedOptionalDependencyLog, SkippedOptionalPackage, SkippedOptionalReason, Stage, StageLog,
     StatsLog, StatsMessage, SummaryLog,
 };
@@ -634,6 +634,27 @@ fn skipped_optional_omits_absent_details() {
         .pipe_as_ref(serde_json::from_str)
         .expect("parse JSON");
     assert!(json.get("details").is_none(), "details must be omitted when absent, got {json:?}");
+}
+
+/// `pnpm:_broken_node_modules` carries a single `missing` field with
+/// the absolute path of the slot that should have been on disk but
+/// wasn't. Mirrors upstream's emit shape at
+/// <https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-builder/src/lockfileToDepGraph.ts#L258>.
+#[test]
+fn broken_modules_event_matches_pnpm_wire_shape() {
+    let event = LogEvent::BrokenModules(BrokenModulesLog {
+        level: LogLevel::Debug,
+        missing: "/proj/node_modules/.pacquet/react@18.0.0/node_modules/react".to_string(),
+    });
+    let envelope = Envelope { time: 1_700_000_000_000, hostname: "host", pid: 4242, event: &event };
+    let json: Value = envelope
+        .pipe_ref(serde_json::to_string)
+        .expect("serialize envelope")
+        .pipe_as_ref(serde_json::from_str)
+        .expect("parse JSON");
+    assert_eq!(json["name"], "pnpm:_broken_node_modules");
+    assert_eq!(json["level"], "debug");
+    assert_eq!(json["missing"], "/proj/node_modules/.pacquet/react@18.0.0/node_modules/react");
 }
 
 /// All four reason variants serialize as the snake_case strings


### PR DESCRIPTION
## Summary

Closes #433. Implements partial install with `--frozen-lockfile`:

- **Read** `<virtual_store_dir>/lock.yaml` at install start (`Lockfile::load_current_from_virtual_store_dir`), mirroring upstream pnpm v11's `readCurrentLockfile`.
- **Skip** any snapshot whose `dependencies`, `optionalDependencies`, and `resolution.integrity` match the current lockfile **and** whose virtual-store slot exists on disk. No fetch, no extract, no relink for skipped snapshots.
- **Write** `<virtual_store_dir>/lock.yaml` at end-of-install (atomically; deletes the file when the lockfile is empty), so the next install sees a fresh diff target.
- **Emit** `pnpm:_broken_node_modules` (`BrokenModulesLog`) when the slot is gone despite the cache key matching, then fall through to a full install for that snapshot.
- `pnpm:context.currentLockfileExists` now reflects reality (was hard-coded `false`); `pnpm:stats.added` reports the post-skip delta instead of the total snapshot count, matching upstream.
- **Side-effects-cache prefetch still covers skipped snapshots** so `BuildModules`'s `is_built` gate fires on warm reinstalls — without this, packages with `allowBuilds: true` re-execute their lifecycle scripts every install (added in 1603f94f after benchmarking caught the regression — see [benchmark comment](https://github.com/pnpm/pacquet/pull/442#issuecomment-4440371477)).

Tracks pnpm v11 `94240bc046` for `readCurrentLockfile` / `writeCurrentLockfile` / `lockfileToDepGraph`'s per-`depPath` skip and `isIntegrityEqual` helper.

## Performance

Two scenarios benchmarked against a 1352-package fixture, hyperfine `--warmup 2 --runs 10`.

**Pure warm reinstall** (every snapshot intact, full `lock.yaml` on disk):

| | mean | sys time |
|---|---:|---:|
| baseline (`main` HEAD~2) | 969 ms | 985 ms |
| **PR** | **896 ms** | **349 ms** |

PR is 1.08× faster, with ~65% less kernel work — the skip filter bypasses the warm-batch's per-snapshot syscalls (1352 → 0). [Full breakdown + the regression we caught + fixed.](https://github.com/pnpm/pacquet/pull/442#issuecomment-4440371477)

**Non-up-to-date `node_modules`** (N virtual-store slots deleted per iteration):

| Damaged slots | PR | Baseline | PR/Baseline |
|---:|---:|---:|---:|
| 0 | 581 ms | 661 ms | **1.14×** |
| 1 | 615 ms | 707 ms | **1.15×** |
| 10 | 660 ms | 707 ms | 1.07× |
| 100 | 2.25 s | 2.25 s | 1.00× |
| 500 | 6.13 s | 7.93 s | **1.29×** |

PR is consistently a small win and never a loss across the damage spectrum; `_broken_node_modules` debug events fire correctly for each missing slot. [Full sweep + caveats.](https://github.com/pnpm/pacquet/pull/442#issuecomment-4440646688)

## Test plan

- [x] `just ready` — 633 tests pass, lint clean.
- [x] `just dylint` — perfectionist clean.
- [x] `taplo format --check` — clean.
- [x] Unit tests: `snapshot_deps_equal`, `integrity_equal`, `BrokenModulesLog` wire shape, `Lockfile::is_empty`, `save_current_to_virtual_store_dir` round-trip / empty-deletes-file / ENOENT-as-none.
- [x] Integration tests in `install/tests.rs`:
  - `warm_reinstall_skips_snapshot_when_current_lockfile_matches` — proves the skip path short-circuits the fetch (the fixture points at a bogus URL; only the skip path makes the install succeed).
  - `warm_reinstall_emits_broken_modules_when_dir_is_missing` — asserts the `_broken_node_modules` debug event fires before the fetch.
  - `warm_reinstall_reports_added_zero_and_emits_no_imported_events` — asserts `pnpm:stats.added: 0` and zero `pnpm:progress imported` events when the skip path drops every snapshot from the install graph.
  - `context_log_reflects_current_lockfile_after_first_install` — `pnpm:context.currentLockfileExists` flips `false` → `true` once `lock.yaml` is on disk, and `lock.yaml` is asserted present on disk after the first install (exercises the real write path).

## Out of scope (tracked in #433)

- Workspace install (#431): once landed, the write site must narrow to the filtered lockfile (selected importers × engine filter). For now we write the wanted lockfile unmodified — a checkbox in the issue description.
- GVS (#432): the per-snapshot skip gains a `.pnpm-needs-build` marker check. The skip helper is structured so adding it is a small extension.
- Surplus / stale package cleanup (`pruneVirtualStore`).

---
Written by an agent (Claude Code, claude-opus-4-7).
