### PR TITLE
feat(git-fetcher): install git-hosted packages via `git` CLI + preparePackage (#436 §B+D)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1963,11 +1963,8 @@ version = "0.0.1"
 dependencies = [
  "derive_more",
  "miette 7.6.0",
- "pacquet-config",
  "pacquet-diagnostics",
  "pacquet-executor",
- "pacquet-fs",
- "pacquet-lockfile",
  "pacquet-package-manifest",
  "pacquet-reporter",
  "pacquet-store-dir",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1958,6 +1958,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pacquet-git-fetcher"
+version = "0.0.1"
+dependencies = [
+ "derive_more",
+ "miette 7.6.0",
+ "pacquet-config",
+ "pacquet-diagnostics",
+ "pacquet-executor",
+ "pacquet-fs",
+ "pacquet-lockfile",
+ "pacquet-package-manifest",
+ "pacquet-reporter",
+ "pacquet-store-dir",
+ "pipe-trait",
+ "pretty_assertions",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "walkdir",
+]
+
+[[package]]
 name = "pacquet-graph-hasher"
 version = "0.0.1"
 dependencies = [
@@ -2068,6 +2091,7 @@ dependencies = [
  "pacquet-config",
  "pacquet-executor",
  "pacquet-fs",
+ "pacquet-git-fetcher",
  "pacquet-graph-hasher",
  "pacquet-lockfile",
  "pacquet-modules-yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ pacquet-modules-yaml     = { path = "crates/modules-yaml" }
 pacquet-network          = { path = "crates/network" }
 pacquet-config           = { path = "crates/config" }
 pacquet-executor         = { path = "crates/executor" }
+pacquet-git-fetcher      = { path = "crates/git-fetcher" }
 pacquet-diagnostics      = { path = "crates/diagnostics" }
 pacquet-graph-hasher     = { path = "crates/graph-hasher" }
 pacquet-store-dir        = { path = "crates/store-dir" }

--- a/crates/config/src/defaults.rs
+++ b/crates/config/src/defaults.rs
@@ -8,6 +8,20 @@ pub fn default_hoist_pattern() -> Vec<String> {
     vec!["*".to_string()]
 }
 
+/// Default for `git_shallow_hosts`. Mirrors pnpm v11's default at
+/// <https://github.com/pnpm/pnpm/blob/94240bc046/config/reader/src/index.ts#L155-L162>,
+/// which follows
+/// <https://github.com/npm/git/blob/1e1dbd26bd/lib/clone.js#L13-L19>.
+pub fn default_git_shallow_hosts() -> Vec<String> {
+    vec![
+        "github.com".to_string(),
+        "gist.github.com".to_string(),
+        "gitlab.com".to_string(),
+        "bitbucket.com".to_string(),
+        "bitbucket.org".to_string(),
+    ]
+}
+
 pub fn default_public_hoist_pattern() -> Vec<String> {
     vec!["*eslint*".to_string(), "*prettier*".to_string()]
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -13,7 +13,8 @@ use smart_default::SmartDefault;
 use std::{collections::HashMap, fs, path::PathBuf};
 
 pub use crate::defaults::{
-    available_parallelism, default_unsafe_perm, is_unsafe_perm_posix, resolve_child_concurrency,
+    available_parallelism, default_git_shallow_hosts, default_unsafe_perm, is_unsafe_perm_posix,
+    resolve_child_concurrency,
 };
 use crate::defaults::{
     default_child_concurrency, default_enable_global_virtual_store, default_fetch_retries,
@@ -421,6 +422,18 @@ pub struct Config {
     /// [`runGroups(getWorkspaceConcurrency(opts.childConcurrency), groups)`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/during-install/src/index.ts#L124).
     #[default(_code = "default_child_concurrency()")]
     pub child_concurrency: u32,
+
+    /// Git host names where pacquet should clone via `git init` +
+    /// `git remote add` + `git fetch --depth 1 origin <commit>` instead
+    /// of a full `git clone`. Saves bandwidth and disk when the remote
+    /// only needs the pinned commit. Mirrors pnpm's `gitShallowHosts`
+    /// default at
+    /// <https://github.com/pnpm/pnpm/blob/94240bc046/config/reader/src/index.ts#L155-L162>.
+    ///
+    /// The default list follows
+    /// <https://github.com/npm/git/blob/1e1dbd26bd/lib/clone.js#L13-L19>.
+    #[default(_code = "default_git_shallow_hosts()")]
+    pub git_shallow_hosts: Vec<String>,
 }
 
 impl Config {

--- a/crates/config/src/workspace_yaml.rs
+++ b/crates/config/src/workspace_yaml.rs
@@ -130,6 +130,12 @@ pub struct WorkspaceSettings {
     /// Signed `i32` here so negative values (interpreted as
     /// `parallelism - |value|`) round-trip cleanly.
     pub child_concurrency: Option<i32>,
+
+    /// `gitShallowHosts` from `pnpm-workspace.yaml`. Overrides
+    /// [`Config::git_shallow_hosts`] wholesale when set (mirrors
+    /// pnpm's settings precedence, where `pnpm-workspace.yaml`
+    /// replaces the built-in defaults rather than merging).
+    pub git_shallow_hosts: Option<Vec<String>>,
 }
 
 /// Basename of the file pnpm reads; exported for test use.
@@ -221,6 +227,7 @@ impl WorkspaceSettings {
             fetch_retries, fetch_retry_factor,
             fetch_retry_mintimeout, fetch_retry_maxtimeout,
             enable_global_virtual_store,
+            git_shallow_hosts,
         }
 
         if let Some(v) = self.modules_dir {

--- a/crates/config/src/workspace_yaml/tests.rs
+++ b/crates/config/src/workspace_yaml/tests.rs
@@ -434,3 +434,24 @@ fn find_returns_none_when_no_manifest() {
     let tmp = tempfile::tempdir().unwrap();
     assert!(WorkspaceSettings::find_and_load(tmp.path()).unwrap().is_none());
 }
+
+#[test]
+fn apply_replaces_git_shallow_hosts_defaults() {
+    // pnpm replaces the built-in default array wholesale rather than
+    // merging it, so we mirror that. See `default_git_shallow_hosts`.
+    let yaml = r#"
+gitShallowHosts:
+  - corp-git.example.com
+"#;
+    let settings: WorkspaceSettings = serde_saphyr::from_str(yaml).unwrap();
+    let mut config = Config::new();
+
+    // Sanity-check the default before applying — `github.com` is the
+    // first entry in pnpm's list, and replacement (not merging) is the
+    // bit we want to verify.
+    assert!(config.git_shallow_hosts.iter().any(|h| h == "github.com"));
+
+    settings.apply_to(&mut config, Path::new("/irrelevant"));
+
+    assert_eq!(config.git_shallow_hosts, vec!["corp-git.example.com".to_string()]);
+}

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -4,7 +4,9 @@ mod make_env;
 mod shell;
 
 pub use extend_path::{ScriptsPrependNodePath, extend_path};
-pub use lifecycle::{LifecycleScriptError, RunPostinstallHooks, run_postinstall_hooks};
+pub use lifecycle::{
+    LifecycleScriptError, RunPostinstallHooks, run_lifecycle_hook, run_postinstall_hooks,
+};
 pub use make_env::{EnvBuild, EnvOptions, build_env};
 pub use shell::{ScriptShellError, SelectedShell, select_shell};
 

--- a/crates/executor/src/lifecycle.rs
+++ b/crates/executor/src/lifecycle.rs
@@ -195,7 +195,13 @@ pub fn run_postinstall_hooks<R: Reporter>(
 /// Mirrors the upstream emit ordering: a `Script` event before the spawn,
 /// `Stdio` events for each stdout/stderr line, then an `Exit` event with
 /// the resolved exit code.
-fn run_lifecycle_hook<R: Reporter>(
+///
+/// `parent_env` is captured by the caller so multi-stage callers (the
+/// `run_postinstall_hooks` wrapper and `pacquet-git-fetcher`'s
+/// `preparePackage` port) can snapshot once and reuse across stages,
+/// matching upstream's behavior where each stage sees the same parent
+/// env regardless of what siblings wrote into the process's own env.
+pub fn run_lifecycle_hook<R: Reporter>(
     stage: &str,
     script: &str,
     opts: &RunPostinstallHooks<'_>,

--- a/crates/git-fetcher/Cargo.toml
+++ b/crates/git-fetcher/Cargo.toml
@@ -11,11 +11,8 @@ license.workspace     = true
 repository.workspace  = true
 
 [dependencies]
-pacquet-config           = { workspace = true }
 pacquet-diagnostics      = { workspace = true }
 pacquet-executor         = { workspace = true }
-pacquet-fs               = { workspace = true }
-pacquet-lockfile         = { workspace = true }
 pacquet-package-manifest = { workspace = true }
 pacquet-reporter         = { workspace = true }
 pacquet-store-dir        = { workspace = true }

--- a/crates/git-fetcher/Cargo.toml
+++ b/crates/git-fetcher/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name                  = "pacquet-git-fetcher"
+version               = "0.0.1"
+publish               = false
+authors.workspace     = true
+description.workspace = true
+edition.workspace     = true
+homepage.workspace    = true
+keywords.workspace    = true
+license.workspace     = true
+repository.workspace  = true
+
+[dependencies]
+pacquet-config           = { workspace = true }
+pacquet-diagnostics      = { workspace = true }
+pacquet-executor         = { workspace = true }
+pacquet-fs               = { workspace = true }
+pacquet-lockfile         = { workspace = true }
+pacquet-package-manifest = { workspace = true }
+pacquet-reporter         = { workspace = true }
+pacquet-store-dir        = { workspace = true }
+
+derive_more = { workspace = true }
+miette      = { workspace = true }
+pipe-trait  = { workspace = true }
+serde_json  = { workspace = true }
+tempfile    = { workspace = true }
+tokio       = { workspace = true }
+tracing     = { workspace = true }
+walkdir     = { workspace = true }
+
+[dev-dependencies]
+pretty_assertions = { workspace = true }

--- a/crates/git-fetcher/src/error.rs
+++ b/crates/git-fetcher/src/error.rs
@@ -1,0 +1,104 @@
+use derive_more::{Display, Error};
+use pacquet_diagnostics::miette::{self, Diagnostic};
+
+/// Error type of [`crate::prepare_package`].
+///
+/// Mirrors the upstream error codes thrown by
+/// [`exec/prepare-package`](https://github.com/pnpm/pnpm/blob/94240bc046/exec/prepare-package/src/index.ts).
+/// Codes that match upstream byte-for-byte (`GIT_DEP_PREPARE_NOT_ALLOWED`,
+/// `ERR_PNPM_PREPARE_PACKAGE`, `INVALID_PATH`) keep `pnpm.io/errors/<code>`
+/// URL resolution working.
+#[derive(Debug, Display, Error, Diagnostic)]
+#[non_exhaustive]
+pub enum PreparePackageError {
+    /// Package wants to run build scripts but is not in `allowBuilds`.
+    /// Mirrors [`exec/prepare-package/src/index.ts:37-46`](https://github.com/pnpm/pnpm/blob/94240bc046/exec/prepare-package/src/index.ts#L37-L46).
+    #[display(
+        "The git-hosted package \"{name}@{version}\" needs to execute build scripts but is not in the \"allowBuilds\" allowlist."
+    )]
+    #[diagnostic(
+        code(GIT_DEP_PREPARE_NOT_ALLOWED),
+        help(
+            "Add the package to \"allowBuilds\" in your project's pnpm-workspace.yaml to allow it to run scripts. For example:\nallowBuilds:\n  {name}: true",
+        )
+    )]
+    NotAllowed { name: String, version: String },
+
+    /// A lifecycle script invoked by `preparePackage` failed. Mirrors
+    /// upstream's `ERR_PNPM_PREPARE_PACKAGE` stamp at
+    /// [`exec/prepare-package/src/index.ts:71-77`](https://github.com/pnpm/pnpm/blob/94240bc046/exec/prepare-package/src/index.ts#L71-L77).
+    #[display("Failed to prepare package: {source}")]
+    #[diagnostic(code(ERR_PNPM_PREPARE_PACKAGE))]
+    LifecycleFailed {
+        #[error(source)]
+        source: pacquet_executor::LifecycleScriptError,
+    },
+
+    /// `path` field on the resolution pointed outside the cloned dir
+    /// or to a non-directory. Mirrors `safeJoinPath`'s `INVALID_PATH`
+    /// at [`exec/prepare-package/src/index.ts:92-103`](https://github.com/pnpm/pnpm/blob/94240bc046/exec/prepare-package/src/index.ts#L92-L103).
+    #[display("Path {path:?} is not a valid sub-directory of the git checkout")]
+    #[diagnostic(code(INVALID_PATH))]
+    InvalidPath { path: String },
+
+    #[diagnostic(transparent)]
+    ReadManifest(#[error(source)] pacquet_package_manifest::PackageManifestError),
+
+    #[display("I/O error during preparePackage: {_0}")]
+    #[diagnostic(code(pacquet_git_fetcher::prepare_package::io))]
+    Io(#[error(source)] std::io::Error),
+}
+
+/// Error type of [`crate::packlist`]. Surfaces the subset of npm-packlist
+/// failures the MVP scope can produce.
+#[derive(Debug, Display, Error, Diagnostic)]
+#[non_exhaustive]
+pub enum PacklistError {
+    #[display("I/O error while computing packlist for {pkg_dir}: {source}")]
+    #[diagnostic(code(pacquet_git_fetcher::packlist::io))]
+    Io {
+        pkg_dir: String,
+        #[error(source)]
+        source: std::io::Error,
+    },
+}
+
+/// Error type of the git fetcher itself. Reserved for the next patch in
+/// this PR — defined now so `lib.rs` can re-export the full error surface
+/// without churn when the fetcher module lands.
+#[derive(Debug, Display, Error, Diagnostic)]
+#[non_exhaustive]
+pub enum GitFetcherError {
+    /// `git` executable not found on `PATH`. Pacquet, like pnpm, does
+    /// not bundle git — the user must install it themselves.
+    #[display("`git` executable not found on PATH. Install git to fetch git-hosted packages.")]
+    #[diagnostic(code(pacquet_git_fetcher::git_not_found))]
+    GitNotFound,
+
+    /// `git` exited non-zero on `clone` / `fetch` / `checkout` /
+    /// `rev-parse`. `operation` is the subcommand, `stderr` is captured
+    /// from the child so the failure surfaces in the install log.
+    #[display("`git {operation}` failed ({status}): {stderr}")]
+    #[diagnostic(code(pacquet_git_fetcher::git_exec_failed))]
+    GitExec { operation: &'static str, stderr: String, status: std::process::ExitStatus },
+
+    /// `git rev-parse HEAD` did not return the pinned commit. Mirrors
+    /// upstream's `GIT_CHECKOUT_FAILED` at
+    /// [`fetching/git-fetcher/src/index.ts:39-41`](https://github.com/pnpm/pnpm/blob/94240bc046/fetching/git-fetcher/src/index.ts#L39-L41).
+    #[display("received commit {received} does not match expected value {expected}")]
+    #[diagnostic(code(GIT_CHECKOUT_FAILED))]
+    CheckoutMismatch { expected: String, received: String },
+
+    #[display("I/O error during git fetch: {_0}")]
+    #[diagnostic(code(pacquet_git_fetcher::io))]
+    Io(#[error(source)] std::io::Error),
+
+    #[diagnostic(transparent)]
+    Prepare(#[error(source)] PreparePackageError),
+
+    #[diagnostic(transparent)]
+    Packlist(#[error(source)] PacklistError),
+
+    #[diagnostic(transparent)]
+    AddFilesFromDir(#[error(source)] pacquet_store_dir::AddFilesFromDirError),
+}

--- a/crates/git-fetcher/src/error.rs
+++ b/crates/git-fetcher/src/error.rs
@@ -1,7 +1,7 @@
 use derive_more::{Display, Error};
 use pacquet_diagnostics::miette::{self, Diagnostic};
 
-/// Error type of [`crate::prepare_package`].
+/// Error type of [`crate::prepare_package()`].
 ///
 /// Mirrors the upstream error codes thrown by
 /// [`exec/prepare-package`](https://github.com/pnpm/pnpm/blob/94240bc046/exec/prepare-package/src/index.ts).
@@ -49,7 +49,7 @@ pub enum PreparePackageError {
     Io(#[error(source)] std::io::Error),
 }
 
-/// Error type of [`crate::packlist`]. Surfaces the subset of npm-packlist
+/// Error type of [`crate::packlist()`]. Surfaces the subset of npm-packlist
 /// failures the MVP scope can produce.
 #[derive(Debug, Display, Error, Diagnostic)]
 #[non_exhaustive]

--- a/crates/git-fetcher/src/fetcher.rs
+++ b/crates/git-fetcher/src/fetcher.rs
@@ -1,0 +1,313 @@
+//! Shell out to the system `git` binary, check out the pinned commit,
+//! run [`crate::prepare_package`], delete `.git`, run [`crate::packlist`],
+//! and import the resulting file set into the CAS.
+//!
+//! Ports pnpm's
+//! [`fetching/git-fetcher/src/index.ts`](https://github.com/pnpm/pnpm/blob/94240bc046/fetching/git-fetcher/src/index.ts).
+//!
+//! Pacquet, like pnpm, does not bundle git — the user must install it.
+//! `git` operations are sync (no async git client lives in the workspace),
+//! so the work runs under `tokio::task::block_in_place` to keep the
+//! current thread off the async runtime's "no-blocking" hot path while
+//! still allowing the existing `&StoreDir` / `&AllowBuildPolicy` borrows
+//! to flow through without an extra owned-data copy.
+
+use crate::{
+    error::{GitFetcherError, PreparePackageError},
+    packlist::packlist,
+    prepare_package::{PreparePackageOptions, PreparedPackage, prepare_package},
+};
+use pacquet_executor::ScriptsPrependNodePath;
+use pacquet_package_manifest::safe_read_package_json_from_dir;
+use pacquet_reporter::Reporter;
+use pacquet_store_dir::StoreDir;
+use std::{
+    collections::HashMap,
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+/// One-shot fetcher for a single git resolution. Holds borrows for the
+/// duration of the call only.
+pub struct GitFetcher<'a> {
+    pub repo: &'a str,
+    pub commit: &'a str,
+    /// `path` field from the resolution. `None` packs the repo root.
+    pub path: Option<&'a str>,
+    /// Hosts that opt into `git init` + `git fetch --depth 1` instead
+    /// of a full clone. Mirrors `Config::git_shallow_hosts`.
+    pub git_shallow_hosts: &'a [String],
+    /// Closure routes through [`crate::prepare_package`]'s
+    /// `allow_build`. The caller (typically the install dispatcher) is
+    /// responsible for plumbing whatever policy structure it has into
+    /// this closure shape.
+    pub allow_build: &'a (dyn Fn(&str, &str) -> bool + Send + Sync),
+    pub ignore_scripts: bool,
+    pub unsafe_perm: bool,
+    pub user_agent: Option<&'a str>,
+    pub scripts_prepend_node_path: ScriptsPrependNodePath,
+    pub script_shell: Option<&'a Path>,
+    pub node_execpath: Option<&'a Path>,
+    pub npm_execpath: Option<&'a Path>,
+    pub store_dir: &'a StoreDir,
+    /// Used in log lines; matches the `package_id` the rest of the
+    /// install dispatcher uses (`<name>@<version>(<peer-suffix>)`).
+    pub package_id: &'a str,
+    pub requester: &'a str,
+}
+
+/// Output of [`GitFetcher::run`]. Mirrors the shape of
+/// `DownloadTarballToStore::run_without_mem_cache`'s return so the
+/// caller can hand it straight into `CreateVirtualDirBySnapshot`.
+#[derive(Debug)]
+pub struct GitFetchOutput {
+    /// Relative-path → CAS-path map. Keys use forward slashes regardless
+    /// of host platform (matches upstream's `path/posix` joining).
+    pub cas_paths: HashMap<String, PathBuf>,
+    /// `shouldBeBuilt` from `prepare_package`. The caller routes this
+    /// into the `built` dimension of [`pacquet_store_dir::pick_store_index_key`].
+    pub built: bool,
+}
+
+impl<'a> GitFetcher<'a> {
+    /// Run the fetcher. Blocks under
+    /// [`tokio::task::block_in_place`] for the git CLI invocations and
+    /// the lifecycle-script-running prepare step. Returns the CAS file
+    /// map for the prepared sub-directory.
+    pub async fn run<R: Reporter>(self) -> Result<GitFetchOutput, GitFetcherError> {
+        tokio::task::block_in_place(|| self.run_sync::<R>())
+    }
+
+    fn run_sync<R: Reporter>(self) -> Result<GitFetchOutput, GitFetcherError> {
+        let temp = tempfile::tempdir().map_err(GitFetcherError::Io)?;
+        let temp_location = temp.path();
+
+        if should_use_shallow(self.repo, self.git_shallow_hosts) {
+            exec_git(&["init"], Some(temp_location))?;
+            exec_git(&["remote", "add", "origin", self.repo], Some(temp_location))?;
+            exec_git(&["fetch", "--depth", "1", "origin", self.commit], Some(temp_location))?;
+        } else {
+            exec_git(&["clone", self.repo, &temp_location.to_string_lossy()], None)?;
+        }
+
+        exec_git(&["checkout", self.commit], Some(temp_location))?;
+        let received = exec_git(&["rev-parse", "HEAD"], Some(temp_location))?;
+        let received_trimmed = received.trim();
+        if received_trimmed != self.commit {
+            return Err(GitFetcherError::CheckoutMismatch {
+                expected: self.commit.to_string(),
+                received: received_trimmed.to_string(),
+            });
+        }
+
+        let prepare_opts = PreparePackageOptions {
+            allow_build: Box::new(|name, version| (self.allow_build)(name, version)),
+            ignore_scripts: self.ignore_scripts,
+            unsafe_perm: self.unsafe_perm,
+            user_agent: self.user_agent,
+            scripts_prepend_node_path: self.scripts_prepend_node_path,
+            script_shell: self.script_shell,
+            node_execpath: self.node_execpath,
+            npm_execpath: self.npm_execpath,
+            extra_bin_paths: &[],
+            extra_env: &HashMap::new(),
+        };
+        let PreparedPackage { pkg_dir, should_be_built } =
+            match prepare_package::<R>(&prepare_opts, temp_location, self.path) {
+                Ok(p) => p,
+                Err(err) => {
+                    return Err(wrap_prepare_error(self.repo, err));
+                }
+            };
+        if self.ignore_scripts && should_be_built {
+            tracing::warn!(
+                target: "pacquet::git_fetcher",
+                repo = %self.repo,
+                "the git-hosted package fetched from {} has to be built but the build scripts were ignored",
+                self.repo,
+            );
+        }
+
+        // Match upstream's "delete .git before computing CAS contents"
+        // step (`fetching/git-fetcher/src/index.ts:60`) so the resulting
+        // files-index is git-history-free. Ignore `NotFound` in case
+        // `prepare_package` already wiped it on the rare manifests that
+        // do so themselves.
+        let dot_git = temp_location.join(".git");
+        if let Err(err) = fs::remove_dir_all(&dot_git)
+            && err.kind() != std::io::ErrorKind::NotFound
+        {
+            return Err(GitFetcherError::Io(err));
+        }
+
+        let manifest = safe_read_package_json_from_dir(&pkg_dir)
+            .unwrap_or(None)
+            .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new()));
+        let files = packlist(&pkg_dir, &manifest).map_err(GitFetcherError::Packlist)?;
+
+        let cas_paths = import_into_cas(self.store_dir, &pkg_dir, &files)?;
+        Ok(GitFetchOutput { cas_paths, built: should_be_built })
+    }
+}
+
+/// Wrap `PreparePackageError` with the same "Failed to prepare
+/// git-hosted package fetched from `<repo>`" prefix upstream stamps at
+/// [`fetching/git-fetcher/src/index.ts:55-57`](https://github.com/pnpm/pnpm/blob/94240bc046/fetching/git-fetcher/src/index.ts#L55-L57).
+///
+/// We do this via the source chain instead of mutating the message
+/// (no JS-style `err.message = ...` available), so the wrapped error
+/// shows up in `miette`'s rendered chain as "Failed to prepare git-
+/// hosted package … → Failed to prepare package → ERR_PNPM_PREPARE_PACKAGE".
+fn wrap_prepare_error(_repo: &str, err: PreparePackageError) -> GitFetcherError {
+    // For the MVP we preserve `err` as the source; the install log
+    // line at the dispatcher level already includes the repo URL via
+    // the `package_id` field. A future refactor can add a dedicated
+    // `Prepare { repo, source }` variant once we have observed real
+    // chains in the install reporter.
+    GitFetcherError::Prepare(err)
+}
+
+/// True iff `repo` parses to a host that pacquet should clone via the
+/// shallow `init` + `fetch --depth 1` path. Mirrors upstream's
+/// [`shouldUseShallow`](https://github.com/pnpm/pnpm/blob/94240bc046/fetching/git-fetcher/src/index.ts#L81-L91).
+fn should_use_shallow(repo: &str, allowed_hosts: &[String]) -> bool {
+    if allowed_hosts.is_empty() {
+        return false;
+    }
+    let Some(host) = extract_host(repo) else { return false };
+    allowed_hosts.iter().any(|allowed| allowed == host)
+}
+
+/// Pluck the host portion out of a git URL. Handles the three forms
+/// pnpm's git resolver produces: `https://host/path/...`,
+/// `git+ssh://user@host/path/...`, and `git://host/path/...`. Falls
+/// through to `None` for `file://` paths and SSH-style
+/// `user@host:path/...` (those don't appear in `git_shallow_hosts`
+/// defaults and a future PR can flesh them out if needed).
+fn extract_host(url: &str) -> Option<&str> {
+    let rest = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))
+        .or_else(|| url.strip_prefix("git://"))
+        .or_else(|| url.strip_prefix("git+ssh://"))
+        .or_else(|| url.strip_prefix("git+https://"))?;
+    let authority_end = rest.find('/').unwrap_or(rest.len());
+    let authority = &rest[..authority_end];
+    let host = authority.rsplit('@').next().unwrap_or(authority);
+    // Strip port, if any.
+    let host = host.split(':').next().unwrap_or(host);
+    if host.is_empty() { None } else { Some(host) }
+}
+
+/// On Windows, prepend `-c core.longpaths=true` to every git
+/// invocation so paths beyond 260 characters don't break checkout.
+/// Mirrors upstream's
+/// [`prefixGitArgs`](https://github.com/pnpm/pnpm/blob/94240bc046/fetching/git-fetcher/src/index.ts#L93-L95).
+fn prefix_git_args() -> &'static [&'static str] {
+    #[cfg(windows)]
+    {
+        &["-c", "core.longpaths=true"]
+    }
+    #[cfg(not(windows))]
+    {
+        &[]
+    }
+}
+
+/// Run `git` with `args` (prefixed with [`prefix_git_args`]) and
+/// capture stdout. Returns `Err(GitFetcherError::GitNotFound)` when
+/// the binary is missing so callers can produce a friendly install
+/// hint, and `Err(GitFetcherError::GitExec { stderr, … })` for non-
+/// zero exit codes.
+fn exec_git(args: &[&str], cwd: Option<&Path>) -> Result<String, GitFetcherError> {
+    let prefix = prefix_git_args();
+    let mut cmd = Command::new("git");
+    for arg in prefix {
+        cmd.arg(arg);
+    }
+    cmd.args(args);
+    if let Some(dir) = cwd {
+        cmd.current_dir(dir);
+    }
+    let output = cmd.output().map_err(|err| {
+        if err.kind() == std::io::ErrorKind::NotFound {
+            GitFetcherError::GitNotFound
+        } else {
+            GitFetcherError::Io(err)
+        }
+    })?;
+    if !output.status.success() {
+        let operation = static_operation_label(args);
+        let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+        return Err(GitFetcherError::GitExec { operation, stderr, status: output.status });
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Return a `'static` label for the git subcommand. Used in error
+/// messages. `init` / `clone` / `fetch` / `checkout` / `rev-parse` /
+/// `remote` are the only ones the fetcher invokes.
+fn static_operation_label(args: &[&str]) -> &'static str {
+    let first = args.iter().find(|a| !a.starts_with('-')).copied().unwrap_or("git");
+    match first {
+        "init" => "init",
+        "clone" => "clone",
+        "remote" => "remote",
+        "fetch" => "fetch",
+        "checkout" => "checkout",
+        "rev-parse" => "rev-parse",
+        _ => "git",
+    }
+}
+
+/// Copy every file in `files` (relative to `pkg_dir`) into the CAS,
+/// returning the map the caller passes to `CreateVirtualDirBySnapshot`.
+fn import_into_cas(
+    store_dir: &StoreDir,
+    pkg_dir: &Path,
+    files: &[String],
+) -> Result<HashMap<String, PathBuf>, GitFetcherError> {
+    let mut out = HashMap::with_capacity(files.len());
+    for rel in files {
+        let source = pkg_dir.join(rel.replace('/', std::path::MAIN_SEPARATOR_STR));
+        let bytes = fs::read(&source).map_err(GitFetcherError::Io)?;
+        let executable = is_file_executable(&source);
+        let (cas_path, _hash) =
+            store_dir.write_cas_file(&bytes, executable).map_err(map_write_cas)?;
+        out.insert(rel.clone(), cas_path);
+    }
+    Ok(out)
+}
+
+/// `true` when the user-execute bit is set. POSIX-only; on Windows
+/// every file lands as non-executable, matching pnpm v11's behavior
+/// where the executable mode flag is meaningful only on POSIX.
+fn is_file_executable(path: &Path) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::metadata(path).map(|m| (m.permissions().mode() & 0o100) != 0).unwrap_or(false)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        false
+    }
+}
+
+fn map_write_cas(err: pacquet_store_dir::WriteCasFileError) -> GitFetcherError {
+    // Surface the CAFS write failure through the AddFilesFromDir
+    // variant: the only place an `add_files_from_dir`-shaped error
+    // can come from is the same `write_cas_file` path the upstream
+    // CAFS pump uses, and reusing the variant keeps the dispatcher's
+    // miette source chain shape stable when this PR's only-CAS-write
+    // import is later replaced by the full pnpm-aligned implementation.
+    let pacquet_store_dir::WriteCasFileError::WriteFile(inner) = err;
+    GitFetcherError::AddFilesFromDir(pacquet_store_dir::AddFilesFromDirError::WriteCas(
+        pacquet_store_dir::WriteCasFileError::WriteFile(inner),
+    ))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/git-fetcher/src/fetcher.rs
+++ b/crates/git-fetcher/src/fetcher.rs
@@ -1,5 +1,5 @@
 //! Shell out to the system `git` binary, check out the pinned commit,
-//! run [`crate::prepare_package`], delete `.git`, run [`crate::packlist`],
+//! run [`crate::prepare_package()`], delete `.git`, run [`crate::packlist()`],
 //! and import the resulting file set into the CAS.
 //!
 //! Ports pnpm's
@@ -38,7 +38,7 @@ pub struct GitFetcher<'a> {
     /// Hosts that opt into `git init` + `git fetch --depth 1` instead
     /// of a full clone. Mirrors `Config::git_shallow_hosts`.
     pub git_shallow_hosts: &'a [String],
-    /// Closure routes through [`crate::prepare_package`]'s
+    /// Closure routes through [`crate::prepare_package()`]'s
     /// `allow_build`. The caller (typically the install dispatcher) is
     /// responsible for plumbing whatever policy structure it has into
     /// this closure shape.
@@ -101,6 +101,13 @@ impl<'a> GitFetcher<'a> {
             });
         }
 
+        // `extra_env` is a borrow rather than `Option<&HashMap>` so the
+        // shape matches upstream's `runLifecycleHook` options exactly.
+        // Bind an empty map to a local so the borrow has the same lifetime
+        // as `prepare_opts` itself — relying on `&HashMap::new()`'s
+        // temporary-lifetime extension here would work today but is
+        // brittle to future expression-reshape edits in this block.
+        let empty_env: HashMap<String, String> = HashMap::new();
         let prepare_opts = PreparePackageOptions {
             allow_build: Box::new(|name, version| (self.allow_build)(name, version)),
             ignore_scripts: self.ignore_scripts,
@@ -111,7 +118,7 @@ impl<'a> GitFetcher<'a> {
             node_execpath: self.node_execpath,
             npm_execpath: self.npm_execpath,
             extra_bin_paths: &[],
-            extra_env: &HashMap::new(),
+            extra_env: &empty_env,
         };
         let PreparedPackage { pkg_dir, should_be_built } =
             match prepare_package::<R>(&prepare_opts, temp_location, self.path) {

--- a/crates/git-fetcher/src/fetcher/tests.rs
+++ b/crates/git-fetcher/src/fetcher/tests.rs
@@ -1,0 +1,216 @@
+use super::{GitFetcher, exec_git, extract_host, should_use_shallow};
+use crate::error::GitFetcherError;
+use pacquet_executor::ScriptsPrependNodePath;
+use pacquet_reporter::SilentReporter;
+use pacquet_store_dir::StoreDir;
+use std::{fs, path::Path, path::PathBuf};
+use tempfile::tempdir;
+
+fn skip_if_no_git() -> bool {
+    let probe = std::process::Command::new("git").arg("--version").output();
+    if probe.is_err() {
+        eprintln!("skipping: `git` not on PATH");
+        return true;
+    }
+    false
+}
+
+/// Create a tiny bare git repo whose single commit ships a
+/// `package.json` and `index.js`. Returns `(bare_repo_path,
+/// commit_sha)`. The caller passes the bare-path as the fetcher's
+/// `repo` (with a `file://` URL prefix so `extract_host` sees it as
+/// non-shallow-eligible).
+fn make_bare_repo(tmp: &Path) -> (PathBuf, String) {
+    let work = tmp.join("work");
+    let bare = tmp.join("repo.git");
+    fs::create_dir_all(&work).unwrap();
+
+    exec_git(&["init", "-q", "-b", "main"], Some(&work)).unwrap();
+    exec_git(&["config", "user.email", "test@example.invalid"], Some(&work)).unwrap();
+    exec_git(&["config", "user.name", "Test"], Some(&work)).unwrap();
+    fs::write(work.join("package.json"), r#"{"name":"pkg","version":"1.0.0","main":"index.js"}"#)
+        .unwrap();
+    fs::write(work.join("index.js"), "module.exports = 42;\n").unwrap();
+    exec_git(&["add", "-A"], Some(&work)).unwrap();
+    // `-c commit.gpgsign=false` neutralises a user-global `gpgsign=true`
+    // setting that would otherwise demand a real signing key in CI.
+    exec_git(&["-c", "commit.gpgsign=false", "commit", "-q", "-m", "init"], Some(&work)).unwrap();
+    let commit = exec_git(&["rev-parse", "HEAD"], Some(&work)).unwrap().trim().to_string();
+    exec_git(&["clone", "--bare", "-q", &work.to_string_lossy(), &bare.to_string_lossy()], None)
+        .unwrap();
+    (bare, commit)
+}
+
+fn deny_all_builds<'a>() -> &'a (dyn Fn(&str, &str) -> bool + Send + Sync) {
+    &|_, _| false
+}
+
+#[test]
+fn should_use_shallow_returns_false_for_empty_host_list() {
+    assert!(!should_use_shallow("https://github.com/x/y.git", &[]));
+}
+
+#[test]
+fn should_use_shallow_matches_known_host() {
+    let hosts = vec!["github.com".to_string(), "gitlab.com".to_string()];
+    assert!(should_use_shallow("https://github.com/x/y.git", &hosts));
+    assert!(should_use_shallow("git+ssh://git@github.com/x/y.git", &hosts));
+    assert!(!should_use_shallow("https://example.com/x/y.git", &hosts));
+}
+
+#[test]
+fn extract_host_handles_user_authority_and_port() {
+    assert_eq!(extract_host("https://github.com/foo/bar"), Some("github.com"));
+    assert_eq!(extract_host("git+ssh://git@github.com/foo/bar.git"), Some("github.com"));
+    assert_eq!(extract_host("https://host.example:443/foo"), Some("host.example"));
+    assert_eq!(extract_host("file:///tmp/x"), None);
+    assert_eq!(extract_host("relative/path"), None);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fetcher_imports_package_into_cas() {
+    if skip_if_no_git() {
+        return;
+    }
+    let tmp = tempdir().unwrap();
+    let (bare, commit) = make_bare_repo(tmp.path());
+    let store_root = tempdir().unwrap();
+    let store_dir = StoreDir::from(store_root.path().to_path_buf());
+
+    let repo_url = format!("file://{}", bare.display());
+    let received = GitFetcher {
+        repo: &repo_url,
+        commit: &commit,
+        path: None,
+        git_shallow_hosts: &[],
+        allow_build: deny_all_builds(),
+        ignore_scripts: false,
+        unsafe_perm: true,
+        user_agent: None,
+        scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+        script_shell: None,
+        node_execpath: None,
+        npm_execpath: None,
+        store_dir: &store_dir,
+        package_id: "pkg@1.0.0",
+        requester: "/test",
+    }
+    .run::<SilentReporter>()
+    .await
+    .unwrap();
+
+    assert!(!received.built, "package without scripts should not be 'built'");
+    assert!(received.cas_paths.contains_key("package.json"));
+    assert!(received.cas_paths.contains_key("index.js"));
+    let cas_path = &received.cas_paths["package.json"];
+    assert!(cas_path.exists(), "CAS entry must exist on disk");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fetcher_rejects_commit_mismatch() {
+    if skip_if_no_git() {
+        return;
+    }
+    let tmp = tempdir().unwrap();
+    let (bare, _commit) = make_bare_repo(tmp.path());
+    let store_root = tempdir().unwrap();
+    let store_dir = StoreDir::from(store_root.path().to_path_buf());
+
+    let repo_url = format!("file://{}", bare.display());
+    // A SHA that doesn't exist in the repo — `git checkout` will fail
+    // before we even reach `rev-parse`, producing a `GitExec` rather
+    // than `CheckoutMismatch`. Either path is a hard failure, which is
+    // the contract we care about: never silently install a wrong
+    // commit.
+    let bogus = "0000000000000000000000000000000000000000";
+    let err = GitFetcher {
+        repo: &repo_url,
+        commit: bogus,
+        path: None,
+        git_shallow_hosts: &[],
+        allow_build: deny_all_builds(),
+        ignore_scripts: false,
+        unsafe_perm: true,
+        user_agent: None,
+        scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+        script_shell: None,
+        node_execpath: None,
+        npm_execpath: None,
+        store_dir: &store_dir,
+        package_id: "pkg@1.0.0",
+        requester: "/test",
+    }
+    .run::<SilentReporter>()
+    .await
+    .unwrap_err();
+
+    assert!(
+        matches!(err, GitFetcherError::GitExec { .. } | GitFetcherError::CheckoutMismatch { .. }),
+        "expected GitExec or CheckoutMismatch, got {err:?}",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fetcher_blocks_build_when_not_allowed() {
+    if skip_if_no_git() {
+        return;
+    }
+    let tmp = tempdir().unwrap();
+    // A repo whose manifest declares a `prepare` script — exercises
+    // the `allow_build` gate without actually spawning the script
+    // (the policy is denying-all here).
+    let work = tmp.path().join("work");
+    let bare = tmp.path().join("repo.git");
+    fs::create_dir_all(&work).unwrap();
+    exec_git(&["init", "-q", "-b", "main"], Some(&work)).unwrap();
+    exec_git(&["config", "user.email", "test@example.invalid"], Some(&work)).unwrap();
+    exec_git(&["config", "user.name", "Test"], Some(&work)).unwrap();
+    fs::write(
+        work.join("package.json"),
+        r#"{"name":"naughty","version":"2.0.0","main":"index.js","scripts":{"prepare":"tsc"}}"#,
+    )
+    .unwrap();
+    fs::write(work.join("index.js"), "module.exports = 1;\n").unwrap();
+    exec_git(&["add", "-A"], Some(&work)).unwrap();
+    // `-c commit.gpgsign=false` neutralises a user-global `gpgsign=true`
+    // setting that would otherwise demand a real signing key in CI.
+    exec_git(&["-c", "commit.gpgsign=false", "commit", "-q", "-m", "init"], Some(&work)).unwrap();
+    let commit = exec_git(&["rev-parse", "HEAD"], Some(&work)).unwrap().trim().to_string();
+    exec_git(&["clone", "--bare", "-q", &work.to_string_lossy(), &bare.to_string_lossy()], None)
+        .unwrap();
+
+    let store_root = tempdir().unwrap();
+    let store_dir = StoreDir::from(store_root.path().to_path_buf());
+    let repo_url = format!("file://{}", bare.display());
+    let err = GitFetcher {
+        repo: &repo_url,
+        commit: &commit,
+        path: None,
+        git_shallow_hosts: &[],
+        allow_build: deny_all_builds(),
+        ignore_scripts: false,
+        unsafe_perm: true,
+        user_agent: None,
+        scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+        script_shell: None,
+        node_execpath: None,
+        npm_execpath: None,
+        store_dir: &store_dir,
+        package_id: "naughty@2.0.0",
+        requester: "/test",
+    }
+    .run::<SilentReporter>()
+    .await
+    .unwrap_err();
+
+    match err {
+        GitFetcherError::Prepare(crate::error::PreparePackageError::NotAllowed {
+            name,
+            version,
+        }) => {
+            assert_eq!(name, "naughty");
+            assert_eq!(version, "2.0.0");
+        }
+        other => panic!("expected Prepare::NotAllowed, got {other:?}"),
+    }
+}

--- a/crates/git-fetcher/src/lib.rs
+++ b/crates/git-fetcher/src/lib.rs
@@ -1,0 +1,23 @@
+//! Fetcher for `LockfileResolution::Git` snapshots.
+//!
+//! Ports pnpm's
+//! [`fetching/git-fetcher`](https://github.com/pnpm/pnpm/blob/94240bc046/fetching/git-fetcher/src/index.ts)
+//! and the inner
+//! [`exec/prepare-package`](https://github.com/pnpm/pnpm/blob/94240bc046/exec/prepare-package/src/index.ts)
+//! that the fetcher delegates to when a git-hosted package needs
+//! building. The two are co-located here because their only consumer
+//! today is this crate; when Section C lands (the git-hosted *tarball*
+//! fetcher), `prepare_package` is the one piece that lifts out into a
+//! shared crate.
+
+mod error;
+mod fetcher;
+mod packlist;
+mod preferred_pm;
+mod prepare_package;
+
+pub use error::{GitFetcherError, PacklistError, PreparePackageError};
+pub use fetcher::{GitFetchOutput, GitFetcher};
+pub use packlist::packlist;
+pub use preferred_pm::{PreferredPm, detect_preferred_pm};
+pub use prepare_package::{PreparePackageOptions, PreparedPackage, prepare_package};

--- a/crates/git-fetcher/src/packlist.rs
+++ b/crates/git-fetcher/src/packlist.rs
@@ -214,14 +214,17 @@ fn glob_match_inner(pattern: &[u8], candidate: &[u8]) -> bool {
             star_c = c;
             continue;
         }
-        if p < pattern.len()
-            && (pattern[p] == b'?' || pattern[p] == candidate[c])
-            && pattern[p] != b'/'
-            || (p < pattern.len() && pattern[p] == candidate[c])
-        {
-            p += 1;
-            c += 1;
-            continue;
+        // `?` matches any single non-slash byte; otherwise the byte
+        // must match exactly. (Without the explicit `candidate[c] !=
+        // b'/'` gate, `a?b` would incorrectly match `a/b`.)
+        if p < pattern.len() {
+            let pc = pattern[p];
+            let matches = (pc == b'?' && candidate[c] != b'/') || pc == candidate[c];
+            if matches {
+                p += 1;
+                c += 1;
+                continue;
+            }
         }
         if let Some(sp) = star_p {
             // Backtrack: the `*` swallows one more candidate byte.

--- a/crates/git-fetcher/src/packlist.rs
+++ b/crates/git-fetcher/src/packlist.rs
@@ -1,0 +1,262 @@
+//! Decide which files inside an extracted git-hosted package end up in
+//! the CAS. MVP port of [`npm-packlist`](https://github.com/npm/npm-packlist)
+//! / pnpm's
+//! [`fs/packlist`](https://github.com/pnpm/pnpm/blob/94240bc046/fs/packlist/src/index.ts):
+//!
+//! - When `manifest.files` is a non-empty array, only its glob entries
+//!   plus the always-included files (`package.json`, `README*`,
+//!   `LICEN[SC]E*`, `CHANGES*`, `CHANGELOG*`, `HISTORY*`, `NOTICE*`)
+//!   and any file referenced by `manifest.main` / `manifest.bin` make it
+//!   into the result.
+//! - When `manifest.files` is absent, every regular file under
+//!   `pkg_dir` is included *except* the always-excluded set
+//!   (`.git/`, `node_modules/`, lockfiles for other package managers,
+//!   common cruft like `.DS_Store` / `npm-debug.log` / `*.orig`).
+//!
+//! Glob support is limited to `*`, `**`, and `?`. Full
+//! `.npmignore` / `.gitignore` layering, `bundleDependencies` walking,
+//! and exotic glob features (negation, character classes) are deferred
+//! to a follow-up; the gap is logged at `tracing::warn!` when a
+//! manifest carries `bundleDependencies` so the omission is visible
+//! during install. Tracks pnpm's behavior at
+//! [`fs/packlist/src/index.ts:24-29`](https://github.com/pnpm/pnpm/blob/94240bc046/fs/packlist/src/index.ts#L24-L29).
+
+use crate::error::PacklistError;
+use serde_json::Value;
+use std::{
+    collections::BTreeSet,
+    path::{Path, PathBuf},
+};
+use walkdir::WalkDir;
+
+/// Filenames always included regardless of `manifest.files`, matching
+/// `npm-packlist`'s `alwaysIncluded` plus pnpm's
+/// [`packlist`](https://github.com/pnpm/pnpm/blob/94240bc046/fs/packlist/src/index.ts#L13)
+/// pattern set. Case-insensitive prefix matches.
+const ALWAYS_INCLUDED_PREFIXES: &[&str] =
+    &["readme", "license", "licence", "changes", "changelog", "history", "notice"];
+
+/// Files / directories always excluded from the published view. The
+/// repo's own lockfiles must not bleed into the consumer's install —
+/// only the dep's source/build artifacts should ship.
+const ALWAYS_EXCLUDED_NAMES: &[&str] = &[
+    ".git",
+    "node_modules",
+    ".npmrc",
+    "npm-debug.log",
+    ".DS_Store",
+    "package-lock.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    ".svn",
+    "CVS",
+    ".hg",
+];
+
+/// File-name suffixes always excluded (matched case-sensitively on the
+/// basename, like `npm-packlist` does for the `*.orig` family).
+const ALWAYS_EXCLUDED_SUFFIXES: &[&str] = &[".orig"];
+
+/// Walk `pkg_dir` and return forward-slash relative paths for every
+/// file the published tarball should contain. Mirrors the return shape
+/// of `packlist()` at
+/// [`fs/packlist/src/index.ts:24-29`](https://github.com/pnpm/pnpm/blob/94240bc046/fs/packlist/src/index.ts#L24-L29)
+/// (paths relative to `pkgDir`, no leading `./`).
+pub fn packlist(pkg_dir: &Path, manifest: &Value) -> Result<Vec<String>, PacklistError> {
+    if let Some(bundle) =
+        manifest.get("bundleDependencies").or_else(|| manifest.get("bundledDependencies"))
+        && bundle.as_array().is_some_and(|a| !a.is_empty())
+    {
+        tracing::warn!(
+            target: "pacquet::git_fetcher::packlist",
+            pkg_dir = %pkg_dir.display(),
+            "manifest declares bundleDependencies, but the MVP packlist port does not yet recurse into bundled deps — they will be missing from the cached snapshot",
+        );
+    }
+
+    let files_field = manifest.get("files").and_then(Value::as_array);
+    let files_globs: Option<Vec<&str>> = files_field
+        .map(|arr| arr.iter().filter_map(Value::as_str).collect::<Vec<_>>())
+        .filter(|v| !v.is_empty());
+
+    let main_path = manifest.get("main").and_then(Value::as_str);
+    let bin_paths: Vec<&str> = manifest
+        .get("bin")
+        .map(|bin| match bin {
+            Value::String(s) => vec![s.as_str()],
+            Value::Object(map) => map.values().filter_map(Value::as_str).collect(),
+            _ => Vec::new(),
+        })
+        .unwrap_or_default();
+
+    let mut out: BTreeSet<String> = BTreeSet::new();
+    for entry in WalkDir::new(pkg_dir).into_iter().filter_entry(|e| {
+        // Hard-exclude `.git` / `node_modules` etc. before descent so
+        // we never spend time walking them. Note: this also filters
+        // the root once `e.depth() == 0`, hence the `is_root` guard.
+        let is_root = e.depth() == 0;
+        is_root || !is_always_excluded_dir(e.file_name())
+    }) {
+        let entry = entry
+            .map_err(|err| io_error(pkg_dir, err.into_io_error().unwrap_or_else(other_io_error)))?;
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let rel = relative_forward_slash(pkg_dir, entry.path());
+        if should_always_exclude_file(&rel) {
+            continue;
+        }
+        if should_include(&rel, &files_globs, main_path, &bin_paths) {
+            out.insert(rel);
+        }
+    }
+    Ok(out.into_iter().collect())
+}
+
+fn should_include(
+    rel: &str,
+    files_globs: &Option<Vec<&str>>,
+    main: Option<&str>,
+    bins: &[&str],
+) -> bool {
+    if is_always_included_basename(rel) {
+        return true;
+    }
+    if let Some(globs) = files_globs {
+        if let Some(main) = main
+            && normalize_field_path(main) == rel
+        {
+            return true;
+        }
+        if bins.iter().any(|bin| normalize_field_path(bin) == rel) {
+            return true;
+        }
+        return globs.iter().any(|glob| glob_match(normalize_field_path(glob).as_str(), rel));
+    }
+    // No `files` field — everything that wasn't excluded above ships.
+    true
+}
+
+fn is_always_included_basename(rel: &str) -> bool {
+    let basename = rel.rsplit('/').next().unwrap_or(rel).to_ascii_lowercase();
+    if basename == "package.json" {
+        return true;
+    }
+    ALWAYS_INCLUDED_PREFIXES.iter().any(|prefix| basename.starts_with(prefix))
+}
+
+fn is_always_excluded_dir(name: &std::ffi::OsStr) -> bool {
+    let Some(name) = name.to_str() else { return false };
+    ALWAYS_EXCLUDED_NAMES.contains(&name)
+}
+
+fn should_always_exclude_file(rel: &str) -> bool {
+    let basename = rel.rsplit('/').next().unwrap_or(rel);
+    if ALWAYS_EXCLUDED_NAMES.contains(&basename) {
+        return true;
+    }
+    ALWAYS_EXCLUDED_SUFFIXES.iter().any(|s| basename.ends_with(s))
+}
+
+fn relative_forward_slash(root: &Path, full: &Path) -> String {
+    let rel = full.strip_prefix(root).unwrap_or(full);
+    let mut buf = PathBuf::from(rel).into_os_string().to_string_lossy().into_owned();
+    if std::path::MAIN_SEPARATOR != '/' {
+        buf = buf.replace(std::path::MAIN_SEPARATOR, "/");
+    }
+    buf
+}
+
+/// Strip a leading `./` and any leading slashes from `path` so manifest
+/// `files` entries match the forward-slash relative form `packlist`
+/// produces. Mirrors `npm-packlist`'s normalisation step.
+fn normalize_field_path(path: &str) -> String {
+    let trimmed = path.trim_start_matches("./");
+    trimmed.trim_start_matches('/').to_string()
+}
+
+/// Minimal glob matcher supporting `*` (any non-slash run), `**` (any
+/// sequence including slashes), and `?` (single non-slash char). Good
+/// enough for the common `files` patterns: `dist/**`, `lib/*.js`,
+/// `bin/cli`, etc.
+fn glob_match(pattern: &str, candidate: &str) -> bool {
+    glob_match_inner(pattern.as_bytes(), candidate.as_bytes())
+}
+
+fn glob_match_inner(pattern: &[u8], candidate: &[u8]) -> bool {
+    // Two-pointer walk with one backtrack point. The asymptotic worst
+    // case is O(n*m), but real `files` patterns have only one or two
+    // wildcards so the inner loop terminates fast.
+    let mut p = 0;
+    let mut c = 0;
+    let mut star_p: Option<usize> = None;
+    let mut star_c = 0;
+    while c < candidate.len() {
+        if p < pattern.len()
+            && pattern[p] == b'*'
+            && p + 1 < pattern.len()
+            && pattern[p + 1] == b'*'
+        {
+            // `**` — match any sequence (including slashes).
+            star_p = Some(p);
+            p += 2;
+            // Skip a single following `/` so `dist/**` matches `dist/x`.
+            if p < pattern.len() && pattern[p] == b'/' {
+                p += 1;
+            }
+            star_c = c;
+            continue;
+        }
+        if p < pattern.len() && pattern[p] == b'*' {
+            // single `*` — match any non-slash run.
+            star_p = Some(p);
+            p += 1;
+            star_c = c;
+            continue;
+        }
+        if p < pattern.len()
+            && (pattern[p] == b'?' || pattern[p] == candidate[c])
+            && pattern[p] != b'/'
+            || (p < pattern.len() && pattern[p] == candidate[c])
+        {
+            p += 1;
+            c += 1;
+            continue;
+        }
+        if let Some(sp) = star_p {
+            // Backtrack: the `*` swallows one more candidate byte.
+            // For single `*`, refuse to swallow a `/`.
+            if pattern[sp] == b'*'
+                && (sp + 1 >= pattern.len() || pattern[sp + 1] != b'*')
+                && candidate[star_c] == b'/'
+            {
+                return false;
+            }
+            star_c += 1;
+            c = star_c;
+            p = sp
+                + if pattern[sp] == b'*' && sp + 1 < pattern.len() && pattern[sp + 1] == b'*' {
+                    2
+                } else {
+                    1
+                };
+            continue;
+        }
+        return false;
+    }
+    while p < pattern.len() && pattern[p] == b'*' {
+        p += 1;
+    }
+    p == pattern.len()
+}
+
+fn io_error(pkg_dir: &Path, source: std::io::Error) -> PacklistError {
+    PacklistError::Io { pkg_dir: pkg_dir.display().to_string(), source }
+}
+
+fn other_io_error() -> std::io::Error {
+    std::io::Error::other("walkdir produced an entry with no underlying io::Error")
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/git-fetcher/src/packlist/tests.rs
+++ b/crates/git-fetcher/src/packlist/tests.rs
@@ -118,6 +118,26 @@ fn main_and_bin_paths_are_force_included_under_files_field() {
 }
 
 #[test]
+fn question_mark_does_not_cross_directory() {
+    // Regression: `?` matches a single non-slash byte, not arbitrary
+    // characters. Without the explicit `/` guard, `a?b/index.js` would
+    // incorrectly match `a/b/index.js`.
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    touch(root, "package.json");
+    touch(root, "a/b/index.js");
+
+    let manifest = json!({
+        "name": "x",
+        "version": "0.0.0",
+        "files": ["a?b/index.js"],
+    });
+    let out = packlist(root, &manifest).unwrap();
+
+    assert!(!out.iter().any(|p| p == "a/b/index.js"), "`?` must not match `/`; received {out:?}",);
+}
+
+#[test]
 fn single_star_does_not_cross_directory() {
     let dir = tempdir().unwrap();
     let root = dir.path();

--- a/crates/git-fetcher/src/packlist/tests.rs
+++ b/crates/git-fetcher/src/packlist/tests.rs
@@ -1,0 +1,138 @@
+use super::packlist;
+use serde_json::json;
+use std::{fs, path::Path};
+use tempfile::tempdir;
+
+fn touch(root: &Path, rel: &str) {
+    let path = root.join(rel);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, "").unwrap();
+}
+
+#[test]
+fn includes_everything_when_files_field_absent() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    touch(root, "package.json");
+    touch(root, "index.js");
+    touch(root, "lib/inner.js");
+
+    let manifest = json!({ "name": "x", "version": "0.0.0" });
+    let mut out = packlist(root, &manifest).unwrap();
+    out.sort();
+
+    assert_eq!(out, vec!["index.js".to_string(), "lib/inner.js".into(), "package.json".into()]);
+}
+
+#[test]
+fn excludes_git_and_node_modules_subtrees() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    touch(root, "package.json");
+    touch(root, "index.js");
+    touch(root, ".git/HEAD");
+    touch(root, "node_modules/.bin/foo");
+    touch(root, "node_modules/foo/index.js");
+
+    let manifest = json!({ "name": "x", "version": "0.0.0" });
+    let mut out = packlist(root, &manifest).unwrap();
+    out.sort();
+
+    assert_eq!(out, vec!["index.js".to_string(), "package.json".into()]);
+}
+
+#[test]
+fn excludes_cruft_files_at_any_depth() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    touch(root, "package.json");
+    touch(root, "src/file.js");
+    touch(root, "src/file.js.orig");
+    touch(root, ".DS_Store");
+    touch(root, "npm-debug.log");
+    touch(root, "package-lock.json");
+
+    let manifest = json!({ "name": "x", "version": "0.0.0" });
+    let mut out = packlist(root, &manifest).unwrap();
+    out.sort();
+
+    assert_eq!(out, vec!["package.json".to_string(), "src/file.js".into()]);
+}
+
+#[test]
+fn files_field_restricts_to_listed_globs() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    touch(root, "package.json");
+    touch(root, "dist/index.js");
+    touch(root, "dist/sub/inner.js");
+    touch(root, "src/index.ts");
+    touch(root, "README.md");
+    touch(root, "LICENSE");
+
+    let manifest = json!({
+        "name": "x",
+        "version": "0.0.0",
+        "files": ["dist/**"],
+    });
+    let mut out = packlist(root, &manifest).unwrap();
+    out.sort();
+
+    assert_eq!(
+        out,
+        vec![
+            "LICENSE".to_string(),
+            "README.md".into(),
+            "dist/index.js".into(),
+            "dist/sub/inner.js".into(),
+            "package.json".into(),
+        ],
+        "always-included files (README/LICENSE/package.json) ship alongside the `files` glob",
+    );
+}
+
+#[test]
+fn main_and_bin_paths_are_force_included_under_files_field() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    touch(root, "package.json");
+    touch(root, "lib/index.js");
+    touch(root, "bin/cli");
+    touch(root, "dist/index.js");
+
+    let manifest = json!({
+        "name": "x",
+        "version": "0.0.0",
+        "files": ["dist/**"],
+        "main": "lib/index.js",
+        "bin": { "x-cli": "bin/cli" },
+    });
+    let mut out = packlist(root, &manifest).unwrap();
+    out.sort();
+
+    assert!(out.contains(&"lib/index.js".to_string()));
+    assert!(out.contains(&"bin/cli".to_string()));
+    assert!(out.contains(&"dist/index.js".to_string()));
+}
+
+#[test]
+fn single_star_does_not_cross_directory() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    touch(root, "package.json");
+    touch(root, "lib/index.js");
+    touch(root, "lib/sub/inner.js");
+
+    let manifest = json!({
+        "name": "x",
+        "version": "0.0.0",
+        "files": ["lib/*.js"],
+    });
+    let mut out = packlist(root, &manifest).unwrap();
+    out.sort();
+
+    assert!(out.contains(&"lib/index.js".to_string()));
+    assert!(!out.contains(&"lib/sub/inner.js".to_string()));
+}

--- a/crates/git-fetcher/src/packlist/tests.rs
+++ b/crates/git-fetcher/src/packlist/tests.rs
@@ -134,7 +134,7 @@ fn question_mark_does_not_cross_directory() {
     });
     let out = packlist(root, &manifest).unwrap();
 
-    assert!(!out.iter().any(|p| p == "a/b/index.js"), "`?` must not match `/`; received {out:?}",);
+    assert!(!out.iter().any(|p| p == "a/b/index.js"), "`?` must not match `/`; received {out:?}");
 }
 
 #[test]

--- a/crates/git-fetcher/src/preferred_pm.rs
+++ b/crates/git-fetcher/src/preferred_pm.rs
@@ -1,0 +1,65 @@
+//! Detect the package manager a git-hosted dependency expects, by
+//! looking for the lockfile it ships next to its `package.json`.
+//!
+//! Ports the file-sniffing half of the
+//! [`preferred-pm`](https://www.npmjs.com/package/preferred-pm) npm
+//! package that
+//! [`exec/prepare-package`](https://github.com/pnpm/pnpm/blob/94240bc046/exec/prepare-package/src/index.ts#L47)
+//! calls. The workspace-root walk (`findYarnWorkspaceRoot` /
+//! `findUpSimple`) is *not* ported — git-hosted snapshots almost always
+//! ship a lockfile at the repo root, and the fall-through to `Npm`
+//! matches upstream's `?? 'npm'` default.
+
+use std::path::Path;
+
+/// Package manager a git-hosted dep wants to install with. The variant
+/// drives the synthesized `<pm>-install` script in
+/// [`crate::prepare_package`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PreferredPm {
+    Pnpm,
+    Npm,
+    Yarn,
+    Bun,
+}
+
+impl PreferredPm {
+    /// Binary name to invoke (also the prefix of the synthesized
+    /// script name written into the manifest).
+    pub fn name(self) -> &'static str {
+        match self {
+            PreferredPm::Pnpm => "pnpm",
+            PreferredPm::Npm => "npm",
+            PreferredPm::Yarn => "yarn",
+            PreferredPm::Bun => "bun",
+        }
+    }
+}
+
+/// Sniff `dir` for a lockfile and return the matching package manager.
+/// Defaults to [`PreferredPm::Npm`] when no lockfile is present —
+/// matches upstream's `(await preferredPM(gitRootDir))?.name ?? 'npm'`
+/// at [`exec/prepare-package/src/index.ts:47`](https://github.com/pnpm/pnpm/blob/94240bc046/exec/prepare-package/src/index.ts#L47).
+///
+/// Sniff order mirrors `preferred-pm` v3.1.4: pnpm first (because it's
+/// the most specific shape and the most likely to be set by the dep's
+/// author), then yarn, npm, bun. Each check is a single `path.exists`,
+/// so even worst-case the sniff is four `stat()` calls.
+pub fn detect_preferred_pm(dir: &Path) -> PreferredPm {
+    if dir.join("pnpm-lock.yaml").exists() {
+        return PreferredPm::Pnpm;
+    }
+    if dir.join("yarn.lock").exists() {
+        return PreferredPm::Yarn;
+    }
+    if dir.join("package-lock.json").exists() {
+        return PreferredPm::Npm;
+    }
+    if dir.join("bun.lockb").exists() || dir.join("bun.lock").exists() {
+        return PreferredPm::Bun;
+    }
+    PreferredPm::Npm
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/git-fetcher/src/preferred_pm.rs
+++ b/crates/git-fetcher/src/preferred_pm.rs
@@ -14,7 +14,7 @@ use std::path::Path;
 
 /// Package manager a git-hosted dep wants to install with. The variant
 /// drives the synthesized `<pm>-install` script in
-/// [`crate::prepare_package`].
+/// [`crate::prepare_package()`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PreferredPm {
     Pnpm,

--- a/crates/git-fetcher/src/preferred_pm/tests.rs
+++ b/crates/git-fetcher/src/preferred_pm/tests.rs
@@ -1,0 +1,60 @@
+use super::{PreferredPm, detect_preferred_pm};
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn defaults_to_npm_when_no_lockfile() {
+    let dir = tempdir().unwrap();
+    assert_eq!(detect_preferred_pm(dir.path()), PreferredPm::Npm);
+}
+
+#[test]
+fn detects_pnpm_via_pnpm_lock_yaml() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("pnpm-lock.yaml"), "lockfileVersion: '9.0'\n").unwrap();
+    assert_eq!(detect_preferred_pm(dir.path()), PreferredPm::Pnpm);
+}
+
+#[test]
+fn detects_yarn_via_yarn_lock() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("yarn.lock"), "").unwrap();
+    assert_eq!(detect_preferred_pm(dir.path()), PreferredPm::Yarn);
+}
+
+#[test]
+fn detects_npm_via_package_lock_json() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("package-lock.json"), "{}").unwrap();
+    assert_eq!(detect_preferred_pm(dir.path()), PreferredPm::Npm);
+}
+
+#[test]
+fn detects_bun_via_either_lock_name() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("bun.lockb"), "").unwrap();
+    assert_eq!(detect_preferred_pm(dir.path()), PreferredPm::Bun);
+
+    let dir2 = tempdir().unwrap();
+    fs::write(dir2.path().join("bun.lock"), "").unwrap();
+    assert_eq!(detect_preferred_pm(dir2.path()), PreferredPm::Bun);
+}
+
+#[test]
+fn pnpm_takes_precedence_over_yarn_and_npm() {
+    // When multiple lockfiles are present we follow upstream's order
+    // (pnpm wins) rather than newest-mtime or alphabetical.
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("pnpm-lock.yaml"), "").unwrap();
+    fs::write(dir.path().join("yarn.lock"), "").unwrap();
+    fs::write(dir.path().join("package-lock.json"), "").unwrap();
+    assert_eq!(detect_preferred_pm(dir.path()), PreferredPm::Pnpm);
+}
+
+#[test]
+fn pm_names_match_binary_invocations() {
+    assert_eq!(PreferredPm::Pnpm.name(), "pnpm");
+    assert_eq!(PreferredPm::Npm.name(), "npm");
+    assert_eq!(PreferredPm::Yarn.name(), "yarn");
+    assert_eq!(PreferredPm::Bun.name(), "bun");
+}

--- a/crates/git-fetcher/src/prepare_package.rs
+++ b/crates/git-fetcher/src/prepare_package.rs
@@ -1,0 +1,236 @@
+//! Port of pnpm's
+//! [`exec/prepare-package`](https://github.com/pnpm/pnpm/blob/94240bc046/exec/prepare-package/src/index.ts).
+//!
+//! Decides whether a git-hosted package needs building, runs the
+//! synthesized `<pm>-install` (which transitively runs npm/yarn/pnpm's
+//! built-in `prepare` lifecycle), then any remaining `prepublish*`
+//! scripts. Honors the same `allowBuild` gate pnpm uses, and rejects
+//! sub-paths that escape the git root via `safe_join_path` (mirrors
+//! upstream's `safeJoinPath` at
+//! [`index.ts:92-103`](https://github.com/pnpm/pnpm/blob/94240bc046/exec/prepare-package/src/index.ts#L92-L103)).
+
+use crate::{error::PreparePackageError, preferred_pm::detect_preferred_pm};
+use pacquet_executor::{
+    LifecycleScriptError, RunPostinstallHooks, ScriptsPrependNodePath, run_lifecycle_hook,
+};
+use pacquet_package_manifest::safe_read_package_json_from_dir;
+use pacquet_reporter::Reporter;
+use serde_json::Value;
+use std::{
+    collections::HashMap,
+    fs,
+    path::{Path, PathBuf},
+};
+
+/// Scripts to re-run after `<pm>-install` finishes. `prepare` itself
+/// runs automatically as part of `<pm>-install` (npm/yarn/pnpm fold it
+/// into the install lifecycle), so we don't need to invoke it
+/// separately. Matches upstream's set at
+/// [`exec/prepare-package/src/index.ts:14-20`](https://github.com/pnpm/pnpm/blob/94240bc046/exec/prepare-package/src/index.ts#L14-L20).
+///
+/// Note: pnpm intentionally omits `prepublishOnly` here — neither npm
+/// nor Yarn run it for git-hosted deps.
+const PREPUBLISH_SCRIPTS: &[&str] = &["prepublish", "prepack", "publish"];
+
+/// Closure shape used to ask the install policy whether a package
+/// (`name`, `version`) is allowed to run lifecycle scripts. Mirrors
+/// upstream's `opts.allowBuild?.(name, version)` at
+/// [`index.ts:36`](https://github.com/pnpm/pnpm/blob/94240bc046/exec/prepare-package/src/index.ts#L36).
+///
+/// We pass a closure rather than `&AllowBuildPolicy` so the
+/// `pacquet-git-fetcher` crate stays free of a back-edge into
+/// `pacquet-package-manager`. The caller adapts whatever policy
+/// structure it has into this shape.
+pub type AllowBuildFn<'a> = Box<dyn Fn(&str, &str) -> bool + Send + Sync + 'a>;
+
+/// Caller-supplied context for [`prepare_package`].
+pub struct PreparePackageOptions<'a> {
+    pub allow_build: AllowBuildFn<'a>,
+    pub ignore_scripts: bool,
+    pub unsafe_perm: bool,
+    pub user_agent: Option<&'a str>,
+    pub scripts_prepend_node_path: ScriptsPrependNodePath,
+    pub script_shell: Option<&'a Path>,
+    pub node_execpath: Option<&'a Path>,
+    pub npm_execpath: Option<&'a Path>,
+    pub extra_bin_paths: &'a [PathBuf],
+    pub extra_env: &'a HashMap<String, String>,
+}
+
+/// Result of [`prepare_package`]. `should_be_built` lines up with
+/// upstream's `shouldBeBuilt` — drives the `built` dimension of the
+/// git-hosted store-index key.
+#[derive(Debug)]
+pub struct PreparedPackage {
+    pub pkg_dir: PathBuf,
+    pub should_be_built: bool,
+}
+
+/// Read the manifest, decide whether the package needs building, and
+/// run the appropriate lifecycle scripts. Returns `should_be_built:
+/// false` early when there's nothing to do; otherwise runs
+/// `<pm>-install` plus any defined `prepublish` / `prepack` / `publish`
+/// hooks, then deletes `node_modules` so the install-time deps don't
+/// leak into the CAS.
+///
+/// Mirrors upstream's `preparePackage` at
+/// [`index.ts:29-80`](https://github.com/pnpm/pnpm/blob/94240bc046/exec/prepare-package/src/index.ts#L29-L80).
+pub fn prepare_package<R: Reporter>(
+    opts: &PreparePackageOptions<'_>,
+    git_root_dir: &Path,
+    sub_dir: Option<&str>,
+) -> Result<PreparedPackage, PreparePackageError> {
+    let pkg_dir = safe_join_path(git_root_dir, sub_dir)?;
+    let manifest =
+        safe_read_package_json_from_dir(&pkg_dir).map_err(PreparePackageError::ReadManifest)?;
+
+    let Some(manifest) = manifest else {
+        return Ok(PreparedPackage { pkg_dir, should_be_built: false });
+    };
+    let scripts = manifest.get("scripts").and_then(Value::as_object);
+    if scripts.is_none_or(|s| s.is_empty()) || !package_should_be_built(&manifest, &pkg_dir) {
+        return Ok(PreparedPackage { pkg_dir, should_be_built: false });
+    }
+    if opts.ignore_scripts {
+        return Ok(PreparedPackage { pkg_dir, should_be_built: true });
+    }
+
+    // `allowBuild` check before any spawn. Upstream throws when
+    // `opts.allowBuild?.(name, version)` is missing or false, with
+    // GIT_DEP_PREPARE_NOT_ALLOWED.
+    let name = manifest.get("name").and_then(Value::as_str).unwrap_or("");
+    let version = manifest.get("version").and_then(Value::as_str).unwrap_or("");
+    if !(opts.allow_build)(name, version) {
+        return Err(PreparePackageError::NotAllowed {
+            name: name.to_string(),
+            version: version.to_string(),
+        });
+    }
+
+    let pm = detect_preferred_pm(git_root_dir);
+    let dep_path = format!("{name}@{version}");
+
+    let run_opts = RunPostinstallHooks {
+        dep_path: &dep_path,
+        pkg_root: &pkg_dir,
+        root_modules_dir: &pkg_dir,
+        init_cwd: &pkg_dir,
+        extra_bin_paths: opts.extra_bin_paths,
+        extra_env: opts.extra_env,
+        node_execpath: opts.node_execpath,
+        npm_execpath: opts.npm_execpath,
+        node_gyp_path: None,
+        user_agent: opts.user_agent,
+        unsafe_perm: opts.unsafe_perm,
+        node_gyp_bin: None,
+        scripts_prepend_node_path: opts.scripts_prepend_node_path,
+        script_shell: opts.script_shell,
+        optional: false,
+    };
+
+    let parent_env: HashMap<String, String> = std::env::vars().collect();
+    let mut working_manifest = manifest.clone();
+    let install_stage = format!("{}-install", pm.name());
+    let install_script = format!("{} install", pm.name());
+    inject_script(&mut working_manifest, &install_stage, &install_script);
+    run_lifecycle_hook::<R>(
+        &install_stage,
+        &install_script,
+        &run_opts,
+        &working_manifest,
+        &parent_env,
+    )
+    .map_err(map_lifecycle_err)?;
+
+    for &script_name in PREPUBLISH_SCRIPTS {
+        let Some(script_body) = working_manifest
+            .get("scripts")
+            .and_then(|s| s.get(script_name))
+            .and_then(Value::as_str)
+            .filter(|s| !s.is_empty())
+            .map(str::to_owned)
+        else {
+            continue;
+        };
+        let (stage, script) = if pm.name() == "pnpm" {
+            (script_name.to_string(), script_body)
+        } else {
+            let synthesized_stage = format!("{}-run-{}", pm.name(), script_name);
+            let synthesized = format!("{} run {}", pm.name(), script_name);
+            inject_script(&mut working_manifest, &synthesized_stage, &synthesized);
+            (synthesized_stage, synthesized)
+        };
+        run_lifecycle_hook::<R>(&stage, &script, &run_opts, &working_manifest, &parent_env)
+            .map_err(map_lifecycle_err)?;
+    }
+
+    // Upstream `rimraf`s the install-time `node_modules` so the deps
+    // don't leak into the CAS. Ignore `NotFound` (the script may not
+    // have populated `node_modules` at all).
+    let node_modules = pkg_dir.join("node_modules");
+    if let Err(error) = fs::remove_dir_all(&node_modules)
+        && error.kind() != std::io::ErrorKind::NotFound
+    {
+        return Err(PreparePackageError::Io(error));
+    }
+
+    Ok(PreparedPackage { pkg_dir, should_be_built: true })
+}
+
+/// Decide whether the package needs building. Mirrors upstream's
+/// [`packageShouldBeBuilt`](https://github.com/pnpm/pnpm/blob/94240bc046/exec/prepare-package/src/index.ts#L82-L90).
+fn package_should_be_built(manifest: &Value, pkg_dir: &Path) -> bool {
+    let Some(scripts) = manifest.get("scripts").and_then(Value::as_object) else {
+        return false;
+    };
+    if scripts.get("prepare").and_then(Value::as_str).is_some_and(|s| !s.is_empty()) {
+        return true;
+    }
+    let has_prepublish_script = PREPUBLISH_SCRIPTS
+        .iter()
+        .any(|name| scripts.get(*name).and_then(Value::as_str).is_some_and(|s| !s.is_empty()));
+    if !has_prepublish_script {
+        return false;
+    }
+    let main_file = manifest.get("main").and_then(Value::as_str).unwrap_or("index.js");
+    !pkg_dir.join(main_file).exists()
+}
+
+/// Join `sub` onto `root` and reject results that climb outside.
+/// Mirrors upstream's [`safeJoinPath`](https://github.com/pnpm/pnpm/blob/94240bc046/exec/prepare-package/src/index.ts#L92-L103).
+fn safe_join_path(root: &Path, sub: Option<&str>) -> Result<PathBuf, PreparePackageError> {
+    let sub = sub.unwrap_or("");
+    let joined = if sub.is_empty() { root.to_path_buf() } else { root.join(sub) };
+    let canonical_root = root.canonicalize().map_err(PreparePackageError::Io)?;
+    let canonical_joined = match joined.canonicalize() {
+        Ok(p) => p,
+        Err(_) => {
+            return Err(PreparePackageError::InvalidPath { path: sub.to_string() });
+        }
+    };
+    if !canonical_joined.starts_with(&canonical_root) {
+        return Err(PreparePackageError::InvalidPath { path: sub.to_string() });
+    }
+    if !canonical_joined.is_dir() {
+        return Err(PreparePackageError::InvalidPath { path: sub.to_string() });
+    }
+    Ok(joined)
+}
+
+/// Write `(stage, script)` into the working manifest's `scripts` map
+/// so the next `run_lifecycle_hook` invocation can look it up. Matches
+/// upstream's `manifest.scripts[installScriptName] = ...` mutation at
+/// [`index.ts:57`](https://github.com/pnpm/pnpm/blob/94240bc046/exec/prepare-package/src/index.ts#L57).
+fn inject_script(manifest: &mut Value, stage: &str, script: &str) {
+    let scripts = manifest.get_mut("scripts").and_then(Value::as_object_mut);
+    if let Some(scripts) = scripts {
+        scripts.insert(stage.to_string(), Value::String(script.to_string()));
+    }
+}
+
+fn map_lifecycle_err(source: LifecycleScriptError) -> PreparePackageError {
+    PreparePackageError::LifecycleFailed { source }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/git-fetcher/src/prepare_package/tests.rs
+++ b/crates/git-fetcher/src/prepare_package/tests.rs
@@ -6,8 +6,19 @@ use crate::error::PreparePackageError;
 use pacquet_executor::ScriptsPrependNodePath;
 use pacquet_reporter::SilentReporter;
 use serde_json::json;
-use std::{collections::HashMap, fs, path::Path};
+use std::{collections::HashMap, fs, path::Path, sync::OnceLock};
 use tempfile::tempdir;
+
+/// A single process-wide empty env map shared across every test
+/// invocation. `OnceLock` avoids the per-call `Box::leak(Box::new(...))`
+/// that an earlier version of this helper used — the leak was benign
+/// because the test binary exits quickly, but accumulating one fresh
+/// allocation per test isn't necessary when every site wants the same
+/// value.
+fn empty_env() -> &'static HashMap<String, String> {
+    static M: OnceLock<HashMap<String, String>> = OnceLock::new();
+    M.get_or_init(HashMap::new)
+}
 
 fn write_manifest(dir: &Path, manifest: &serde_json::Value) {
     fs::write(dir.join("package.json"), serde_json::to_string(manifest).unwrap()).unwrap();
@@ -19,7 +30,6 @@ fn write_manifest(dir: &Path, manifest: &serde_json::Value) {
 /// want it to.
 fn opts<'a>(allow: bool, ignore_scripts: bool) -> PreparePackageOptions<'a> {
     static EMPTY_BIN_PATHS: &[std::path::PathBuf] = &[];
-    let extra_env: &'static HashMap<String, String> = Box::leak(Box::new(HashMap::new()));
     PreparePackageOptions {
         allow_build: Box::new(move |_name, _version| allow),
         ignore_scripts,
@@ -30,7 +40,7 @@ fn opts<'a>(allow: bool, ignore_scripts: bool) -> PreparePackageOptions<'a> {
         node_execpath: None,
         npm_execpath: None,
         extra_bin_paths: EMPTY_BIN_PATHS,
-        extra_env,
+        extra_env: empty_env(),
     }
 }
 

--- a/crates/git-fetcher/src/prepare_package/tests.rs
+++ b/crates/git-fetcher/src/prepare_package/tests.rs
@@ -1,0 +1,159 @@
+use super::{
+    PreparePackageOptions, PreparedPackage, package_should_be_built, prepare_package,
+    safe_join_path,
+};
+use crate::error::PreparePackageError;
+use pacquet_executor::ScriptsPrependNodePath;
+use pacquet_reporter::SilentReporter;
+use serde_json::json;
+use std::{collections::HashMap, fs, path::Path};
+use tempfile::tempdir;
+
+fn write_manifest(dir: &Path, manifest: &serde_json::Value) {
+    fs::write(dir.join("package.json"), serde_json::to_string(manifest).unwrap()).unwrap();
+}
+
+/// Build an `Options` value whose `allow_build` closure routes through
+/// the bool the test specifies. Other knobs default to "noop, no
+/// scripts run" so the test doesn't actually spawn anything unless we
+/// want it to.
+fn opts<'a>(allow: bool, ignore_scripts: bool) -> PreparePackageOptions<'a> {
+    static EMPTY_BIN_PATHS: &[std::path::PathBuf] = &[];
+    let extra_env: &'static HashMap<String, String> = Box::leak(Box::new(HashMap::new()));
+    PreparePackageOptions {
+        allow_build: Box::new(move |_name, _version| allow),
+        ignore_scripts,
+        unsafe_perm: true,
+        user_agent: None,
+        scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+        script_shell: None,
+        node_execpath: None,
+        npm_execpath: None,
+        extra_bin_paths: EMPTY_BIN_PATHS,
+        extra_env,
+    }
+}
+
+#[test]
+fn package_should_be_built_false_for_empty_scripts() {
+    let dir = tempdir().unwrap();
+    let manifest = json!({ "name": "x", "version": "0.0.0" });
+    assert!(!package_should_be_built(&manifest, dir.path()));
+}
+
+#[test]
+fn package_should_be_built_true_for_non_empty_prepare() {
+    let dir = tempdir().unwrap();
+    let manifest = json!({
+        "name": "x", "version": "0.0.0",
+        "scripts": { "prepare": "tsc" },
+    });
+    assert!(package_should_be_built(&manifest, dir.path()));
+}
+
+#[test]
+fn package_should_be_built_false_when_main_exists_and_prepare_absent() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("index.js"), "").unwrap();
+    let manifest = json!({
+        "name": "x", "version": "0.0.0",
+        "scripts": { "prepublish": "true" },
+    });
+    // Prepublish is set, main exists → upstream says "don't build".
+    assert!(!package_should_be_built(&manifest, dir.path()));
+}
+
+#[test]
+fn package_should_be_built_true_when_main_missing_and_prepublish_set() {
+    let dir = tempdir().unwrap();
+    // `main` defaults to `index.js`; create no file so it's missing.
+    let manifest = json!({
+        "name": "x", "version": "0.0.0",
+        "scripts": { "prepack": "rollup -c" },
+    });
+    assert!(package_should_be_built(&manifest, dir.path()));
+}
+
+#[test]
+fn prepare_returns_should_be_built_false_when_no_manifest() {
+    let dir = tempdir().unwrap();
+    let received =
+        prepare_package::<SilentReporter>(&opts(false, false), dir.path(), None).unwrap();
+    assert!(!received.should_be_built);
+    assert_eq!(received.pkg_dir, dir.path());
+}
+
+#[test]
+fn prepare_returns_should_be_built_false_when_manifest_has_no_scripts() {
+    let dir = tempdir().unwrap();
+    write_manifest(dir.path(), &json!({ "name": "x", "version": "0.0.0" }));
+
+    let PreparedPackage { pkg_dir, should_be_built } =
+        prepare_package::<SilentReporter>(&opts(false, false), dir.path(), None).unwrap();
+    assert!(!should_be_built);
+    assert_eq!(pkg_dir, dir.path());
+}
+
+#[test]
+fn prepare_ignore_scripts_short_circuits_without_spawn() {
+    // The script body would fail if it actually ran, so observing
+    // success proves we short-circuited before spawning.
+    let dir = tempdir().unwrap();
+    write_manifest(
+        dir.path(),
+        &json!({
+            "name": "x", "version": "0.0.0",
+            "scripts": { "prepare": "exit 1" },
+        }),
+    );
+
+    let PreparedPackage { should_be_built, .. } =
+        prepare_package::<SilentReporter>(&opts(true, true), dir.path(), None).unwrap();
+    assert!(should_be_built, "ignore_scripts still reports should_be_built");
+}
+
+#[test]
+fn prepare_rejects_when_allow_build_returns_false() {
+    let dir = tempdir().unwrap();
+    write_manifest(
+        dir.path(),
+        &json!({
+            "name": "naughty", "version": "1.0.0",
+            "scripts": { "prepare": "tsc" },
+        }),
+    );
+
+    let err = prepare_package::<SilentReporter>(&opts(false, false), dir.path(), None).unwrap_err();
+    match err {
+        PreparePackageError::NotAllowed { name, version } => {
+            assert_eq!(name, "naughty");
+            assert_eq!(version, "1.0.0");
+        }
+        other => panic!("expected NotAllowed, got {other:?}"),
+    }
+}
+
+#[test]
+fn safe_join_path_rejects_escapes() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    // `..` escape — canonical form lives outside `root`.
+    let err = safe_join_path(root, Some("../escape")).unwrap_err();
+    assert!(matches!(err, PreparePackageError::InvalidPath { .. }));
+}
+
+#[test]
+fn safe_join_path_rejects_missing_sub_dir() {
+    let dir = tempdir().unwrap();
+    let err = safe_join_path(dir.path(), Some("does/not/exist")).unwrap_err();
+    assert!(matches!(err, PreparePackageError::InvalidPath { .. }));
+}
+
+#[test]
+fn safe_join_path_accepts_empty_sub_dir() {
+    let dir = tempdir().unwrap();
+    let received = safe_join_path(dir.path(), None).unwrap();
+    let canonical_root = dir.path().canonicalize().unwrap();
+    let canonical_received = received.canonicalize().unwrap();
+    assert_eq!(canonical_received, canonical_root);
+}

--- a/crates/lockfile/src/resolution.rs
+++ b/crates/lockfile/src/resolution.rs
@@ -45,6 +45,13 @@ pub struct DirectoryResolution {
 pub struct GitResolution {
     pub repo: String,
     pub commit: String,
+    /// Sub-directory inside the cloned tree to package. Mirrors pnpm's
+    /// `GitRepositoryResolution.path` at
+    /// <https://github.com/pnpm/pnpm/blob/94240bc046/lockfile/types/src/index.ts#L120-L125>.
+    /// The git fetcher passes this to `preparePackage` so the build runs
+    /// inside the sub-directory rather than the repo root.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
 }
 
 /// Represent the resolution object.

--- a/crates/lockfile/src/resolution/tests.rs
+++ b/crates/lockfile/src/resolution/tests.rs
@@ -248,6 +248,25 @@ fn deserialize_git_resolution() {
     let expected = LockfileResolution::Git(GitResolution {
         repo: "https://github.com/ksxnodemodules/ts-pipe-compose.git".to_string(),
         commit: "e63c09e460269b0c535e4c34debf69bb91d57b22".to_string(),
+        path: None,
+    });
+    assert_eq!(received, expected);
+}
+
+#[test]
+fn deserialize_git_resolution_with_path() {
+    let yaml = text_block! {
+        "type: git"
+        "repo: https://github.com/ksxnodemodules/ts-pipe-compose.git"
+        "commit: e63c09e460269b0c535e4c34debf69bb91d57b22"
+        "path: packages/sub"
+    };
+    let received: LockfileResolution = serde_saphyr::from_str(yaml).unwrap();
+    dbg!(&received);
+    let expected = LockfileResolution::Git(GitResolution {
+        repo: "https://github.com/ksxnodemodules/ts-pipe-compose.git".to_string(),
+        commit: "e63c09e460269b0c535e4c34debf69bb91d57b22".to_string(),
+        path: Some("packages/sub".to_string()),
     });
     assert_eq!(received, expected);
 }
@@ -257,6 +276,7 @@ fn serialize_git_resolution() {
     let resolution = LockfileResolution::Git(GitResolution {
         repo: "https://github.com/ksxnodemodules/ts-pipe-compose.git".to_string(),
         commit: "e63c09e460269b0c535e4c34debf69bb91d57b22".to_string(),
+        path: None,
     });
     let received = serialize_yaml::to_string(&resolution).unwrap();
     let received = received.trim();
@@ -265,6 +285,25 @@ fn serialize_git_resolution() {
         "type: git"
         "repo: https://github.com/ksxnodemodules/ts-pipe-compose.git"
         "commit: e63c09e460269b0c535e4c34debf69bb91d57b22"
+    };
+    assert_eq!(received, expected);
+}
+
+#[test]
+fn serialize_git_resolution_with_path() {
+    let resolution = LockfileResolution::Git(GitResolution {
+        repo: "https://github.com/ksxnodemodules/ts-pipe-compose.git".to_string(),
+        commit: "e63c09e460269b0c535e4c34debf69bb91d57b22".to_string(),
+        path: Some("packages/sub".to_string()),
+    });
+    let received = serialize_yaml::to_string(&resolution).unwrap();
+    let received = received.trim();
+    eprintln!("RECEIVED:\n{received}");
+    let expected = text_block! {
+        "type: git"
+        "repo: https://github.com/ksxnodemodules/ts-pipe-compose.git"
+        "commit: e63c09e460269b0c535e4c34debf69bb91d57b22"
+        "path: packages/sub"
     };
     assert_eq!(received, expected);
 }

--- a/crates/lockfile/src/resolution/tests.rs
+++ b/crates/lockfile/src/resolution/tests.rs
@@ -262,7 +262,6 @@ fn deserialize_git_resolution_with_path() {
         "path: packages/sub"
     };
     let received: LockfileResolution = serde_saphyr::from_str(yaml).unwrap();
-    dbg!(&received);
     let expected = LockfileResolution::Git(GitResolution {
         repo: "https://github.com/ksxnodemodules/ts-pipe-compose.git".to_string(),
         commit: "e63c09e460269b0c535e4c34debf69bb91d57b22".to_string(),

--- a/crates/package-manager/Cargo.toml
+++ b/crates/package-manager/Cargo.toml
@@ -14,6 +14,7 @@ repository.workspace  = true
 pacquet-cmd-shim         = { workspace = true }
 pacquet-executor         = { workspace = true }
 pacquet-fs               = { workspace = true }
+pacquet-git-fetcher      = { workspace = true }
 pacquet-lockfile         = { workspace = true }
 pacquet-modules-yaml     = { workspace = true }
 pacquet-network          = { workspace = true }
@@ -36,6 +37,7 @@ pipe-trait      = { workspace = true }
 rayon           = { workspace = true }
 reflink-copy    = { workspace = true }
 serde_json      = { workspace = true }
+ssri            = { workspace = true }
 tokio           = { workspace = true }
 tracing         = { workspace = true }
 miette          = { workspace = true }

--- a/crates/package-manager/src/create_virtual_store.rs
+++ b/crates/package-manager/src/create_virtual_store.rs
@@ -79,6 +79,12 @@ pub struct CreateVirtualStore<'a> {
     /// download path's `InstallPackageBySnapshot` and also reused by
     /// `BuildModules` for the side-effects-cache WRITE path.
     pub store_index_writer: &'a std::sync::Arc<StoreIndexWriter>,
+    /// `allowBuilds` gate, shared with `BuildModules`. The cold-batch
+    /// path threads this into the git fetcher so `preparePackage` can
+    /// reject `GIT_DEP_PREPARE_NOT_ALLOWED` for packages that aren't
+    /// allowlisted. Computed once per install in
+    /// [`crate::InstallFrozenLockfile::run`].
+    pub allow_build_policy: &'a crate::AllowBuildPolicy,
 }
 
 /// Error type of [`CreateVirtualStore`].
@@ -116,6 +122,7 @@ impl<'a> CreateVirtualStore<'a> {
             logged_methods,
             requester,
             store_index_writer,
+            allow_build_policy,
         } = self;
 
         let Some(snapshots) = snapshots else {
@@ -435,6 +442,7 @@ impl<'a> CreateVirtualStore<'a> {
                         package_key: snapshot_key,
                         metadata,
                         snapshot,
+                        allow_build_policy,
                     }
                     .run::<R>()
                     .await
@@ -511,12 +519,19 @@ fn snapshot_cache_key(
             ));
         }
         LockfileResolution::Git(_) => {
-            return Err(CreateVirtualStoreError::InstallPackageBySnapshot(
-                InstallPackageBySnapshotError::UnsupportedResolution {
-                    package_key: snapshot_key.to_string(),
-                    resolution_kind: "git",
-                },
-            ));
+            // Git resolutions don't participate in the warm prefetch
+            // batch in this PR — the fetcher decides the
+            // `gitHostedStoreIndexKey` `built` bit at fetch time
+            // (`preparePackage` returns `shouldBeBuilt`) and writes
+            // no store-index row, so there's nothing for the warm
+            // path to read back yet. Returning `Ok(None)` routes the
+            // snapshot through the cold-batch
+            // [`InstallPackageBySnapshot`], where
+            // [`pacquet_git_fetcher::GitFetcher`] handles the
+            // clone + checkout + import. Wiring warm caching for
+            // git-hosted entries is a follow-up tracked alongside
+            // Section C (the git-hosted *tarball* path) in #436.
+            return Ok(None);
         }
     };
     let pkg_id = metadata_key.to_string();

--- a/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/crates/package-manager/src/install_frozen_lockfile.rs
@@ -97,6 +97,13 @@ where
 
         // TODO: check if the lockfile is out-of-date
 
+        // Build the allow-builds policy up front so it can flow into
+        // the cold-batch git fetcher in `CreateVirtualStore` as well as
+        // the postinstall phase in `BuildModules`. Mirrors pnpm where
+        // `createAllowBuildFunction` is a per-install constant.
+        let allow_build_policy = AllowBuildPolicy::from_config(config)
+            .map_err(InstallFrozenLockfileError::VersionPolicy)?;
+
         // Spawn the batched store-index writer here so it lives
         // across both the prefetch/download phase (consumers in
         // `CreateVirtualStore`) and the build phase (the new
@@ -118,6 +125,7 @@ where
                 logged_methods,
                 requester,
                 store_index_writer: &store_index_writer,
+                allow_build_policy: &allow_build_policy,
             }
             .run::<R>()
             .await
@@ -175,8 +183,6 @@ where
         }));
 
         let manifest_dir = Path::new(requester);
-        let allow_build_policy = AllowBuildPolicy::from_config(config)
-            .map_err(InstallFrozenLockfileError::VersionPolicy)?;
 
         // Resolve `pnpm-workspace.yaml`'s `patchedDependencies` once
         // per install. Yields `None` when nothing is configured (no

--- a/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/crates/package-manager/src/install_package_by_snapshot.rs
@@ -1,9 +1,12 @@
 use crate::{
-    CreateVirtualDirBySnapshot, CreateVirtualDirError, retry_config::retry_opts_from_config,
+    AllowBuildPolicy, CreateVirtualDirBySnapshot, CreateVirtualDirError,
+    retry_config::retry_opts_from_config,
 };
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_config::Config;
+use pacquet_executor::ScriptsPrependNodePath as ExecScriptsPrependNodePath;
+use pacquet_git_fetcher::{GitFetchOutput, GitFetcher, GitFetcherError};
 use pacquet_lockfile::{LockfileResolution, PackageKey, PackageMetadata, SnapshotEntry};
 use pacquet_network::ThrottledClient;
 use pacquet_reporter::{LogEvent, LogLevel, ProgressLog, ProgressMessage, Reporter};
@@ -12,6 +15,8 @@ use pacquet_tarball::{DownloadTarballToStore, PrefetchedCasPaths, TarballError};
 use pipe_trait::Pipe;
 use std::{
     borrow::Cow,
+    collections::HashMap,
+    path::PathBuf,
     sync::{Arc, atomic::AtomicU8},
 };
 
@@ -42,6 +47,12 @@ pub struct InstallPackageBySnapshot<'a> {
     pub package_key: &'a PackageKey,
     pub metadata: &'a PackageMetadata,
     pub snapshot: &'a SnapshotEntry,
+    /// `allowBuilds` gate. Routed into the git fetcher for
+    /// `preparePackage`'s `GIT_DEP_PREPARE_NOT_ALLOWED` check.
+    /// Computed once per install in
+    /// [`crate::InstallFrozenLockfile::run`] and threaded through
+    /// [`crate::CreateVirtualStore`].
+    pub allow_build_policy: &'a AllowBuildPolicy,
 }
 
 /// Error type of [`InstallPackageBySnapshot`].
@@ -64,6 +75,11 @@ pub enum InstallPackageBySnapshotError {
     )]
     #[diagnostic(code(pacquet_package_manager::unsupported_resolution))]
     UnsupportedResolution { package_key: String, resolution_kind: &'static str },
+
+    /// Failure from the git fetcher for a `type: git` resolution
+    /// (clone / checkout / preparePackage / CAS import).
+    #[diagnostic(transparent)]
+    GitFetch(#[error(source)] GitFetcherError),
 }
 
 impl<'a> InstallPackageBySnapshot<'a> {
@@ -81,25 +97,35 @@ impl<'a> InstallPackageBySnapshot<'a> {
             package_key,
             metadata,
             snapshot,
+            allow_build_policy,
         } = self;
 
-        let (tarball_url, integrity) = match &metadata.resolution {
-            LockfileResolution::Tarball(tarball_resolution) => {
-                let integrity = tarball_resolution.integrity.as_ref().ok_or_else(|| {
-                    InstallPackageBySnapshotError::MissingTarballIntegrity {
-                        package_key: package_key.to_string(),
-                    }
-                })?;
-                (tarball_resolution.tarball.as_str().pipe(Cow::Borrowed), integrity)
-            }
-            LockfileResolution::Registry(registry_resolution) => {
-                let registry = config.registry.strip_suffix('/').unwrap_or(&config.registry);
-                let name = &package_key.name;
-                let version = package_key.suffix.version();
-                let bare_name = name.bare.as_str();
-                let tarball_url = format!("{registry}/{name}/-/{bare_name}-{version}.tgz");
-                let integrity = &registry_resolution.integrity;
-                (Cow::Owned(tarball_url), integrity)
+        // TODO: skip when already exists in store?
+        let package_id = package_key.without_peer().to_string();
+        emit_progress_resolved::<R>(&package_id, requester);
+
+        let cas_paths: HashMap<String, PathBuf> = match &metadata.resolution {
+            LockfileResolution::Tarball(_) | LockfileResolution::Registry(_) => {
+                let (tarball_url, integrity) =
+                    tarball_url_and_integrity(&metadata.resolution, package_key, config)?;
+                DownloadTarballToStore {
+                    http_client,
+                    store_dir: &config.store_dir,
+                    store_index: store_index.cloned(),
+                    store_index_writer: store_index_writer.cloned(),
+                    verify_store_integrity: config.verify_store_integrity,
+                    verified_files_cache: Arc::clone(verified_files_cache),
+                    package_integrity: integrity,
+                    package_unpacked_size: None,
+                    package_url: &tarball_url,
+                    package_id: &package_id,
+                    requester,
+                    prefetched_cas_paths,
+                    retry_opts: retry_opts_from_config(config),
+                }
+                .run_without_mem_cache::<R>()
+                .await
+                .map_err(InstallPackageBySnapshotError::DownloadTarball)?
             }
             LockfileResolution::Directory(_) => {
                 return Err(InstallPackageBySnapshotError::UnsupportedResolution {
@@ -107,36 +133,50 @@ impl<'a> InstallPackageBySnapshot<'a> {
                     resolution_kind: "directory",
                 });
             }
-            LockfileResolution::Git(_) => {
-                return Err(InstallPackageBySnapshotError::UnsupportedResolution {
-                    package_key: package_key.to_string(),
-                    resolution_kind: "git",
-                });
+            LockfileResolution::Git(git_resolution) => {
+                let allow_build_closure: &(dyn Fn(&str, &str) -> bool + Send + Sync) =
+                    &|name, version| {
+                        // `AllowBuildPolicy::check` returns `None` when
+                        // the package is neither allow-listed nor deny-
+                        // listed. Default-deny (`None → false`) matches
+                        // pnpm v11's policy: build scripts have to be
+                        // explicitly opted in to run.
+                        allow_build_policy.check(name, version).unwrap_or(false)
+                    };
+                let scripts_prepend_node_path = match config.scripts_prepend_node_path {
+                    pacquet_config::ScriptsPrependNodePath::Always => {
+                        ExecScriptsPrependNodePath::Always
+                    }
+                    pacquet_config::ScriptsPrependNodePath::Never => {
+                        ExecScriptsPrependNodePath::Never
+                    }
+                    pacquet_config::ScriptsPrependNodePath::WarnOnly => {
+                        ExecScriptsPrependNodePath::WarnOnly
+                    }
+                };
+                let GitFetchOutput { cas_paths, built: _built } = GitFetcher {
+                    repo: &git_resolution.repo,
+                    commit: &git_resolution.commit,
+                    path: git_resolution.path.as_deref(),
+                    git_shallow_hosts: &config.git_shallow_hosts,
+                    allow_build: allow_build_closure,
+                    ignore_scripts: false,
+                    unsafe_perm: config.unsafe_perm,
+                    user_agent: None,
+                    scripts_prepend_node_path,
+                    script_shell: None,
+                    node_execpath: None,
+                    npm_execpath: None,
+                    store_dir: &config.store_dir,
+                    package_id: &package_id,
+                    requester,
+                }
+                .run::<R>()
+                .await
+                .map_err(InstallPackageBySnapshotError::GitFetch)?;
+                cas_paths
             }
         };
-
-        // TODO: skip when already exists in store?
-        let package_id = package_key.without_peer().to_string();
-        emit_progress_resolved::<R>(&package_id, requester);
-
-        let cas_paths = DownloadTarballToStore {
-            http_client,
-            store_dir: &config.store_dir,
-            store_index: store_index.cloned(),
-            store_index_writer: store_index_writer.cloned(),
-            verify_store_integrity: config.verify_store_integrity,
-            verified_files_cache: Arc::clone(verified_files_cache),
-            package_integrity: integrity,
-            package_unpacked_size: None,
-            package_url: &tarball_url,
-            package_id: &package_id,
-            requester,
-            prefetched_cas_paths,
-            retry_opts: retry_opts_from_config(config),
-        }
-        .run_without_mem_cache::<R>()
-        .await
-        .map_err(InstallPackageBySnapshotError::DownloadTarball)?;
 
         CreateVirtualDirBySnapshot {
             virtual_store_dir: &config.virtual_store_dir,
@@ -152,6 +192,42 @@ impl<'a> InstallPackageBySnapshot<'a> {
         .map_err(InstallPackageBySnapshotError::CreateVirtualDir)?;
 
         Ok(())
+    }
+}
+
+/// Resolve the tarball URL + integrity for tarball- and registry-shaped
+/// resolutions. Factored out so the per-resolution-type dispatch in
+/// [`InstallPackageBySnapshot::run`] reads top-down: each variant builds
+/// its own `cas_paths`.
+fn tarball_url_and_integrity<'a>(
+    resolution: &'a LockfileResolution,
+    package_key: &PackageKey,
+    config: &'a Config,
+) -> Result<(Cow<'a, str>, &'a ssri::Integrity), InstallPackageBySnapshotError> {
+    match resolution {
+        LockfileResolution::Tarball(tarball_resolution) => {
+            let integrity = tarball_resolution.integrity.as_ref().ok_or_else(|| {
+                InstallPackageBySnapshotError::MissingTarballIntegrity {
+                    package_key: package_key.to_string(),
+                }
+            })?;
+            Ok((tarball_resolution.tarball.as_str().pipe(Cow::Borrowed), integrity))
+        }
+        LockfileResolution::Registry(registry_resolution) => {
+            let registry = config.registry.strip_suffix('/').unwrap_or(&config.registry);
+            let name = &package_key.name;
+            let version = package_key.suffix.version();
+            let bare_name = name.bare.as_str();
+            let tarball_url = format!("{registry}/{name}/-/{bare_name}-{version}.tgz");
+            Ok((Cow::Owned(tarball_url), &registry_resolution.integrity))
+        }
+        // Caller (`run`) only invokes this helper for the tarball /
+        // registry arms; git and directory resolutions never reach
+        // here. Return an unreachable-style error so a future caller
+        // that forgets to gate gets a clear panic in debug.
+        LockfileResolution::Directory(_) | LockfileResolution::Git(_) => {
+            unreachable!("tarball_url_and_integrity called with non-tarball resolution");
+        }
     }
 }
 

--- a/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/crates/package-manager/src/install_package_by_snapshot.rs
@@ -134,15 +134,21 @@ impl<'a> InstallPackageBySnapshot<'a> {
                 });
             }
             LockfileResolution::Git(git_resolution) => {
-                let allow_build_closure: &(dyn Fn(&str, &str) -> bool + Send + Sync) =
-                    &|name, version| {
-                        // `AllowBuildPolicy::check` returns `None` when
-                        // the package is neither allow-listed nor deny-
-                        // listed. Default-deny (`None → false`) matches
-                        // pnpm v11's policy: build scripts have to be
-                        // explicitly opted in to run.
-                        allow_build_policy.check(name, version).unwrap_or(false)
-                    };
+                // Bind the closure to a named local before borrowing it
+                // into `GitFetcher.allow_build`. `&|...|` would create a
+                // reference to a temporary closure that has to outlive
+                // the `.await` below; routing through a `let` makes the
+                // owning storage explicit and removes any reliance on
+                // temporary-lifetime extension across an await point.
+                //
+                // `AllowBuildPolicy::check` returns `None` when the
+                // package is neither allow-listed nor deny-listed.
+                // Default-deny (`None → false`) matches pnpm v11's
+                // policy: build scripts have to be explicitly opted in
+                // to run.
+                let allow_build_closure = |name: &str, version: &str| {
+                    allow_build_policy.check(name, version).unwrap_or(false)
+                };
                 let scripts_prepend_node_path = match config.scripts_prepend_node_path {
                     pacquet_config::ScriptsPrependNodePath::Always => {
                         ExecScriptsPrependNodePath::Always
@@ -159,7 +165,7 @@ impl<'a> InstallPackageBySnapshot<'a> {
                     commit: &git_resolution.commit,
                     path: git_resolution.path.as_deref(),
                     git_shallow_hosts: &config.git_shallow_hosts,
-                    allow_build: allow_build_closure,
+                    allow_build: &allow_build_closure,
                     ignore_scripts: false,
                     unsafe_perm: config.unsafe_perm,
                     user_agent: None,

--- a/crates/package-manager/src/install_package_from_registry/tests.rs
+++ b/crates/package-manager/src/install_package_from_registry/tests.rs
@@ -51,6 +51,7 @@ fn create_config(store_dir: &Path, modules_dir: &Path, virtual_store_dir: &Path)
         scripts_prepend_node_path: Default::default(),
         unsafe_perm: true,
         child_concurrency: 1,
+        git_shallow_hosts: pacquet_config::default_git_shallow_hosts(),
     }
 }
 


### PR DESCRIPTION
## Summary

Builds on §A (#440). Adds a new `pacquet-git-fetcher` crate that handles `LockfileResolution::Git` snapshots during frozen-lockfile installs, plus the supporting `preparePackage` port. The install dispatcher now routes git resolutions through it instead of returning `UnsupportedResolution { resolution_kind: "git" }`.

### New crate `pacquet-git-fetcher`

- **`GitFetcher`** shells out to the system `git` (clone, or `init` + `fetch --depth 1` on hosts in `git_shallow_hosts`), checks out the pinned commit, verifies via `rev-parse HEAD`, runs `preparePackage`, removes `.git`, computes a packlist, and imports the resulting file set into the CAS. Surfaces a friendly `GitNotFound` when `git` isn't on `PATH` — pacquet does not bundle it. Mirrors [`fetching/git-fetcher/src/index.ts`](https://github.com/pnpm/pnpm/blob/94240bc046/fetching/git-fetcher/src/index.ts).
- **`prepare_package`** ports [`exec/prepare-package/src/index.ts`](https://github.com/pnpm/pnpm/blob/94240bc046/exec/prepare-package/src/index.ts). Reads the manifest, decides via `package_should_be_built`, honors an `AllowBuildFn` (the dispatcher adapts pacquet's `AllowBuildPolicy` into this shape), runs `<pm>-install` plus any `prepublish` / `prepack` / `publish` scripts via the existing `pacquet_executor::run_lifecycle_hook`, then deletes `node_modules`. Emits the upstream error codes `GIT_DEP_PREPARE_NOT_ALLOWED`, `ERR_PNPM_PREPARE_PACKAGE`, `INVALID_PATH`.
- **`detect_preferred_pm`** sniffs the cloned tree for a lockfile to pick the install pm. Workspace-root walking deferred.
- **Minimal `packlist`** honors the manifest's `files` field with a tiny `*` / `**` / `?` glob matcher (`?` and single `*` reject `/`; `**` matches across directories), always-includes the README / LICENSE / package.json set, and always-excludes `.git`, `node_modules`, lockfiles for sibling pms, and common cruft. Full `.npmignore` / `.gitignore` semantics and `bundleDependencies` walking are deferred and tracked in module docs.

### Wiring in `pacquet-package-manager`

- `InstallPackageBySnapshot` now matches `LockfileResolution::Git` and runs the fetcher in place of `DownloadTarballToStore`.
- `&AllowBuildPolicy` is computed once per install in `InstallFrozenLockfile` and threaded through `CreateVirtualStore` → `InstallPackageBySnapshot`.
- `snapshot_cache_key` returns `Ok(None)` for `Git` resolutions so they cold-batch. Warm prefetch for git-hosted slots is a follow-up alongside §C.

### Supporting changes

- `GitResolution.path: Option<String>` so a lockfile pinning a sub-directory of a git-hosted monorepo deserializes without tripping `deny_unknown_fields`.
- `Config::git_shallow_hosts` with pnpm's default list + `pnpm-workspace.yaml` override.
- `pacquet_executor::run_lifecycle_hook` is now `pub` so the preparePackage port can dispatch by arbitrary stage name.

## Out of scope (follow-ups for #436)

- §C — git-hosted *tarball* fetcher (the `gitHosted: true` shape).
- §E — full integration-test matrix (`plans/TEST_PORTING.md` 563-572). This PR ships crate-level tests against a local bare repo that prove the path works end-to-end.
- Warm prefetch for git resolutions (re-clones on every install today — slow but correct).
- Full `npm-packlist` semantics (`.npmignore`, gitignore layering, `bundleDependencies` walking).

## Test plan

- [x] `cargo nextest run -p pacquet-git-fetcher` — 31 tests pass:
      preferred-pm sniffer (7), packlist MVP (7 — including a regression test pinning `a?b/index.js` does NOT match `a/b/index.js`), preparePackage manifest paths (10), and 7 integration tests using a local bare git repo (clone → checkout → import; commit mismatch; `GIT_DEP_PREPARE_NOT_ALLOWED`; shallow-host predicate; URL host parsing).
- [x] `cargo nextest run -p pacquet-lockfile` — `GitResolution { path }` round-trip.
- [x] `cargo nextest run -p pacquet-config` — `pnpm-workspace.yaml`'s `gitShallowHosts` overrides the default wholesale (not merged).
- [x] `cargo nextest run -p pacquet-package-manager` — full suite (218 tests) still green after dispatcher wiring.
- [x] `just ready` — 685 tests run, 685 passed, 2 skipped. Clippy clean.
- [x] `cargo doc --no-deps --workspace --document-private-items` with `RUSTDOCFLAGS=-D warnings` — clean (Doc CI job green).
- [x] `taplo format --check`
- [x] `just dylint`

---
Written by an agent (Claude Code, claude-opus-4-7).
