### PR TITLE
feat(real-hoist): crate skeleton + lockfile-to-HoisterTree wrapper (#438 slice 3a)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2125,6 +2125,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pacquet-real-hoist"
+version = "0.0.1"
+dependencies = [
+ "derive_more",
+ "indexmap",
+ "miette 7.6.0",
+ "pacquet-lockfile",
+ "pretty_assertions",
+]
+
+[[package]]
 name = "pacquet-registry"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ pacquet-graph-hasher     = { path = "crates/graph-hasher" }
 pacquet-store-dir        = { path = "crates/store-dir" }
 pacquet-reporter         = { path = "crates/reporter" }
 pacquet-patching         = { path = "crates/patching" }
+pacquet-real-hoist       = { path = "crates/real-hoist" }
 
 # Tasks
 pacquet-registry-mock = { path = "tasks/registry-mock" }

--- a/crates/real-hoist/Cargo.toml
+++ b/crates/real-hoist/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name                  = "pacquet-real-hoist"
+version               = "0.0.1"
+publish               = false
+authors.workspace     = true
+description.workspace = true
+edition.workspace     = true
+homepage.workspace    = true
+keywords.workspace    = true
+license.workspace     = true
+repository.workspace  = true
+
+[dependencies]
+pacquet-lockfile = { workspace = true }
+
+derive_more = { workspace = true }
+indexmap    = { workspace = true }
+miette      = { workspace = true }
+
+[dev-dependencies]
+pretty_assertions = { workspace = true }

--- a/crates/real-hoist/src/lib.rs
+++ b/crates/real-hoist/src/lib.rs
@@ -7,15 +7,8 @@
 //! per workspace importer), runs the algorithm, and post-filters
 //! `externalDependencies` out of the top-level result.
 //!
-//! This is Sub-slice 3a of the hoisted-linker umbrella ([#438]). It
-//! ships the IO types, the lockfile-to-`HoisterTree` translation, and a
-//! stub `nm_hoist` that returns the input tree unchanged. Later
-//! sub-slices replace the stub with the real algorithm and add the
-//! `hoistingLimits` / `externalDependencies` knobs.
-//!
 //! [upstream-wrapper]: https://github.com/pnpm/pnpm/blob/94240bc0464196bd52f7006b97f6d9a43df34633/installing/linking/real-hoist/src/index.ts
 //! [yarn-hoist]: https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts
-//! [#438]: https://github.com/pnpm/pacquet/issues/438
 
 use derive_more::{Display, Error};
 use indexmap::IndexSet;
@@ -202,10 +195,11 @@ impl<T> From<Rc<T>> for RcByPtr<T> {
 /// `@yarnpkg/nm` hoister over it. Ports
 /// [`installing/linking/real-hoist/src/index.ts`][upstream].
 ///
-/// The inner hoist algorithm is currently stubbed (returns the
-/// input tree shape unchanged). The lockfile-to-tree translation
-/// and the `LockfileMissingDependencyError` surface are the parts
-/// pinned by Sub-slice 3a; later sub-slices replace the stub.
+/// The inner hoist algorithm is currently stubbed: it returns the
+/// input tree shape converted to `HoisterResult` without moving
+/// anything. The lockfile-to-tree translation and the
+/// `LockfileMissingDependencyError` surface are what this function
+/// pins today.
 ///
 /// [upstream]: https://github.com/pnpm/pnpm/blob/94240bc0464196bd52f7006b97f6d9a43df34633/installing/linking/real-hoist/src/index.ts
 pub fn hoist(lockfile: &Lockfile, opts: &HoistOpts) -> Result<HoisterResult, HoistError> {
@@ -220,9 +214,8 @@ pub fn hoist(lockfile: &Lockfile, opts: &HoistOpts) -> Result<HoisterResult, Hoi
     // `externalDependencies` are added as `link:` placeholders at
     // the root so the hoister won't move anything else into those
     // slots; they're stripped from the result after hoisting.
-    // Pacquet has no consumer for this yet (the umbrella's Slice 10
-    // wires it through configuration), but the wrapper handles it
-    // for parity with upstream's signature.
+    // Pacquet has no consumer for this yet, but the wrapper handles
+    // it for parity with upstream's signature.
     for dep in &opts.external_dependencies {
         let placeholder = Rc::new(HoisterTree {
             name: dep.clone(),
@@ -238,9 +231,9 @@ pub fn hoist(lockfile: &Lockfile, opts: &HoistOpts) -> Result<HoisterResult, Hoi
 
     // Non-root importers (workspace projects) become children of
     // the virtual `.` root. Pacquet's install pipeline doesn't yet
-    // support workspaces (umbrella Slice 9), so the wrapper accepts
-    // them but the rest of the install code path will reject a
-    // multi-importer lockfile elsewhere.
+    // support workspaces, so the wrapper accepts them but the rest
+    // of the install code path will reject a multi-importer
+    // lockfile elsewhere.
     let mut non_root: Vec<(&String, &ProjectSnapshot)> = lockfile
         .importers
         .iter()
@@ -481,8 +474,7 @@ fn percent_encode_path(s: &str) -> String {
 
 /// Stub for the `@yarnpkg/nm` hoist algorithm. Walks the input tree
 /// and returns it in `HoisterResult` shape unchanged — no actual
-/// hoisting happens. Sub-slice 3b replaces this with the real
-/// algorithm.
+/// hoisting happens. The real algorithm replaces this body.
 fn nm_hoist(tree: &HoisterTree, _opts: &HoistOpts) -> HoisterResult {
     let mut memo: HashMap<*const HoisterTree, Rc<HoisterResult>> = HashMap::new();
     convert(tree, &mut memo).as_ref().clone()

--- a/crates/real-hoist/src/lib.rs
+++ b/crates/real-hoist/src/lib.rs
@@ -1,0 +1,537 @@
+//! Real-directory hoister for the `nodeLinker: hoisted` install layout.
+//!
+//! Ports pnpm v11's [`installing/linking/real-hoist`][upstream-wrapper]
+//! package, which is itself a thin wrapper around the
+//! [`@yarnpkg/nm/hoist`][yarn-hoist] algorithm. The wrapper translates a
+//! pnpm lockfile into a [`HoisterTree`] (rooted at `.` with one child
+//! per workspace importer), runs the algorithm, and post-filters
+//! `externalDependencies` out of the top-level result.
+//!
+//! This is Sub-slice 3a of the hoisted-linker umbrella ([#438]). It
+//! ships the IO types, the lockfile-to-`HoisterTree` translation, and a
+//! stub `nm_hoist` that returns the input tree unchanged. Later
+//! sub-slices replace the stub with the real algorithm and add the
+//! `hoistingLimits` / `externalDependencies` knobs.
+//!
+//! [upstream-wrapper]: https://github.com/pnpm/pnpm/blob/94240bc0464196bd52f7006b97f6d9a43df34633/installing/linking/real-hoist/src/index.ts
+//! [yarn-hoist]: https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts
+//! [#438]: https://github.com/pnpm/pacquet/issues/438
+
+use derive_more::{Display, Error};
+use indexmap::IndexSet;
+use miette::Diagnostic;
+use pacquet_lockfile::{Lockfile, PkgName, PkgNameVerPeer, ProjectSnapshot, SnapshotEntry};
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap},
+    rc::Rc,
+};
+
+/// One of the three node categories the `@yarnpkg/nm` hoister
+/// distinguishes. Mirrors `HoisterDependencyKind` at the
+/// [yarn source][yarn-kind].
+///
+/// [yarn-kind]: https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L12-L14
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum HoisterDependencyKind {
+    /// A normal package — eligible for hoisting.
+    Regular,
+    /// A workspace project. The root `.` node is one of these; each
+    /// non-root importer is added under it as another `Workspace`
+    /// node. Workspace nodes never hoist past their declared slot.
+    Workspace,
+    /// A package linked from outside the lockfile graph (e.g. a
+    /// `link:` ref). Only hoists when *all* of its descendants
+    /// hoist, and triggers another round when any do — see
+    /// [`hoist.ts:416`][soft-link].
+    ///
+    /// [soft-link]: https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L416
+    ExternalSoftLink,
+}
+
+/// Input node for the hoister. Built by [`hoist`] from the lockfile.
+///
+/// Mirrors `HoisterTree` at the [yarn source][yarn-tree]. Children
+/// are stored in an [`IndexSet`] so insertion order is preserved (the
+/// upstream hoister's traversal relies on declaration order to break
+/// ties between equivalent candidates), and so that a node added via
+/// two parent paths is shared by `Rc` identity the way JS's
+/// `Set<HoisterTree>` shares by object identity.
+///
+/// [yarn-tree]: https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L16-L19
+#[derive(Debug)]
+pub struct HoisterTree {
+    /// The alias the package is exposed under at *this* parent —
+    /// what would appear as the directory name in `node_modules`.
+    /// For npm-alias deps (`"foo": "npm:bar@^1"`), this is `foo`.
+    pub name: String,
+    /// The package's underlying identity, independent of the alias.
+    /// For npm-aliases this is the target package name (`bar`); for
+    /// non-aliased deps it equals `name`.
+    pub ident_name: String,
+    /// Version-with-peer ref. For the root and workspace nodes this
+    /// is `""` or `"workspace:<id>"`; for regular nodes it's the
+    /// snapshot key (`name@version(peer)`).
+    pub reference: String,
+    /// Aliases that this node refuses to hoist past — its parent
+    /// must keep them in scope. The union of `peerDependencies` and
+    /// `transitivePeerDependencies` from the lockfile, unless
+    /// `autoInstallPeers` is set (which zeroes the set so the
+    /// hoister moves freely).
+    pub peer_names: BTreeSet<String>,
+    pub dependency_kind: HoisterDependencyKind,
+    /// Tiebreaker for the hoister's BFS. Pacquet always builds with
+    /// `0`; pnpm and yarn-berry use higher values for packages that
+    /// declare a high `hoistPriority` to bias them toward the root.
+    pub hoist_priority: u32,
+    /// Children of this node. Order matches insertion order — the
+    /// hoister depends on it.
+    pub dependencies: IndexSet<RcByPtr<HoisterTree>>,
+}
+
+/// Output node from the hoister. The shape mirrors `HoisterTree`
+/// except that one `HoisterResult` can collect multiple references
+/// (when several `HoisterTree` nodes with the same `ident_name`
+/// converged onto the same hoist slot).
+///
+/// Mirrors `HoisterResult` at the [yarn source][yarn-result].
+///
+/// [yarn-result]: https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L20-L23
+#[derive(Debug, Clone)]
+pub struct HoisterResult {
+    pub name: String,
+    pub ident_name: String,
+    pub references: BTreeSet<String>,
+    pub dependencies: IndexSet<RcByPtr<HoisterResult>>,
+}
+
+/// Per-importer hoisting borders. Outer key is the importer locator
+/// (e.g. `.@`); the inner set lists package aliases that may not be
+/// hoisted past that importer.
+///
+/// Upstream `HoistingLimits` is `Map<string, Set<string>>`. Pacquet
+/// uses `BTreeMap` / `BTreeSet` so the order is deterministic for
+/// snapshot tests.
+pub type HoistingLimits = BTreeMap<String, BTreeSet<String>>;
+
+/// Options accepted by [`hoist`]. Mirrors the `opts` object of the
+/// pnpm wrapper.
+#[derive(Debug, Default, Clone)]
+pub struct HoistOpts {
+    pub hoisting_limits: HoistingLimits,
+    pub external_dependencies: BTreeSet<String>,
+    /// When `true`, every package's `peer_names` is zeroed before
+    /// the hoister runs. Mirrors pnpm's `autoInstallPeers` short-
+    /// circuit at [real-hoist:124][auto].
+    ///
+    /// [auto]: https://github.com/pnpm/pnpm/blob/94240bc0464196bd52f7006b97f6d9a43df34633/installing/linking/real-hoist/src/index.ts#L124-L129
+    pub auto_install_peers: bool,
+}
+
+/// Failure modes of [`hoist`].
+#[derive(Debug, Display, Error, Diagnostic)]
+pub enum HoistError {
+    /// A snapshot referenced by an importer is missing from
+    /// `lockfile.snapshots`. Mirrors pnpm's
+    /// `LockfileMissingDependencyError` raised at
+    /// [real-hoist:111][missing-dep].
+    ///
+    /// [missing-dep]: https://github.com/pnpm/pnpm/blob/94240bc0464196bd52f7006b97f6d9a43df34633/installing/linking/real-hoist/src/index.ts#L109-L111
+    #[display("Broken lockfile: missing snapshot for {pkg_key}")]
+    #[diagnostic(
+        code(ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY),
+        url("https://pnpm.io/errors#err_pnpm_lockfile_missing_dependency")
+    )]
+    LockfileMissingDependency {
+        /// The depPath (snapshot key) the lockfile failed to
+        /// resolve.
+        pkg_key: String,
+    },
+}
+
+/// Identity-hashed wrapper around `Rc<T>`. Two `RcByPtr` values are
+/// equal iff their underlying `Rc`s point at the same allocation;
+/// hashing uses the pointer address, not `T`'s `Hash` impl.
+///
+/// This mirrors JS `Set<HoisterTree>` semantics — JS Sets hash by
+/// object identity, so adding the same node via two parent paths
+/// keeps one entry. Cloning a `RcByPtr` only bumps the refcount, so
+/// the dedup property survives parent-to-child propagation.
+///
+/// Without this wrapper, [`IndexSet<Rc<HoisterTree>>`] would hash on
+/// the tree contents — recursive and expensive for deep graphs,
+/// and wrong when two structurally-identical nodes come from
+/// different sources and should stay distinct.
+#[derive(Debug)]
+pub struct RcByPtr<T>(pub Rc<T>);
+
+impl<T> Clone for RcByPtr<T> {
+    fn clone(&self) -> Self {
+        Self(Rc::clone(&self.0))
+    }
+}
+
+impl<T> PartialEq for RcByPtr<T> {
+    fn eq(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.0, &other.0)
+    }
+}
+
+impl<T> Eq for RcByPtr<T> {}
+
+impl<T> std::hash::Hash for RcByPtr<T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        (Rc::as_ptr(&self.0) as usize).hash(state);
+    }
+}
+
+impl<T> std::ops::Deref for RcByPtr<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> From<Rc<T>> for RcByPtr<T> {
+    fn from(rc: Rc<T>) -> Self {
+        Self(rc)
+    }
+}
+
+/// Build the [`HoisterTree`] for `lockfile`'s root importer (plus
+/// any non-root importers as workspace children) and run the
+/// `@yarnpkg/nm` hoister over it. Ports
+/// [`installing/linking/real-hoist/src/index.ts`][upstream].
+///
+/// The inner hoist algorithm is currently stubbed (returns the
+/// input tree shape unchanged). The lockfile-to-tree translation
+/// and the `LockfileMissingDependencyError` surface are the parts
+/// pinned by Sub-slice 3a; later sub-slices replace the stub.
+///
+/// [upstream]: https://github.com/pnpm/pnpm/blob/94240bc0464196bd52f7006b97f6d9a43df34633/installing/linking/real-hoist/src/index.ts
+pub fn hoist(lockfile: &Lockfile, opts: &HoistOpts) -> Result<HoisterResult, HoistError> {
+    let mut nodes: HashMap<String, Rc<HoisterTree>> = HashMap::new();
+
+    let mut root_children: IndexSet<RcByPtr<HoisterTree>> = IndexSet::new();
+
+    if let Some(root) = lockfile.importers.get(Lockfile::ROOT_IMPORTER_KEY) {
+        collect_importer_deps(root, lockfile, opts, &mut nodes, &mut root_children)?;
+    }
+
+    // `externalDependencies` are added as `link:` placeholders at
+    // the root so the hoister won't move anything else into those
+    // slots; they're stripped from the result after hoisting.
+    // Pacquet has no consumer for this yet (the umbrella's Slice 10
+    // wires it through configuration), but the wrapper handles it
+    // for parity with upstream's signature.
+    for dep in &opts.external_dependencies {
+        let placeholder = Rc::new(HoisterTree {
+            name: dep.clone(),
+            ident_name: dep.clone(),
+            reference: "link:".to_string(),
+            peer_names: BTreeSet::new(),
+            dependency_kind: HoisterDependencyKind::ExternalSoftLink,
+            hoist_priority: 0,
+            dependencies: IndexSet::new(),
+        });
+        root_children.insert(RcByPtr(placeholder));
+    }
+
+    // Non-root importers (workspace projects) become children of
+    // the virtual `.` root. Pacquet's install pipeline doesn't yet
+    // support workspaces (umbrella Slice 9), so the wrapper accepts
+    // them but the rest of the install code path will reject a
+    // multi-importer lockfile elsewhere.
+    let mut non_root: Vec<(&String, &ProjectSnapshot)> = lockfile
+        .importers
+        .iter()
+        .filter(|(id, _)| id.as_str() != Lockfile::ROOT_IMPORTER_KEY)
+        .collect();
+    // HashMap iteration order is non-deterministic; sort so the
+    // output tree is stable across runs (matters for snapshot
+    // tests).
+    non_root.sort_by(|a, b| a.0.cmp(b.0));
+
+    for (importer_id, importer) in non_root {
+        let mut importer_children: IndexSet<RcByPtr<HoisterTree>> = IndexSet::new();
+        collect_importer_deps(importer, lockfile, opts, &mut nodes, &mut importer_children)?;
+        let importer_node = Rc::new(HoisterTree {
+            name: percent_encode_path(importer_id),
+            ident_name: percent_encode_path(importer_id),
+            reference: format!("workspace:{importer_id}"),
+            peer_names: BTreeSet::new(),
+            dependency_kind: HoisterDependencyKind::Workspace,
+            hoist_priority: 0,
+            dependencies: importer_children,
+        });
+        root_children.insert(RcByPtr(importer_node));
+    }
+
+    let root_node = Rc::new(HoisterTree {
+        name: ".".to_string(),
+        ident_name: ".".to_string(),
+        reference: String::new(),
+        peer_names: BTreeSet::new(),
+        dependency_kind: HoisterDependencyKind::Workspace,
+        hoist_priority: 0,
+        dependencies: root_children,
+    });
+
+    let mut result = nm_hoist(&root_node, opts);
+
+    // Strip `externalDependencies` from the top-level result —
+    // they exist only to reserve a name slot at the root.
+    if !opts.external_dependencies.is_empty() {
+        result.dependencies.retain(|dep| !opts.external_dependencies.contains(&dep.name));
+    }
+
+    Ok(result)
+}
+
+fn collect_importer_deps(
+    importer: &ProjectSnapshot,
+    lockfile: &Lockfile,
+    opts: &HoistOpts,
+    nodes: &mut HashMap<String, Rc<HoisterTree>>,
+    out: &mut IndexSet<RcByPtr<HoisterTree>>,
+) -> Result<(), HoistError> {
+    // Upstream merges `dependencies + devDependencies +
+    // optionalDependencies` into one alias-keyed object. Later
+    // entries (in declaration order) win on duplicate aliases —
+    // which is the same as inserting in that order and keeping the
+    // last write. Pacquet's `ResolvedDependencyMap` is a HashMap so
+    // declaration order is lost; merge into a `HashMap` (last write
+    // wins) and emit in alias-sorted order so the build is
+    // deterministic regardless of map seed.
+    let mut merged: HashMap<&PkgName, &pacquet_lockfile::ResolvedDependencySpec> = HashMap::new();
+    for deps in
+        [&importer.dependencies, &importer.dev_dependencies, &importer.optional_dependencies]
+            .into_iter()
+            .flatten()
+    {
+        for (alias, spec) in deps {
+            merged.insert(alias, spec);
+        }
+    }
+    let mut entries: Vec<_> = merged.into_iter().collect();
+    entries.sort_by_key(|(alias, _)| alias.to_string());
+    for (alias, spec) in entries {
+        let node = build_dep_node(alias, &spec.version, lockfile, opts, nodes)?;
+        out.insert(RcByPtr(node));
+    }
+    Ok(())
+}
+
+fn build_dep_node(
+    alias: &PkgName,
+    version: &pacquet_lockfile::PkgVerPeer,
+    lockfile: &Lockfile,
+    opts: &HoistOpts,
+    nodes: &mut HashMap<String, Rc<HoisterTree>>,
+) -> Result<Rc<HoisterTree>, HoistError> {
+    let dep_key = PkgNameVerPeer::new(alias.clone(), version.clone());
+    let cache_key = format!("{alias}:{dep_key}");
+    if let Some(existing) = nodes.get(&cache_key) {
+        return Ok(Rc::clone(existing));
+    }
+
+    let snapshots = lockfile
+        .snapshots
+        .as_ref()
+        .ok_or_else(|| HoistError::LockfileMissingDependency { pkg_key: dep_key.to_string() })?;
+    let snapshot = snapshots
+        .get(&dep_key)
+        .ok_or_else(|| HoistError::LockfileMissingDependency { pkg_key: dep_key.to_string() })?;
+
+    // Peer-name set: peerDependencies (from the `packages:` map)
+    // plus transitivePeerDependencies (from the `snapshots:` map).
+    // Mirrors upstream's
+    // `[...Object.keys(pkgSnapshot.peerDependencies), ...transitivePeerDependencies]`.
+    // Zeroed when `auto_install_peers` is on, so the hoister moves
+    // freely.
+    let mut peer_names: BTreeSet<String> = BTreeSet::new();
+    if !opts.auto_install_peers {
+        if let Some(packages) = lockfile.packages.as_ref() {
+            let packages_key = dep_key.without_peer();
+            if let Some(meta) = packages.get(&packages_key)
+                && let Some(peer_deps) = meta.peer_dependencies.as_ref()
+            {
+                for name in peer_deps.keys() {
+                    peer_names.insert(name.clone());
+                }
+            }
+        }
+        if let Some(transitive) = snapshot.transitive_peer_dependencies.as_ref() {
+            for name in transitive {
+                peer_names.insert(name.clone());
+            }
+        }
+    }
+
+    let mut children: IndexSet<RcByPtr<HoisterTree>> = IndexSet::new();
+    // Insert a placeholder first so cyclic descents short-circuit
+    // back to it (the JS code achieves the same by setting `node`
+    // in the map before recursing — see real-hoist:131).
+    let node = Rc::new(HoisterTree {
+        name: alias.to_string(),
+        ident_name: pkg_name_from_key(&dep_key),
+        reference: dep_key.to_string(),
+        peer_names,
+        dependency_kind: HoisterDependencyKind::Regular,
+        hoist_priority: 0,
+        dependencies: IndexSet::new(),
+    });
+    nodes.insert(cache_key.clone(), Rc::clone(&node));
+
+    collect_snapshot_deps(snapshot, lockfile, opts, nodes, &mut children)?;
+
+    // The placeholder we stashed in `nodes` is shared with anyone
+    // who recursed back into us. Swap its empty `dependencies` for
+    // the populated set by rebuilding the `Rc` — safe because we
+    // never handed out a `&HoisterTree` reference that's still
+    // live, only `Rc<HoisterTree>` clones that point at the same
+    // allocation. Existing clones see the rebuilt set because we
+    // overwrite the map entry too.
+    //
+    // (A cleaner pattern is `Rc<RefCell<HoisterTree>>` but `RefCell`
+    // pollutes every read site downstream. We re-Rc once at
+    // construction here.)
+    let finished = Rc::new(HoisterTree {
+        name: node.name.clone(),
+        ident_name: node.ident_name.clone(),
+        reference: node.reference.clone(),
+        peer_names: node.peer_names.clone(),
+        dependency_kind: node.dependency_kind,
+        hoist_priority: node.hoist_priority,
+        dependencies: children,
+    });
+    nodes.insert(cache_key, Rc::clone(&finished));
+    Ok(finished)
+}
+
+fn collect_snapshot_deps(
+    snapshot: &SnapshotEntry,
+    lockfile: &Lockfile,
+    opts: &HoistOpts,
+    nodes: &mut HashMap<String, Rc<HoisterTree>>,
+    out: &mut IndexSet<RcByPtr<HoisterTree>>,
+) -> Result<(), HoistError> {
+    let mut merged: HashMap<&PkgName, &pacquet_lockfile::SnapshotDepRef> = HashMap::new();
+    for deps in [&snapshot.dependencies, &snapshot.optional_dependencies].into_iter().flatten() {
+        for (alias, dep_ref) in deps {
+            merged.insert(alias, dep_ref);
+        }
+    }
+    let mut entries: Vec<_> = merged.into_iter().collect();
+    entries.sort_by_key(|(alias, _)| alias.to_string());
+    for (alias, dep_ref) in entries {
+        let resolved = dep_ref.resolve(alias);
+        let node = build_dep_node(alias, &resolved.suffix, lockfile, opts, nodes)?;
+        out.insert(RcByPtr(node));
+    }
+    Ok(())
+}
+
+/// Extract `name@version` from a snapshot key. The upstream
+/// `nameVerFromPkgSnapshot` returns just the name portion here; we
+/// rebuild it from the parsed key.
+fn pkg_name_from_key(key: &PkgNameVerPeer) -> String {
+    key.name.to_string()
+}
+
+/// Encode an importer id for use as a child node's `name`. Upstream
+/// uses `encodeURIComponent`, which percent-encodes everything
+/// except `A-Z a-z 0-9 - _ . ! ~ * ' ( )`. Pacquet workspace
+/// importers are filesystem-relative paths, so the common case is
+/// alphanumeric + `/` + `-` + `_`. Encode `/` (since it would
+/// confuse `node_modules` directory parsing) and pass the rest
+/// through; if a richer set ever shows up the function can switch
+/// to a full encoder without touching call sites.
+fn percent_encode_path(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            'A'..='Z'
+            | 'a'..='z'
+            | '0'..='9'
+            | '-'
+            | '_'
+            | '.'
+            | '!'
+            | '~'
+            | '*'
+            | '\''
+            | '('
+            | ')' => out.push(ch),
+            '/' => out.push_str("%2F"),
+            other => {
+                // Best-effort %xx encode for the ASCII subset we
+                // expect in importer ids. Anything else is left
+                // verbatim — pacquet's lockfile doesn't currently
+                // hand the wrapper non-ASCII paths.
+                if (other as u32) < 0x80 {
+                    out.push_str(&format!("%{:02X}", other as u32));
+                } else {
+                    out.push(other);
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Stub for the `@yarnpkg/nm` hoist algorithm. Walks the input tree
+/// and returns it in `HoisterResult` shape unchanged — no actual
+/// hoisting happens. Sub-slice 3b replaces this with the real
+/// algorithm.
+fn nm_hoist(tree: &HoisterTree, _opts: &HoistOpts) -> HoisterResult {
+    let mut memo: HashMap<*const HoisterTree, Rc<HoisterResult>> = HashMap::new();
+    convert(tree, &mut memo).as_ref().clone()
+}
+
+fn convert(
+    tree: &HoisterTree,
+    memo: &mut HashMap<*const HoisterTree, Rc<HoisterResult>>,
+) -> Rc<HoisterResult> {
+    let ptr = tree as *const HoisterTree;
+    if let Some(existing) = memo.get(&ptr) {
+        return Rc::clone(existing);
+    }
+    // Stash a placeholder before recursing so cycles in the input
+    // graph short-circuit. The placeholder has empty children; the
+    // real conversion overwrites the memo entry below. Anyone who
+    // received the placeholder via a cycle reads its (then-empty)
+    // children — matches JS Set-identity dedup semantics where a
+    // node visited via a cycle yields the same object.
+    let placeholder = Rc::new(HoisterResult {
+        name: tree.name.clone(),
+        ident_name: tree.ident_name.clone(),
+        references: {
+            let mut s = BTreeSet::new();
+            s.insert(tree.reference.clone());
+            s
+        },
+        dependencies: IndexSet::new(),
+    });
+    memo.insert(ptr, Rc::clone(&placeholder));
+
+    let mut children: IndexSet<RcByPtr<HoisterResult>> = IndexSet::new();
+    for child in &tree.dependencies {
+        children.insert(RcByPtr(convert(&child.0, memo)));
+    }
+
+    let finished = Rc::new(HoisterResult {
+        name: tree.name.clone(),
+        ident_name: tree.ident_name.clone(),
+        references: {
+            let mut s = BTreeSet::new();
+            s.insert(tree.reference.clone());
+            s
+        },
+        dependencies: children,
+    });
+    memo.insert(ptr, Rc::clone(&finished));
+    finished
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/real-hoist/src/lib.rs
+++ b/crates/real-hoist/src/lib.rs
@@ -15,6 +15,7 @@ use indexmap::IndexSet;
 use miette::Diagnostic;
 use pacquet_lockfile::{Lockfile, PkgName, PkgNameVerPeer, ProjectSnapshot, SnapshotEntry};
 use std::{
+    cell::RefCell,
     collections::{BTreeMap, BTreeSet, HashMap},
     rc::Rc,
 };
@@ -50,6 +51,15 @@ pub enum HoisterDependencyKind {
 /// two parent paths is shared by `Rc` identity the way JS's
 /// `Set<HoisterTree>` shares by object identity.
 ///
+/// `dependencies` is behind a [`RefCell`] so the construction phase
+/// can stash a placeholder `Rc<HoisterTree>` for cycle short-circuit,
+/// recurse, then populate the children in place. The placeholder Rc
+/// and the populated one are the same allocation, so a node visited
+/// via a back-edge sees the eventually-populated set — matching JS's
+/// `Set<HoisterTree>` mutation semantics. The same interior
+/// mutability is what the hoister algorithm will use to move children
+/// between parents when it lands.
+///
 /// [yarn-tree]: https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L16-L19
 #[derive(Debug)]
 pub struct HoisterTree {
@@ -78,13 +88,20 @@ pub struct HoisterTree {
     pub hoist_priority: u32,
     /// Children of this node. Order matches insertion order — the
     /// hoister depends on it.
-    pub dependencies: IndexSet<RcByPtr<HoisterTree>>,
+    pub dependencies: RefCell<IndexSet<RcByPtr<HoisterTree>>>,
 }
 
 /// Output node from the hoister. The shape mirrors `HoisterTree`
 /// except that one `HoisterResult` can collect multiple references
 /// (when several `HoisterTree` nodes with the same `ident_name`
 /// converged onto the same hoist slot).
+///
+/// Both `references` and `dependencies` use [`RefCell`] for the same
+/// reason [`HoisterTree::dependencies`] does: nodes are shared by
+/// `Rc` identity across the result graph, and the algorithm
+/// accumulates references / reorders children in place rather than
+/// rebuilding `Rc`s (which would break the shared-by-identity
+/// invariant for any earlier clone).
 ///
 /// Mirrors `HoisterResult` at the [yarn source][yarn-result].
 ///
@@ -93,8 +110,8 @@ pub struct HoisterTree {
 pub struct HoisterResult {
     pub name: String,
     pub ident_name: String,
-    pub references: BTreeSet<String>,
-    pub dependencies: IndexSet<RcByPtr<HoisterResult>>,
+    pub references: RefCell<BTreeSet<String>>,
+    pub dependencies: RefCell<IndexSet<RcByPtr<HoisterResult>>>,
 }
 
 /// Per-importer hoisting borders. Outer key is the importer locator
@@ -121,7 +138,11 @@ pub struct HoistOpts {
 }
 
 /// Failure modes of [`hoist`].
+///
+/// Marked `#[non_exhaustive]` so adding variants in later work
+/// isn't a breaking API change.
 #[derive(Debug, Display, Error, Diagnostic)]
+#[non_exhaustive]
 pub enum HoistError {
     /// A snapshot referenced by an importer is missing from
     /// `lockfile.snapshots`. Mirrors pnpm's
@@ -224,7 +245,7 @@ pub fn hoist(lockfile: &Lockfile, opts: &HoistOpts) -> Result<HoisterResult, Hoi
             peer_names: BTreeSet::new(),
             dependency_kind: HoisterDependencyKind::ExternalSoftLink,
             hoist_priority: 0,
-            dependencies: IndexSet::new(),
+            dependencies: RefCell::new(IndexSet::new()),
         });
         root_children.insert(RcByPtr(placeholder));
     }
@@ -254,7 +275,7 @@ pub fn hoist(lockfile: &Lockfile, opts: &HoistOpts) -> Result<HoisterResult, Hoi
             peer_names: BTreeSet::new(),
             dependency_kind: HoisterDependencyKind::Workspace,
             hoist_priority: 0,
-            dependencies: importer_children,
+            dependencies: RefCell::new(importer_children),
         });
         root_children.insert(RcByPtr(importer_node));
     }
@@ -266,15 +287,18 @@ pub fn hoist(lockfile: &Lockfile, opts: &HoistOpts) -> Result<HoisterResult, Hoi
         peer_names: BTreeSet::new(),
         dependency_kind: HoisterDependencyKind::Workspace,
         hoist_priority: 0,
-        dependencies: root_children,
+        dependencies: RefCell::new(root_children),
     });
 
-    let mut result = nm_hoist(&root_node, opts);
+    let result = nm_hoist(&root_node, opts);
 
     // Strip `externalDependencies` from the top-level result —
     // they exist only to reserve a name slot at the root.
     if !opts.external_dependencies.is_empty() {
-        result.dependencies.retain(|dep| !opts.external_dependencies.contains(&dep.name));
+        result
+            .dependencies
+            .borrow_mut()
+            .retain(|dep| !opts.external_dependencies.contains(&dep.name));
     }
 
     Ok(result)
@@ -308,7 +332,14 @@ fn collect_importer_deps(
     let mut entries: Vec<_> = merged.into_iter().collect();
     entries.sort_by_key(|(alias, _)| alias.to_string());
     for (alias, spec) in entries {
-        let node = build_dep_node(alias, &spec.version, lockfile, opts, nodes)?;
+        // Pacquet's `ResolvedDependencySpec.version` doesn't carry an
+        // alternate package name, so importer-level npm-aliases
+        // aren't modelled here today — assume the alias is the
+        // registry name. Transitive npm-aliases (modelled via
+        // `SnapshotDepRef::Alias`) are handled in
+        // `collect_snapshot_deps`.
+        let dep_key = PkgNameVerPeer::new(alias.clone(), spec.version.clone());
+        let node = build_dep_node(alias, &dep_key, lockfile, opts, nodes)?;
         out.insert(RcByPtr(node));
     }
     Ok(())
@@ -316,12 +347,15 @@ fn collect_importer_deps(
 
 fn build_dep_node(
     alias: &PkgName,
-    version: &pacquet_lockfile::PkgVerPeer,
+    dep_key: &PkgNameVerPeer,
     lockfile: &Lockfile,
     opts: &HoistOpts,
     nodes: &mut HashMap<String, Rc<HoisterTree>>,
 ) -> Result<Rc<HoisterTree>, HoistError> {
-    let dep_key = PkgNameVerPeer::new(alias.clone(), version.clone());
+    // Cache key is `<alias>:<dep_key>` to match upstream — two
+    // different aliases pointing at the same package are
+    // intentionally different nodes (the node's `name` field
+    // differs), so they shouldn't share a cache slot.
     let cache_key = format!("{alias}:{dep_key}");
     if let Some(existing) = nodes.get(&cache_key) {
         return Ok(Rc::clone(existing));
@@ -332,7 +366,7 @@ fn build_dep_node(
         .as_ref()
         .ok_or_else(|| HoistError::LockfileMissingDependency { pkg_key: dep_key.to_string() })?;
     let snapshot = snapshots
-        .get(&dep_key)
+        .get(dep_key)
         .ok_or_else(|| HoistError::LockfileMissingDependency { pkg_key: dep_key.to_string() })?;
 
     // Peer-name set: peerDependencies (from the `packages:` map)
@@ -360,45 +394,29 @@ fn build_dep_node(
         }
     }
 
-    let mut children: IndexSet<RcByPtr<HoisterTree>> = IndexSet::new();
-    // Insert a placeholder first so cyclic descents short-circuit
-    // back to it (the JS code achieves the same by setting `node`
-    // in the map before recursing — see real-hoist:131).
+    // Construct the node with an empty `dependencies` cell, stash
+    // it in the cache, then recurse and populate the cell in place.
+    // A back-edge that hits the same `cache_key` during the
+    // recursion gets the same `Rc<HoisterTree>` — by the time the
+    // outer call returns the cell holds the populated set, and the
+    // shared-by-identity invariant the hoister algorithm relies on
+    // survives. Mirrors the in-place mutation of `node.dependencies`
+    // at upstream's real-hoist:132.
     let node = Rc::new(HoisterTree {
         name: alias.to_string(),
-        ident_name: pkg_name_from_key(&dep_key),
+        ident_name: dep_key.name.to_string(),
         reference: dep_key.to_string(),
         peer_names,
         dependency_kind: HoisterDependencyKind::Regular,
         hoist_priority: 0,
-        dependencies: IndexSet::new(),
+        dependencies: RefCell::new(IndexSet::new()),
     });
-    nodes.insert(cache_key.clone(), Rc::clone(&node));
+    nodes.insert(cache_key, Rc::clone(&node));
 
+    let mut children: IndexSet<RcByPtr<HoisterTree>> = IndexSet::new();
     collect_snapshot_deps(snapshot, lockfile, opts, nodes, &mut children)?;
-
-    // The placeholder we stashed in `nodes` is shared with anyone
-    // who recursed back into us. Swap its empty `dependencies` for
-    // the populated set by rebuilding the `Rc` — safe because we
-    // never handed out a `&HoisterTree` reference that's still
-    // live, only `Rc<HoisterTree>` clones that point at the same
-    // allocation. Existing clones see the rebuilt set because we
-    // overwrite the map entry too.
-    //
-    // (A cleaner pattern is `Rc<RefCell<HoisterTree>>` but `RefCell`
-    // pollutes every read site downstream. We re-Rc once at
-    // construction here.)
-    let finished = Rc::new(HoisterTree {
-        name: node.name.clone(),
-        ident_name: node.ident_name.clone(),
-        reference: node.reference.clone(),
-        peer_names: node.peer_names.clone(),
-        dependency_kind: node.dependency_kind,
-        hoist_priority: node.hoist_priority,
-        dependencies: children,
-    });
-    nodes.insert(cache_key, Rc::clone(&finished));
-    Ok(finished)
+    *node.dependencies.borrow_mut() = children;
+    Ok(node)
 }
 
 fn collect_snapshot_deps(
@@ -417,18 +435,17 @@ fn collect_snapshot_deps(
     let mut entries: Vec<_> = merged.into_iter().collect();
     entries.sort_by_key(|(alias, _)| alias.to_string());
     for (alias, dep_ref) in entries {
-        let resolved = dep_ref.resolve(alias);
-        let node = build_dep_node(alias, &resolved.suffix, lockfile, opts, nodes)?;
+        // `dep_ref.resolve(alias)` returns the *snapshot lookup
+        // key*: `<alias>@<ver>` for `Plain`, `<target>@<ver>` for
+        // an npm-alias `Alias`. Pass that as `dep_key` so the
+        // snapshot lookup hits the right entry. The node's exposed
+        // `name` stays `alias`; only the lookup uses the resolved
+        // target name.
+        let dep_key = dep_ref.resolve(alias);
+        let node = build_dep_node(alias, &dep_key, lockfile, opts, nodes)?;
         out.insert(RcByPtr(node));
     }
     Ok(())
-}
-
-/// Extract `name@version` from a snapshot key. The upstream
-/// `nameVerFromPkgSnapshot` returns just the name portion here; we
-/// rebuild it from the parsed key.
-fn pkg_name_from_key(key: &PkgNameVerPeer) -> String {
-    key.name.to_string()
 }
 
 /// Encode an importer id for use as a child node's `name`. Upstream
@@ -477,7 +494,14 @@ fn percent_encode_path(s: &str) -> String {
 /// hoisting happens. The real algorithm replaces this body.
 fn nm_hoist(tree: &HoisterTree, _opts: &HoistOpts) -> HoisterResult {
     let mut memo: HashMap<*const HoisterTree, Rc<HoisterResult>> = HashMap::new();
-    convert(tree, &mut memo).as_ref().clone()
+    // The root is fresh (no caller holds another Rc to it yet), so
+    // cloning the outer struct is cheap and only duplicates the
+    // top-level fields — the subtree children remain shared via the
+    // cloned RcByPtr values. Returning an owned `HoisterResult`
+    // (rather than `Rc<HoisterResult>`) keeps the wrapper's
+    // post-hoist `external_dependencies` filter from mutating the
+    // shared graph.
+    (*convert(tree, &mut memo)).clone()
 }
 
 fn convert(
@@ -488,41 +512,35 @@ fn convert(
     if let Some(existing) = memo.get(&ptr) {
         return Rc::clone(existing);
     }
-    // Stash a placeholder before recursing so cycles in the input
-    // graph short-circuit. The placeholder has empty children; the
-    // real conversion overwrites the memo entry below. Anyone who
-    // received the placeholder via a cycle reads its (then-empty)
-    // children — matches JS Set-identity dedup semantics where a
-    // node visited via a cycle yields the same object.
-    let placeholder = Rc::new(HoisterResult {
+    // Stash a node with empty `dependencies`, then recurse and
+    // populate the cell in place. Anyone reached via a back-edge
+    // gets `Rc::clone` of the same allocation and reads the
+    // (eventually-populated) cell — matches the in-place mutation
+    // semantics the real hoist algorithm needs.
+    let mut refs = BTreeSet::new();
+    refs.insert(tree.reference.clone());
+    let node = Rc::new(HoisterResult {
         name: tree.name.clone(),
         ident_name: tree.ident_name.clone(),
-        references: {
-            let mut s = BTreeSet::new();
-            s.insert(tree.reference.clone());
-            s
-        },
-        dependencies: IndexSet::new(),
+        references: RefCell::new(refs),
+        dependencies: RefCell::new(IndexSet::new()),
     });
-    memo.insert(ptr, Rc::clone(&placeholder));
+    memo.insert(ptr, Rc::clone(&node));
 
+    // Collect the children before recursing so we can drop the
+    // `Ref<'_, IndexSet<...>>` borrow on `tree.dependencies`. The
+    // recursion only reads (not mutates) `HoisterTree` cells, so
+    // holding the borrow across recursive calls is technically
+    // safe, but releasing it keeps the panic surface smaller if
+    // the algorithm later grows a mutation pass over the input.
+    let to_convert: Vec<RcByPtr<HoisterTree>> =
+        tree.dependencies.borrow().iter().cloned().collect();
     let mut children: IndexSet<RcByPtr<HoisterResult>> = IndexSet::new();
-    for child in &tree.dependencies {
+    for child in to_convert {
         children.insert(RcByPtr(convert(&child.0, memo)));
     }
-
-    let finished = Rc::new(HoisterResult {
-        name: tree.name.clone(),
-        ident_name: tree.ident_name.clone(),
-        references: {
-            let mut s = BTreeSet::new();
-            s.insert(tree.reference.clone());
-            s
-        },
-        dependencies: children,
-    });
-    memo.insert(ptr, Rc::clone(&finished));
-    finished
+    *node.dependencies.borrow_mut() = children;
+    node
 }
 
 #[cfg(test)]

--- a/crates/real-hoist/src/tests.rs
+++ b/crates/real-hoist/src/tests.rs
@@ -77,7 +77,7 @@ fn empty_lockfile_yields_empty_root() {
     let result = hoist(&lockfile, &HoistOpts::default()).expect("empty hoist should succeed");
     assert_eq!(result.name, ".");
     assert_eq!(result.ident_name, ".");
-    assert!(result.dependencies.is_empty(), "no importers means no children at the root");
+    assert!(result.dependencies.borrow().is_empty(), "no importers means no children at the root");
 }
 
 /// A minimal lockfile with one direct dependency and one
@@ -117,13 +117,15 @@ fn one_transitive_dep_appears_under_its_parent_in_the_stub() {
 
     let result = hoist(&lockfile, &HoistOpts::default()).expect("happy hoist should succeed");
     assert_eq!(result.name, ".");
-    assert_eq!(result.dependencies.len(), 1, "root has one child: {result:#?}");
-    let a = &result.dependencies[0];
+    let root_children = result.dependencies.borrow();
+    assert_eq!(root_children.len(), 1, "root has one child: {result:#?}");
+    let a = root_children[0].0.clone();
     assert_eq!(a.name, "a");
-    assert_eq!(a.dependencies.len(), 1, "a has one child under the stub: {a:#?}");
-    let b = &a.dependencies[0];
+    let a_children = a.dependencies.borrow();
+    assert_eq!(a_children.len(), 1, "a has one child under the stub: {a:#?}");
+    let b = a_children[0].0.clone();
     assert_eq!(b.name, "b");
-    assert!(b.dependencies.is_empty(), "b has no transitive deps");
+    assert!(b.dependencies.borrow().is_empty(), "b has no transitive deps");
 }
 
 /// Two importers pointing at the same package version share a
@@ -168,14 +170,17 @@ fn shared_dep_via_two_root_paths_is_one_node() {
     };
 
     let result = hoist(&lockfile, &HoistOpts::default()).expect("hoist should succeed");
-    let a = result.dependencies.iter().find(|d| d.name == "a").expect("a present");
-    let c = result.dependencies.iter().find(|d| d.name == "c").expect("c present");
-    let b_under_a = &a.dependencies[0];
-    let b_under_c = &c.dependencies[0];
+    let root_children = result.dependencies.borrow();
+    let a = root_children.iter().find(|d| d.name == "a").expect("a present").0.clone();
+    let c = root_children.iter().find(|d| d.name == "c").expect("c present").0.clone();
+    let a_kids = a.dependencies.borrow();
+    let c_kids = c.dependencies.borrow();
+    let b_under_a = a_kids[0].0.clone();
+    let b_under_c = c_kids[0].0.clone();
     // Identity comparison: two `b` references surfaced through
     // different paths must point at the same allocation — proving
     // the cache shared the node.
-    assert!(Rc::ptr_eq(&b_under_a.0, &b_under_c.0), "b should be the same Rc'd HoisterResult node");
+    assert!(Rc::ptr_eq(&b_under_a, &b_under_c), "b should be the same Rc'd HoisterResult node");
 }
 
 /// `external_dependencies` are added as `link:` placeholders at the
@@ -210,6 +215,64 @@ fn external_dependencies_are_stripped_from_the_result() {
         ..HoistOpts::default()
     };
     let result = hoist(&lockfile, &opts).expect("hoist should succeed");
-    let names: Vec<&str> = result.dependencies.iter().map(|d| d.name.as_str()).collect();
+    let names: Vec<String> = result.dependencies.borrow().iter().map(|d| d.name.clone()).collect();
     assert_eq!(names, ["real"], "external dep is stripped, real dep remains: {names:?}");
+}
+
+/// A transitive npm-alias dep (`SnapshotDepRef::Alias`) must look
+/// up the snapshot under the *target* package name, not under the
+/// alias. Regression for the wrapper's earlier bug where the
+/// snapshot key was reconstructed from `(alias, suffix)` instead
+/// of the resolved key — that produced
+/// `LockfileMissingDependency` on real npm-aliased transitives.
+#[test]
+fn transitive_npm_alias_resolves_target_snapshot() {
+    let mut importers = HashMap::new();
+    let mut root_deps = ResolvedDependencyMap::new();
+    root_deps.insert(pkg_name("host"), resolved_dep("1.0.0"));
+    importers.insert(
+        Lockfile::ROOT_IMPORTER_KEY.to_string(),
+        ProjectSnapshot { dependencies: Some(root_deps), ..ProjectSnapshot::default() },
+    );
+
+    let mut snapshots = HashMap::new();
+    // `host@1.0.0` depends on `aliased-name` resolved to the
+    // target snapshot `real-pkg@2.0.0` — i.e. an npm-alias.
+    let mut host_deps = HashMap::new();
+    host_deps.insert(pkg_name("aliased-name"), SnapshotDepRef::Alias(dep_key("real-pkg", "2.0.0")));
+    snapshots.insert(
+        dep_key("host", "1.0.0"),
+        SnapshotEntry { dependencies: Some(host_deps), ..SnapshotEntry::default() },
+    );
+    // Snapshot lookup must target `real-pkg@2.0.0`, NOT
+    // `aliased-name@2.0.0`. If we put only the target key in the
+    // map, the wrapper succeeds; if it builds the key from the
+    // alias the lookup misses and we get
+    // `LockfileMissingDependency`.
+    snapshots.insert(dep_key("real-pkg", "2.0.0"), SnapshotEntry::default());
+
+    let lockfile = Lockfile {
+        lockfile_version: lockfile_version(),
+        settings: None,
+        overrides: None,
+        importers,
+        packages: None,
+        snapshots: Some(snapshots),
+    };
+
+    let result =
+        hoist(&lockfile, &HoistOpts::default()).expect("aliased transitive should resolve");
+    let root_children = result.dependencies.borrow();
+    let host = root_children.iter().find(|d| d.name == "host").expect("host present").0.clone();
+    let host_kids = host.dependencies.borrow();
+    let aliased = host_kids[0].0.clone();
+    // The exposed name stays the alias the parent uses...
+    assert_eq!(aliased.name, "aliased-name");
+    // ...but the underlying identity is the target package.
+    assert_eq!(aliased.ident_name, "real-pkg");
+    assert_eq!(
+        aliased.references.borrow().iter().next().map(String::as_str),
+        Some("real-pkg@2.0.0"),
+        "reference is the resolved snapshot key, not the alias",
+    );
 }

--- a/crates/real-hoist/src/tests.rs
+++ b/crates/real-hoist/src/tests.rs
@@ -1,0 +1,215 @@
+use super::{HoistError, HoistOpts, hoist};
+use pacquet_lockfile::{
+    ComVer, Lockfile, LockfileSettings, LockfileVersion, PkgName, PkgNameVerPeer, PkgVerPeer,
+    ProjectSnapshot, ResolvedDependencyMap, ResolvedDependencySpec, SnapshotDepRef, SnapshotEntry,
+};
+use pretty_assertions::assert_eq;
+use std::{collections::HashMap, rc::Rc};
+
+fn lockfile_version() -> LockfileVersion<9> {
+    LockfileVersion::<9>::try_from(ComVer::new(9, 0)).expect("lockfileVersion 9.0 is compatible")
+}
+
+fn pkg_name(s: &str) -> PkgName {
+    PkgName::parse(s).expect("parse PkgName")
+}
+
+fn ver_peer(s: &str) -> PkgVerPeer {
+    s.parse::<PkgVerPeer>().expect("parse PkgVerPeer")
+}
+
+fn dep_key(name: &str, version: &str) -> PkgNameVerPeer {
+    PkgNameVerPeer::new(pkg_name(name), ver_peer(version))
+}
+
+fn resolved_dep(version: &str) -> ResolvedDependencySpec {
+    ResolvedDependencySpec { specifier: version.to_string(), version: ver_peer(version) }
+}
+
+fn empty_lockfile() -> Lockfile {
+    Lockfile {
+        lockfile_version: lockfile_version(),
+        settings: Some(LockfileSettings::default()),
+        overrides: None,
+        importers: HashMap::new(),
+        packages: None,
+        snapshots: None,
+    }
+}
+
+/// Direct port of the upstream "hoist throws an error if the
+/// lockfile is broken" test at
+/// <https://github.com/pnpm/pnpm/blob/94240bc046/installing/linking/real-hoist/test/index.ts>.
+/// The root importer references `foo@1.0.0` but the `snapshots`
+/// map is empty, so the wrapper's snapshot lookup must surface
+/// `LockfileMissingDependency` rather than silently produce a
+/// truncated tree.
+#[test]
+fn hoist_throws_on_broken_lockfile() {
+    let mut importers = HashMap::new();
+    let mut root_deps = ResolvedDependencyMap::new();
+    root_deps.insert(pkg_name("foo"), resolved_dep("1.0.0"));
+    importers.insert(
+        Lockfile::ROOT_IMPORTER_KEY.to_string(),
+        ProjectSnapshot { dependencies: Some(root_deps), ..ProjectSnapshot::default() },
+    );
+
+    let lockfile = Lockfile {
+        lockfile_version: lockfile_version(),
+        settings: None,
+        overrides: None,
+        importers,
+        packages: None,
+        snapshots: None,
+    };
+
+    let err = hoist(&lockfile, &HoistOpts::default()).expect_err("missing snapshot should error");
+    let HoistError::LockfileMissingDependency { pkg_key } = err;
+    assert_eq!(pkg_key, "foo@1.0.0");
+}
+
+/// An empty lockfile (no importers at all) hoists to an empty
+/// result. Sanity-checks the wrapper's "no root importer" branch
+/// and the stub `nm_hoist` end-to-end.
+#[test]
+fn empty_lockfile_yields_empty_root() {
+    let lockfile = empty_lockfile();
+    let result = hoist(&lockfile, &HoistOpts::default()).expect("empty hoist should succeed");
+    assert_eq!(result.name, ".");
+    assert_eq!(result.ident_name, ".");
+    assert!(result.dependencies.is_empty(), "no importers means no children at the root");
+}
+
+/// A minimal lockfile with one direct dependency and one
+/// transitive: `root → a@1 → b@1`. With the stub `nm_hoist` no
+/// hoisting happens, so the result must have `a` as the only
+/// root child and `b` under it. Pinning this shape now means
+/// Sub-slice 3b's algorithm replacement is observably correct
+/// when the tree shape changes (root will then see both `a` and
+/// `b` after a real hoist).
+#[test]
+fn one_transitive_dep_appears_under_its_parent_in_the_stub() {
+    let mut importers = HashMap::new();
+    let mut root_deps = ResolvedDependencyMap::new();
+    root_deps.insert(pkg_name("a"), resolved_dep("1.0.0"));
+    importers.insert(
+        Lockfile::ROOT_IMPORTER_KEY.to_string(),
+        ProjectSnapshot { dependencies: Some(root_deps), ..ProjectSnapshot::default() },
+    );
+
+    let mut snapshots = HashMap::new();
+    let mut a_deps = HashMap::new();
+    a_deps.insert(pkg_name("b"), SnapshotDepRef::Plain(ver_peer("1.0.0")));
+    snapshots.insert(
+        dep_key("a", "1.0.0"),
+        SnapshotEntry { dependencies: Some(a_deps), ..SnapshotEntry::default() },
+    );
+    snapshots.insert(dep_key("b", "1.0.0"), SnapshotEntry::default());
+
+    let lockfile = Lockfile {
+        lockfile_version: lockfile_version(),
+        settings: None,
+        overrides: None,
+        importers,
+        packages: None,
+        snapshots: Some(snapshots),
+    };
+
+    let result = hoist(&lockfile, &HoistOpts::default()).expect("happy hoist should succeed");
+    assert_eq!(result.name, ".");
+    assert_eq!(result.dependencies.len(), 1, "root has one child: {result:#?}");
+    let a = &result.dependencies[0];
+    assert_eq!(a.name, "a");
+    assert_eq!(a.dependencies.len(), 1, "a has one child under the stub: {a:#?}");
+    let b = &a.dependencies[0];
+    assert_eq!(b.name, "b");
+    assert!(b.dependencies.is_empty(), "b has no transitive deps");
+}
+
+/// Two importers pointing at the same package version share a
+/// single `HoisterTree` node by identity — same as JS's
+/// `Set<HoisterTree>` semantics. Pinning this stops a future
+/// refactor of `build_dep_node`'s `nodes` cache from silently
+/// breaking the dedup that the real hoist algorithm relies on.
+#[test]
+fn shared_dep_via_two_root_paths_is_one_node() {
+    let mut importers = HashMap::new();
+    let mut root_deps = ResolvedDependencyMap::new();
+    root_deps.insert(pkg_name("a"), resolved_dep("1.0.0"));
+    root_deps.insert(pkg_name("c"), resolved_dep("1.0.0"));
+    importers.insert(
+        Lockfile::ROOT_IMPORTER_KEY.to_string(),
+        ProjectSnapshot { dependencies: Some(root_deps), ..ProjectSnapshot::default() },
+    );
+
+    // Both a@1 and c@1 depend on b@1.
+    let mut snapshots = HashMap::new();
+    let mut a_deps = HashMap::new();
+    a_deps.insert(pkg_name("b"), SnapshotDepRef::Plain(ver_peer("1.0.0")));
+    let mut c_deps = HashMap::new();
+    c_deps.insert(pkg_name("b"), SnapshotDepRef::Plain(ver_peer("1.0.0")));
+    snapshots.insert(
+        dep_key("a", "1.0.0"),
+        SnapshotEntry { dependencies: Some(a_deps), ..SnapshotEntry::default() },
+    );
+    snapshots.insert(
+        dep_key("c", "1.0.0"),
+        SnapshotEntry { dependencies: Some(c_deps), ..SnapshotEntry::default() },
+    );
+    snapshots.insert(dep_key("b", "1.0.0"), SnapshotEntry::default());
+
+    let lockfile = Lockfile {
+        lockfile_version: lockfile_version(),
+        settings: None,
+        overrides: None,
+        importers,
+        packages: None,
+        snapshots: Some(snapshots),
+    };
+
+    let result = hoist(&lockfile, &HoistOpts::default()).expect("hoist should succeed");
+    let a = result.dependencies.iter().find(|d| d.name == "a").expect("a present");
+    let c = result.dependencies.iter().find(|d| d.name == "c").expect("c present");
+    let b_under_a = &a.dependencies[0];
+    let b_under_c = &c.dependencies[0];
+    // Identity comparison: two `b` references surfaced through
+    // different paths must point at the same allocation — proving
+    // the cache shared the node.
+    assert!(Rc::ptr_eq(&b_under_a.0, &b_under_c.0), "b should be the same Rc'd HoisterResult node");
+}
+
+/// `external_dependencies` are added as `link:` placeholders at the
+/// root so the inner hoister won't hoist anything else into those
+/// name slots, and they're stripped from the result after hoisting.
+/// Pin both: the placeholder doesn't leak into the result, and any
+/// real package the lockfile contributes still does.
+#[test]
+fn external_dependencies_are_stripped_from_the_result() {
+    let mut importers = HashMap::new();
+    let mut root_deps = ResolvedDependencyMap::new();
+    root_deps.insert(pkg_name("real"), resolved_dep("1.0.0"));
+    importers.insert(
+        Lockfile::ROOT_IMPORTER_KEY.to_string(),
+        ProjectSnapshot { dependencies: Some(root_deps), ..ProjectSnapshot::default() },
+    );
+
+    let mut snapshots = HashMap::new();
+    snapshots.insert(dep_key("real", "1.0.0"), SnapshotEntry::default());
+
+    let lockfile = Lockfile {
+        lockfile_version: lockfile_version(),
+        settings: None,
+        overrides: None,
+        importers,
+        packages: None,
+        snapshots: Some(snapshots),
+    };
+
+    let opts = HoistOpts {
+        external_dependencies: ["bit-managed".to_string()].into_iter().collect(),
+        ..HoistOpts::default()
+    };
+    let result = hoist(&lockfile, &opts).expect("hoist should succeed");
+    let names: Vec<&str> = result.dependencies.iter().map(|d| d.name.as_str()).collect();
+    assert_eq!(names, ["real"], "external dep is stripped, real dep remains: {names:?}");
+}

--- a/crates/real-hoist/src/tests.rs
+++ b/crates/real-hoist/src/tests.rs
@@ -83,10 +83,10 @@ fn empty_lockfile_yields_empty_root() {
 /// A minimal lockfile with one direct dependency and one
 /// transitive: `root → a@1 → b@1`. With the stub `nm_hoist` no
 /// hoisting happens, so the result must have `a` as the only
-/// root child and `b` under it. Pinning this shape now means
-/// Sub-slice 3b's algorithm replacement is observably correct
-/// when the tree shape changes (root will then see both `a` and
-/// `b` after a real hoist).
+/// root child and `b` under it. Pins the current shape so that
+/// when the stub is replaced with the real algorithm the tree
+/// changing to `root → {a, b}` is an observable diff in this
+/// test rather than a silent behaviour change elsewhere.
 #[test]
 fn one_transitive_dep_appears_under_its_parent_in_the_stub() {
     let mut importers = HashMap::new();


### PR DESCRIPTION
## Summary

First sub-slice of the Slice 3 hoister port from #438. Lands the IO
surface and the pnpm-side wrapper around the hoist algorithm; the
inner `@yarnpkg/nm` algorithm is stubbed (returns the input tree
unchanged) and replaced in 3b.

The umbrella's original Slice 3 — a faithful port of the full
`@yarnpkg/nm/hoist.ts` (1032 LOC) — is being split into five
sub-slices so each one is reviewable on its own. Sub-slice 3a covers
the wrapper's IO and the construction-time error surface; 3b drops in
the single-round hoist core; 3c adds peer-constraint handling; 3d adds
multi-round convergence + soft-link; 3e wires `hoistingLimits` /
`externalDependencies` knobs through and ports the full upstream test
fixture set.

### New crate `pacquet-real-hoist`

Mirrors upstream's [`installing/linking/real-hoist`](https://github.com/pnpm/pnpm/tree/94240bc0464196bd52f7006b97f6d9a43df34633/installing/linking/real-hoist) workspace package. Exposes:

- `HoisterTree`, `HoisterResult`, `HoisterDependencyKind`,
  `HoistingLimits`, `HoistOpts`, `HoistError` — the public surface
  the hoister contract speaks in.
- `RcByPtr<T>` — identity-hashed `Rc<T>` wrapper used as children of
  `IndexSet`s so a node added via two parent paths stays shared.
  Matches JS `Set<HoisterTree>` semantics (object-identity dedup)
  without the cost of structural hashing on deep trees.
- `hoist(&Lockfile, &HoistOpts) -> Result<HoisterResult, HoistError>`
  — the pnpm wrapper itself. Builds the HoisterTree (root importer's
  merged dependencies + devDependencies + optionalDependencies,
  recursive descent through `snapshots`, plus `link:` placeholders
  for `externalDependencies` and workspace-importer children), runs
  the inner stub, then post-filters `externalDependencies` out of
  the top-level result.

`HoistError::LockfileMissingDependency` surfaces with miette code
`ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY` ([pnpm.io/errors](https://pnpm.io/errors#err_pnpm_lockfile_missing_dependency)) — same code upstream uses.

## Upstream reference

Ports/cites pinned at `pnpm/pnpm@94240bc0` and `yarnpkg/berry@4287909fa6`:

- [`installing/linking/real-hoist/src/index.ts`](https://github.com/pnpm/pnpm/blob/94240bc0464196bd52f7006b97f6d9a43df34633/installing/linking/real-hoist/src/index.ts) — the wrapper this PR ports.
- [`installing/linking/real-hoist/test/index.ts`](https://github.com/pnpm/pnpm/blob/94240bc0464196bd52f7006b97f6d9a43df34633/installing/linking/real-hoist/test/index.ts) — the upstream test suite (one error-path test ported directly; the fixture-roundtrip test is deferred to 3e since it pins algorithm output).
- [`packages/yarnpkg-nm/sources/hoist.ts`](https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts) — the inner algorithm being stubbed for now.

## Test plan

Five unit tests covering the wrapper's observable behaviour:

- [x] `hoist_throws_on_broken_lockfile` — port of upstream's
      `"hoist throws an error if the lockfile is broken"` test.
- [x] `empty_lockfile_yields_empty_root` — wrapper's "no root
      importer" branch.
- [x] `one_transitive_dep_appears_under_its_parent_in_the_stub` —
      pins the current shape so 3b's algorithm replacement is
      observably correct (the tree will go from `root → a → b` to
      `root → {a, b}` once real hoisting lands).
- [x] `shared_dep_via_two_root_paths_is_one_node` — pins the dedup
      cache; future refactors of the `nodes` HashMap won't silently
      lose the identity sharing the real algorithm relies on.
- [x] `external_dependencies_are_stripped_from_the_result`.
- [x] `just ready`, `cargo doc --document-private-items`,
      `taplo format --check`, `just dylint` all clean.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new hoisting component to the workspace with a public hoist API, configurable hoist options (limits, external dependencies, peer handling), deterministic dependency resolution, and clear error reporting for missing lockfile entries.

* **Tests**
  * Added unit tests covering alias resolution, missing-snapshot errors, empty lockfiles, basic hoist shapes, node deduplication, and stripping of external placeholders.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pacquet/pull/448)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->