### PR TITLE
feat: workspace support for `pacquet install --frozen-lockfile` (#431)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,6 +408,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_format"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
+dependencies = [
+ "const_format_proc_macros",
+ "konst",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1415,6 +1436,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2114,6 +2150,7 @@ dependencies = [
  "pacquet-store-dir",
  "pacquet-tarball",
  "pacquet-testing-utils",
+ "pacquet-workspace",
  "pipe-trait",
  "pretty_assertions",
  "rayon",
@@ -2282,6 +2319,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "pacquet-workspace"
+version = "0.0.1"
+dependencies = [
+ "derive_more",
+ "miette 7.6.0",
+ "pacquet-package-manifest",
+ "pretty_assertions",
+ "serde",
+ "serde-saphyr",
+ "tempfile",
+ "wax",
+]
+
+[[package]]
 name = "page_size"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2376,6 +2427,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "pori"
+version = "0.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a63d338dec139f56dacc692ca63ad35a6be6a797442479b55acd611d79e906"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -3662,6 +3722,21 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "wax"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f8cbf8125142b9b30321ac8721f54c52fbcd6659f76cf863d5e2e38c07a3d7b"
+dependencies = [
+ "const_format",
+ "itertools 0.14.0",
+ "nom",
+ "pori",
+ "regex",
+ "thiserror 2.0.18",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ pacquet-store-dir              = { path = "crates/store-dir" }
 pacquet-reporter               = { path = "crates/reporter" }
 pacquet-patching               = { path = "crates/patching" }
 pacquet-real-hoist             = { path = "crates/real-hoist" }
+pacquet-workspace              = { path = "crates/workspace" }
 
 # Tasks
 pacquet-registry-mock = { path = "tasks/registry-mock" }
@@ -88,6 +89,7 @@ tracing            = { version = "0.1.44" }
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 tokio              = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 walkdir            = { version = "2.5.0" }
+wax                = { version = "0.7.0" }
 which              = { version = "8.0.2" }
 zune-inflate       = { version = "0.2.54" }
 

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -594,10 +594,52 @@ impl Config {
         // diverging from today's behaviour without any of the
         // GVS-aware path computation downstream. Tracked as part of
         // pnpm/pacquet#432 (Section B).
-        if let Some(start) = cwd
-            && let Some((path, settings)) = WorkspaceSettings::find_and_load(&start)?
-        {
-            let base_dir = path.parent().unwrap_or(&start).to_path_buf();
+        // Resolve the workspace dir: `NPM_CONFIG_WORKSPACE_DIR`
+        // override first (mirroring upstream's `findWorkspaceDir` and
+        // [`pacquet_workspace::find_workspace_dir`]; both must agree on
+        // where the workspace lives, otherwise the per-importer
+        // `SymlinkDirectDependencies` writes and the virtual store
+        // would end up in different directories). Fall back to the
+        // upward walk for `pnpm-workspace.yaml` when the env var is
+        // unset or empty.
+        //
+        // The env var is read here rather than via
+        // [`pacquet_workspace`] to avoid adding a cross-crate
+        // dependency just for the lookup — the contract is fixed by
+        // pnpm upstream, so the duplication is low-risk.
+        let env_workspace_dir = std::env::var_os("NPM_CONFIG_WORKSPACE_DIR")
+            .or_else(|| std::env::var_os("npm_config_workspace_dir"))
+            .filter(|v| !v.is_empty())
+            .map(PathBuf::from);
+        let workspace_yaml = if let Some(env_dir) = env_workspace_dir {
+            // Env-var path: load yaml directly from the env dir. A
+            // missing file is silent (matching upstream), but the
+            // re-anchor still fires because the user has explicitly
+            // told us where the workspace lives.
+            let yaml_path = env_dir.join(WORKSPACE_MANIFEST_FILENAME);
+            match fs::read_to_string(&yaml_path) {
+                Ok(text) => {
+                    let settings: WorkspaceSettings =
+                        serde_saphyr::from_str(&text).map_err(Box::new).map_err(|source| {
+                            LoadWorkspaceYamlError::ParseYaml { path: yaml_path, source }
+                        })?;
+                    Some((env_dir, Some(settings)))
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => Some((env_dir, None)),
+                Err(source) => {
+                    return Err(LoadWorkspaceYamlError::ReadFile { path: yaml_path, source });
+                }
+            }
+        } else if let Some(start) = &cwd {
+            WorkspaceSettings::find_and_load(start)?.map(|(path, settings)| {
+                let base_dir = path.parent().unwrap_or(start).to_path_buf();
+                (base_dir, Some(settings))
+            })
+        } else {
+            None
+        };
+
+        if let Some((base_dir, settings)) = workspace_yaml {
             // Re-anchor the path-valued defaults to the workspace root
             // before applying settings. Without this, a `pacquet install`
             // run from a workspace subdirectory leaves
@@ -614,7 +656,9 @@ impl Config {
             // still wins.
             config.modules_dir = base_dir.join("node_modules");
             config.virtual_store_dir = base_dir.join("node_modules/.pnpm");
-            settings.apply_to(&mut config, &base_dir);
+            if let Some(settings) = settings {
+                settings.apply_to(&mut config, &base_dir);
+            }
         }
 
         Ok(config)
@@ -949,10 +993,87 @@ mod tests {
     /// re-anchor block accidentally firing when no workspace exists.
     #[test]
     pub fn single_project_anchors_modules_at_cwd() {
+        // Even though this test doesn't `set_var`, hold the env
+        // guard so a *concurrent* `NPM_CONFIG_WORKSPACE_DIR` test
+        // can't make this one fall into the env-var override path.
+        let _guard = crate::test_env_guard::EnvGuard::snapshot([
+            "NPM_CONFIG_WORKSPACE_DIR",
+            "npm_config_workspace_dir",
+        ]);
+        // SAFETY: lock held by `_guard`.
+        unsafe {
+            env::remove_var("NPM_CONFIG_WORKSPACE_DIR");
+            env::remove_var("npm_config_workspace_dir");
+        }
         let tmp = tempdir().unwrap();
         let config =
             Config::current(|| tmp.path().to_path_buf().pipe(Ok::<_, ()>), || None, Config::new)
                 .expect("config loads");
+        assert_eq!(config.modules_dir, tmp.path().join("node_modules"));
+        assert_eq!(config.virtual_store_dir, tmp.path().join("node_modules/.pnpm"));
+    }
+
+    /// `NPM_CONFIG_WORKSPACE_DIR` must steer `Config::current`'s
+    /// path-anchoring just like it steers
+    /// [`pacquet_workspace::find_workspace_dir`] — otherwise the
+    /// virtual store would land in the cwd while the per-importer
+    /// `SymlinkDirectDependencies` writes land under the env-var
+    /// path, producing two `node_modules` layouts for the same
+    /// install. Matches the consistency guarantee Copilot flagged
+    /// during PR #443 review.
+    #[test]
+    pub fn npm_config_workspace_dir_re_anchors_modules() {
+        let _guard = crate::test_env_guard::EnvGuard::snapshot([
+            "NPM_CONFIG_WORKSPACE_DIR",
+            "npm_config_workspace_dir",
+        ]);
+
+        let env_workspace = tempdir().unwrap();
+        let cwd_dir = tempdir().unwrap();
+        // SAFETY: lock held by `_guard`. Cleared on drop.
+        unsafe {
+            env::set_var("NPM_CONFIG_WORKSPACE_DIR", env_workspace.path());
+            env::remove_var("npm_config_workspace_dir");
+        }
+
+        let config = Config::current(
+            || cwd_dir.path().to_path_buf().pipe(Ok::<_, ()>),
+            || None,
+            Config::new,
+        )
+        .expect("config loads");
+        assert_eq!(
+            config.modules_dir,
+            env_workspace.path().join("node_modules"),
+            "modules_dir must follow NPM_CONFIG_WORKSPACE_DIR, not the cwd",
+        );
+        assert_eq!(
+            config.virtual_store_dir,
+            env_workspace.path().join("node_modules/.pnpm"),
+            "virtual_store_dir must follow NPM_CONFIG_WORKSPACE_DIR, not the cwd",
+        );
+    }
+
+    /// An empty `NPM_CONFIG_WORKSPACE_DIR` falls through to the
+    /// upward walk, matching pnpm's truthy `if (workspaceDir)` check.
+    /// Pairs with `pacquet_workspace`'s
+    /// `empty_env_var_is_treated_as_unset`.
+    #[test]
+    pub fn empty_npm_config_workspace_dir_falls_through() {
+        let _guard = crate::test_env_guard::EnvGuard::snapshot([
+            "NPM_CONFIG_WORKSPACE_DIR",
+            "npm_config_workspace_dir",
+        ]);
+        // SAFETY: lock held by `_guard`.
+        unsafe {
+            env::set_var("NPM_CONFIG_WORKSPACE_DIR", "");
+            env::remove_var("npm_config_workspace_dir");
+        }
+        let tmp = tempdir().unwrap();
+        let config =
+            Config::current(|| tmp.path().to_path_buf().pipe(Ok::<_, ()>), || None, Config::new)
+                .expect("config loads");
+        // No yaml in tmp → no re-anchor → cwd-anchored defaults.
         assert_eq!(config.modules_dir, tmp.path().join("node_modules"));
         assert_eq!(config.virtual_store_dir, tmp.path().join("node_modules/.pnpm"));
     }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1000,7 +1000,10 @@ mod tests {
             "NPM_CONFIG_WORKSPACE_DIR",
             "npm_config_workspace_dir",
         ]);
-        // SAFETY: lock held by `_guard`.
+        // SAFETY: lock held by `_guard`. Two removes are fine on
+        // both POSIX (case-sensitive: two distinct vars) and Windows
+        // (case-insensitive: the second remove is a no-op on an
+        // already-absent variable).
         unsafe {
             env::remove_var("NPM_CONFIG_WORKSPACE_DIR");
             env::remove_var("npm_config_workspace_dir");
@@ -1031,9 +1034,20 @@ mod tests {
         let env_workspace = tempdir().unwrap();
         let cwd_dir = tempdir().unwrap();
         // SAFETY: lock held by `_guard`. Cleared on drop.
+        //
+        // Set the uppercase name only and let the lowercase name
+        // keep whatever the inherited environment had. Touching the
+        // lowercase name here would corrupt the test on Windows,
+        // where env vars are case-insensitive: `remove_var` on
+        // either spelling clears the *same* variable that
+        // `set_var("NPM_CONFIG_WORKSPACE_DIR", ...)` just set, and
+        // the test would observe "no env override" instead of the
+        // env path. Since [`Config::current`] checks the uppercase
+        // spelling first via `or_else` (matching pnpm), an
+        // externally-set lowercase value is unobservable here, so
+        // leaving it alone keeps both platforms green.
         unsafe {
             env::set_var("NPM_CONFIG_WORKSPACE_DIR", env_workspace.path());
-            env::remove_var("npm_config_workspace_dir");
         }
 
         let config = Config::current(
@@ -1064,10 +1078,15 @@ mod tests {
             "NPM_CONFIG_WORKSPACE_DIR",
             "npm_config_workspace_dir",
         ]);
-        // SAFETY: lock held by `_guard`.
+        // SAFETY: lock held by `_guard`. Setting *both* names to
+        // empty handles both platforms: on POSIX they're distinct
+        // vars (clear each); on Windows they're aliases for the
+        // same variable (the second `set_var` is a no-op). Either
+        // way, both reads return empty, the truthy filter rejects
+        // both, and the install falls through to the cwd-walk.
         unsafe {
             env::set_var("NPM_CONFIG_WORKSPACE_DIR", "");
-            env::remove_var("npm_config_workspace_dir");
+            env::set_var("npm_config_workspace_dir", "");
         }
         let tmp = tempdir().unwrap();
         let config =

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -598,6 +598,22 @@ impl Config {
             && let Some((path, settings)) = WorkspaceSettings::find_and_load(&start)?
         {
             let base_dir = path.parent().unwrap_or(&start).to_path_buf();
+            // Re-anchor the path-valued defaults to the workspace root
+            // before applying settings. Without this, a `pacquet install`
+            // run from a workspace subdirectory leaves
+            // `modules_dir` / `virtual_store_dir` anchored at the CLI
+            // `--dir` (the subdir), while the per-importer
+            // [`SymlinkDirectDependencies`] writes are anchored at the
+            // workspace root — producing two `node_modules` layouts
+            // for the same install. pnpm v11 ties
+            // `pnpmConfig.dir = lockfileDir` exactly so its defaults
+            // resolve from the workspace root; we mirror that here.
+            //
+            // Applied *before* `settings.apply_to` so an explicit
+            // `modulesDir` / `virtualStoreDir` in `pnpm-workspace.yaml`
+            // still wins.
+            config.modules_dir = base_dir.join("node_modules");
+            config.virtual_store_dir = base_dir.join("node_modules/.pnpm");
             settings.apply_to(&mut config, &base_dir);
         }
 
@@ -894,5 +910,50 @@ mod tests {
             matches!(err, crate::LoadWorkspaceYamlError::ParseYaml { .. }),
             "expected ParseYaml, got {err:?}",
         );
+    }
+
+    /// Running `pacquet install` from a workspace subdirectory must
+    /// not leave `modules_dir` / `virtual_store_dir` anchored at the
+    /// CLI `--dir`. The presence of `pnpm-workspace.yaml` in an
+    /// ancestor signals that the workspace root is the install anchor,
+    /// matching pnpm v11's `pnpmConfig.dir = lockfileDir` rule. Without
+    /// this, the per-importer `node_modules` writes (under the
+    /// workspace root) and the virtual store (under the subdir) would
+    /// produce two inconsistent layouts for the same install.
+    #[test]
+    pub fn workspace_subdir_anchors_modules_at_workspace_root() {
+        let tmp = tempdir().unwrap();
+        let workspace_root = tmp.path();
+        let subdir = workspace_root.join("packages/web");
+        fs::create_dir_all(&subdir).expect("create subdir");
+        fs::write(workspace_root.join("pnpm-workspace.yaml"), "packages:\n  - packages/*\n")
+            .expect("write to pnpm-workspace.yaml");
+
+        let config = Config::current(|| subdir.clone().pipe(Ok::<_, ()>), || None, Config::new)
+            .expect("config loads");
+
+        assert_eq!(
+            config.modules_dir,
+            workspace_root.join("node_modules"),
+            "modules_dir must be anchored at the workspace root, not the subdir",
+        );
+        assert_eq!(
+            config.virtual_store_dir,
+            workspace_root.join("node_modules/.pnpm"),
+            "virtual_store_dir must be anchored at the workspace root, not the subdir",
+        );
+    }
+
+    /// A single-project install (no `pnpm-workspace.yaml` anywhere)
+    /// keeps the CLI `--dir` as the anchor. Guards against the
+    /// re-anchor block accidentally firing when no workspace exists.
+    #[test]
+    pub fn single_project_anchors_modules_at_cwd() {
+        let tmp = tempdir().unwrap();
+        let config =
+            Config::current(|| tmp.path().to_path_buf().pipe(Ok::<_, ()>), || None, Config::new)
+                .expect("config loads");
+        assert_eq!(config.modules_dir, tmp.path().join("node_modules"));
+        assert_eq!(config.virtual_store_dir, tmp.path().join("node_modules/.pnpm"));
     }
 }

--- a/crates/lockfile/src/resolved_dependency.rs
+++ b/crates/lockfile/src/resolved_dependency.rs
@@ -1,6 +1,12 @@
-use crate::{PkgName, PkgVerPeer};
+use crate::{ParsePkgVerPeerError, PkgName, PkgVerPeer};
+use derive_more::{Display, Error};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::{
+    borrow::Cow,
+    collections::HashMap,
+    fmt::{self, Display},
+    str::FromStr,
+};
 
 /// Map of resolved dependencies stored in a [`ProjectSnapshot`](crate::ProjectSnapshot).
 ///
@@ -12,5 +18,147 @@ pub type ResolvedDependencyMap = HashMap<PkgName, ResolvedDependencySpec>;
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct ResolvedDependencySpec {
     pub specifier: String,
-    pub version: PkgVerPeer,
+    pub version: ImporterDepVersion,
 }
+
+/// Resolved `version` of an importer-level dependency.
+///
+/// Importer dependencies (the values inside `importers.<id>.dependencies`
+/// in a pnpm v9 lockfile) carry one of two shapes for `version:`:
+///
+/// - A bare semver-with-peer string like `4.0.0` or `17.0.2(react@17.0.2)`,
+///   meaning the dependency is in the shared virtual store.
+/// - A `link:<path>` value, meaning the dependency is a workspace
+///   sibling at `<path>` relative to the importer's `rootDir`. The
+///   workspace project is not duplicated in the virtual store — pnpm
+///   creates a direct symlink to the sibling's directory.
+///
+/// `ImporterDepVersion` encodes the distinction so consumers (the
+/// installer, the build-sequence builder, the reporter) can branch on
+/// shape without re-parsing the raw string at every call site.
+///
+/// Snapshot-level dependencies (the values inside `snapshots.*.dependencies`)
+/// use [`crate::SnapshotDepRef`] instead, which carries a different
+/// distinction (plain vs. alias) and never holds a `link:` value —
+/// `link:` only appears at the importer level.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ImporterDepVersion {
+    /// Bare semver-with-peer; resolves to a snapshot in `snapshots:`.
+    Regular(PkgVerPeer),
+
+    /// `link:<path>` value; resolves to a workspace sibling. The path
+    /// is stored verbatim from the lockfile (relative to the
+    /// importer's `rootDir`, or absolute) — interpreting it is the
+    /// installer's job, not this layer's.
+    Link(String),
+}
+
+impl ImporterDepVersion {
+    /// `Some(ver)` when this dependency resolves through the virtual
+    /// store; `None` when it's a `link:` sibling. Mirrors upstream's
+    /// `if (depPath.startsWith('link:'))` checks at the install layer.
+    pub fn as_regular(&self) -> Option<&'_ PkgVerPeer> {
+        match self {
+            ImporterDepVersion::Regular(v) => Some(v),
+            ImporterDepVersion::Link(_) => None,
+        }
+    }
+
+    /// `Some(target)` when this dependency is a `link:` sibling;
+    /// `None` when it resolves through the virtual store. The
+    /// returned string is the path portion *without* the `link:`
+    /// prefix.
+    pub fn as_link_target(&self) -> Option<&'_ str> {
+        match self {
+            ImporterDepVersion::Regular(_) => None,
+            ImporterDepVersion::Link(target) => Some(target.as_str()),
+        }
+    }
+}
+
+/// Error when parsing [`ImporterDepVersion`].
+#[derive(Debug, Display, Error)]
+#[non_exhaustive]
+pub enum ParseImporterDepVersionError {
+    #[display("Failed to parse importer dependency version {value:?}: {source}")]
+    Parse {
+        value: String,
+        #[error(source)]
+        source: ParsePkgVerPeerError,
+    },
+}
+
+impl FromStr for ImporterDepVersion {
+    type Err = ParseImporterDepVersionError;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        // `link:` keeps the path verbatim; everything else parses as a
+        // semver-with-peer. The `link:` discriminator is upstream's
+        // own — pnpm itself looks for the literal `link:` prefix at
+        // install time (see `installDepsResolve` / `lockfileToDepGraph`).
+        if let Some(target) = value.strip_prefix("link:") {
+            return Ok(ImporterDepVersion::Link(target.to_string()));
+        }
+        value.parse::<PkgVerPeer>().map(ImporterDepVersion::Regular).map_err(|source| {
+            ParseImporterDepVersionError::Parse { value: value.to_string(), source }
+        })
+    }
+}
+
+impl<'a> TryFrom<Cow<'a, str>> for ImporterDepVersion {
+    type Error = ParseImporterDepVersionError;
+    fn try_from(value: Cow<'a, str>) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+
+impl From<ImporterDepVersion> for String {
+    fn from(value: ImporterDepVersion) -> Self {
+        match value {
+            ImporterDepVersion::Regular(v) => v.to_string(),
+            ImporterDepVersion::Link(target) => format!("link:{target}"),
+        }
+    }
+}
+
+impl Serialize for ImporterDepVersion {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            ImporterDepVersion::Regular(v) => v.serialize(serializer),
+            ImporterDepVersion::Link(target) => {
+                let formatted = format!("link:{target}");
+                serializer.serialize_str(&formatted)
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ImporterDepVersion {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = Cow::<'de, str>::deserialize(deserializer)?;
+        raw.parse().map_err(serde::de::Error::custom)
+    }
+}
+
+impl From<PkgVerPeer> for ImporterDepVersion {
+    fn from(value: PkgVerPeer) -> Self {
+        ImporterDepVersion::Regular(value)
+    }
+}
+
+impl Display for ImporterDepVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ImporterDepVersion::Regular(v) => Display::fmt(v, f),
+            ImporterDepVersion::Link(target) => write!(f, "link:{target}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/lockfile/src/resolved_dependency/tests.rs
+++ b/crates/lockfile/src/resolved_dependency/tests.rs
@@ -1,0 +1,57 @@
+use super::{ImporterDepVersion, ResolvedDependencySpec};
+use pretty_assertions::assert_eq;
+
+/// Bare semver versions parse into `Regular` and round-trip through
+/// the string form.
+#[test]
+fn parses_regular_version() {
+    let parsed: ImporterDepVersion = "4.0.0".parse().unwrap();
+    assert_eq!(parsed.as_regular().map(ToString::to_string), Some("4.0.0".to_string()));
+    assert!(parsed.as_link_target().is_none());
+    let serialized: String = parsed.into();
+    assert_eq!(serialized, "4.0.0");
+}
+
+/// Peer-suffixed semver versions still parse into `Regular`.
+#[test]
+fn parses_regular_version_with_peer() {
+    let parsed: ImporterDepVersion = "17.0.2(react@17.0.2)".parse().unwrap();
+    assert!(matches!(parsed, ImporterDepVersion::Regular(_)));
+}
+
+/// `link:<path>` parses into `Link` and keeps the path verbatim
+/// (without the `link:` prefix).
+#[test]
+fn parses_link_version() {
+    let parsed: ImporterDepVersion = "link:../shared".parse().unwrap();
+    assert_eq!(parsed.as_link_target(), Some("../shared"));
+    assert!(parsed.as_regular().is_none());
+    let serialized: String = parsed.into();
+    assert_eq!(serialized, "link:../shared");
+}
+
+/// `link:` with an absolute path is preserved verbatim.
+#[test]
+fn parses_link_with_absolute_path() {
+    let parsed: ImporterDepVersion = "link:/abs/sibling".parse().unwrap();
+    assert_eq!(parsed.as_link_target(), Some("/abs/sibling"));
+}
+
+/// A `ResolvedDependencySpec` with a `link:` value round-trips
+/// through serde, the load path the lockfile reader uses.
+#[test]
+fn resolved_spec_deserialize_link() {
+    let yaml = "specifier: workspace:*\nversion: link:../shared\n";
+    let spec: ResolvedDependencySpec = serde_saphyr::from_str(yaml).unwrap();
+    assert_eq!(spec.specifier, "workspace:*");
+    assert_eq!(spec.version.as_link_target(), Some("../shared"));
+}
+
+/// And the regular case round-trips too.
+#[test]
+fn resolved_spec_deserialize_regular() {
+    let yaml = "specifier: ^4.0.0\nversion: 4.0.0\n";
+    let spec: ResolvedDependencySpec = serde_saphyr::from_str(yaml).unwrap();
+    assert_eq!(spec.specifier, "^4.0.0");
+    assert!(spec.version.as_regular().is_some());
+}

--- a/crates/lockfile/src/save_lockfile/tests.rs
+++ b/crates/lockfile/src/save_lockfile/tests.rs
@@ -84,6 +84,83 @@ fn round_trip_parse_save_parse_preserves_lockfile() {
     assert_eq!(original, reparsed);
 }
 
+/// A workspace lockfile with multiple importers, one of which has a
+/// `workspace:` dependency, must round-trip cleanly. Guards two things
+/// at once:
+///
+/// 1. The importer map is heterogeneous — multiple keys, not just `.`.
+/// 2. `version: link:<path>` values deserialize into
+///    [`crate::ImporterDepVersion::Link`] and re-serialize back to
+///    the same wire form.
+///
+/// This is the smallest possible v9 workspace lockfile pacquet needs
+/// to load to do anything useful for #431.
+#[test]
+fn workspace_lockfile_with_link_dep_round_trips() {
+    const WORKSPACE_YAML: &str = text_block! {
+        "lockfileVersion: '9.0'"
+        ""
+        "settings:"
+        "  autoInstallPeers: true"
+        "  excludeLinksFromLockfile: false"
+        ""
+        "importers:"
+        ""
+        "  packages/shared:"
+        "    dependencies:"
+        "      react:"
+        "        specifier: ^17.0.2"
+        "        version: 17.0.2"
+        ""
+        "  packages/web:"
+        "    dependencies:"
+        "      shared:"
+        "        specifier: workspace:*"
+        "        version: link:../shared"
+        "      react:"
+        "        specifier: ^17.0.2"
+        "        version: 17.0.2"
+        ""
+        "packages:"
+        ""
+        "  react@17.0.2:"
+        "    resolution: {integrity: sha512-TIE61hcgbI/SlJh/0c1sT1SZbBlpg7WiZcs65WPJhoIZQPhH1SCpcGA7LgrVXT15lwN3HV4GQM/MJ9aKEn3Qfg==}"
+        "    engines: {node: '>=0.10.0'}"
+        ""
+        "snapshots:"
+        ""
+        "  react@17.0.2: {}"
+    };
+
+    let original: Lockfile =
+        serde_saphyr::from_str(WORKSPACE_YAML).expect("parse workspace lockfile");
+    assert_eq!(original.importers.len(), 2);
+
+    // The `link:` dep landed in the typed enum's `Link` variant.
+    let web = original.importers.get("packages/web").expect("web importer present");
+    let shared_dep = web
+        .dependencies
+        .as_ref()
+        .unwrap()
+        .iter()
+        .find(|(name, _)| name.to_string() == "shared")
+        .map(|(_, spec)| spec)
+        .expect("shared dep present");
+    assert_eq!(shared_dep.version.as_link_target(), Some("../shared"));
+
+    // Save and reparse — the `link:` value must round-trip unchanged.
+    let tmp = tempdir().expect("create tempdir");
+    let path = tmp.path().join("pnpm-lock.yaml");
+    original.save_to_path(&path).expect("save lockfile");
+    let saved = std::fs::read_to_string(&path).expect("read saved");
+    assert!(
+        saved.contains("version: link:../shared"),
+        "expected `link:` to survive serialization:\n{saved}",
+    );
+    let reparsed: Lockfile = serde_saphyr::from_str(&saved).expect("reparse");
+    assert_eq!(original, reparsed);
+}
+
 #[test]
 fn save_fails_with_wrapped_io_error_when_path_is_invalid() {
     let empty_lockfile: Lockfile =

--- a/crates/package-manager/Cargo.toml
+++ b/crates/package-manager/Cargo.toml
@@ -27,6 +27,7 @@ pacquet-registry               = { workspace = true }
 pacquet-reporter               = { workspace = true }
 pacquet-store-dir              = { workspace = true }
 pacquet-tarball                = { workspace = true }
+pacquet-workspace              = { workspace = true }
 
 async-recursion = { workspace = true }
 dashmap         = { workspace = true }

--- a/crates/package-manager/src/build_modules/tests.rs
+++ b/crates/package-manager/src/build_modules/tests.rs
@@ -250,7 +250,10 @@ fn root_importers(deps: &[(&str, &str)]) -> HashMap<String, ProjectSnapshot> {
     let map: ResolvedDependencyMap = deps
         .iter()
         .map(|(n, v)| {
-            (name(n), ResolvedDependencySpec { specifier: (*v).to_string(), version: ver(v) })
+            (
+                name(n),
+                ResolvedDependencySpec { specifier: (*v).to_string(), version: ver(v).into() },
+            )
         })
         .collect();
     HashMap::from([(

--- a/crates/package-manager/src/build_sequence.rs
+++ b/crates/package-manager/src/build_sequence.rs
@@ -139,7 +139,16 @@ fn collect_root_dep_paths(
         .flatten()
         {
             for (name, spec) in map {
-                let key = PackageKey::new(name.clone(), spec.version.clone());
+                // `link:` deps don't live in the virtual store —
+                // they're per-importer directory symlinks — so they
+                // are not snapshot roots. Mirrors upstream's
+                // `if (depPath.startsWith('link:')) continue` at
+                // build-time in
+                // <https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/src/install/index.ts>.
+                let Some(ver_peer) = spec.version.as_regular() else {
+                    continue;
+                };
+                let key = PackageKey::new(name.clone(), ver_peer.clone());
                 if !snapshots.contains_key(&key) {
                     continue;
                 }

--- a/crates/package-manager/src/build_sequence/tests.rs
+++ b/crates/package-manager/src/build_sequence/tests.rs
@@ -44,7 +44,10 @@ fn importer(deps: &[(&str, &str)]) -> ProjectSnapshot {
     let map: ResolvedDependencyMap = deps
         .iter()
         .map(|(n, v)| {
-            (name(n), ResolvedDependencySpec { specifier: (*v).to_string(), version: ver(v) })
+            (
+                name(n),
+                ResolvedDependencySpec { specifier: (*v).to_string(), version: ver(v).into() },
+            )
         })
         .collect();
     ProjectSnapshot {

--- a/crates/package-manager/src/install.rs
+++ b/crates/package-manager/src/install.rs
@@ -151,8 +151,13 @@ where
         let workspace_root = pacquet_workspace::find_workspace_dir(manifest_dir)
             .map_err(InstallError::FindWorkspaceDir)?
             .unwrap_or_else(|| manifest_dir.to_path_buf());
-        let prefix =
-            workspace_root.to_str().expect("workspace root path is valid UTF-8").to_owned();
+        // Use `to_string_lossy` rather than `to_str().expect(...)` so a
+        // valid filesystem path with non-UTF-8 bytes (possible on Unix)
+        // doesn't panic the installer. `prefix` is used only for
+        // reporter envelopes, so a lossy conversion is acceptable —
+        // the rest of the install path uses the same pattern for
+        // paths threaded into log events.
+        let prefix = workspace_root.to_string_lossy().into_owned();
 
         // `pnpm:package-manifest initial` carries the on-disk
         // `package.json` body. Mirrors pnpm's per-project emit at

--- a/crates/package-manager/src/install.rs
+++ b/crates/package-manager/src/install.rs
@@ -320,11 +320,14 @@ where
         // a manifest failure can't leave a fresh current-lockfile
         // pointing at incomplete install state — the next frozen
         // reinstall would otherwise diff against a graph that never
-        // finished committing (review on #442). Today pacquet writes
-        // the wanted lockfile unchanged because there's only one
-        // importer to filter to; once workspace install (#431) lands
-        // this needs to narrow to the *filtered* lockfile (selected
-        // importers × engine filter).
+        // finished committing (review on #442).
+        //
+        // Workspace installs (#431) ship every importer's section of
+        // the wanted lockfile unchanged because the install fans out
+        // across all of them. Once `--filter` lands (Stage 2 of
+        // #299), this needs to narrow to the filtered lockfile
+        // (selected importers × engine filter) so the saved current
+        // lockfile reflects only what was actually materialized.
         if frozen_lockfile && let Some(lockfile) = lockfile {
             lockfile
                 .save_current_to_virtual_store_dir(&config.virtual_store_dir)

--- a/crates/package-manager/src/install.rs
+++ b/crates/package-manager/src/install.rs
@@ -264,6 +264,7 @@ where
                 current_packages: current_lockfile.as_ref().and_then(|l| l.packages.as_ref()),
                 dependency_groups,
                 logged_methods: &logged_methods,
+                workspace_root: &workspace_root,
                 requester: &prefix,
             }
             .run::<R>()

--- a/crates/package-manager/src/install.rs
+++ b/crates/package-manager/src/install.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, path::Path, sync::atomic::AtomicU8, time::SystemTime};
+use std::{collections::BTreeMap, sync::atomic::AtomicU8, time::SystemTime};
 
 use crate::{
     InstallFrozenLockfile, InstallFrozenLockfileError, InstallWithoutLockfile,
@@ -103,6 +103,9 @@ pub enum InstallError {
     )]
     #[diagnostic(code(pacquet_package_manager::no_importer))]
     NoImporter { importer_id: String },
+
+    #[diagnostic(transparent)]
+    FindWorkspaceDir(#[error(source)] pacquet_workspace::FindWorkspaceDirError),
 }
 
 impl<'a, DependencyGroupList> Install<'a, DependencyGroupList>
@@ -137,19 +140,19 @@ where
         // Project root for the [bunyan]-envelope `prefix`. Upstream pnpm
         // emits this as `lockfileDir`, the directory containing
         // `pnpm-lock.yaml`. With workspace support that equals the
-        // workspace root. Pacquet has no workspace support yet, so the
-        // manifest's parent directory is the correct value today.
-        // pnpm/pacquet#357 tracks resolving this via a
-        // `findWorkspaceDir`-equivalent once workspaces land.
+        // workspace root — pacquet finds it via [`find_workspace_dir`]
+        // (port of upstream's `findWorkspaceDir`). Falls back to the
+        // manifest's parent dir when no `pnpm-workspace.yaml` exists in
+        // any ancestor, matching upstream's single-project behavior.
+        // Closes pnpm/pacquet#357.
         //
         // [bunyan]: https://github.com/trentm/node-bunyan
-        let prefix = manifest
-            .path()
-            .parent()
-            .map(Path::to_str)
-            .map(Option::<&str>::unwrap)
-            .unwrap()
-            .to_owned();
+        let manifest_dir = manifest.path().parent().expect("manifest path always has a parent dir");
+        let workspace_root = pacquet_workspace::find_workspace_dir(manifest_dir)
+            .map_err(InstallError::FindWorkspaceDir)?
+            .unwrap_or_else(|| manifest_dir.to_path_buf());
+        let prefix =
+            workspace_root.to_str().expect("workspace root path is valid UTF-8").to_owned();
 
         // `pnpm:package-manifest initial` carries the on-disk
         // `package.json` body. Mirrors pnpm's per-project emit at

--- a/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/crates/package-manager/src/install_frozen_lockfile.rs
@@ -16,7 +16,11 @@ use pacquet_patching::{
 };
 use pacquet_reporter::{IgnoredScriptsLog, LogEvent, LogLevel, Reporter, Stage, StageLog};
 use pacquet_store_dir::StoreIndexWriter;
-use std::{collections::HashMap, path::Path, sync::atomic::AtomicU8};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::atomic::AtomicU8,
+};
 
 /// This subroutine installs dependencies from a frozen lockfile.
 ///
@@ -49,7 +53,13 @@ where
     /// Install-scoped dedupe state for `pnpm:package-import-method`.
     /// See `link_file::log_method_once`.
     pub logged_methods: &'a AtomicU8,
-    /// Install root, threaded into reporter `requester` fields.
+    /// Install root — the directory containing `pnpm-lock.yaml`.
+    /// For a real workspace, this is the workspace root (the dir
+    /// containing `pnpm-workspace.yaml`); for a single-project
+    /// install, it's the project dir. Threaded into reporter
+    /// `prefix` fields for install-wide events (`pnpm:stage`,
+    /// `pnpm:summary`, `pnpm:lifecycle`) — per-importer events
+    /// like `pnpm:root` use the importer's own `rootDir` instead.
     pub requester: &'a str,
 }
 
@@ -251,11 +261,12 @@ where
             .flatten(),
         };
 
+        let workspace_root: PathBuf = PathBuf::from(requester);
         SymlinkDirectDependencies {
             config,
             importers,
             dependency_groups,
-            requester,
+            workspace_root: &workspace_root,
             skipped: &skipped,
         }
         .run::<R>()

--- a/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/crates/package-manager/src/install_frozen_lockfile.rs
@@ -16,11 +16,7 @@ use pacquet_patching::{
 };
 use pacquet_reporter::{IgnoredScriptsLog, LogEvent, LogLevel, Reporter, Stage, StageLog};
 use pacquet_store_dir::StoreIndexWriter;
-use std::{
-    collections::HashMap,
-    path::{Path, PathBuf},
-    sync::atomic::AtomicU8,
-};
+use std::{collections::HashMap, path::Path, sync::atomic::AtomicU8};
 
 /// This subroutine installs dependencies from a frozen lockfile.
 ///
@@ -56,10 +52,28 @@ where
     /// Install root — the directory containing `pnpm-lock.yaml`.
     /// For a real workspace, this is the workspace root (the dir
     /// containing `pnpm-workspace.yaml`); for a single-project
-    /// install, it's the project dir. Threaded into reporter
-    /// `prefix` fields for install-wide events (`pnpm:stage`,
-    /// `pnpm:summary`, `pnpm:lifecycle`) — per-importer events
-    /// like `pnpm:root` use the importer's own `rootDir` instead.
+    /// install, it's the project dir.
+    ///
+    /// Reporter envelopes (`pnpm:stage`, `pnpm:summary`, `pnpm:lifecycle`)
+    /// use [`requester`], a lossy-UTF-8 string view of this path —
+    /// per-importer events like `pnpm:root` use the importer's own
+    /// `rootDir` instead. Filesystem operations that need the real
+    /// path (the per-importer `node_modules/` write under
+    /// `SymlinkDirectDependencies`, the `lockfile_dir` threaded into
+    /// `BuildModules`) use `workspace_root` directly so the round-trip
+    /// through a lossy string can never corrupt the on-disk path on
+    /// hosts with non-UTF-8 filenames.
+    ///
+    /// [`requester`]: Self::requester
+    pub workspace_root: &'a Path,
+
+    /// Lossy-UTF-8 view of [`workspace_root`] for reporter envelopes.
+    /// Kept as a separate field rather than recomputed from
+    /// `workspace_root` so the caller controls how the conversion is
+    /// performed (today: `to_string_lossy().into_owned()` in
+    /// `Install::run`).
+    ///
+    /// [`workspace_root`]: Self::workspace_root
     pub requester: &'a str,
 }
 
@@ -136,6 +150,7 @@ where
             current_packages,
             dependency_groups,
             logged_methods,
+            workspace_root,
             requester,
         } = self;
 
@@ -261,12 +276,11 @@ where
             .flatten(),
         };
 
-        let workspace_root: PathBuf = PathBuf::from(requester);
         SymlinkDirectDependencies {
             config,
             importers,
             dependency_groups,
-            workspace_root: &workspace_root,
+            workspace_root,
             skipped: &skipped,
         }
         .run::<R>()
@@ -303,7 +317,14 @@ where
             stage: Stage::ImportingDone,
         }));
 
-        let manifest_dir = Path::new(requester);
+        // `manifest_dir` (= upstream's `lockfileDir`) is the workspace
+        // root threaded through `BuildModules`. Use the real `Path`
+        // here rather than reconstructing it from the lossy
+        // `requester` string so non-UTF-8 filenames survive intact.
+        // `allow_build_policy` was already constructed up-front
+        // (before `CreateVirtualStore`) on `main` so the git fetcher
+        // can consult it — no second construction needed here.
+        let manifest_dir: &Path = workspace_root;
 
         // Resolve `pnpm-workspace.yaml`'s `patchedDependencies` once
         // per install. Yields `None` when nothing is configured (no

--- a/crates/package-manager/src/installability/tests.rs
+++ b/crates/package-manager/src/installability/tests.rs
@@ -57,6 +57,7 @@ fn synthetic_metadata(
             integrity: None,
             tarball: "https://example.test/pkg.tgz".to_string(),
             git_hosted: None,
+            path: None,
         }),
         engines: engines
             .map(|e| e.iter().map(|(k, v)| ((*k).to_string(), (*v).to_string())).collect()),

--- a/crates/package-manager/src/symlink_direct_dependencies.rs
+++ b/crates/package-manager/src/symlink_direct_dependencies.rs
@@ -1,4 +1,4 @@
-use crate::{SkippedSnapshots, link_direct_dep_bins, symlink_package};
+use crate::{SkippedSnapshots, SymlinkPackageError, link_direct_dep_bins, symlink_package};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_cmd_shim::LinkBinsError;
@@ -34,8 +34,9 @@ use std::{
 ///   <https://github.com/pnpm/pnpm/blob/94240bc046/installing/linking/direct-dep-linker/src/linkDirectDeps.ts#L131>.
 ///
 /// The virtual store dir (`config.virtual_store_dir`) stays singular —
-/// it lives at `workspace_root/node_modules/.pnpm`. Only the per-project
-/// `node_modules/` and its symlinks fan out.
+/// it lives at `<workspace_root>/node_modules/.pacquet` (pnpm uses
+/// `.pnpm`; pacquet's directory name is fixed by `default_virtual_store_dir`).
+/// Only the per-project `node_modules/` and its symlinks fan out.
 #[must_use]
 pub struct SymlinkDirectDependencies<'a, DependencyGroupList>
 where
@@ -64,6 +65,40 @@ where
 pub enum SymlinkDirectDependenciesError {
     #[diagnostic(transparent)]
     LinkBins(#[error(source)] LinkBinsError),
+
+    /// A lockfile importer key that would escape the workspace root.
+    /// Pnpm's lockfile spec uses POSIX relative paths for importer
+    /// keys (e.g. `packages/web`); a key that is absolute, contains
+    /// `..` traversal, or carries a Windows drive prefix is treated
+    /// as a malformed lockfile so we don't end up creating
+    /// `node_modules` outside the workspace. Upstream pnpm does not
+    /// guard this explicitly, but the importer keys it writes are
+    /// always relative POSIX paths under the workspace root — so
+    /// this check is parity-preserving on conforming input.
+    #[display("Refusing to install importer with unsafe path key {importer_id:?}")]
+    #[diagnostic(
+        code(pacquet_package_manager::unsafe_importer_path),
+        help(
+            "Importer keys in pnpm-lock.yaml must be POSIX paths relative to the workspace root (e.g. `packages/web`). Absolute paths, drive prefixes, and `..` components are rejected."
+        )
+    )]
+    UnsafeImporterPath {
+        #[error(not(source))]
+        importer_id: String,
+    },
+
+    /// Surfaces a per-package symlink failure (e.g. permission denied,
+    /// disk full, an existing non-symlink file). Replaces the prior
+    /// `expect("symlink pkg")` which panicked inside a rayon task and
+    /// took the whole install down.
+    #[display("Failed to symlink {name:?} for importer {importer_id:?}: {source}")]
+    #[diagnostic(code(pacquet_package_manager::symlink_failed))]
+    SymlinkPackage {
+        importer_id: String,
+        name: String,
+        #[error(source)]
+        source: SymlinkPackageError,
+    },
 }
 
 impl<'a, DependencyGroupList> SymlinkDirectDependencies<'a, DependencyGroupList>
@@ -94,12 +129,20 @@ where
         keys.sort_unstable();
 
         for importer_id in keys {
+            // Reject importer keys that would escape the workspace
+            // root. A malformed (or hostile) lockfile could otherwise
+            // make `Path::join` create `node_modules` outside the
+            // workspace — `Path::join` discards the base when the
+            // RHS is absolute, and `..` components are otherwise
+            // permitted.
+            validate_importer_id(importer_id)?;
             // Safe: we just iterated `importers.keys()`.
             let project_snapshot = &importers[importer_id];
             let project_dir = importer_root_dir(workspace_root, importer_id);
             let modules_dir = project_dir.join("node_modules");
 
             link_one_importer::<R>(
+                importer_id,
                 config,
                 project_snapshot,
                 &project_dir,
@@ -111,6 +154,52 @@ where
 
         Ok(())
     }
+}
+
+/// Reject importer keys that would resolve outside the workspace root.
+///
+/// Pnpm's lockfile spec writes importer keys as POSIX paths relative
+/// to the workspace root (`.` for the root, `packages/web` for a
+/// subproject). Anything else — an absolute POSIX path, a Windows
+/// drive prefix, a `..` segment — is either malformed or hostile, so
+/// surface it as a typed error rather than silently letting
+/// `Path::join` produce an off-workspace path.
+fn validate_importer_id(importer_id: &str) -> Result<(), SymlinkDirectDependenciesError> {
+    let unsafe_path = || SymlinkDirectDependenciesError::UnsafeImporterPath {
+        importer_id: importer_id.to_string(),
+    };
+
+    if importer_id == "." || importer_id.is_empty() {
+        return Ok(());
+    }
+
+    // Absolute POSIX path. Pnpm writes relative paths; an absolute
+    // value would cause `Path::join` to discard `workspace_root`.
+    if importer_id.starts_with('/') {
+        return Err(unsafe_path());
+    }
+    // Windows drive prefix (e.g. `C:` or `C:/foo`). Same blast radius
+    // as the absolute POSIX case on Windows hosts.
+    let bytes = importer_id.as_bytes();
+    if bytes.len() >= 2 && bytes[1] == b':' && bytes[0].is_ascii_alphabetic() {
+        return Err(unsafe_path());
+    }
+    // Backslash separator. Pnpm writes POSIX `/`; a backslash key
+    // would be either a Windows-native path or pnpm-incompatible
+    // garbage.
+    if importer_id.contains('\\') {
+        return Err(unsafe_path());
+    }
+    // Any `..` segment. Mirrors `path::Component::ParentDir` rejection
+    // without paying for full component iteration since importer keys
+    // are tiny.
+    for segment in importer_id.split('/') {
+        if segment == ".." {
+            return Err(unsafe_path());
+        }
+    }
+
+    Ok(())
 }
 
 /// Resolve `importer_id` (a lockfile key) against the workspace root.
@@ -131,6 +220,7 @@ fn importer_root_dir(workspace_root: &Path, importer_id: &str) -> PathBuf {
 }
 
 fn link_one_importer<R: Reporter>(
+    importer_id: &str,
     config: &Config,
     project_snapshot: &ProjectSnapshot,
     project_dir: &Path,
@@ -205,89 +295,105 @@ fn link_one_importer<R: Reporter>(
     // <https://github.com/pnpm/pnpm/blob/94240bc046/installing/linking/direct-dep-linker/src/linkDirectDeps.ts#L131>.
     let prefix = project_dir.to_string_lossy().into_owned();
 
-    entries.par_iter().for_each(|(name, spec, group)| {
-        let name_str = name.to_string();
-        let target_path: PathBuf = match &spec.version {
-            ImporterDepVersion::Regular(ver_peer) => {
-                // TODO: the code below is not optimal
-                let virtual_store_name =
-                    PkgNameVerPeer::new(PkgName::clone(name), ver_peer.clone())
-                        .to_virtual_store_name();
-                config
-                    .virtual_store_dir
-                    .join(virtual_store_name)
-                    .join("node_modules")
-                    .join(&name_str)
-            }
-            ImporterDepVersion::Link(target) => {
-                // `link:<path>` values are relative to the
-                // importer's `rootDir` (or absolute). Resolve them
-                // here so the on-disk symlink points at the right
-                // sibling project. Pnpm does the same conversion in
-                // `lockfileToDepGraph` —
-                // <https://github.com/pnpm/pnpm/blob/94240bc046/lockfile/types/src/index.ts>
-                // — but pacquet's lockfile snapshot already carries
-                // the raw `link:` payload, so the resolution lives
-                // at the install layer.
-                let candidate = Path::new(target);
-                if candidate.is_absolute() {
-                    candidate.to_path_buf()
-                } else {
-                    project_dir.join(candidate)
+    // `try_for_each` short-circuits on the first error and returns it
+    // to the caller, replacing the prior `expect("symlink pkg")` that
+    // panicked the rayon worker on any FS failure. The full result
+    // collection forces every task to settle before we surface a
+    // single error.
+    entries.par_iter().try_for_each(
+        |(name, spec, group)| -> Result<(), SymlinkDirectDependenciesError> {
+            let name_str = name.to_string();
+            let target_path: PathBuf = match &spec.version {
+                ImporterDepVersion::Regular(ver_peer) => {
+                    // TODO: the code below is not optimal
+                    let virtual_store_name =
+                        PkgNameVerPeer::new(PkgName::clone(name), ver_peer.clone())
+                            .to_virtual_store_name();
+                    config
+                        .virtual_store_dir
+                        .join(virtual_store_name)
+                        .join("node_modules")
+                        .join(&name_str)
                 }
-            }
-        };
+                ImporterDepVersion::Link(target) => {
+                    // `link:<path>` values are relative to the
+                    // importer's `rootDir` (or absolute). Resolve them
+                    // here so the on-disk symlink points at the right
+                    // sibling project. Pnpm does the same conversion in
+                    // `lockfileToDepGraph` —
+                    // <https://github.com/pnpm/pnpm/blob/94240bc046/lockfile/types/src/index.ts>
+                    // — but pacquet's lockfile snapshot already carries
+                    // the raw `link:` payload, so the resolution lives
+                    // at the install layer.
+                    let candidate = Path::new(target);
+                    if candidate.is_absolute() {
+                        candidate.to_path_buf()
+                    } else {
+                        project_dir.join(candidate)
+                    }
+                }
+            };
 
-        symlink_package(&target_path, &modules_dir.join(&name_str)).expect("symlink pkg"); // TODO: properly propagate this error
+            symlink_package(&target_path, &modules_dir.join(&name_str)).map_err(|source| {
+                SymlinkDirectDependenciesError::SymlinkPackage {
+                    importer_id: importer_id.to_string(),
+                    name: name_str.clone(),
+                    source,
+                }
+            })?;
 
-        // `pnpm:root added` mirrors pnpm's emit at
-        // <https://github.com/pnpm/pnpm/blob/94240bc046/installing/linking/direct-dep-linker/src/linkDirectDeps.ts#L131>:
-        // one event per direct dependency once the symlink has
-        // been created. pacquet's frozen-lockfile snapshot doesn't
-        // preserve npm-alias keys at this layer, so `realName`
-        // mirrors `name`; the optional `id` / `latest` /
-        // `linkedFrom` fields are out of pacquet's reach today
-        // and skip from the wire shape rather than serializing as
-        // JSON `null`.
-        let dependency_type = match group {
-            DependencyGroup::Prod => DependencyType::Prod,
-            DependencyGroup::Dev => DependencyType::Dev,
-            DependencyGroup::Optional => DependencyType::Optional,
-            // Filtered upfront. See the comment on the `entries`
-            // builder above.
-            DependencyGroup::Peer => unreachable!("peers are filtered out before this point"),
-        };
-        // For a `link:` dep, upstream's `version` field is the
-        // resolved `link:<path>` payload (re-prepended on the
-        // wire) so reporters can render the link target. Pacquet
-        // mirrors that here; for `Regular` deps we keep the
-        // semver-only formatting upstream uses on the wire.
-        let version = match &spec.version {
-            ImporterDepVersion::Regular(ver) => Some(ver.version().to_string()),
-            ImporterDepVersion::Link(target) => Some(format!("link:{target}")),
-        };
-        // Pacquet's lockfile snapshot doesn't track the
-        // npm-alias key separately from the resolved package
-        // name at this layer, so `name` and `real_name` carry
-        // the same value. Clone the already-built string
-        // instead of formatting `name` a second time.
-        let real_name = name_str.clone();
-        R::emit(&LogEvent::Root(RootLog {
-            level: LogLevel::Debug,
-            message: RootMessage::Added {
-                prefix: prefix.clone(),
-                added: AddedRoot {
-                    name: name_str,
-                    real_name,
-                    version,
-                    dependency_type: Some(dependency_type),
-                    id: None,
-                    latest: None,
-                    linked_from: None,
+            // `pnpm:root added` mirrors pnpm's emit at
+            // <https://github.com/pnpm/pnpm/blob/94240bc046/installing/linking/direct-dep-linker/src/linkDirectDeps.ts#L131>:
+            // one event per direct dependency once the symlink has
+            // been created. pacquet's frozen-lockfile snapshot doesn't
+            // preserve npm-alias keys at this layer, so `realName`
+            // mirrors `name`; the optional `id` / `latest` /
+            // `linkedFrom` fields are out of pacquet's reach today
+            // and skip from the wire shape rather than serializing as
+            // JSON `null`.
+            let dependency_type = match group {
+                DependencyGroup::Prod => DependencyType::Prod,
+                DependencyGroup::Dev => DependencyType::Dev,
+                DependencyGroup::Optional => DependencyType::Optional,
+                // Filtered upfront. See the comment on the `entries`
+                // builder above.
+                DependencyGroup::Peer => {
+                    unreachable!("peers are filtered out before this point")
+                }
+            };
+            // For a `link:` dep, upstream's `version` field is the
+            // resolved `link:<path>` payload (re-prepended on the
+            // wire) so reporters can render the link target. Pacquet
+            // mirrors that here; for `Regular` deps we keep the
+            // semver-only formatting upstream uses on the wire.
+            let version = match &spec.version {
+                ImporterDepVersion::Regular(ver) => Some(ver.version().to_string()),
+                ImporterDepVersion::Link(target) => Some(format!("link:{target}")),
+            };
+            // Pacquet's lockfile snapshot doesn't track the
+            // npm-alias key separately from the resolved package
+            // name at this layer, so `name` and `real_name` carry
+            // the same value. Clone the already-built string
+            // instead of formatting `name` a second time.
+            let real_name = name_str.clone();
+            R::emit(&LogEvent::Root(RootLog {
+                level: LogLevel::Debug,
+                message: RootMessage::Added {
+                    prefix: prefix.clone(),
+                    added: AddedRoot {
+                        name: name_str,
+                        real_name,
+                        version,
+                        dependency_type: Some(dependency_type),
+                        id: None,
+                        latest: None,
+                        linked_from: None,
+                    },
                 },
-            },
-        }));
-    });
+            }));
+            Ok(())
+        },
+    )?;
 
     // After the symlinks exist, walk them to discover each
     // direct dep's `package.json` and link declared bins into

--- a/crates/package-manager/src/symlink_direct_dependencies.rs
+++ b/crates/package-manager/src/symlink_direct_dependencies.rs
@@ -3,20 +3,39 @@ use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_cmd_shim::LinkBinsError;
 use pacquet_config::Config;
-use pacquet_lockfile::{Lockfile, PkgName, PkgNameVerPeer, ProjectSnapshot};
+use pacquet_lockfile::{
+    ImporterDepVersion, PkgName, PkgNameVerPeer, ProjectSnapshot, ResolvedDependencySpec,
+};
 use pacquet_package_manifest::DependencyGroup;
 use pacquet_reporter::{
     AddedRoot, DependencyType, LogEvent, LogLevel, Reporter, RootLog, RootMessage,
 };
 use rayon::prelude::*;
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    path::{Path, PathBuf},
+};
 
-/// This subroutine creates symbolic links in the `node_modules` directory for
-/// the direct dependencies. The targets of the link are the virtual directories.
+/// Create the `node_modules/` symlinks for every importer in the lockfile.
 ///
-/// If package `foo@x.y.z` is declared as a dependency in `package.json`,
-/// symlink `foo -> .pacquet/foo@x.y.z/node_modules/foo` shall be created
-/// in the `node_modules` directory.
+/// For each `importers.<id>` entry:
+///
+/// - Resolve the importer's `rootDir = workspace_root.join(id)` (with
+///   `id == "."` meaning the workspace root itself).
+/// - For every direct dependency in the importer's groups, create the
+///   appropriate symlink under `rootDir/node_modules/`. Snapshots that
+///   resolve through the shared virtual store get a link to
+///   `<virtual_store_dir>/<name>@<ver>/node_modules/<name>`. `link:`
+///   snapshots (cross-importer `workspace:` deps) get a direct symlink
+///   to the dependee's `rootDir`.
+/// - Emit one `pnpm:root added` per direct dependency with the
+///   importer's `rootDir` as the event prefix, matching upstream's
+///   per-project emit at
+///   <https://github.com/pnpm/pnpm/blob/94240bc046/installing/linking/direct-dep-linker/src/linkDirectDeps.ts#L131>.
+///
+/// The virtual store dir (`config.virtual_store_dir`) stays singular —
+/// it lives at `workspace_root/node_modules/.pnpm`. Only the per-project
+/// `node_modules/` and its symlinks fan out.
 #[must_use]
 pub struct SymlinkDirectDependencies<'a, DependencyGroupList>
 where
@@ -25,9 +44,12 @@ where
     pub config: &'static Config,
     pub importers: &'a HashMap<String, ProjectSnapshot>,
     pub dependency_groups: DependencyGroupList,
-    /// Install root, threaded into the `pnpm:root` `prefix` field.
-    /// Same value as the `prefix` in [`pacquet_reporter::StageLog`].
-    pub requester: &'a str,
+    /// Workspace root. For a single-project install this is the
+    /// directory containing the user's `package.json`; for a real
+    /// workspace it's the directory containing `pnpm-workspace.yaml`.
+    /// Same value as the `lockfileDir` upstream pnpm uses for
+    /// `pnpm:stage` / `pnpm:summary` events.
+    pub workspace_root: &'a Path,
     /// Snapshots the installability pass marked optional+incompatible.
     /// A direct dep whose resolved snapshot key is in this set is
     /// omitted from `node_modules/<name>` (no symlink, no
@@ -40,12 +62,6 @@ where
 /// Error type of [`SymlinkDirectDependencies`].
 #[derive(Debug, Display, Error, Diagnostic)]
 pub enum SymlinkDirectDependenciesError {
-    #[display(
-        "Lockfile has no `importers.{root_key:?}` entry for the root project; pacquet cannot decide which direct dependencies to symlink into `node_modules`."
-    )]
-    #[diagnostic(code(pacquet_package_manager::missing_root_importer))]
-    MissingRootImporter { root_key: String },
-
     #[diagnostic(transparent)]
     LinkBins(#[error(source)] LinkBinsError),
 }
@@ -56,136 +72,232 @@ where
 {
     /// Execute the subroutine.
     pub fn run<R: Reporter>(self) -> Result<(), SymlinkDirectDependenciesError> {
-        let SymlinkDirectDependencies { config, importers, dependency_groups, requester, skipped } =
-            self;
+        let SymlinkDirectDependencies {
+            config,
+            importers,
+            dependency_groups,
+            workspace_root,
+            skipped,
+        } = self;
 
-        let project_snapshot = importers.get(Lockfile::ROOT_IMPORTER_KEY).ok_or_else(|| {
-            SymlinkDirectDependenciesError::MissingRootImporter {
-                root_key: Lockfile::ROOT_IMPORTER_KEY.to_string(),
-            }
-        })?;
+        // Collect once so the same group order can drive every importer.
+        // Upstream calls `linkDirectDeps` once with a per-importer
+        // `dependencies` list, so the group order is shared across all
+        // importers anyway.
+        let dependency_groups: Vec<DependencyGroup> = dependency_groups.into_iter().collect();
 
-        // Iterate per group so each emit can label the dependency
-        // with its [`DependencyType`]. pnpm's reporter renders the
-        // diff with that hint, so dropping it would silently
-        // misclassify devDependencies as prod.
-        // [`ProjectSnapshot::dependencies_by_groups`] flattens the
-        // groups together, which is convenient for the symlink loop
-        // but loses the per-group identity we need for the emit.
-        //
-        // Peers are filtered upfront: pnpm doesn't emit `pnpm:root`
-        // for peer dependencies (they're materialised through their
-        // host package, not directly under `node_modules/`), and
-        // [`ProjectSnapshot::get_map_by_group`] also returns `None`
-        // for `Peer` so this filter is belt-and-braces. It lets
-        // the per-group → [`DependencyType`] match below stay
-        // exhaustive without a misleading `Peer` arm that maps to
-        // an "absent" type.
-        //
-        // Dedup with a `HashSet<PkgName>`, first-wins. A v9 lockfile
-        // pnpm itself wrote shouldn't list the same package across
-        // multiple importer sections (pnpm's resolver normalises:
-        // a package with `optional: true` lands in
-        // `optionalDependencies` only). But pacquet ingests
-        // user-supplied lockfiles, and a malformed one with the same
-        // key in two sections would race two `symlink_package` calls
-        // to the same `node_modules/<name>` and emit duplicate
-        // `pnpm:root added` events. First-wins picks up the highest-
-        // priority group from the caller-supplied
-        // `dependency_groups` order. The CLI today passes
-        // `[Prod, Dev, Optional]`, matching pnpm's
-        // dependencies-over-optional precedence.
-        let mut seen: HashSet<&PkgName> = HashSet::new();
-        let entries: Vec<(&PkgName, &_, DependencyGroup)> = dependency_groups
-            .into_iter()
-            .filter(|group| !matches!(group, DependencyGroup::Peer))
-            .flat_map(|group| {
-                project_snapshot
-                    .get_map_by_group(group)
-                    .into_iter()
-                    .flatten()
-                    .map(move |(name, spec)| (name, spec, group))
-            })
-            .filter(|(name, _, _)| seen.insert(*name))
-            // Drop direct deps whose resolved snapshot landed in the
-            // skipped set. Without this filter, the symlink would
-            // either dangle (no virtual-store slot was created) or
-            // — worse — point at a half-installed slot from a prior
-            // install. Mirrors upstream's `linkDirectDeps` walk
-            // skipping entries whose `depPath` is in `skipPkgIds`.
-            .filter(|(name, spec, _)| {
-                let resolved = PkgNameVerPeer::new(PkgName::clone(name), spec.version.clone());
-                !skipped.contains(&resolved)
-            })
-            .collect();
+        // Sorted iteration so `pnpm:root` event order stays
+        // deterministic. The wire shape doesn't require this, but a
+        // deterministic order makes assertions in tests (and the
+        // upstream snapshot tests we will be porting) tractable.
+        let mut keys: Vec<&str> = importers.keys().map(String::as_str).collect();
+        keys.sort_unstable();
 
-        entries.par_iter().for_each(|(name, spec, group)| {
-            // TODO: the code below is not optimal
-            let virtual_store_name =
-                PkgNameVerPeer::new(PkgName::clone(name), spec.version.clone())
-                    .to_virtual_store_name();
+        for importer_id in keys {
+            // Safe: we just iterated `importers.keys()`.
+            let project_snapshot = &importers[importer_id];
+            let project_dir = importer_root_dir(workspace_root, importer_id);
+            let modules_dir = project_dir.join("node_modules");
 
-            let name_str = name.to_string();
-            symlink_package(
-                &config
-                    .virtual_store_dir
-                    .join(virtual_store_name)
-                    .join("node_modules")
-                    .join(&name_str),
-                &config.modules_dir.join(&name_str),
-            )
-            .expect("symlink pkg"); // TODO: properly propagate this error
-
-            // `pnpm:root added` mirrors pnpm's emit at
-            // <https://github.com/pnpm/pnpm/blob/086c5e91e8/installing/linking/direct-dep-linker/src/linkDirectDeps.ts#L131>:
-            // one event per direct dependency once the symlink has
-            // been created. pacquet's frozen-lockfile snapshot doesn't
-            // preserve npm-alias keys at this layer, so `realName`
-            // mirrors `name`; the optional `id` / `latest` /
-            // `linkedFrom` fields are out of pacquet's reach today
-            // and skip from the wire shape rather than serializing as
-            // JSON `null`.
-            let dependency_type = match group {
-                DependencyGroup::Prod => DependencyType::Prod,
-                DependencyGroup::Dev => DependencyType::Dev,
-                DependencyGroup::Optional => DependencyType::Optional,
-                // Filtered upfront. See the comment on the `entries`
-                // builder above.
-                DependencyGroup::Peer => unreachable!("peers are filtered out before this point"),
-            };
-            // Pacquet's lockfile snapshot doesn't track the
-            // npm-alias key separately from the resolved package
-            // name at this layer, so `name` and `real_name` carry
-            // the same value. Clone the already-built string
-            // instead of formatting `name` a second time.
-            let real_name = name_str.clone();
-            R::emit(&LogEvent::Root(RootLog {
-                level: LogLevel::Debug,
-                message: RootMessage::Added {
-                    prefix: requester.to_owned(),
-                    added: AddedRoot {
-                        name: name_str,
-                        real_name,
-                        version: Some(spec.version.version().to_string()),
-                        dependency_type: Some(dependency_type),
-                        id: None,
-                        latest: None,
-                        linked_from: None,
-                    },
-                },
-            }));
-        });
-
-        // After the symlinks exist, walk them to discover each
-        // direct dep's `package.json` and link declared bins into
-        // `<modules_dir>/.bin`. Mirrors pnpm v11's `linkBinsOfPackages`
-        // call site for direct deps.
-        let dep_names: Vec<String> = entries.iter().map(|(name, _, _)| name.to_string()).collect();
-        link_direct_dep_bins(&config.modules_dir, &dep_names)
-            .map_err(SymlinkDirectDependenciesError::LinkBins)?;
+            link_one_importer::<R>(
+                config,
+                project_snapshot,
+                &project_dir,
+                &modules_dir,
+                dependency_groups.iter().copied(),
+                skipped,
+            )?;
+        }
 
         Ok(())
     }
+}
+
+/// Resolve `importer_id` (a lockfile key) against the workspace root.
+///
+/// Pnpm's lockfile spec uses `"."` for the root importer and
+/// forward-slash POSIX paths for sub-importers. Mirroring that here
+/// keeps lockfiles written by pacquet and pnpm interchangeable. The
+/// returned path is platform-native (`Path::join` handles the
+/// conversion on Windows).
+fn importer_root_dir(workspace_root: &Path, importer_id: &str) -> PathBuf {
+    if importer_id == "." || importer_id.is_empty() {
+        workspace_root.to_path_buf()
+    } else {
+        // `importer_id` is POSIX in the lockfile; `Path::join` accepts
+        // forward slashes and converts to native separators.
+        workspace_root.join(importer_id)
+    }
+}
+
+fn link_one_importer<R: Reporter>(
+    config: &Config,
+    project_snapshot: &ProjectSnapshot,
+    project_dir: &Path,
+    modules_dir: &Path,
+    dependency_groups: impl IntoIterator<Item = DependencyGroup>,
+    skipped: &SkippedSnapshots,
+) -> Result<(), SymlinkDirectDependenciesError> {
+    // Iterate per group so each emit can label the dependency
+    // with its [`DependencyType`]. pnpm's reporter renders the
+    // diff with that hint, so dropping it would silently
+    // misclassify devDependencies as prod.
+    // [`ProjectSnapshot::dependencies_by_groups`] flattens the
+    // groups together, which is convenient for the symlink loop
+    // but loses the per-group identity we need for the emit.
+    //
+    // Peers are filtered upfront: pnpm doesn't emit `pnpm:root`
+    // for peer dependencies (they're materialised through their
+    // host package, not directly under `node_modules/`), and
+    // [`ProjectSnapshot::get_map_by_group`] also returns `None`
+    // for `Peer` so this filter is belt-and-braces. It lets
+    // the per-group → [`DependencyType`] match below stay
+    // exhaustive without a misleading `Peer` arm that maps to
+    // an "absent" type.
+    //
+    // Dedup with a `HashSet<PkgName>`, first-wins. A v9 lockfile
+    // pnpm itself wrote shouldn't list the same package across
+    // multiple importer sections (pnpm's resolver normalises:
+    // a package with `optional: true` lands in
+    // `optionalDependencies` only). But pacquet ingests
+    // user-supplied lockfiles, and a malformed one with the same
+    // key in two sections would race two `symlink_package` calls
+    // to the same `node_modules/<name>` and emit duplicate
+    // `pnpm:root added` events. First-wins picks up the highest-
+    // priority group from the caller-supplied
+    // `dependency_groups` order. The CLI today passes
+    // `[Prod, Dev, Optional]`, matching pnpm's
+    // dependencies-over-optional precedence.
+    let mut seen: HashSet<&PkgName> = HashSet::new();
+    let entries: Vec<(&PkgName, &ResolvedDependencySpec, DependencyGroup)> = dependency_groups
+        .into_iter()
+        .filter(|group| !matches!(group, DependencyGroup::Peer))
+        .flat_map(|group| {
+            project_snapshot
+                .get_map_by_group(group)
+                .into_iter()
+                .flatten()
+                .map(move |(name, spec)| (name, spec, group))
+        })
+        .filter(|(name, _, _)| seen.insert(*name))
+        // Drop direct deps whose resolved snapshot landed in the
+        // skipped set. Without this filter, the symlink would
+        // either dangle (no virtual-store slot was created) or —
+        // worse — point at a half-installed slot from a prior
+        // install. Mirrors pnpm's `linkDirectDeps` walk skipping
+        // entries whose `depPath` is in `skipPkgIds`. `link:` deps
+        // never participate in the virtual store, so they are
+        // exempt from the skipped check (the resolved snapshot key
+        // wouldn't exist in the set anyway).
+        .filter(|(name, spec, _)| match &spec.version {
+            ImporterDepVersion::Regular(ver) => {
+                let resolved = PkgNameVerPeer::new(PkgName::clone(name), ver.clone());
+                !skipped.contains(&resolved)
+            }
+            ImporterDepVersion::Link(_) => true,
+        })
+        .collect();
+
+    // `prefix` for the `pnpm:root` envelope. Upstream uses the
+    // project's `rootDir` so the JS reporter can scope progress to
+    // the right project — `lockfileDir` is reserved for the install-
+    // wide stage / summary events. See
+    // <https://github.com/pnpm/pnpm/blob/94240bc046/installing/linking/direct-dep-linker/src/linkDirectDeps.ts#L131>.
+    let prefix = project_dir.to_string_lossy().into_owned();
+
+    entries.par_iter().for_each(|(name, spec, group)| {
+        let name_str = name.to_string();
+        let target_path: PathBuf = match &spec.version {
+            ImporterDepVersion::Regular(ver_peer) => {
+                // TODO: the code below is not optimal
+                let virtual_store_name =
+                    PkgNameVerPeer::new(PkgName::clone(name), ver_peer.clone())
+                        .to_virtual_store_name();
+                config
+                    .virtual_store_dir
+                    .join(virtual_store_name)
+                    .join("node_modules")
+                    .join(&name_str)
+            }
+            ImporterDepVersion::Link(target) => {
+                // `link:<path>` values are relative to the
+                // importer's `rootDir` (or absolute). Resolve them
+                // here so the on-disk symlink points at the right
+                // sibling project. Pnpm does the same conversion in
+                // `lockfileToDepGraph` —
+                // <https://github.com/pnpm/pnpm/blob/94240bc046/lockfile/types/src/index.ts>
+                // — but pacquet's lockfile snapshot already carries
+                // the raw `link:` payload, so the resolution lives
+                // at the install layer.
+                let candidate = Path::new(target);
+                if candidate.is_absolute() {
+                    candidate.to_path_buf()
+                } else {
+                    project_dir.join(candidate)
+                }
+            }
+        };
+
+        symlink_package(&target_path, &modules_dir.join(&name_str)).expect("symlink pkg"); // TODO: properly propagate this error
+
+        // `pnpm:root added` mirrors pnpm's emit at
+        // <https://github.com/pnpm/pnpm/blob/94240bc046/installing/linking/direct-dep-linker/src/linkDirectDeps.ts#L131>:
+        // one event per direct dependency once the symlink has
+        // been created. pacquet's frozen-lockfile snapshot doesn't
+        // preserve npm-alias keys at this layer, so `realName`
+        // mirrors `name`; the optional `id` / `latest` /
+        // `linkedFrom` fields are out of pacquet's reach today
+        // and skip from the wire shape rather than serializing as
+        // JSON `null`.
+        let dependency_type = match group {
+            DependencyGroup::Prod => DependencyType::Prod,
+            DependencyGroup::Dev => DependencyType::Dev,
+            DependencyGroup::Optional => DependencyType::Optional,
+            // Filtered upfront. See the comment on the `entries`
+            // builder above.
+            DependencyGroup::Peer => unreachable!("peers are filtered out before this point"),
+        };
+        // For a `link:` dep, upstream's `version` field is the
+        // resolved `link:<path>` payload (re-prepended on the
+        // wire) so reporters can render the link target. Pacquet
+        // mirrors that here; for `Regular` deps we keep the
+        // semver-only formatting upstream uses on the wire.
+        let version = match &spec.version {
+            ImporterDepVersion::Regular(ver) => Some(ver.version().to_string()),
+            ImporterDepVersion::Link(target) => Some(format!("link:{target}")),
+        };
+        // Pacquet's lockfile snapshot doesn't track the
+        // npm-alias key separately from the resolved package
+        // name at this layer, so `name` and `real_name` carry
+        // the same value. Clone the already-built string
+        // instead of formatting `name` a second time.
+        let real_name = name_str.clone();
+        R::emit(&LogEvent::Root(RootLog {
+            level: LogLevel::Debug,
+            message: RootMessage::Added {
+                prefix: prefix.clone(),
+                added: AddedRoot {
+                    name: name_str,
+                    real_name,
+                    version,
+                    dependency_type: Some(dependency_type),
+                    id: None,
+                    latest: None,
+                    linked_from: None,
+                },
+            },
+        }));
+    });
+
+    // After the symlinks exist, walk them to discover each
+    // direct dep's `package.json` and link declared bins into
+    // `<modules_dir>/.bin`. Mirrors pnpm v11's `linkBinsOfPackages`
+    // call site for direct deps.
+    let dep_names: Vec<String> = entries.iter().map(|(name, _, _)| name.to_string()).collect();
+    link_direct_dep_bins(modules_dir, &dep_names)
+        .map_err(SymlinkDirectDependenciesError::LinkBins)?;
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/package-manager/src/symlink_direct_dependencies.rs
+++ b/crates/package-manager/src/symlink_direct_dependencies.rs
@@ -169,8 +169,14 @@ fn validate_importer_id(importer_id: &str) -> Result<(), SymlinkDirectDependenci
         importer_id: importer_id.to_string(),
     };
 
-    if importer_id == "." || importer_id.is_empty() {
+    // `.` is the canonical root importer key. An empty string is
+    // non-standard — pnpm never writes one — and conflating it with
+    // `.` would mask malformed lockfiles, so reject it explicitly.
+    if importer_id == "." {
         return Ok(());
+    }
+    if importer_id.is_empty() {
+        return Err(unsafe_path());
     }
 
     // Absolute POSIX path. Pnpm writes relative paths; an absolute
@@ -210,11 +216,14 @@ fn validate_importer_id(importer_id: &str) -> Result<(), SymlinkDirectDependenci
 /// returned path is platform-native (`Path::join` handles the
 /// conversion on Windows).
 fn importer_root_dir(workspace_root: &Path, importer_id: &str) -> PathBuf {
-    if importer_id == "." || importer_id.is_empty() {
+    if importer_id == "." {
         workspace_root.to_path_buf()
     } else {
         // `importer_id` is POSIX in the lockfile; `Path::join` accepts
-        // forward slashes and converts to native separators.
+        // forward slashes and converts to native separators. The
+        // empty-key case is rejected upstream by
+        // [`validate_importer_id`], so this branch only runs on
+        // POSIX-relative sub-importer paths.
         workspace_root.join(importer_id)
     }
 }

--- a/crates/package-manager/src/symlink_direct_dependencies.rs
+++ b/crates/package-manager/src/symlink_direct_dependencies.rs
@@ -13,6 +13,7 @@ use pacquet_reporter::{
 use rayon::prelude::*;
 use std::{
     collections::{HashMap, HashSet},
+    ffi::OsStr,
     path::{Path, PathBuf},
 };
 
@@ -123,6 +124,20 @@ where
         // importers anyway.
         let dependency_groups: Vec<DependencyGroup> = dependency_groups.into_iter().collect();
 
+        // Each importer's modules dir is `<importer_root>/<modules_dir_basename>`.
+        // Pnpm's `modulesDir` setting is a directory name (a single
+        // component, default `node_modules`) applied uniformly under
+        // every importer. Pacquet stores `config.modules_dir` as a
+        // full path anchored at the workspace root, so peel off the
+        // last component to get the per-importer suffix — that way a
+        // `modulesDir: custom_modules` override in
+        // `pnpm-workspace.yaml` propagates to every importer instead
+        // of leaving the symlink stage stuck on `node_modules` while
+        // other stages (`.modules.yaml` writing, bin linking) use
+        // `config.modules_dir`.
+        let modules_dir_name: &OsStr =
+            config.modules_dir.file_name().unwrap_or_else(|| OsStr::new("node_modules"));
+
         // Sorted iteration so `pnpm:root` event order stays
         // deterministic. The wire shape doesn't require this, but a
         // deterministic order makes assertions in tests (and the
@@ -141,7 +156,7 @@ where
             // Safe: we just iterated `importers.keys()`.
             let project_snapshot = &importers[importer_id];
             let project_dir = importer_root_dir(workspace_root, importer_id);
-            let modules_dir = project_dir.join("node_modules");
+            let modules_dir = project_dir.join(modules_dir_name);
 
             link_one_importer::<R>(
                 importer_id,

--- a/crates/package-manager/src/symlink_direct_dependencies.rs
+++ b/crates/package-manager/src/symlink_direct_dependencies.rs
@@ -33,10 +33,12 @@ use std::{
 ///   per-project emit at
 ///   <https://github.com/pnpm/pnpm/blob/94240bc046/installing/linking/direct-dep-linker/src/linkDirectDeps.ts#L131>.
 ///
-/// The virtual store dir (`config.virtual_store_dir`) stays singular —
-/// it lives at `<workspace_root>/node_modules/.pacquet` (pnpm uses
-/// `.pnpm`; pacquet's directory name is fixed by `default_virtual_store_dir`).
-/// Only the per-project `node_modules/` and its symlinks fan out.
+/// The virtual store dir (`config.virtual_store_dir`) stays singular
+/// across the install — only the per-project `node_modules/` and its
+/// symlinks fan out. By default `pacquet_config::default_virtual_store_dir`
+/// anchors it at `<workspace_root>/node_modules/.pnpm` (matching pnpm),
+/// but the actual location is whatever the resolved `Config` field
+/// holds — `pnpm-workspace.yaml`'s `virtualStoreDir` can move it.
 #[must_use]
 pub struct SymlinkDirectDependencies<'a, DependencyGroupList>
 where

--- a/crates/package-manager/src/symlink_direct_dependencies/tests.rs
+++ b/crates/package-manager/src/symlink_direct_dependencies/tests.rs
@@ -95,10 +95,14 @@ fn emits_pnpm_root_added_per_direct_dependency() {
     // matching FS effect would mask a real regression.
     let fastify_link = modules_dir.join("fastify");
     let dev_dep_link = modules_dir.join("@pnpm.e2e/dev-dep");
-    eprintln!("fastify_link = {fastify_link:?}");
-    assert!(is_symlink_or_junction(&fastify_link).unwrap());
-    eprintln!("dev_dep_link = {dev_dep_link:?}");
-    assert!(is_symlink_or_junction(&dev_dep_link).unwrap());
+    assert!(
+        is_symlink_or_junction(&fastify_link).unwrap(),
+        "expected a symlink at {fastify_link:?}",
+    );
+    assert!(
+        is_symlink_or_junction(&dev_dep_link).unwrap(),
+        "expected a symlink at {dev_dep_link:?}",
+    );
 
     let captured = EVENTS.lock().unwrap();
     let expected_prefix = project_root.to_string_lossy().into_owned();
@@ -496,4 +500,69 @@ fn unsafe_importer_keys_error_before_filesystem_writes() {
         );
         drop(dir);
     }
+}
+
+/// A custom `modulesDir` (set via `pnpm-workspace.yaml`'s
+/// `modulesDir` field) must propagate to every importer's per-project
+/// dir, not stay hard-coded to `node_modules`. Otherwise the symlink
+/// stage would write under `<importer>/node_modules/` while
+/// `.modules.yaml` writing and bin linking (which still use
+/// `config.modules_dir`) would target the configured name — two
+/// inconsistent layouts for the same install. Mirrors pnpm where
+/// `modulesDir` is one directory-name applied uniformly under every
+/// importer's `rootDir`.
+#[test]
+fn custom_modules_dir_propagates_to_each_importer() {
+    let dir = tempdir().unwrap();
+    let workspace_root: PathBuf = dir.path().into();
+    let virtual_store_dir = workspace_root.join("custom_modules/.pacquet");
+
+    let mut config = Config::new();
+    config.store_dir = dir.path().join("pacquet-store").into();
+    // `config.modules_dir`'s basename is the per-importer suffix.
+    // Use a non-default name so a regression to the hard-coded
+    // `node_modules` would fail the assertion below.
+    config.modules_dir = workspace_root.join("custom_modules");
+    config.virtual_store_dir = virtual_store_dir.clone();
+    let config = config.leak();
+
+    let target = virtual_store_dir.join("fastify@4.0.0").join("node_modules").join("fastify");
+    fs::create_dir_all(&target).expect("create symlink target");
+
+    let mut deps = ResolvedDependencyMap::new();
+    deps.insert(
+        "fastify".parse().unwrap(),
+        ResolvedDependencySpec {
+            specifier: "^4.0.0".to_string(),
+            version: "4.0.0".parse::<pacquet_lockfile::PkgVerPeer>().unwrap().into(),
+        },
+    );
+    let mut importers = HashMap::new();
+    importers.insert(
+        "packages/web".to_string(),
+        ProjectSnapshot { dependencies: Some(deps), ..ProjectSnapshot::default() },
+    );
+
+    SymlinkDirectDependencies {
+        config,
+        importers: &importers,
+        dependency_groups: [DependencyGroup::Prod],
+        workspace_root: &workspace_root,
+    }
+    .run::<SilentReporter>()
+    .expect("symlink should succeed");
+
+    let expected = workspace_root.join("packages/web/custom_modules/fastify");
+    assert!(
+        is_symlink_or_junction(&expected).unwrap(),
+        "expected per-importer symlink under the configured `modulesDir`: {expected:?}",
+    );
+    // The default `node_modules/` must NOT exist under the
+    // importer's rootDir — that would mean the symlink stage
+    // ignored the override.
+    assert!(
+        !workspace_root.join("packages/web/node_modules").exists(),
+        "no `node_modules/` should be created when `modulesDir` overrides the suffix",
+    );
+    drop(dir);
 }

--- a/crates/package-manager/src/symlink_direct_dependencies/tests.rs
+++ b/crates/package-manager/src/symlink_direct_dependencies/tests.rs
@@ -446,6 +446,7 @@ fn unsafe_importer_keys_error_before_filesystem_writes() {
     // Each case is an importer key that must produce
     // `UnsafeImporterPath` without touching the filesystem.
     let cases: &[&str] = &[
+        "",                   // empty key (non-standard; `.` is the root)
         "/abs/path",          // absolute POSIX
         "..",                 // single parent
         "../sibling",         // traversal

--- a/crates/package-manager/src/symlink_direct_dependencies/tests.rs
+++ b/crates/package-manager/src/symlink_direct_dependencies/tests.rs
@@ -282,6 +282,7 @@ fn cross_importer_link_dep_symlinks_to_sibling_rootdir() {
         importers: &importers,
         dependency_groups: [DependencyGroup::Prod],
         workspace_root: &workspace_root,
+        skipped: &SkippedSnapshots::default(),
     }
     .run::<RecordingReporter>()
     .expect("symlink should succeed");
@@ -414,6 +415,7 @@ fn per_importer_prefix_in_pnpm_root_events() {
         importers: &importers,
         dependency_groups: [DependencyGroup::Prod],
         workspace_root: &workspace_root,
+        skipped: &SkippedSnapshots::default(),
     }
     .run::<RecordingReporter>()
     .unwrap();
@@ -476,6 +478,7 @@ fn unsafe_importer_keys_error_before_filesystem_writes() {
             importers: &importers,
             dependency_groups: [DependencyGroup::Prod],
             workspace_root: &workspace_root,
+            skipped: &SkippedSnapshots::default(),
         }
         .run::<SilentReporter>();
 
@@ -548,6 +551,7 @@ fn custom_modules_dir_propagates_to_each_importer() {
         importers: &importers,
         dependency_groups: [DependencyGroup::Prod],
         workspace_root: &workspace_root,
+        skipped: &SkippedSnapshots::default(),
     }
     .run::<SilentReporter>()
     .expect("symlink should succeed");

--- a/crates/package-manager/src/symlink_direct_dependencies/tests.rs
+++ b/crates/package-manager/src/symlink_direct_dependencies/tests.rs
@@ -480,6 +480,22 @@ fn unsafe_importer_keys_error_before_filesystem_writes() {
             }
             other => panic!("expected UnsafeImporterPath for {importer_id:?}, got {other:?}"),
         }
+
+        // The rejection happens before any per-importer work begins,
+        // so nothing should have landed on disk. Guard that contract:
+        // the workspace_root must not have grown a `node_modules`,
+        // and the workspace_root's parent (where a `/abs/path` or
+        // `..` traversal would aim) must not have one either.
+        assert!(
+            !workspace_root.join("node_modules").exists(),
+            "no node_modules should be created under workspace_root for {importer_id:?}",
+        );
+        if let Some(parent) = workspace_root.parent() {
+            assert!(
+                !parent.join("node_modules").exists(),
+                "no node_modules should escape workspace_root for {importer_id:?}",
+            );
+        }
         drop(dir);
     }
 }

--- a/crates/package-manager/src/symlink_direct_dependencies/tests.rs
+++ b/crates/package-manager/src/symlink_direct_dependencies/tests.rs
@@ -1,4 +1,4 @@
-use super::{SymlinkDirectDependencies, SymlinkDirectDependenciesError};
+use super::SymlinkDirectDependencies;
 use crate::SkippedSnapshots;
 use pacquet_config::Config;
 use pacquet_lockfile::{Lockfile, ProjectSnapshot, ResolvedDependencyMap, ResolvedDependencySpec};
@@ -60,7 +60,7 @@ fn emits_pnpm_root_added_per_direct_dependency() {
         "fastify".parse().expect("parse fastify pkg name"),
         ResolvedDependencySpec {
             specifier: "^4.0.0".to_string(),
-            version: "4.0.0".parse().expect("parse fastify version"),
+            version: "4.0.0".parse::<pacquet_lockfile::PkgVerPeer>().unwrap().into(),
         },
     );
     let mut dev = ResolvedDependencyMap::new();
@@ -68,7 +68,7 @@ fn emits_pnpm_root_added_per_direct_dependency() {
         "@pnpm.e2e/dev-dep".parse().expect("parse dev pkg name"),
         ResolvedDependencySpec {
             specifier: "^1.2.3".to_string(),
-            version: "1.2.3".parse().expect("parse dev version"),
+            version: "1.2.3".parse::<pacquet_lockfile::PkgVerPeer>().unwrap().into(),
         },
     );
 
@@ -80,12 +80,11 @@ fn emits_pnpm_root_added_per_direct_dependency() {
     let mut importers = HashMap::new();
     importers.insert(Lockfile::ROOT_IMPORTER_KEY.to_string(), project_snapshot);
 
-    let requester = "/proj";
     SymlinkDirectDependencies {
         config,
         importers: &importers,
         dependency_groups: [DependencyGroup::Prod, DependencyGroup::Dev],
-        requester,
+        workspace_root: &project_root,
         skipped: &SkippedSnapshots::default(),
     }
     .run::<RecordingReporter>()
@@ -102,11 +101,12 @@ fn emits_pnpm_root_added_per_direct_dependency() {
     assert!(is_symlink_or_junction(&dev_dep_link).unwrap());
 
     let captured = EVENTS.lock().unwrap();
+    let expected_prefix = project_root.to_string_lossy().into_owned();
     let added: Vec<&AddedRoot> = captured
         .iter()
         .filter_map(|e| match e {
             LogEvent::Root(RootLog { message: RootMessage::Added { added, prefix }, .. }) => {
-                assert_eq!(prefix, requester);
+                assert_eq!(prefix, &expected_prefix);
                 Some(added)
             }
             _ => None,
@@ -174,7 +174,7 @@ fn duplicate_dep_across_groups_collapses_to_one_entry() {
         "fastify".parse().expect("parse fastify pkg name"),
         ResolvedDependencySpec {
             specifier: "^4.0.0".to_string(),
-            version: "4.0.0".parse().expect("parse fastify version"),
+            version: "4.0.0".parse::<pacquet_lockfile::PkgVerPeer>().unwrap().into(),
         },
     );
     let mut optional = ResolvedDependencyMap::new();
@@ -182,7 +182,7 @@ fn duplicate_dep_across_groups_collapses_to_one_entry() {
         "fastify".parse().expect("parse fastify pkg name"),
         ResolvedDependencySpec {
             specifier: "^4.0.0".to_string(),
-            version: "4.0.0".parse().expect("parse fastify version"),
+            version: "4.0.0".parse::<pacquet_lockfile::PkgVerPeer>().unwrap().into(),
         },
     );
 
@@ -199,7 +199,7 @@ fn duplicate_dep_across_groups_collapses_to_one_entry() {
         importers: &importers,
         // Prod first → first-wins gives `dependencyType: prod`.
         dependency_groups: [DependencyGroup::Prod, DependencyGroup::Optional],
-        requester: "/proj",
+        workspace_root: &project_root,
         skipped: &SkippedSnapshots::default(),
     }
     .run::<RecordingReporter>()
@@ -222,16 +222,112 @@ fn duplicate_dep_across_groups_collapses_to_one_entry() {
     drop(dir);
 }
 
-/// Missing root importer in the lockfile is the only error the
-/// subroutine produces. Pin it so a future refactor that elides
-/// the lookup doesn't silently turn into a no-op install.
+/// A `workspace:*` dep in a sub-importer surfaces as `version:
+/// link:<path>` in the lockfile. The symlink-direct-deps stage must
+/// resolve that relative to the importer's `rootDir` and point the
+/// `node_modules/<name>` symlink at the dependee project, NOT into
+/// the virtual store. Mirrors upstream's
+/// [`lockfileToDepGraph`](https://github.com/pnpm/pnpm/blob/94240bc046/lockfile/types/src/index.ts)
+/// branch for `link:` dependencies.
 #[test]
-fn missing_root_importer_surfaces_as_error() {
+fn cross_importer_link_dep_symlinks_to_sibling_rootdir() {
+    static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
+    EVENTS.lock().unwrap().clear();
+
+    struct RecordingReporter;
+    impl Reporter for RecordingReporter {
+        fn emit(event: &LogEvent) {
+            EVENTS.lock().unwrap().push(event.clone());
+        }
+    }
+
     let dir = tempdir().unwrap();
+    let workspace_root = dir.path().to_path_buf();
+
     let mut config = Config::new();
     config.store_dir = dir.path().join("pacquet-store").into();
-    config.modules_dir = dir.path().join("project/node_modules");
-    config.virtual_store_dir = dir.path().join("project/node_modules/.pacquet");
+    config.modules_dir = workspace_root.join("node_modules");
+    config.virtual_store_dir = workspace_root.join("node_modules/.pacquet");
+    let config = config.leak();
+
+    // Materialize the dependee project so the symlink target exists
+    // before we create it. (Platform-uniform — same reasoning as the
+    // single-importer test above.)
+    let shared_dir = workspace_root.join("packages/shared");
+    fs::create_dir_all(&shared_dir).unwrap();
+    fs::write(shared_dir.join("package.json"), r#"{"name": "shared", "version": "1.0.0"}"#)
+        .unwrap();
+
+    let mut deps = ResolvedDependencyMap::new();
+    deps.insert(
+        "shared".parse().unwrap(),
+        ResolvedDependencySpec {
+            specifier: "workspace:*".to_string(),
+            version: "link:../shared".parse().unwrap(),
+        },
+    );
+
+    let mut importers = HashMap::new();
+    importers.insert(
+        "packages/web".to_string(),
+        ProjectSnapshot { dependencies: Some(deps), ..ProjectSnapshot::default() },
+    );
+
+    SymlinkDirectDependencies {
+        config,
+        importers: &importers,
+        dependency_groups: [DependencyGroup::Prod],
+        workspace_root: &workspace_root,
+    }
+    .run::<RecordingReporter>()
+    .expect("symlink should succeed");
+
+    // The symlink lives under the importer's `node_modules/` and
+    // points at the sibling's `rootDir`, NOT into the virtual store.
+    let symlink_path = workspace_root.join("packages/web/node_modules/shared");
+    assert!(
+        is_symlink_or_junction(&symlink_path).unwrap(),
+        "expected a symlink at {symlink_path:?}",
+    );
+
+    // Confirm the reporter saw a `pnpm:root added` with the
+    // resolved `link:` payload as `version` and the importer's
+    // own `rootDir` as `prefix`.
+    let captured = EVENTS.lock().unwrap();
+    let added: Vec<(&str, &AddedRoot)> = captured
+        .iter()
+        .filter_map(|e| match e {
+            LogEvent::Root(RootLog { message: RootMessage::Added { added, prefix }, .. }) => {
+                Some((prefix.as_str(), added))
+            }
+            _ => None,
+        })
+        .collect();
+    assert_eq!(added.len(), 1);
+    let (prefix, added) = added[0];
+    let expected_prefix = workspace_root.join("packages/web").to_string_lossy().into_owned();
+    assert_eq!(prefix, expected_prefix.as_str());
+    assert_eq!(added.name, "shared");
+    assert_eq!(added.version.as_deref(), Some("link:../shared"));
+
+    drop(dir);
+}
+
+/// An empty `importers` map is a valid (if degenerate) lockfile —
+/// nothing to link, no events emitted, no error. After per-importer
+/// iteration landed for #431, the old "missing root importer is a
+/// hard error" contract is gone: each importer is now installed
+/// independently, and a lockfile with zero importers simply produces
+/// zero pnpm:root events. Pin this so the iteration loop never
+/// regresses into requiring a root.
+#[test]
+fn empty_importers_is_a_no_op() {
+    let dir = tempdir().unwrap();
+    let project_root = dir.path().join("project");
+    let mut config = Config::new();
+    config.store_dir = dir.path().join("pacquet-store").into();
+    config.modules_dir = project_root.join("node_modules");
+    config.virtual_store_dir = project_root.join("node_modules/.pacquet");
     let config = config.leak();
 
     let importers = HashMap::new();
@@ -239,12 +335,103 @@ fn missing_root_importer_surfaces_as_error() {
         config,
         importers: &importers,
         dependency_groups: [DependencyGroup::Prod],
-        requester: "/proj",
+        workspace_root: &project_root,
         skipped: &SkippedSnapshots::default(),
     }
     .run::<SilentReporter>();
 
     dbg!(&result);
-    assert!(matches!(result, Err(SymlinkDirectDependenciesError::MissingRootImporter { .. })));
+    assert!(result.is_ok(), "empty importers must not error");
+    drop(dir);
+}
+
+/// Two importers under one workspace root each produce their own
+/// `pnpm:root added` event with the importer's `rootDir` as the
+/// event prefix. Mirrors upstream's per-project emit at
+/// <https://github.com/pnpm/pnpm/blob/94240bc046/installing/linking/direct-dep-linker/src/linkDirectDeps.ts#L131>.
+#[test]
+fn per_importer_prefix_in_pnpm_root_events() {
+    static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
+    EVENTS.lock().unwrap().clear();
+
+    struct RecordingReporter;
+    impl Reporter for RecordingReporter {
+        fn emit(event: &LogEvent) {
+            EVENTS.lock().unwrap().push(event.clone());
+        }
+    }
+
+    let dir = tempdir().unwrap();
+    let workspace_root = dir.path().to_path_buf();
+    let virtual_store_dir = workspace_root.join("node_modules/.pacquet");
+
+    let mut config = Config::new();
+    config.store_dir = dir.path().join("pacquet-store").into();
+    config.modules_dir = workspace_root.join("node_modules");
+    config.virtual_store_dir = virtual_store_dir.clone();
+    let config = config.leak();
+
+    // Materialize the virtual-store targets each importer's symlink
+    // points at — same precondition the single-importer test sets up.
+    for store_name in ["fastify@4.0.0", "react@18.0.0"] {
+        let real_name = store_name.split('@').next().unwrap();
+        let target = virtual_store_dir.join(store_name).join("node_modules").join(real_name);
+        fs::create_dir_all(&target).unwrap();
+    }
+
+    let mut alpha_deps = ResolvedDependencyMap::new();
+    alpha_deps.insert(
+        "fastify".parse().unwrap(),
+        ResolvedDependencySpec {
+            specifier: "^4.0.0".to_string(),
+            version: "4.0.0".parse::<pacquet_lockfile::PkgVerPeer>().unwrap().into(),
+        },
+    );
+    let mut beta_deps = ResolvedDependencyMap::new();
+    beta_deps.insert(
+        "react".parse().unwrap(),
+        ResolvedDependencySpec {
+            specifier: "^18.0.0".to_string(),
+            version: "18.0.0".parse::<pacquet_lockfile::PkgVerPeer>().unwrap().into(),
+        },
+    );
+
+    let mut importers = HashMap::new();
+    importers.insert(
+        "packages/alpha".to_string(),
+        ProjectSnapshot { dependencies: Some(alpha_deps), ..ProjectSnapshot::default() },
+    );
+    importers.insert(
+        "packages/beta".to_string(),
+        ProjectSnapshot { dependencies: Some(beta_deps), ..ProjectSnapshot::default() },
+    );
+
+    SymlinkDirectDependencies {
+        config,
+        importers: &importers,
+        dependency_groups: [DependencyGroup::Prod],
+        workspace_root: &workspace_root,
+    }
+    .run::<RecordingReporter>()
+    .unwrap();
+
+    let captured = EVENTS.lock().unwrap();
+    let added: Vec<(&str, &AddedRoot)> = captured
+        .iter()
+        .filter_map(|e| match e {
+            LogEvent::Root(RootLog { message: RootMessage::Added { added, prefix }, .. }) => {
+                Some((prefix.as_str(), added))
+            }
+            _ => None,
+        })
+        .collect();
+    assert_eq!(added.len(), 2, "one event per importer's direct dep");
+
+    let alpha_prefix = workspace_root.join("packages/alpha").to_string_lossy().into_owned();
+    let beta_prefix = workspace_root.join("packages/beta").to_string_lossy().into_owned();
+    let by_prefix: HashMap<&str, &AddedRoot> = added.iter().copied().collect();
+    assert_eq!(by_prefix.get(alpha_prefix.as_str()).unwrap().name, "fastify");
+    assert_eq!(by_prefix.get(beta_prefix.as_str()).unwrap().name, "react");
+
     drop(dir);
 }

--- a/crates/package-manager/src/symlink_direct_dependencies/tests.rs
+++ b/crates/package-manager/src/symlink_direct_dependencies/tests.rs
@@ -483,20 +483,17 @@ fn unsafe_importer_keys_error_before_filesystem_writes() {
         }
 
         // The rejection happens before any per-importer work begins,
-        // so nothing should have landed on disk. Guard that contract:
-        // the workspace_root must not have grown a `node_modules`,
-        // and the workspace_root's parent (where a `/abs/path` or
-        // `..` traversal would aim) must not have one either.
+        // so nothing should have landed on disk. Guard that contract
+        // by checking the workspace_root itself. We deliberately do
+        // NOT inspect `workspace_root.parent()` here: on most CI hosts
+        // the tempdir's parent is a shared system temp directory that
+        // other tests (or unrelated processes) may have populated, so
+        // an assertion there would be flaky for reasons unrelated to
+        // the importer-id validator.
         assert!(
             !workspace_root.join("node_modules").exists(),
             "no node_modules should be created under workspace_root for {importer_id:?}",
         );
-        if let Some(parent) = workspace_root.parent() {
-            assert!(
-                !parent.join("node_modules").exists(),
-                "no node_modules should escape workspace_root for {importer_id:?}",
-            );
-        }
         drop(dir);
     }
 }

--- a/crates/package-manager/src/symlink_direct_dependencies/tests.rs
+++ b/crates/package-manager/src/symlink_direct_dependencies/tests.rs
@@ -1,4 +1,4 @@
-use super::SymlinkDirectDependencies;
+use super::{SymlinkDirectDependencies, SymlinkDirectDependenciesError};
 use crate::SkippedSnapshots;
 use pacquet_config::Config;
 use pacquet_lockfile::{Lockfile, ProjectSnapshot, ResolvedDependencyMap, ResolvedDependencySpec};
@@ -7,7 +7,7 @@ use pacquet_reporter::{
     AddedRoot, DependencyType, LogEvent, Reporter, RootLog, RootMessage, SilentReporter,
 };
 use pacquet_testing_utils::fs::is_symlink_or_junction;
-use std::{collections::HashMap, fs, sync::Mutex};
+use std::{collections::HashMap, fs, path::PathBuf, sync::Mutex};
 use tempfile::tempdir;
 
 /// `pnpm:root added` fires once per direct dependency, after the
@@ -340,8 +340,7 @@ fn empty_importers_is_a_no_op() {
     }
     .run::<SilentReporter>();
 
-    dbg!(&result);
-    assert!(result.is_ok(), "empty importers must not error");
+    assert!(result.is_ok(), "empty importers must not error: {result:?}");
     drop(dir);
 }
 
@@ -434,4 +433,53 @@ fn per_importer_prefix_in_pnpm_root_events() {
     assert_eq!(by_prefix.get(beta_prefix.as_str()).unwrap().name, "react");
 
     drop(dir);
+}
+
+/// A malformed (or hostile) lockfile importer key that would resolve
+/// outside the workspace root must error rather than silently
+/// creating `node_modules` somewhere unrelated. `Path::join` discards
+/// the workspace root when the right-hand side is absolute, and
+/// allows `..` traversal otherwise, so the install layer enforces a
+/// stricter shape.
+#[test]
+fn unsafe_importer_keys_error_before_filesystem_writes() {
+    // Each case is an importer key that must produce
+    // `UnsafeImporterPath` without touching the filesystem.
+    let cases: &[&str] = &[
+        "/abs/path",          // absolute POSIX
+        "..",                 // single parent
+        "../sibling",         // traversal
+        "packages/../escape", // mid-string traversal
+        "C:/win",             // Windows drive prefix
+        "packages\\web",      // backslash separator
+    ];
+
+    for &importer_id in cases {
+        let dir = tempdir().unwrap();
+        let workspace_root: PathBuf = dir.path().into();
+        let mut config = Config::new();
+        config.store_dir = dir.path().join("pacquet-store").into();
+        config.modules_dir = workspace_root.join("node_modules");
+        config.virtual_store_dir = workspace_root.join("node_modules/.pacquet");
+        let config = config.leak();
+
+        let mut importers = HashMap::new();
+        importers.insert(importer_id.to_string(), ProjectSnapshot::default());
+
+        let result = SymlinkDirectDependencies {
+            config,
+            importers: &importers,
+            dependency_groups: [DependencyGroup::Prod],
+            workspace_root: &workspace_root,
+        }
+        .run::<SilentReporter>();
+
+        match result {
+            Err(SymlinkDirectDependenciesError::UnsafeImporterPath { importer_id: id }) => {
+                assert_eq!(id, importer_id, "expected the rejected key in the diagnostic");
+            }
+            other => panic!("expected UnsafeImporterPath for {importer_id:?}, got {other:?}"),
+        }
+        drop(dir);
+    }
 }

--- a/crates/real-hoist/src/lib.rs
+++ b/crates/real-hoist/src/lib.rs
@@ -338,7 +338,16 @@ fn collect_importer_deps(
         // registry name. Transitive npm-aliases (modelled via
         // `SnapshotDepRef::Alias`) are handled in
         // `collect_snapshot_deps`.
-        let dep_key = PkgNameVerPeer::new(alias.clone(), spec.version.clone());
+        //
+        // `link:` deps (cross-importer `workspace:*` resolutions, see
+        // [`ImporterDepVersion::Link`]) don't live in the virtual
+        // store — they're directory symlinks materialised by
+        // [`pacquet_package_manager::SymlinkDirectDependencies`] —
+        // so they have no snapshot to hoist and we skip them here.
+        let Some(ver_peer) = spec.version.as_regular() else {
+            continue;
+        };
+        let dep_key = PkgNameVerPeer::new(alias.clone(), ver_peer.clone());
         let node = build_dep_node(alias, &dep_key, lockfile, opts, nodes)?;
         out.insert(RcByPtr(node));
     }

--- a/crates/real-hoist/src/tests.rs
+++ b/crates/real-hoist/src/tests.rs
@@ -23,7 +23,7 @@ fn dep_key(name: &str, version: &str) -> PkgNameVerPeer {
 }
 
 fn resolved_dep(version: &str) -> ResolvedDependencySpec {
-    ResolvedDependencySpec { specifier: version.to_string(), version: ver_peer(version) }
+    ResolvedDependencySpec { specifier: version.to_string(), version: ver_peer(version).into() }
 }
 
 fn empty_lockfile() -> Lockfile {

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name                  = "pacquet-workspace"
+version               = "0.0.1"
+publish               = false
+authors.workspace     = true
+description.workspace = true
+edition.workspace     = true
+homepage.workspace    = true
+keywords.workspace    = true
+license.workspace     = true
+repository.workspace  = true
+
+[dependencies]
+pacquet-package-manifest = { workspace = true }
+
+derive_more  = { workspace = true }
+miette       = { workspace = true }
+serde        = { workspace = true }
+serde-saphyr = { workspace = true }
+wax          = { workspace = true }
+
+[dev-dependencies]
+pretty_assertions = { workspace = true }
+tempfile          = { workspace = true }

--- a/crates/workspace/src/lib.rs
+++ b/crates/workspace/src/lib.rs
@@ -7,12 +7,15 @@
 //! and
 //! [`workspace/project-manifest-reader`](https://github.com/pnpm/pnpm/blob/94240bc046/workspace/project-manifest-reader/src/index.ts).
 //!
-//! Three responsibilities, kept in separate modules so the upstream
-//! split stays visible:
+//! Three responsibilities, kept in separate private modules so the
+//! upstream split stays visible while keeping the public surface flat:
 //!
-//! - [`root_finder`] — locate the workspace dir (`pnpm-workspace.yaml`).
-//! - [`manifest`]    — parse `packages:` (plus the catalog skeletons).
-//! - [`projects`]    — glob-expand `packages:` into [`Project`]s.
+//! - `root_finder` — locate the workspace dir (`pnpm-workspace.yaml`).
+//!   Public entry point: [`find_workspace_dir`].
+//! - `manifest`    — parse `packages:` (plus catalog skeletons).
+//!   Public entry point: [`read_workspace_manifest`].
+//! - `projects`    — glob-expand `packages:` into [`Project`]s.
+//!   Public entry point: [`find_workspace_projects`].
 
 mod manifest;
 mod project_manifest;

--- a/crates/workspace/src/lib.rs
+++ b/crates/workspace/src/lib.rs
@@ -1,0 +1,37 @@
+//! Workspace discovery and project enumeration.
+//!
+//! Mirrors pnpm's
+//! [`workspace/root-finder`](https://github.com/pnpm/pnpm/blob/94240bc046/workspace/root-finder/src/index.ts),
+//! [`workspace/workspace-manifest-reader`](https://github.com/pnpm/pnpm/blob/94240bc046/workspace/workspace-manifest-reader/src/index.ts),
+//! [`workspace/projects-reader`](https://github.com/pnpm/pnpm/blob/94240bc046/workspace/projects-reader/src/index.ts),
+//! and
+//! [`workspace/project-manifest-reader`](https://github.com/pnpm/pnpm/blob/94240bc046/workspace/project-manifest-reader/src/index.ts).
+//!
+//! Three responsibilities, kept in separate modules so the upstream
+//! split stays visible:
+//!
+//! - [`root_finder`] — locate the workspace dir (`pnpm-workspace.yaml`).
+//! - [`manifest`]    — parse `packages:` (plus the catalog skeletons).
+//! - [`projects`]    — glob-expand `packages:` into [`Project`]s.
+
+mod manifest;
+mod project_manifest;
+mod projects;
+mod root_finder;
+
+pub use manifest::{
+    InvalidWorkspaceManifestError, ReadWorkspaceManifestError, WORKSPACE_MANIFEST_FILENAME,
+    WorkspaceManifest, read_workspace_manifest,
+};
+pub use project_manifest::{
+    ReadProjectManifestError, ReadProjectManifestOnlyError, read_exact_project_manifest,
+    read_project_manifest_only, safe_read_project_manifest_only, try_read_project_manifest,
+};
+pub use projects::{
+    FindWorkspaceProjectsError, FindWorkspaceProjectsOpts, Project, find_workspace_projects,
+    find_workspace_projects_no_check,
+};
+pub use root_finder::{
+    BadWorkspaceManifestNameError, FindWorkspaceDirError, find_workspace_dir,
+    find_workspace_dir_from_env,
+};

--- a/crates/workspace/src/manifest.rs
+++ b/crates/workspace/src/manifest.rs
@@ -3,13 +3,14 @@
 //! Port of upstream's
 //! [`readWorkspaceManifest`](https://github.com/pnpm/pnpm/blob/94240bc046/workspace/workspace-manifest-reader/src/index.ts).
 //!
-//! Pacquet already has [`pacquet_config::WorkspaceSettings`] parsing
+//! Pacquet already has `pacquet_config::WorkspaceSettings` parsing
 //! the file for *settings* (`storeDir`, `registry`, …). That stays the
 //! authoritative settings parser; this module is concerned only with
 //! the workspace-shape fields (`packages:`, catalogs) that drive
 //! project enumeration. Splitting them mirrors upstream's package
 //! split: `workspace-manifest-reader` returns the typed shape;
-//! settings live elsewhere.
+//! settings live elsewhere. (Not a rustdoc link — `pacquet-config`
+//! is not a dependency of this crate.)
 //!
 //! The validation rules mirror upstream's
 //! [`validateWorkspaceManifest`](https://github.com/pnpm/pnpm/blob/94240bc046/workspace/workspace-manifest-reader/src/index.ts):
@@ -36,7 +37,7 @@ pub const WORKSPACE_MANIFEST_FILENAME: &str = "pnpm-workspace.yaml";
 /// Subset of `pnpm-workspace.yaml` consumed by project enumeration.
 ///
 /// The settings half (`storeDir`, `registry`, lifecycle policies, …)
-/// is read separately by [`pacquet_config::WorkspaceSettings`].
+/// is read separately by `pacquet_config::WorkspaceSettings`.
 /// Splitting along the upstream package boundary keeps each reader
 /// focused on the shape its callers actually need and avoids a
 /// monolithic struct that has to grow with every new pnpm setting.
@@ -56,15 +57,18 @@ pub struct WorkspaceManifest {
     pub packages: Vec<String>,
 }
 
-/// Raised when `pnpm-workspace.yaml` parses as YAML but fails one of
-/// upstream's shape checks. Same error code as upstream's
-/// `InvalidWorkspaceManifestError`.
+/// Raised when `pnpm-workspace.yaml` parses as YAML but fails an
+/// upstream-mirrored shape check that serde itself can't enforce.
+/// Same error code as upstream's `InvalidWorkspaceManifestError`.
+///
+/// Note: upstream's "packages field is not an array" branch is
+/// covered by [`ReadWorkspaceManifestError::ParseYaml`] in pacquet —
+/// `serde_saphyr` rejects a non-array shape before this layer runs.
+/// Only the empty-string-entry check needs a dedicated variant.
 #[derive(Debug, Display, Error, Diagnostic)]
 #[diagnostic(code(pacquet_workspace::invalid_workspace_configuration))]
 #[non_exhaustive]
 pub enum InvalidWorkspaceManifestError {
-    #[display("packages field is not an array")]
-    PackagesNotArray,
     #[display("Missing or empty package")]
     EmptyPackageEntry,
 }

--- a/crates/workspace/src/manifest.rs
+++ b/crates/workspace/src/manifest.rs
@@ -50,11 +50,17 @@ pub const WORKSPACE_MANIFEST_FILENAME: &str = "pnpm-workspace.yaml";
 #[serde(rename_all = "camelCase")]
 pub struct WorkspaceManifest {
     /// Glob patterns identifying the workspace's projects, relative to
-    /// the workspace dir. Empty when omitted; an explicit empty list is
-    /// distinguishable from "omitted" because an empty document yields
-    /// the default (empty) value too.
+    /// the workspace dir.
+    ///
+    /// `Option` rather than `Vec` so callers can distinguish three
+    /// states: `None` (the `packages` key is absent — fall back to the
+    /// default `['.', '**']` patterns, matching upstream's
+    /// `opts.patterns ?? defaults`), `Some(vec![])` (explicit empty
+    /// array — enumerate only the workspace root), and `Some(...)`
+    /// (the user's patterns). Collapsing the first two would silently
+    /// promote `packages: []` into a recursive scan.
     #[serde(default)]
-    pub packages: Vec<String>,
+    pub packages: Option<Vec<String>>,
 }
 
 /// Raised when `pnpm-workspace.yaml` parses as YAML but fails an
@@ -124,11 +130,13 @@ pub fn read_workspace_manifest(
     // for `packages:` at deserialization. The remaining upstream
     // invariant — entries cannot be empty strings — needs a manual
     // pass since serde doesn't know about that constraint.
-    for entry in &manifest.packages {
-        if entry.is_empty() {
-            return Err(ReadWorkspaceManifestError::Invalid(
-                InvalidWorkspaceManifestError::EmptyPackageEntry,
-            ));
+    if let Some(packages) = &manifest.packages {
+        for entry in packages {
+            if entry.is_empty() {
+                return Err(ReadWorkspaceManifestError::Invalid(
+                    InvalidWorkspaceManifestError::EmptyPackageEntry,
+                ));
+            }
         }
     }
 

--- a/crates/workspace/src/manifest.rs
+++ b/crates/workspace/src/manifest.rs
@@ -1,0 +1,135 @@
+//! Read `pnpm-workspace.yaml` into a [`WorkspaceManifest`].
+//!
+//! Port of upstream's
+//! [`readWorkspaceManifest`](https://github.com/pnpm/pnpm/blob/94240bc046/workspace/workspace-manifest-reader/src/index.ts).
+//!
+//! Pacquet already has [`pacquet_config::WorkspaceSettings`] parsing
+//! the file for *settings* (`storeDir`, `registry`, …). That stays the
+//! authoritative settings parser; this module is concerned only with
+//! the workspace-shape fields (`packages:`, catalogs) that drive
+//! project enumeration. Splitting them mirrors upstream's package
+//! split: `workspace-manifest-reader` returns the typed shape;
+//! settings live elsewhere.
+//!
+//! The validation rules mirror upstream's
+//! [`validateWorkspaceManifest`](https://github.com/pnpm/pnpm/blob/94240bc046/workspace/workspace-manifest-reader/src/index.ts):
+//!
+//! - File missing → `None`.
+//! - Empty / `{}` document → `Some(default)`.
+//! - Root is not an object (e.g. a YAML sequence) → error.
+//! - `packages` present but not a string array → error.
+//! - Empty-string entries in `packages` → error.
+
+use derive_more::{Display, Error};
+use miette::Diagnostic;
+use serde::Deserialize;
+use std::{
+    fs,
+    io::{self, ErrorKind},
+    path::{Path, PathBuf},
+};
+
+/// Basename of the workspace manifest. Same constant pnpm uses
+/// internally via `@pnpm/constants`.
+pub const WORKSPACE_MANIFEST_FILENAME: &str = "pnpm-workspace.yaml";
+
+/// Subset of `pnpm-workspace.yaml` consumed by project enumeration.
+///
+/// The settings half (`storeDir`, `registry`, lifecycle policies, …)
+/// is read separately by [`pacquet_config::WorkspaceSettings`].
+/// Splitting along the upstream package boundary keeps each reader
+/// focused on the shape its callers actually need and avoids a
+/// monolithic struct that has to grow with every new pnpm setting.
+///
+/// Catalogs are accepted at parse time but not yet consumed downstream
+/// — they belong to Stage 2 of the workspace roadmap. Parsing them now
+/// keeps `pnpm-workspace.yaml` files with catalog entries valid input
+/// to pacquet rather than tripping `deny_unknown_fields`.
+#[derive(Debug, Default, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceManifest {
+    /// Glob patterns identifying the workspace's projects, relative to
+    /// the workspace dir. Empty when omitted; an explicit empty list is
+    /// distinguishable from "omitted" because an empty document yields
+    /// the default (empty) value too.
+    #[serde(default)]
+    pub packages: Vec<String>,
+}
+
+/// Raised when `pnpm-workspace.yaml` parses as YAML but fails one of
+/// upstream's shape checks. Same error code as upstream's
+/// `InvalidWorkspaceManifestError`.
+#[derive(Debug, Display, Error, Diagnostic)]
+#[diagnostic(code(pacquet_workspace::invalid_workspace_configuration))]
+#[non_exhaustive]
+pub enum InvalidWorkspaceManifestError {
+    #[display("packages field is not an array")]
+    PackagesNotArray,
+    #[display("Missing or empty package")]
+    EmptyPackageEntry,
+}
+
+/// Error type of [`read_workspace_manifest`].
+#[derive(Debug, Display, Error, Diagnostic)]
+#[non_exhaustive]
+pub enum ReadWorkspaceManifestError {
+    #[display("Failed to read pnpm-workspace.yaml at {}: {source}", path.display())]
+    ReadFile {
+        path: PathBuf,
+        #[error(source)]
+        source: io::Error,
+    },
+    #[display("Failed to parse pnpm-workspace.yaml at {}: {source}", path.display())]
+    ParseYaml {
+        path: PathBuf,
+        #[error(source)]
+        source: Box<serde_saphyr::Error>,
+    },
+    #[diagnostic(transparent)]
+    Invalid(#[error(source)] InvalidWorkspaceManifestError),
+}
+
+/// Read and validate the `pnpm-workspace.yaml` under `dir`.
+///
+/// Returns `Ok(None)` when the file does not exist (matching upstream's
+/// `ENOENT`-as-undefined contract). Every other read or parse failure
+/// propagates.
+pub fn read_workspace_manifest(
+    dir: &Path,
+) -> Result<Option<WorkspaceManifest>, ReadWorkspaceManifestError> {
+    let path = dir.join(WORKSPACE_MANIFEST_FILENAME);
+    let text = match fs::read_to_string(&path) {
+        Ok(text) => text,
+        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(source) => return Err(ReadWorkspaceManifestError::ReadFile { path, source }),
+    };
+
+    // An empty workspace manifest is valid and means "no settings, no
+    // packages" — same as `{}`. `serde_saphyr` would otherwise reject
+    // an empty document; short-circuit to the default value to match
+    // upstream's behavior.
+    if text.trim().is_empty() {
+        return Ok(Some(WorkspaceManifest::default()));
+    }
+
+    let manifest: WorkspaceManifest = serde_saphyr::from_str(&text).map_err(|source| {
+        ReadWorkspaceManifestError::ParseYaml { path: path.clone(), source: Box::new(source) }
+    })?;
+
+    // serde_saphyr already enforces the array shape and string type
+    // for `packages:` at deserialization. The remaining upstream
+    // invariant — entries cannot be empty strings — needs a manual
+    // pass since serde doesn't know about that constraint.
+    for entry in &manifest.packages {
+        if entry.is_empty() {
+            return Err(ReadWorkspaceManifestError::Invalid(
+                InvalidWorkspaceManifestError::EmptyPackageEntry,
+            ));
+        }
+    }
+
+    Ok(Some(manifest))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/workspace/src/manifest/tests.rs
+++ b/crates/workspace/src/manifest/tests.rs
@@ -30,15 +30,19 @@ fn parses_packages_array() {
     )
     .unwrap();
     let manifest = read_workspace_manifest(tmp.path()).unwrap().unwrap();
-    assert_eq!(manifest.packages, vec!["packages/*".to_string(), "apps/*".to_string()]);
+    assert_eq!(manifest.packages, Some(vec!["packages/*".to_string(), "apps/*".to_string()]));
 }
 
-/// Settings-only manifests (no `packages:`) still produce a valid
-/// manifest with an empty `packages` list. Matches upstream's
-/// `validateWorkspaceManifest`, which only errors on a *non-array*
-/// `packages` value — omitted is fine.
+/// Settings-only manifests (no `packages:`) leave `packages` as
+/// `None` so [`find_workspace_projects`] can apply the
+/// `['.', '**']` defaults. Matches upstream's
+/// `opts.patterns ?? defaults` rule, where the fallback fires for
+/// omitted-only, not for an explicit empty array. Distinguishing
+/// the two states is the whole point of the [`Option`] wrapper.
+///
+/// [`find_workspace_projects`]: crate::find_workspace_projects
 #[test]
-fn settings_only_manifest_has_empty_packages() {
+fn settings_only_manifest_leaves_packages_none() {
     let tmp = TempDir::new().unwrap();
     fs::write(
         tmp.path().join(WORKSPACE_MANIFEST_FILENAME),
@@ -46,7 +50,19 @@ fn settings_only_manifest_has_empty_packages() {
     )
     .unwrap();
     let manifest = read_workspace_manifest(tmp.path()).unwrap().unwrap();
-    assert_eq!(manifest.packages, Vec::<String>::new());
+    assert_eq!(manifest.packages, None);
+}
+
+/// An explicit `packages: []` survives as `Some(vec![])` and is
+/// distinct from the omitted case. Downstream this means "enumerate
+/// only the workspace root project," not "fall back to the recursive
+/// `**` default."
+#[test]
+fn empty_packages_array_preserved_as_some_empty() {
+    let tmp = TempDir::new().unwrap();
+    fs::write(tmp.path().join(WORKSPACE_MANIFEST_FILENAME), "packages: []\n").unwrap();
+    let manifest = read_workspace_manifest(tmp.path()).unwrap().unwrap();
+    assert_eq!(manifest.packages, Some(Vec::<String>::new()));
 }
 
 #[test]

--- a/crates/workspace/src/manifest/tests.rs
+++ b/crates/workspace/src/manifest/tests.rs
@@ -1,0 +1,65 @@
+use super::{
+    InvalidWorkspaceManifestError, ReadWorkspaceManifestError, WORKSPACE_MANIFEST_FILENAME,
+    WorkspaceManifest, read_workspace_manifest,
+};
+use pretty_assertions::assert_eq;
+use std::fs;
+use tempfile::TempDir;
+
+#[test]
+fn missing_file_returns_none() {
+    let tmp = TempDir::new().unwrap();
+    let manifest = read_workspace_manifest(tmp.path()).unwrap();
+    assert_eq!(manifest, None);
+}
+
+#[test]
+fn empty_file_returns_default() {
+    let tmp = TempDir::new().unwrap();
+    fs::write(tmp.path().join(WORKSPACE_MANIFEST_FILENAME), "").unwrap();
+    let manifest = read_workspace_manifest(tmp.path()).unwrap();
+    assert_eq!(manifest, Some(WorkspaceManifest::default()));
+}
+
+#[test]
+fn parses_packages_array() {
+    let tmp = TempDir::new().unwrap();
+    fs::write(
+        tmp.path().join(WORKSPACE_MANIFEST_FILENAME),
+        "packages:\n  - packages/*\n  - apps/*\n",
+    )
+    .unwrap();
+    let manifest = read_workspace_manifest(tmp.path()).unwrap().unwrap();
+    assert_eq!(manifest.packages, vec!["packages/*".to_string(), "apps/*".to_string()]);
+}
+
+/// Settings-only manifests (no `packages:`) still produce a valid
+/// manifest with an empty `packages` list. Matches upstream's
+/// `validateWorkspaceManifest`, which only errors on a *non-array*
+/// `packages` value — omitted is fine.
+#[test]
+fn settings_only_manifest_has_empty_packages() {
+    let tmp = TempDir::new().unwrap();
+    fs::write(
+        tmp.path().join(WORKSPACE_MANIFEST_FILENAME),
+        "storeDir: /tmp/store\nregistry: https://example.com/\n",
+    )
+    .unwrap();
+    let manifest = read_workspace_manifest(tmp.path()).unwrap().unwrap();
+    assert_eq!(manifest.packages, Vec::<String>::new());
+}
+
+#[test]
+fn empty_package_entry_rejected() {
+    let tmp = TempDir::new().unwrap();
+    fs::write(tmp.path().join(WORKSPACE_MANIFEST_FILENAME), "packages:\n  - ''\n  - apps/*\n")
+        .unwrap();
+    let err = read_workspace_manifest(tmp.path()).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            ReadWorkspaceManifestError::Invalid(InvalidWorkspaceManifestError::EmptyPackageEntry),
+        ),
+        "unexpected error: {err}",
+    );
+}

--- a/crates/workspace/src/project_manifest.rs
+++ b/crates/workspace/src/project_manifest.rs
@@ -1,0 +1,106 @@
+//! Read a project's `package.json`.
+//!
+//! Port of upstream's
+//! [`readProjectManifest` / `tryReadProjectManifest` / `readExactProjectManifest`](https://github.com/pnpm/pnpm/blob/94240bc046/workspace/project-manifest-reader/src/index.ts).
+//!
+//! Upstream also supports `package.json5` and `package.yaml` and
+//! returns a writer closure that preserves formatting. Pacquet doesn't
+//! consume either alternative format yet, and the install pipeline
+//! never writes the manifest back — so this port handles `package.json`
+//! only and drops the writer closure. Adding the other formats is a
+//! follow-up if real workspaces in the wild use them.
+
+use derive_more::{Display, Error};
+use miette::Diagnostic;
+use pacquet_package_manifest::{PackageManifest, PackageManifestError};
+use std::path::{Path, PathBuf};
+
+/// Error type of [`read_exact_project_manifest`].
+#[derive(Debug, Display, Error, Diagnostic)]
+#[non_exhaustive]
+pub enum ReadProjectManifestError {
+    #[diagnostic(transparent)]
+    Read(#[error(source)] PackageManifestError),
+
+    #[display("Not supported manifest name {basename:?}")]
+    #[diagnostic(code(pacquet_workspace::unsupported_project_manifest))]
+    UnsupportedName { basename: String },
+}
+
+/// Error type of [`read_project_manifest_only`] /
+/// [`try_read_project_manifest`].
+#[derive(Debug, Display, Error, Diagnostic)]
+#[non_exhaustive]
+pub enum ReadProjectManifestOnlyError {
+    #[display(
+        "No package.json (or package.yaml, or package.json5) was found in {:?}",
+        project_dir.display()
+    )]
+    #[diagnostic(code(pacquet_workspace::no_importer_manifest_found))]
+    NoImporterManifestFound { project_dir: PathBuf },
+
+    #[diagnostic(transparent)]
+    Read(#[error(source)] PackageManifestError),
+}
+
+/// Read the manifest under `project_dir`.
+///
+/// Returns the manifest plus the basename that was loaded. Today the
+/// only supported basename is `package.json`; the function exists in
+/// its current shape to mirror upstream's tri-format probing so callers
+/// can stay structurally the same when `package.json5` / `package.yaml`
+/// support lands.
+pub fn try_read_project_manifest(
+    project_dir: &Path,
+) -> Result<Option<(&'static str, PackageManifest)>, ReadProjectManifestOnlyError> {
+    let json_path = project_dir.join("package.json");
+    if !json_path.is_file() {
+        return Ok(None);
+    }
+    let manifest =
+        PackageManifest::from_path(json_path).map_err(ReadProjectManifestOnlyError::Read)?;
+    Ok(Some(("package.json", manifest)))
+}
+
+/// Strict version: error when no manifest is found. Mirrors upstream's
+/// `readProjectManifest`.
+pub fn read_project_manifest_only(
+    project_dir: &Path,
+) -> Result<PackageManifest, ReadProjectManifestOnlyError> {
+    match try_read_project_manifest(project_dir)? {
+        Some((_, manifest)) => Ok(manifest),
+        None => Err(ReadProjectManifestOnlyError::NoImporterManifestFound {
+            project_dir: project_dir.to_path_buf(),
+        }),
+    }
+}
+
+/// Like [`read_project_manifest_only`] but returns `None` instead of
+/// erroring when the manifest is missing. Mirrors upstream's
+/// `safeReadProjectManifestOnly`.
+pub fn safe_read_project_manifest_only(
+    project_dir: &Path,
+) -> Result<Option<PackageManifest>, ReadProjectManifestOnlyError> {
+    Ok(try_read_project_manifest(project_dir)?.map(|(_, m)| m))
+}
+
+/// Read a manifest from an explicit path. Mirrors upstream's
+/// `readExactProjectManifest`, which probes the basename to pick a
+/// parser. Pacquet only supports `package.json`; other basenames are
+/// rejected with the same wording upstream uses.
+pub fn read_exact_project_manifest(
+    manifest_path: &Path,
+) -> Result<PackageManifest, ReadProjectManifestError> {
+    let basename = manifest_path
+        .file_name()
+        .map(|name| name.to_string_lossy().to_ascii_lowercase())
+        .unwrap_or_default();
+    match basename.as_str() {
+        "package.json" => PackageManifest::from_path(manifest_path.to_path_buf())
+            .map_err(ReadProjectManifestError::Read),
+        _ => Err(ReadProjectManifestError::UnsupportedName { basename }),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/workspace/src/project_manifest.rs
+++ b/crates/workspace/src/project_manifest.rs
@@ -32,10 +32,11 @@ pub enum ReadProjectManifestError {
 #[derive(Debug, Display, Error, Diagnostic)]
 #[non_exhaustive]
 pub enum ReadProjectManifestOnlyError {
-    #[display(
-        "No package.json (or package.yaml, or package.json5) was found in {:?}",
-        project_dir.display()
-    )]
+    // Upstream's variant of this message lists `package.yaml` and
+    // `package.json5` alongside `package.json`. Pacquet only probes
+    // `package.json` today, so the diagnostic mentions just that one —
+    // bring back the alternatives when the readers do.
+    #[display("No package.json was found in {:?}", project_dir.display())]
     #[diagnostic(code(pacquet_workspace::no_importer_manifest_found))]
     NoImporterManifestFound { project_dir: PathBuf },
 

--- a/crates/workspace/src/project_manifest/tests.rs
+++ b/crates/workspace/src/project_manifest/tests.rs
@@ -1,0 +1,67 @@
+use super::{
+    ReadProjectManifestError, ReadProjectManifestOnlyError, read_exact_project_manifest,
+    read_project_manifest_only, safe_read_project_manifest_only, try_read_project_manifest,
+};
+use pretty_assertions::assert_eq;
+use std::fs;
+use tempfile::TempDir;
+
+fn write_manifest(dir: &std::path::Path, body: &str) {
+    fs::write(dir.join("package.json"), body).unwrap();
+}
+
+#[test]
+fn try_read_returns_manifest_when_present() {
+    let tmp = TempDir::new().unwrap();
+    write_manifest(tmp.path(), r#"{"name": "alpha", "version": "1.2.3"}"#);
+    let result = try_read_project_manifest(tmp.path()).unwrap().unwrap();
+    assert_eq!(result.0, "package.json");
+    assert_eq!(result.1.value().get("name").and_then(|v| v.as_str()), Some("alpha"));
+}
+
+#[test]
+fn try_read_returns_none_when_missing() {
+    let tmp = TempDir::new().unwrap();
+    assert!(try_read_project_manifest(tmp.path()).unwrap().is_none());
+}
+
+#[test]
+fn safe_read_returns_none_when_missing() {
+    let tmp = TempDir::new().unwrap();
+    assert!(safe_read_project_manifest_only(tmp.path()).unwrap().is_none());
+}
+
+#[test]
+fn strict_read_errors_when_missing() {
+    let tmp = TempDir::new().unwrap();
+    match read_project_manifest_only(tmp.path()) {
+        Ok(_) => panic!("expected NoImporterManifestFound"),
+        Err(ReadProjectManifestOnlyError::NoImporterManifestFound { project_dir }) => {
+            assert_eq!(project_dir, tmp.path());
+        }
+        Err(err) => panic!("unexpected error: {err}"),
+    }
+}
+
+#[test]
+fn read_exact_rejects_other_basenames() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("package.yaml");
+    fs::write(&path, "name: alpha\n").unwrap();
+    match read_exact_project_manifest(&path) {
+        Ok(_) => panic!("expected UnsupportedName"),
+        Err(ReadProjectManifestError::UnsupportedName { basename }) => {
+            assert_eq!(basename, "package.yaml");
+        }
+        Err(err) => panic!("unexpected error: {err}"),
+    }
+}
+
+#[test]
+fn read_exact_accepts_package_json() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("package.json");
+    fs::write(&path, r#"{"name": "beta", "version": "0.1.0"}"#).unwrap();
+    let manifest = read_exact_project_manifest(&path).unwrap();
+    assert_eq!(manifest.value().get("name").and_then(|v| v.as_str()), Some("beta"));
+}

--- a/crates/workspace/src/projects.rs
+++ b/crates/workspace/src/projects.rs
@@ -1,0 +1,229 @@
+//! Glob-expand `packages:` from `pnpm-workspace.yaml` into the
+//! workspace's [`Project`] list.
+//!
+//! Port of upstream's
+//! [`findWorkspaceProjects`](https://github.com/pnpm/pnpm/blob/94240bc046/workspace/projects-reader/src/index.ts)
+//! and
+//! [`findPackages`](https://github.com/pnpm/pnpm/blob/94240bc046/workspace/projects-reader/src/findPackages.ts).
+//!
+//! Behavior preserved against upstream:
+//!
+//! - Glob-walk the workspace root using the user's `packages:` patterns
+//!   (defaulting to `['.', '**']` when omitted, matching tinyglobby's
+//!   call site upstream).
+//! - Always include the workspace root itself, per
+//!   <https://github.com/pnpm/pnpm/issues/1986>.
+//! - Filter `**/node_modules/**` and `**/bower_components/**` so a
+//!   pre-existing install doesn't surface synthetic projects.
+//! - Dedupe matches (a path can satisfy multiple patterns) and sort
+//!   lexicographically by `rootDir`, matching upstream's
+//!   `lexCompare(path.dirname(path1), path.dirname(path2))`.
+//!
+//! Out of scope (tracked as upstream parity follow-ups):
+//!
+//! - `engines` / `os` / `cpu` installability filtering. Issue #431
+//!   explicitly defers this.
+//! - The `resolutions`-on-non-root warning. Single-line emission that
+//!   can land when the reporter side is in place.
+//! - Real-path resolution of `rootDir` for case-insensitive
+//!   filesystems. Same divergence as [`root_finder`].
+//!
+//! [`root_finder`]: super::root_finder
+
+use crate::project_manifest::{ReadProjectManifestError, read_exact_project_manifest};
+use derive_more::{Display, Error};
+use miette::Diagnostic;
+use pacquet_package_manifest::PackageManifest;
+use std::{
+    collections::BTreeSet,
+    path::{Path, PathBuf},
+};
+use wax::{
+    Glob,
+    walk::{Entry, FileIterator},
+};
+
+/// A project discovered under the workspace root.
+///
+/// Pacquet keeps this shape narrower than upstream's `Project` (which
+/// also carries `rootDirRealPath`, `modulesDir`, etc.). The fields here
+/// are what `pacquet-package-manager` actually needs at install time;
+/// anything else is read on demand from the manifest. If a caller
+/// needs more, extend here rather than reaching back into the
+/// `package.json` value directly.
+pub struct Project {
+    pub root_dir: PathBuf,
+    pub manifest: PackageManifest,
+}
+
+/// Options for [`find_workspace_projects`].
+///
+/// Field names mirror upstream's `FindWorkspaceProjectsOpts` so a port
+/// of any individual install entry point doesn't have to translate
+/// option names.
+#[derive(Debug, Default, Clone)]
+pub struct FindWorkspaceProjectsOpts {
+    /// `packages:` from `pnpm-workspace.yaml`. When `None`, upstream
+    /// falls back to `['.', '**']`. Pacquet mirrors that default so a
+    /// workspace whose manifest only carries settings still enumerates
+    /// projects.
+    pub patterns: Option<Vec<String>>,
+}
+
+/// Error type of the public entry points.
+#[derive(Debug, Display, Error, Diagnostic)]
+#[non_exhaustive]
+pub enum FindWorkspaceProjectsError {
+    #[display("Invalid glob pattern in pnpm-workspace.yaml packages: {pattern:?}: {message}")]
+    #[diagnostic(code(pacquet_workspace::invalid_glob))]
+    InvalidGlob {
+        pattern: String,
+        // Built once at construction. wax errors carry a borrow of the
+        // input glob, so flatten to a string here for ergonomic storage.
+        message: String,
+    },
+
+    #[display("Failed to walk workspace projects under {}: {source}", root.display())]
+    #[diagnostic(code(pacquet_workspace::walk_error))]
+    Walk {
+        root: PathBuf,
+        #[error(source)]
+        source: std::io::Error,
+    },
+
+    #[diagnostic(transparent)]
+    ReadManifest(#[error(source)] ReadProjectManifestError),
+}
+
+/// Find every project under `workspace_root` matching `opts.patterns`.
+///
+/// Mirrors upstream's
+/// [`findWorkspaceProjects`](https://github.com/pnpm/pnpm/blob/94240bc046/workspace/projects-reader/src/index.ts)
+/// except for the per-project `packageIsInstallable` /
+/// `checkNonRootProjectManifest` validations, which are explicitly
+/// deferred by #431. When validation lands, this entry point grows
+/// the filter; today it's a thin wrapper over
+/// [`find_workspace_projects_no_check`].
+pub fn find_workspace_projects(
+    workspace_root: &Path,
+    opts: &FindWorkspaceProjectsOpts,
+) -> Result<Vec<Project>, FindWorkspaceProjectsError> {
+    find_workspace_projects_no_check(workspace_root, opts)
+}
+
+/// Skip-validation variant, matching upstream's
+/// [`findWorkspaceProjectsNoCheck`](https://github.com/pnpm/pnpm/blob/94240bc046/workspace/projects-reader/src/index.ts).
+pub fn find_workspace_projects_no_check(
+    workspace_root: &Path,
+    opts: &FindWorkspaceProjectsOpts,
+) -> Result<Vec<Project>, FindWorkspaceProjectsError> {
+    // Upstream default mirrors tinyglobby's call site: when no patterns
+    // were configured, search the workspace root non-recursively *and*
+    // recursively. The two-pattern fallback covers both single-project
+    // and monorepo-with-no-`packages` setups.
+    let default_patterns = [".".to_string(), "**".to_string()];
+    let patterns: &[String] =
+        opts.patterns.as_deref().filter(|p| !p.is_empty()).unwrap_or(&default_patterns);
+
+    let mut manifest_paths: BTreeSet<PathBuf> = BTreeSet::new();
+    for pattern in patterns {
+        let normalized = normalize_pattern(pattern);
+        let glob =
+            Glob::new(&normalized).map_err(|err| FindWorkspaceProjectsError::InvalidGlob {
+                pattern: pattern.clone(),
+                message: err.to_string(),
+            })?;
+
+        // wax's `not` takes a single pattern; combine the ignores with
+        // `wax::any` so the walk filters them all in one pass, matching
+        // upstream's `ignore: ['**/node_modules/**', '**/bower_components/**']`.
+        let ignore = wax::any(IGNORE_PATTERNS.iter().copied()).map_err(|err| {
+            FindWorkspaceProjectsError::InvalidGlob {
+                pattern: pattern.clone(),
+                message: err.to_string(),
+            }
+        })?;
+        let walk = glob.walk(workspace_root).not(ignore).map_err(|err| {
+            FindWorkspaceProjectsError::InvalidGlob {
+                pattern: pattern.clone(),
+                message: err.to_string(),
+            }
+        })?;
+
+        for entry in walk {
+            let entry = entry.map_err(|err| FindWorkspaceProjectsError::Walk {
+                root: workspace_root.to_path_buf(),
+                source: std::io::Error::other(err.to_string()),
+            })?;
+            manifest_paths.insert(entry.path().to_path_buf());
+        }
+    }
+
+    // Upstream's `findPackages` always includes the workspace root,
+    // even when no `packages:` pattern matches it
+    // (https://github.com/pnpm/pnpm/issues/1986). Mirror that by
+    // unconditionally adding the root's manifest if present.
+    let root_manifest = workspace_root.join("package.json");
+    if root_manifest.is_file() {
+        manifest_paths.insert(root_manifest);
+    }
+
+    // Sort lexicographically by `rootDir` (= parent of the manifest),
+    // matching upstream's `lexCompare(path.dirname(p1), path.dirname(p2))`.
+    // `BTreeSet` already sorts by full path, but the upstream contract
+    // is "by dir then by basename"; with our basename always being
+    // `package.json` the two orderings coincide. Keep the explicit
+    // sort below to make the contract visible.
+    let mut sorted: Vec<PathBuf> = manifest_paths.into_iter().collect();
+    sorted.sort_by(|a, b| {
+        let dir_a = a.parent().unwrap_or(Path::new(""));
+        let dir_b = b.parent().unwrap_or(Path::new(""));
+        dir_a.cmp(dir_b)
+    });
+
+    let mut projects = Vec::with_capacity(sorted.len());
+    for manifest_path in sorted {
+        let manifest = match read_exact_project_manifest(&manifest_path) {
+            Ok(m) => m,
+            Err(ReadProjectManifestError::Read(_)) => {
+                // Upstream swallows ENOENT mid-walk (a file vanished
+                // between listing and reading). Treat any read error
+                // the same here as a parity hedge — the lockfile is
+                // still the source of truth for which importers must
+                // be linked, so a "skip this candidate" recovery is
+                // safer than aborting the install on a stale glob hit.
+                continue;
+            }
+            Err(err) => return Err(FindWorkspaceProjectsError::ReadManifest(err)),
+        };
+        let root_dir = manifest_path.parent().unwrap_or(workspace_root).to_path_buf();
+        projects.push(Project { root_dir, manifest });
+    }
+
+    Ok(projects)
+}
+
+/// Hardcoded ignore patterns, matching upstream's `DEFAULT_IGNORE`
+/// minus the `**/test/**` / `**/tests/**` exclusions (which are only
+/// relevant to `findPackages` callers that aren't enumerating a real
+/// workspace — `findWorkspaceProjects` overrides them with just the
+/// `node_modules` / `bower_components` pair).
+const IGNORE_PATTERNS: &[&str] = &["**/node_modules/**", "**/bower_components/**"];
+
+fn normalize_pattern(pattern: &str) -> String {
+    // Mirrors upstream `normalizePatterns`: each user pattern is
+    // suffixed with the manifest basename so the glob matches manifest
+    // files rather than directories. Pacquet only supports
+    // `package.json` today; upstream's `{json,yaml,json5}` brace
+    // expansion is dropped to match the [`project_manifest`] reader.
+    let trimmed = pattern.trim_end_matches('/');
+    if trimmed.is_empty() {
+        // `.` and `''` both mean "match the workspace root itself".
+        "package.json".to_string()
+    } else {
+        format!("{trimmed}/package.json")
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/workspace/src/projects.rs
+++ b/crates/workspace/src/projects.rs
@@ -119,12 +119,31 @@ pub fn find_workspace_projects_no_check(
     opts: &FindWorkspaceProjectsOpts,
 ) -> Result<Vec<Project>, FindWorkspaceProjectsError> {
     // Upstream default mirrors tinyglobby's call site: when no patterns
-    // were configured, search the workspace root non-recursively *and*
-    // recursively. The two-pattern fallback covers both single-project
-    // and monorepo-with-no-`packages` setups.
+    // were configured (`opts.patterns ?? defaults`), search the
+    // workspace root non-recursively *and* recursively. The two-pattern
+    // fallback fires only on `None`, not on `Some(vec![])` — an explicit
+    // empty array means "enumerate only the workspace root" (which is
+    // unconditionally added below per upstream's
+    // https://github.com/pnpm/pnpm/issues/1986 rule).
     let default_patterns = [".".to_string(), "**".to_string()];
-    let patterns: &[String] =
-        opts.patterns.as_deref().filter(|p| !p.is_empty()).unwrap_or(&default_patterns);
+    let patterns: &[String] = match opts.patterns.as_deref() {
+        Some(p) => p,
+        None => &default_patterns,
+    };
+
+    // wax's `not` takes a single pattern; combine the ignores with
+    // `wax::any` so the walk filters them all in one pass, matching
+    // upstream's `ignore: ['**/node_modules/**', '**/bower_components/**']`.
+    // Built once outside the per-pattern loop and `.clone()`-d into each
+    // `Walk::not` call (both `Glob` and `Any` derive `Clone` in wax),
+    // since `IGNORE_PATTERNS` is a constant and reparsing it on every
+    // user-supplied pattern is wasted work.
+    let ignore_template = wax::any(IGNORE_PATTERNS.iter().copied()).map_err(|err| {
+        FindWorkspaceProjectsError::InvalidGlob {
+            pattern: "<built-in ignore>".to_string(),
+            message: err.to_string(),
+        }
+    })?;
 
     let mut manifest_paths: BTreeSet<PathBuf> = BTreeSet::new();
     for pattern in patterns {
@@ -135,16 +154,7 @@ pub fn find_workspace_projects_no_check(
                 message: err.to_string(),
             })?;
 
-        // wax's `not` takes a single pattern; combine the ignores with
-        // `wax::any` so the walk filters them all in one pass, matching
-        // upstream's `ignore: ['**/node_modules/**', '**/bower_components/**']`.
-        let ignore = wax::any(IGNORE_PATTERNS.iter().copied()).map_err(|err| {
-            FindWorkspaceProjectsError::InvalidGlob {
-                pattern: pattern.clone(),
-                message: err.to_string(),
-            }
-        })?;
-        let walk = glob.walk(workspace_root).not(ignore).map_err(|err| {
+        let walk = glob.walk(workspace_root).not(ignore_template.clone()).map_err(|err| {
             FindWorkspaceProjectsError::InvalidGlob {
                 pattern: pattern.clone(),
                 message: err.to_string(),

--- a/crates/workspace/src/projects.rs
+++ b/crates/workspace/src/projects.rs
@@ -33,9 +33,10 @@
 use crate::project_manifest::{ReadProjectManifestError, read_exact_project_manifest};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
-use pacquet_package_manifest::PackageManifest;
+use pacquet_package_manifest::{PackageManifest, PackageManifestError};
 use std::{
     collections::BTreeSet,
+    io::ErrorKind,
     path::{Path, PathBuf},
 };
 use wax::{
@@ -185,15 +186,22 @@ pub fn find_workspace_projects_no_check(
     for manifest_path in sorted {
         let manifest = match read_exact_project_manifest(&manifest_path) {
             Ok(m) => m,
-            Err(ReadProjectManifestError::Read(_)) => {
-                // Upstream swallows ENOENT mid-walk (a file vanished
-                // between listing and reading). Treat any read error
-                // the same here as a parity hedge — the lockfile is
-                // still the source of truth for which importers must
-                // be linked, so a "skip this candidate" recovery is
-                // safer than aborting the install on a stale glob hit.
+            // Upstream swallows ENOENT mid-walk (a file vanished
+            // between listing and reading) at
+            // <https://github.com/pnpm/pnpm/blob/94240bc046/workspace/projects-reader/src/findPackages.ts>.
+            // Mirror that exact-and-only carve-out: parse errors,
+            // permission failures, and "is a directory" must still
+            // propagate so a malformed `package.json` surfaces as a
+            // diagnostic instead of being silently dropped from the
+            // workspace.
+            Err(ReadProjectManifestError::Read(PackageManifestError::Io(err)))
+                if err.kind() == ErrorKind::NotFound =>
+            {
                 continue;
             }
+            Err(ReadProjectManifestError::Read(PackageManifestError::NoImporterManifestFound(
+                _,
+            ))) => continue,
             Err(err) => return Err(FindWorkspaceProjectsError::ReadManifest(err)),
         };
         let root_dir = manifest_path.parent().unwrap_or(workspace_root).to_path_buf();

--- a/crates/workspace/src/projects/tests.rs
+++ b/crates/workspace/src/projects/tests.rs
@@ -73,7 +73,10 @@ fn filters_node_modules() {
         !names.contains(&"foo".to_string()),
         "node_modules contents must not surface as workspace projects: {names:?}",
     );
-    assert!(names.contains(&"real".to_string()));
+    assert!(
+        names.contains(&"real".to_string()),
+        "expected the `real` project to be enumerated; got {names:?}",
+    );
 }
 
 #[test]

--- a/crates/workspace/src/projects/tests.rs
+++ b/crates/workspace/src/projects/tests.rs
@@ -1,0 +1,117 @@
+use super::{FindWorkspaceProjectsOpts, find_workspace_projects};
+use pretty_assertions::assert_eq;
+use std::fs;
+use tempfile::TempDir;
+
+fn make_project(root: &std::path::Path, rel: &str, name: &str) {
+    let dir = root.join(rel);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join("package.json"), format!(r#"{{"name": "{name}", "version": "0.0.1"}}"#))
+        .unwrap();
+}
+
+#[test]
+fn expands_packages_glob() {
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), ".", "root");
+    make_project(tmp.path(), "packages/alpha", "alpha");
+    make_project(tmp.path(), "packages/beta", "beta");
+
+    let projects = find_workspace_projects(
+        tmp.path(),
+        &FindWorkspaceProjectsOpts { patterns: Some(vec!["packages/*".to_string()]) },
+    )
+    .unwrap();
+
+    let names: Vec<String> = projects
+        .iter()
+        .map(|p| p.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
+        .collect();
+    // Sorted lex by rootDir → root then alpha then beta.
+    assert_eq!(names, vec!["root".to_string(), "alpha".to_string(), "beta".to_string()]);
+}
+
+#[test]
+fn always_includes_workspace_root() {
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), ".", "root");
+    make_project(tmp.path(), "apps/web", "web");
+
+    // Patterns deliberately do NOT cover the root. Upstream still
+    // surfaces it (https://github.com/pnpm/pnpm/issues/1986).
+    let projects = find_workspace_projects(
+        tmp.path(),
+        &FindWorkspaceProjectsOpts { patterns: Some(vec!["apps/*".to_string()]) },
+    )
+    .unwrap();
+
+    let names: Vec<String> = projects
+        .iter()
+        .map(|p| p.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(names, vec!["root".to_string(), "web".to_string()]);
+}
+
+#[test]
+fn filters_node_modules() {
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), ".", "root");
+    make_project(tmp.path(), "node_modules/foo", "foo");
+    make_project(tmp.path(), "packages/real", "real");
+
+    let projects = find_workspace_projects(
+        tmp.path(),
+        &FindWorkspaceProjectsOpts { patterns: Some(vec!["**".to_string()]) },
+    )
+    .unwrap();
+
+    let names: Vec<String> = projects
+        .iter()
+        .map(|p| p.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
+        .collect();
+    assert!(
+        !names.contains(&"foo".to_string()),
+        "node_modules contents must not surface as workspace projects: {names:?}",
+    );
+    assert!(names.contains(&"real".to_string()));
+}
+
+#[test]
+fn dedupes_overlapping_patterns() {
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), ".", "root");
+    make_project(tmp.path(), "packages/alpha", "alpha");
+
+    // Two patterns that both match `packages/alpha/package.json` should
+    // produce exactly one entry.
+    let projects = find_workspace_projects(
+        tmp.path(),
+        &FindWorkspaceProjectsOpts {
+            patterns: Some(vec!["packages/*".to_string(), "**".to_string()]),
+        },
+    )
+    .unwrap();
+
+    let names: Vec<String> = projects
+        .iter()
+        .map(|p| p.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(names, vec!["root".to_string(), "alpha".to_string()]);
+}
+
+#[test]
+fn default_patterns_when_packages_omitted() {
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), ".", "root");
+    make_project(tmp.path(), "apps/web", "web");
+
+    let projects =
+        find_workspace_projects(tmp.path(), &FindWorkspaceProjectsOpts { patterns: None }).unwrap();
+
+    let names: Vec<String> = projects
+        .iter()
+        .map(|p| p.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
+        .collect();
+    // `.` + `**` enumerates everything.
+    assert_eq!(names, vec!["root".to_string(), "web".to_string()]);
+}

--- a/crates/workspace/src/projects/tests.rs
+++ b/crates/workspace/src/projects/tests.rs
@@ -118,3 +118,29 @@ fn default_patterns_when_packages_omitted() {
     // `.` + `**` enumerates everything.
     assert_eq!(names, vec!["root".to_string(), "web".to_string()]);
 }
+
+/// `packages: []` (explicit empty array) is *not* the same as
+/// omitted: it means "enumerate only the workspace root project,"
+/// matching upstream's `opts.patterns ?? defaults` where `[]` is a
+/// truthy value that survives the nullish-coalesce. Without this,
+/// `packages: []` would silently fall back to `['.', '**']` and
+/// recurse through the whole tree.
+#[test]
+fn empty_patterns_array_enumerates_root_only() {
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), ".", "root");
+    make_project(tmp.path(), "apps/web", "web");
+
+    let projects = find_workspace_projects(
+        tmp.path(),
+        &FindWorkspaceProjectsOpts { patterns: Some(Vec::new()) },
+    )
+    .unwrap();
+
+    let names: Vec<String> = projects
+        .iter()
+        .map(|p| p.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
+        .collect();
+    // Only the workspace root surfaces — `web` is not enumerated.
+    assert_eq!(names, vec!["root".to_string()]);
+}

--- a/crates/workspace/src/root_finder.rs
+++ b/crates/workspace/src/root_finder.rs
@@ -1,0 +1,136 @@
+//! Locate the workspace root directory (the dir containing
+//! `pnpm-workspace.yaml`).
+//!
+//! Port of upstream's
+//! [`findWorkspaceDir`](https://github.com/pnpm/pnpm/blob/94240bc046/workspace/root-finder/src/index.ts).
+//!
+//! Three behaviors must match upstream:
+//!
+//! 1. Honor the `NPM_CONFIG_WORKSPACE_DIR` env var (also the lowercase
+//!    spelling) as an override — when set, the workspace dir is taken
+//!    verbatim and the upward walk is skipped.
+//! 2. Walk up from `cwd` looking for `pnpm-workspace.yaml` (and the
+//!    "looks like a workspace manifest but is misnamed" variants below).
+//! 3. If a misnamed variant is found before the correct file, raise
+//!    `BAD_WORKSPACE_MANIFEST_NAME` rather than silently treating the
+//!    project as non-workspace.
+//!
+//! Pacquet does not yet realpath the start dir like upstream does (used
+//! for case-insensitive filesystems on Windows / macOS). Tracked as a
+//! known divergence — typical workspace installs on those platforms
+//! still resolve correctly because the upward walk operates on the
+//! canonical components Node hands us. Revisit if a regression turns up.
+
+use crate::manifest::WORKSPACE_MANIFEST_FILENAME;
+use derive_more::{Display, Error};
+use miette::Diagnostic;
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
+
+/// Misnamed `pnpm-workspace.yaml` variants that upstream specifically
+/// rejects rather than silently treating as "no workspace manifest". Order
+/// preserved against upstream's
+/// [`INVALID_WORKSPACE_MANIFEST_FILENAME`](https://github.com/pnpm/pnpm/blob/94240bc046/workspace/root-finder/src/index.ts).
+pub(crate) const INVALID_WORKSPACE_MANIFEST_FILENAMES: &[&str] = &[
+    "pnpm-workspaces.yaml",
+    "pnpm-workspaces.yml",
+    "pnpm-workspace.yml",
+    ".pnpm-workspace.yaml",
+    ".pnpm-workspace.yml",
+    ".pnpm-workspaces.yaml",
+    ".pnpm-workspaces.yml",
+];
+
+/// Env var that overrides the upward walk. Matches upstream's
+/// `WORKSPACE_DIR_ENV_VAR`.
+pub(crate) const WORKSPACE_DIR_ENV_VAR: &str = "NPM_CONFIG_WORKSPACE_DIR";
+
+/// Raised when an ancestor contains a misnamed workspace manifest
+/// before any `pnpm-workspace.yaml`. Same code as upstream's
+/// `BAD_WORKSPACE_MANIFEST_NAME`.
+#[derive(Debug, Display, Error, Diagnostic)]
+#[display(
+    "The workspace manifest file should be named \"pnpm-workspace.yaml\". File found: {}",
+    path.display()
+)]
+#[diagnostic(code(pacquet_workspace::bad_workspace_manifest_name))]
+pub struct BadWorkspaceManifestNameError {
+    pub path: PathBuf,
+}
+
+/// Error type of [`find_workspace_dir`].
+#[derive(Debug, Display, Error, Diagnostic)]
+#[non_exhaustive]
+pub enum FindWorkspaceDirError {
+    #[diagnostic(transparent)]
+    BadName(#[error(source)] BadWorkspaceManifestNameError),
+}
+
+/// Resolve the workspace directory for the given `cwd`.
+///
+/// Returns:
+///
+/// - `Ok(Some(dir))` — the directory containing `pnpm-workspace.yaml`.
+/// - `Ok(None)`      — no workspace manifest in any ancestor.
+/// - `Err(BadName)`  — a misnamed variant (e.g. `pnpm-workspace.yml`)
+///   was found and rejected.
+///
+/// Mirrors upstream's
+/// [`findWorkspaceDir`](https://github.com/pnpm/pnpm/blob/94240bc046/workspace/root-finder/src/index.ts).
+/// The env-var override is read through [`find_workspace_dir_from_env`]
+/// so tests can opt out of process-global state.
+pub fn find_workspace_dir(cwd: &Path) -> Result<Option<PathBuf>, FindWorkspaceDirError> {
+    if let Some(dir) = find_workspace_dir_from_env() {
+        return Ok(Some(dir));
+    }
+    find_workspace_dir_by_walk(cwd)
+}
+
+/// Read `NPM_CONFIG_WORKSPACE_DIR` (and its lowercase spelling) and
+/// return the workspace dir it points at, if any. Exposed separately
+/// so callers can record where the workspace dir came from for
+/// debugging and so tests can avoid the upward walk.
+///
+/// Upstream looks at `process.env[VAR]` and falls through to the
+/// lowercase spelling — Node's process env is case-sensitive on
+/// POSIX but `NPM_CONFIG_*` is conventionally accepted in either
+/// case. The two-step lookup preserves that contract.
+pub fn find_workspace_dir_from_env() -> Option<PathBuf> {
+    env::var_os(WORKSPACE_DIR_ENV_VAR)
+        .or_else(|| env::var_os(WORKSPACE_DIR_ENV_VAR.to_lowercase()))
+        .map(PathBuf::from)
+}
+
+fn find_workspace_dir_by_walk(cwd: &Path) -> Result<Option<PathBuf>, FindWorkspaceDirError> {
+    for dir in cwd.ancestors() {
+        let correct = dir.join(WORKSPACE_MANIFEST_FILENAME);
+        if correct.is_file() {
+            return Ok(Some(dir.to_path_buf()));
+        }
+
+        // Upstream's [`findUp`] inspects the correct filename and each
+        // misnamed variant in one shot at every ancestor. The first
+        // hit at a given level wins, but a misnamed hit raises rather
+        // than being silently treated as "no workspace". Mirror that
+        // by checking the variants only after we've confirmed the
+        // correct file isn't here — otherwise a project with
+        // `pnpm-workspace.yaml` alongside an accidental `.yml` copy
+        // would error instead of working.
+        //
+        // [`findUp`]: https://github.com/sindresorhus/find-up
+        for bad in INVALID_WORKSPACE_MANIFEST_FILENAMES {
+            let candidate = dir.join(bad);
+            if candidate.is_file() {
+                return Err(FindWorkspaceDirError::BadName(BadWorkspaceManifestNameError {
+                    path: candidate,
+                }));
+            }
+        }
+    }
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/workspace/src/root_finder.rs
+++ b/crates/workspace/src/root_finder.rs
@@ -26,6 +26,7 @@ use derive_more::{Display, Error};
 use miette::Diagnostic;
 use std::{
     env,
+    ffi::OsString,
     path::{Path, PathBuf},
 };
 
@@ -105,8 +106,24 @@ pub fn find_workspace_dir(cwd: &Path) -> Result<Option<PathBuf>, FindWorkspaceDi
 /// the upward walk and force the install into an invalid empty
 /// workspace dir.
 pub fn find_workspace_dir_from_env() -> Option<PathBuf> {
-    env::var_os(WORKSPACE_DIR_ENV_VAR)
-        .or_else(|| env::var_os(WORKSPACE_DIR_ENV_VAR.to_lowercase()))
+    find_workspace_dir_from_env_with(|name| env::var_os(name))
+}
+
+/// Variant of [`find_workspace_dir_from_env`] that reads from a
+/// caller-supplied env accessor instead of [`std::env::var_os`].
+///
+/// Exposed for tests: `std::env::set_var` has documented undefined
+/// behavior when other threads access the process environment
+/// concurrently, and Rust's default test runner is multi-threaded.
+/// Threading an accessor through here lets the test exercise the
+/// "empty value falls through" branch without touching the
+/// process-wide env at all.
+pub(crate) fn find_workspace_dir_from_env_with<F>(mut env: F) -> Option<PathBuf>
+where
+    F: FnMut(&str) -> Option<OsString>,
+{
+    env(WORKSPACE_DIR_ENV_VAR)
+        .or_else(|| env(&WORKSPACE_DIR_ENV_VAR.to_lowercase()))
         .filter(|value| !value.is_empty())
         .map(PathBuf::from)
 }

--- a/crates/workspace/src/root_finder.rs
+++ b/crates/workspace/src/root_finder.rs
@@ -97,9 +97,17 @@ pub fn find_workspace_dir(cwd: &Path) -> Result<Option<PathBuf>, FindWorkspaceDi
 /// lowercase spelling — Node's process env is case-sensitive on
 /// POSIX but `NPM_CONFIG_*` is conventionally accepted in either
 /// case. The two-step lookup preserves that contract.
+///
+/// An empty value is treated as unset (matches upstream's truthy
+/// `if (workspaceDir)` check in
+/// <https://github.com/pnpm/pnpm/blob/94240bc046/workspace/root-finder/src/index.ts>).
+/// Without this, an exported-but-empty env var would short-circuit
+/// the upward walk and force the install into an invalid empty
+/// workspace dir.
 pub fn find_workspace_dir_from_env() -> Option<PathBuf> {
     env::var_os(WORKSPACE_DIR_ENV_VAR)
         .or_else(|| env::var_os(WORKSPACE_DIR_ENV_VAR.to_lowercase()))
+        .filter(|value| !value.is_empty())
         .map(PathBuf::from)
 }
 

--- a/crates/workspace/src/root_finder/tests.rs
+++ b/crates/workspace/src/root_finder/tests.rs
@@ -1,6 +1,6 @@
 use super::{
     BadWorkspaceManifestNameError, FindWorkspaceDirError, INVALID_WORKSPACE_MANIFEST_FILENAMES,
-    find_workspace_dir,
+    find_workspace_dir, find_workspace_dir_from_env,
 };
 use crate::WORKSPACE_MANIFEST_FILENAME;
 use pretty_assertions::assert_eq;
@@ -64,4 +64,31 @@ fn correct_filename_wins_over_misnamed_sibling() {
     fs::write(tmp.path().join("pnpm-workspace.yml"), "packages: [bad]\n").unwrap();
     let found = find_workspace_dir(tmp.path()).unwrap();
     assert_eq!(found.as_deref(), Some(tmp.path()));
+}
+
+/// An empty `NPM_CONFIG_WORKSPACE_DIR` must be treated as unset so
+/// the upward walk takes over. Otherwise an exported-but-empty
+/// variable would short-circuit discovery and force the install into
+/// `PathBuf::from("")`. Mirrors upstream's truthy `if (workspaceDir)`
+/// check.
+///
+/// `std::env::set_var` mutates process-wide state, so this test is
+/// `#[serial]`-ish in spirit; in practice no other test in the crate
+/// reads these vars, so we keep it simple and just restore at the end.
+#[test]
+fn empty_env_var_is_treated_as_unset() {
+    use std::env;
+    const VAR: &str = "NPM_CONFIG_WORKSPACE_DIR";
+
+    let prior = env::var_os(VAR);
+    // SAFETY: single-threaded test runner pinpoints this var to one
+    // test process; no other test reads it. Restored below.
+    unsafe { env::set_var(VAR, "") };
+    let result = find_workspace_dir_from_env();
+    // Restore before asserting so a failure doesn't pollute neighbors.
+    match prior {
+        Some(value) => unsafe { env::set_var(VAR, value) },
+        None => unsafe { env::remove_var(VAR) },
+    }
+    assert_eq!(result, None, "empty env var must fall through to the upward walk");
 }

--- a/crates/workspace/src/root_finder/tests.rs
+++ b/crates/workspace/src/root_finder/tests.rs
@@ -1,8 +1,9 @@
 use super::{
     BadWorkspaceManifestNameError, FindWorkspaceDirError, INVALID_WORKSPACE_MANIFEST_FILENAMES,
-    find_workspace_dir, find_workspace_dir_from_env,
+    WORKSPACE_DIR_ENV_VAR, find_workspace_dir, find_workspace_dir_from_env_with,
 };
 use crate::WORKSPACE_MANIFEST_FILENAME;
+use std::ffi::OsString;
 use pretty_assertions::assert_eq;
 use std::fs;
 use tempfile::TempDir;
@@ -72,23 +73,58 @@ fn correct_filename_wins_over_misnamed_sibling() {
 /// `PathBuf::from("")`. Mirrors upstream's truthy `if (workspaceDir)`
 /// check.
 ///
-/// `std::env::set_var` mutates process-wide state, so this test is
-/// `#[serial]`-ish in spirit; in practice no other test in the crate
-/// reads these vars, so we keep it simple and just restore at the end.
+/// `std::env::set_var` has documented UB when other threads access
+/// the process environment concurrently (and Rust tests default to
+/// multi-threaded). The injected accessor on
+/// [`find_workspace_dir_from_env_with`] lets this test exercise the
+/// fall-through branch without touching the process env at all.
 #[test]
 fn empty_env_var_is_treated_as_unset() {
-    use std::env;
-    const VAR: &str = "NPM_CONFIG_WORKSPACE_DIR";
+    let env = |name: &str| -> Option<OsString> {
+        if name == WORKSPACE_DIR_ENV_VAR {
+            Some(OsString::from(""))
+        } else {
+            None
+        }
+    };
+    assert_eq!(
+        find_workspace_dir_from_env_with(env),
+        None,
+        "empty env var must fall through to the upward walk",
+    );
+}
 
-    let prior = env::var_os(VAR);
-    // SAFETY: single-threaded test runner pinpoints this var to one
-    // test process; no other test reads it. Restored below.
-    unsafe { env::set_var(VAR, "") };
-    let result = find_workspace_dir_from_env();
-    // Restore before asserting so a failure doesn't pollute neighbors.
-    match prior {
-        Some(value) => unsafe { env::set_var(VAR, value) },
-        None => unsafe { env::remove_var(VAR) },
-    }
-    assert_eq!(result, None, "empty env var must fall through to the upward walk");
+/// A non-empty value resolves to the workspace dir verbatim, via the
+/// same code path the production accessor uses. Pinning this here
+/// guards the truthy-value side of the fall-through above.
+#[test]
+fn non_empty_env_var_resolves_verbatim() {
+    let env = |name: &str| -> Option<OsString> {
+        if name == WORKSPACE_DIR_ENV_VAR {
+            Some(OsString::from("/explicit/root"))
+        } else {
+            None
+        }
+    };
+    assert_eq!(
+        find_workspace_dir_from_env_with(env),
+        Some(std::path::PathBuf::from("/explicit/root")),
+    );
+}
+
+/// The lowercase spelling is also honored, matching upstream's
+/// `process.env[VAR] ?? process.env[VAR.toLowerCase()]` lookup.
+#[test]
+fn lowercase_env_var_is_honored_as_fallback() {
+    let env = |name: &str| -> Option<OsString> {
+        if name == WORKSPACE_DIR_ENV_VAR.to_lowercase() {
+            Some(OsString::from("/lowercase/root"))
+        } else {
+            None
+        }
+    };
+    assert_eq!(
+        find_workspace_dir_from_env_with(env),
+        Some(std::path::PathBuf::from("/lowercase/root")),
+    );
 }

--- a/crates/workspace/src/root_finder/tests.rs
+++ b/crates/workspace/src/root_finder/tests.rs
@@ -1,0 +1,67 @@
+use super::{
+    BadWorkspaceManifestNameError, FindWorkspaceDirError, INVALID_WORKSPACE_MANIFEST_FILENAMES,
+    find_workspace_dir,
+};
+use crate::WORKSPACE_MANIFEST_FILENAME;
+use pretty_assertions::assert_eq;
+use std::fs;
+use tempfile::TempDir;
+
+/// `pnpm-workspace.yaml` exists at the start dir → returns that dir.
+#[test]
+fn finds_workspace_dir_at_start() {
+    let tmp = TempDir::new().unwrap();
+    fs::write(tmp.path().join(WORKSPACE_MANIFEST_FILENAME), "packages:\n  - pkgs/*\n").unwrap();
+    let found = find_workspace_dir(tmp.path()).unwrap();
+    assert_eq!(found.as_deref(), Some(tmp.path()));
+}
+
+/// Walk up: start dir is a child, manifest lives in an ancestor.
+#[test]
+fn finds_workspace_dir_in_ancestor() {
+    let tmp = TempDir::new().unwrap();
+    let nested = tmp.path().join("packages").join("a");
+    fs::create_dir_all(&nested).unwrap();
+    fs::write(tmp.path().join(WORKSPACE_MANIFEST_FILENAME), "packages:\n  - packages/*\n").unwrap();
+    let found = find_workspace_dir(&nested).unwrap();
+    assert_eq!(found.as_deref(), Some(tmp.path()));
+}
+
+/// No `pnpm-workspace.yaml` anywhere → `Ok(None)` (not an error).
+#[test]
+fn returns_none_when_no_manifest() {
+    let tmp = TempDir::new().unwrap();
+    let found = find_workspace_dir(tmp.path()).unwrap();
+    assert_eq!(found, None);
+}
+
+/// `pnpm-workspace.yml` (or any other misnamed variant) → error.
+/// One sub-test per variant so a failure points at the exact filename.
+#[test]
+fn rejects_invalid_filenames() {
+    for bad in INVALID_WORKSPACE_MANIFEST_FILENAMES {
+        let tmp = TempDir::new().unwrap();
+        let bad_path = tmp.path().join(bad);
+        fs::write(&bad_path, "packages: [a]\n").unwrap();
+        let err = find_workspace_dir(tmp.path()).unwrap_err();
+        match err {
+            FindWorkspaceDirError::BadName(BadWorkspaceManifestNameError { path }) => {
+                assert_eq!(path, bad_path, "bad variant: {bad}");
+            }
+        }
+    }
+}
+
+/// When both the correct file and a misnamed variant are present,
+/// the correct one wins — upstream's `findUp` returns the first match
+/// in pattern order at each level, but the misnamed-variant check
+/// applies only after the correct file is ruled out at the current
+/// level. Same reasoning preserved here.
+#[test]
+fn correct_filename_wins_over_misnamed_sibling() {
+    let tmp = TempDir::new().unwrap();
+    fs::write(tmp.path().join(WORKSPACE_MANIFEST_FILENAME), "packages:\n  - pkgs/*\n").unwrap();
+    fs::write(tmp.path().join("pnpm-workspace.yml"), "packages: [bad]\n").unwrap();
+    let found = find_workspace_dir(tmp.path()).unwrap();
+    assert_eq!(found.as_deref(), Some(tmp.path()));
+}

--- a/crates/workspace/src/root_finder/tests.rs
+++ b/crates/workspace/src/root_finder/tests.rs
@@ -3,8 +3,8 @@ use super::{
     WORKSPACE_DIR_ENV_VAR, find_workspace_dir, find_workspace_dir_from_env_with,
 };
 use crate::WORKSPACE_MANIFEST_FILENAME;
-use std::ffi::OsString;
 use pretty_assertions::assert_eq;
+use std::ffi::OsString;
 use std::fs;
 use tempfile::TempDir;
 
@@ -81,11 +81,7 @@ fn correct_filename_wins_over_misnamed_sibling() {
 #[test]
 fn empty_env_var_is_treated_as_unset() {
     let env = |name: &str| -> Option<OsString> {
-        if name == WORKSPACE_DIR_ENV_VAR {
-            Some(OsString::from(""))
-        } else {
-            None
-        }
+        if name == WORKSPACE_DIR_ENV_VAR { Some(OsString::from("")) } else { None }
     };
     assert_eq!(
         find_workspace_dir_from_env_with(env),
@@ -100,11 +96,7 @@ fn empty_env_var_is_treated_as_unset() {
 #[test]
 fn non_empty_env_var_resolves_verbatim() {
     let env = |name: &str| -> Option<OsString> {
-        if name == WORKSPACE_DIR_ENV_VAR {
-            Some(OsString::from("/explicit/root"))
-        } else {
-            None
-        }
+        if name == WORKSPACE_DIR_ENV_VAR { Some(OsString::from("/explicit/root")) } else { None }
     };
     assert_eq!(
         find_workspace_dir_from_env_with(env),


### PR DESCRIPTION
## Summary

Stage 1 of pnpm/pnpm#11633 / closes pnpm/pacquet#431 (Stage 1 scope) / partially closes pnpm/pacquet#357.

- **New crate `pacquet-workspace`** — ports pnpm's `workspace/root-finder`, `workspace/workspace-manifest-reader`, `workspace/projects-reader`, and `workspace/project-manifest-reader` (pinned to [`94240bc046`](https://github.com/pnpm/pnpm/tree/94240bc046)). `find_workspace_dir` honours `NPM_CONFIG_WORKSPACE_DIR` (and its lowercase spelling, with empty-value fall-through), walks up to `pnpm-workspace.yaml`, and rejects misnamed variants (`pnpm-workspace.yml`, `.pnpm-workspace.yaml`, ...) with `BAD_WORKSPACE_MANIFEST_NAME`. Project enumeration glob-expands `packages:` via `wax`, always includes the workspace root (https://github.com/pnpm/pnpm/issues/1986), filters `**/node_modules/**` + `**/bower_components/**`, sorts lex by `rootDir`, and preserves the omitted-vs-explicit-empty distinction so `packages: []` enumerates only the root rather than falling back to the recursive `['.', '**']` default.

- **Per-importer install path** — `SymlinkDirectDependencies` iterates every entry in `Lockfile.importers`, computes per-project `rootDir` and `node_modules/`, and uses `rootDir` as the `prefix` for `pnpm:root added` events (matching upstream's [`linkDirectDeps`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/linking/direct-dep-linker/src/linkDirectDeps.ts#L131)). Install-wide events (`pnpm:stage`, `pnpm:summary`) still use `lockfileDir`, now resolved through `find_workspace_dir`. `MissingRootImporter` is gone — an empty importers map is a silent no-op. A custom `modulesDir` from `pnpm-workspace.yaml` propagates to every importer (the symlink stage reads `config.modules_dir.file_name()` rather than hard-coding `node_modules`).

- **Path-anchoring consistency** — `Config::current` re-anchors `modules_dir` / `virtual_store_dir` to the workspace root when `pnpm-workspace.yaml` is found in an ancestor, mirroring pnpm v11's `pnpmConfig.dir = lockfileDir`. Running `pacquet install` from a workspace subdirectory no longer produces two inconsistent `node_modules` layouts (subdir virtual store vs workspace-root per-importer symlinks). `Config::current` also honours `NPM_CONFIG_WORKSPACE_DIR` so the env-var override drives both `find_workspace_dir` and the path anchors. `workspace_root` is threaded through `InstallFrozenLockfile` as a real `&Path` (no lossy-UTF-8 round-trip), so non-UTF-8 filenames survive the install layer intact.

- **Lockfile `link:` support** — `ResolvedDependencySpec.version` is now an `ImporterDepVersion` enum (`Regular(PkgVerPeer) | Link(String)`), so a v9 workspace lockfile with `version: link:../shared` parses. The symlink stage resolves the link target against the importer's `rootDir` and points `node_modules/<name>` at the sibling project rather than the virtual store; `BuildModules`, `pacquet-real-hoist`, and the side-effects-cache write path all skip `Link` variants when collecting snapshot-key roots.

- **Importer-key validation** — rejects absolute POSIX paths, Windows drive prefixes, backslash separators, `..` segments, and the empty string with a typed `UnsafeImporterPath` error, so a malformed (or hostile) lockfile cannot make `Path::join` create `node_modules` outside the workspace root.

- **Symlink error propagation** — the prior `expect("symlink pkg")` is replaced with `try_for_each` + a `SymlinkDirectDependenciesError::SymlinkPackage` variant carrying the `importer_id`, `name`, and underlying `SymlinkPackageError`. A filesystem failure no longer crashes the rayon pool.

- **Adds `wax = 0.7.0`** to `[workspace.dependencies]` for project globbing.

## Test plan

- [x] `just ready` — 825 tests pass (2 skipped)
- [x] `taplo format --check` — clean
- [x] `just dylint` (perfectionist) — clean
- [x] 25 new tests in `pacquet-workspace` covering discovery, env-var override (incl. empty-fall-through, lowercase spelling, in-memory injection so no `set_var` UB), manifest parsing (omitted vs explicit-empty `packages:`), and project enumeration (overlap dedup, root-always-included, node_modules ignore, custom defaults)
- [x] New `pacquet-config` tests pin path anchoring: workspace-subdir re-anchors at workspace root, single-project keeps the cwd, `NPM_CONFIG_WORKSPACE_DIR` re-anchors, empty env-var falls through (`EnvGuard` so concurrent tests don't race)
- [x] `pacquet-lockfile` round-trips a workspace lockfile with a `workspace:*` → `link:../shared` dep, and pins `ImporterDepVersion::{Regular, Link}` parsing
- [x] `pacquet-package-manager` covers per-importer `pnpm:root` prefix, cross-importer `link:` symlink targets, custom `modulesDir` propagation, unsafe-importer-key rejection (7 shapes, no filesystem writes), and empty-importers no-op

## Out of scope (Stage 2 of pnpm/pnpm#11633)

- `--filter` / `--filter-prod` / change-based filtering
- `projects-graph` + topological sort across local packages
- `engines` / `os` / `cpu` installability filtering at project enumeration (separate from the per-snapshot filter that already landed in pnpm/pacquet#439)
- The `resolutions`-on-non-root warning
- Real-path resolution of `rootDir` for case-insensitive filesystems

---
Written by an agent (Claude Code, claude-opus-4-7).
