### PR TITLE
feat: activate global-virtual-store install path (#432)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2127,6 +2127,7 @@ dependencies = [
  "async-recursion",
  "dashmap",
  "derive_more",
+ "dunce",
  "futures-util",
  "httpdate",
  "insta",

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -509,15 +509,26 @@ impl Config {
     /// keeps the without-lockfile path on the project-local layout
     /// while the frozen-lockfile path consumes the GVS-derived value.
     ///
-    /// `virtual_store_dir_explicit` carries the "did the user set it"
-    /// signal `SmartDefault` cannot express on its own — yaml's
-    /// [`WorkspaceSettings::virtual_store_dir`] is the source today.
-    /// When `true` *and* GVS is on, `global_virtual_store_dir` mirrors
-    /// `virtual_store_dir` (the user picked the GVS root explicitly).
-    /// Otherwise it falls back to `<store_dir>/links`, mirroring
-    /// upstream's unconditional `globalVirtualStoreDir = storeDir/links`
-    /// assignment for the unset case.
-    pub fn apply_global_virtual_store_derivation(&mut self, virtual_store_dir_explicit: bool) {
+    /// `virtual_store_dir_explicit` carries the "did the user set
+    /// `virtualStoreDir` in yaml" signal `SmartDefault` cannot express
+    /// on its own. When `true` *and* GVS is on, `global_virtual_store_dir`
+    /// mirrors `virtual_store_dir` (the user picked the GVS root via the
+    /// shared key). `global_virtual_store_dir_explicit` is the analogous
+    /// signal for the dedicated `globalVirtualStoreDir` yaml key — when
+    /// set, that value wins and the derivation leaves
+    /// `global_virtual_store_dir` alone. Otherwise the field falls back
+    /// to `<store_dir>/links`, mirroring upstream's unconditional
+    /// `globalVirtualStoreDir = storeDir/links` assignment for the unset
+    /// case.
+    pub fn apply_global_virtual_store_derivation(
+        &mut self,
+        virtual_store_dir_explicit: bool,
+        global_virtual_store_dir_explicit: bool,
+    ) {
+        if global_virtual_store_dir_explicit {
+            // User pinned the dedicated GVS key in yaml — honor it.
+            return;
+        }
         self.global_virtual_store_dir =
             if self.enable_global_virtual_store && virtual_store_dir_explicit {
                 self.virtual_store_dir.clone()
@@ -611,13 +622,13 @@ impl Config {
         // dependency just for the lookup — the contract is fixed by
         // pnpm upstream, so the duplication is low-risk.
         //
-        // Capture `virtual_store_dir_explicit` from the yaml *before*
-        // applying it so the GVS derivation downstream can tell apart
-        // "user pinned virtualStoreDir" from "default value falling
-        // through from SmartDefault". Without this signal the
-        // derivation would always see a populated
-        // `config.virtual_store_dir` (the SmartDefault already wrote
-        // one in) and could never re-point it at `<store_dir>/links`.
+        // Capture the "did yaml set this field" booleans *before*
+        // applying yaml so the GVS derivation downstream can tell apart
+        // user-pinned values from SmartDefault fallbacks. Without these
+        // signals the derivation would always see populated values
+        // (SmartDefault wrote them in) and would either always or never
+        // re-point them, neither of which matches upstream's
+        // [`extendInstallOptions.ts:343-355`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/src/install/extendInstallOptions.ts#L343-L355).
         let env_workspace_dir = std::env::var_os("NPM_CONFIG_WORKSPACE_DIR")
             .or_else(|| std::env::var_os("npm_config_workspace_dir"))
             .filter(|v| !v.is_empty())
@@ -651,6 +662,7 @@ impl Config {
         };
 
         let mut virtual_store_dir_explicit = false;
+        let mut global_virtual_store_dir_explicit = false;
         if let Some((base_dir, settings)) = workspace_yaml {
             // Re-anchor the path-valued defaults to the workspace root
             // before applying settings. Without this, a `pacquet install`
@@ -670,18 +682,22 @@ impl Config {
             config.virtual_store_dir = base_dir.join("node_modules/.pnpm");
             if let Some(settings) = settings {
                 virtual_store_dir_explicit = settings.virtual_store_dir.is_some();
+                global_virtual_store_dir_explicit = settings.global_virtual_store_dir.is_some();
                 settings.apply_to(&mut config, &base_dir);
             }
         }
 
-        // Derive the GVS-related paths last so they see the final
+        // Derive `global_virtual_store_dir` last so it sees the final
         // `store_dir` / `virtual_store_dir` after yaml has been
-        // applied. Mirrors upstream's
-        // [`extendInstallOptions.ts:343-355`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/src/install/extendInstallOptions.ts#L343-L355):
-        // when GVS is on and the user hasn't pinned `virtualStoreDir`,
-        // it's re-pointed at `<store_dir>/links`. The install layer
-        // then reads the resolved value through `VirtualStoreLayout`.
-        config.apply_global_virtual_store_derivation(virtual_store_dir_explicit);
+        // applied. An explicit `globalVirtualStoreDir` in yaml wins
+        // over the derivation; otherwise the field falls back to the
+        // user's pinned `virtualStoreDir` (under GVS-on) or to
+        // `<store_dir>/links`. See
+        // [`Self::apply_global_virtual_store_derivation`].
+        config.apply_global_virtual_store_derivation(
+            virtual_store_dir_explicit,
+            global_virtual_store_dir_explicit,
+        );
 
         Ok(config)
     }
@@ -959,6 +975,37 @@ mod tests {
         assert!(config.enable_global_virtual_store);
         assert_eq!(config.virtual_store_dir, user_path);
         assert_eq!(config.global_virtual_store_dir, user_path);
+    }
+
+    /// An explicit `globalVirtualStoreDir` in yaml wins over the
+    /// derivation: the resolved field equals the user-supplied path,
+    /// not `<store_dir>/links` and not the user's `virtualStoreDir`.
+    /// Mirrors upstream's
+    /// [`getOptionsFromRootManifest.ts`](https://github.com/pnpm/pnpm/blob/94240bc046/config/reader/src/getOptionsFromRootManifest.ts)
+    /// — `globalVirtualStoreDir` is read into the config there with
+    /// the same resolve-relative-to-workspace semantics. Without this
+    /// preservation the value parses from yaml and then gets
+    /// silently overwritten by the derivation.
+    #[test]
+    pub fn yaml_global_virtual_store_dir_wins_over_derivation() {
+        let tmp = tempdir().unwrap();
+        let yaml_gvs = tmp.path().join("my-shared-store");
+        fs::write(
+            tmp.path().join("pnpm-workspace.yaml"),
+            format!("globalVirtualStoreDir: {}\n", yaml_gvs.display()),
+        )
+        .expect("write to pnpm-workspace.yaml");
+        let config =
+            Config::current(|| tmp.path().to_path_buf().pipe(Ok::<_, ()>), || None, Config::new)
+                .expect("yaml is valid");
+        assert!(config.enable_global_virtual_store, "GVS defaults to true");
+        // `virtual_store_dir` stays at the project-local default,
+        // because the user didn't pin `virtualStoreDir`.
+        assert_eq!(config.virtual_store_dir, tmp.path().join("node_modules/.pnpm"));
+        // The explicit yaml value wins — neither the derivation's
+        // `<store_dir>/links` fallback nor any mirroring of
+        // `virtual_store_dir` clobbers it.
+        assert_eq!(config.global_virtual_store_dir, yaml_gvs);
     }
 
     /// Pnpm's

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -483,33 +483,47 @@ impl Config {
     ///
     /// IO-heavy; call once per install rather than at every site
     /// that needs the resolved record.
-    /// Apply the global-virtual-store derivation rules from upstream's
-    /// [`extendInstallOptions.ts:343-355`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/src/install/extendInstallOptions.ts#L343-L355).
+    /// Derive [`Self::global_virtual_store_dir`] from
+    /// `enable_global_virtual_store` + the existing `store_dir` /
+    /// `virtual_store_dir` fields.
     ///
-    /// - When `enable_global_virtual_store` is `true` and the user did
-    ///   not explicitly set `virtual_store_dir`, point it at
-    ///   `<store_dir>/links`. Pacquet has no `allow_builds ??= {}`
-    ///   sibling because the `allow_builds` map already defaults to
-    ///   empty (the pnpm initialization upstream guards is itself only
-    ///   reachable when `allowBuilds == null`, which doesn't have a
-    ///   Rust analogue).
-    /// - Always set `global_virtual_store_dir` to the resolved
-    ///   `virtual_store_dir` when GVS is on, or to `<store_dir>/links`
-    ///   when GVS is off — matching the unconditional assignment at
-    ///   the bottom of upstream's block.
+    /// Pacquet diverges from upstream's
+    /// [`extendInstallOptions.ts:343-355`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/src/install/extendInstallOptions.ts#L343-L355)
+    /// on *which* field carries the GVS path:
+    ///
+    /// - **Upstream**: mutates `virtualStoreDir` in place when GVS is
+    ///   on and the user hasn't pinned it, so every consumer that
+    ///   reads `virtualStoreDir` ends up looking at `<storeDir>/links`.
+    /// - **Pacquet**: keeps `virtual_store_dir` at its project-local
+    ///   value (`<cwd>/node_modules/.pnpm` by default, or the user's
+    ///   yaml-pinned path) and writes the GVS path into the separate
+    ///   `global_virtual_store_dir` field. The install layer picks the
+    ///   right field through [`crate::Config::enable_global_virtual_store`]
+    ///   (or, in practice, through `pacquet_package_manager::VirtualStoreLayout`).
+    ///
+    /// The reason: pacquet still has a non-frozen
+    /// `InstallWithoutLockfile` path that upstream pnpm doesn't have.
+    /// Mutating `virtual_store_dir` would redirect that path to
+    /// `<storeDir>/links` too — but the issue (pnpm/pacquet#432)
+    /// scopes GVS to frozen-lockfile installs. Splitting the field
+    /// keeps the without-lockfile path on the project-local layout
+    /// while the frozen-lockfile path consumes the GVS-derived value.
     ///
     /// `virtual_store_dir_explicit` carries the "did the user set it"
     /// signal `SmartDefault` cannot express on its own — yaml's
     /// [`WorkspaceSettings::virtual_store_dir`] is the source today.
+    /// When `true` *and* GVS is on, `global_virtual_store_dir` mirrors
+    /// `virtual_store_dir` (the user picked the GVS root explicitly).
+    /// Otherwise it falls back to `<store_dir>/links`, mirroring
+    /// upstream's unconditional `globalVirtualStoreDir = storeDir/links`
+    /// assignment for the unset case.
     pub fn apply_global_virtual_store_derivation(&mut self, virtual_store_dir_explicit: bool) {
-        if self.enable_global_virtual_store && !virtual_store_dir_explicit {
-            self.virtual_store_dir = self.store_dir.links();
-        }
-        self.global_virtual_store_dir = if self.enable_global_virtual_store {
-            self.virtual_store_dir.clone()
-        } else {
-            self.store_dir.links()
-        };
+        self.global_virtual_store_dir =
+            if self.enable_global_virtual_store && virtual_store_dir_explicit {
+                self.virtual_store_dir.clone()
+            } else {
+                self.store_dir.links()
+            };
     }
 
     pub fn resolved_patched_dependencies(
@@ -583,17 +597,6 @@ impl Config {
         // Layer pnpm-workspace.yaml overrides on top. A missing file is
         // silent. Read or parse failures propagate to the caller.
         //
-        // The GVS-derived paths (`virtual_store_dir = <store_dir>/links`
-        // when GVS is on and unset, plus `global_virtual_store_dir`)
-        // are intentionally NOT applied here. The derivation lives on
-        // [`Self::apply_global_virtual_store_derivation`] for the
-        // install layer to invoke once it's wired to actually
-        // consume the new fields. Pulling the mutation into
-        // [`Self::current`] before that wiring lands would silently
-        // redirect every existing pacquet install to `<store_dir>/links`,
-        // diverging from today's behaviour without any of the
-        // GVS-aware path computation downstream. Tracked as part of
-        // pnpm/pacquet#432 (Section B).
         // Resolve the workspace dir: `NPM_CONFIG_WORKSPACE_DIR`
         // override first (mirroring upstream's `findWorkspaceDir` and
         // [`pacquet_workspace::find_workspace_dir`]; both must agree on
@@ -607,6 +610,14 @@ impl Config {
         // [`pacquet_workspace`] to avoid adding a cross-crate
         // dependency just for the lookup — the contract is fixed by
         // pnpm upstream, so the duplication is low-risk.
+        //
+        // Capture `virtual_store_dir_explicit` from the yaml *before*
+        // applying it so the GVS derivation downstream can tell apart
+        // "user pinned virtualStoreDir" from "default value falling
+        // through from SmartDefault". Without this signal the
+        // derivation would always see a populated
+        // `config.virtual_store_dir` (the SmartDefault already wrote
+        // one in) and could never re-point it at `<store_dir>/links`.
         let env_workspace_dir = std::env::var_os("NPM_CONFIG_WORKSPACE_DIR")
             .or_else(|| std::env::var_os("npm_config_workspace_dir"))
             .filter(|v| !v.is_empty())
@@ -639,6 +650,7 @@ impl Config {
             None
         };
 
+        let mut virtual_store_dir_explicit = false;
         if let Some((base_dir, settings)) = workspace_yaml {
             // Re-anchor the path-valued defaults to the workspace root
             // before applying settings. Without this, a `pacquet install`
@@ -657,9 +669,19 @@ impl Config {
             config.modules_dir = base_dir.join("node_modules");
             config.virtual_store_dir = base_dir.join("node_modules/.pnpm");
             if let Some(settings) = settings {
+                virtual_store_dir_explicit = settings.virtual_store_dir.is_some();
                 settings.apply_to(&mut config, &base_dir);
             }
         }
+
+        // Derive the GVS-related paths last so they see the final
+        // `store_dir` / `virtual_store_dir` after yaml has been
+        // applied. Mirrors upstream's
+        // [`extendInstallOptions.ts:343-355`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/src/install/extendInstallOptions.ts#L343-L355):
+        // when GVS is on and the user hasn't pinned `virtualStoreDir`,
+        // it's re-pointed at `<store_dir>/links`. The install layer
+        // then reads the resolved value through `VirtualStoreLayout`.
+        config.apply_global_virtual_store_derivation(virtual_store_dir_explicit);
 
         Ok(config)
     }
@@ -876,48 +898,54 @@ mod tests {
     }
 
     /// `enableGlobalVirtualStore` defaults to `true`. The derivation
-    /// fires when [`Config::apply_global_virtual_store_derivation`] is
-    /// invoked and the user has not pinned `virtual_store_dir`. Mirrors
-    /// upstream's
+    /// fires automatically from [`Config::current`] after yaml has
+    /// been applied, writing `<store_dir>/links` into
+    /// `global_virtual_store_dir` while leaving `virtual_store_dir`
+    /// at its project-local default — pacquet's split-field variant
+    /// of upstream's
     /// [`extendInstallOptions.ts:343-355`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/src/install/extendInstallOptions.ts#L343-L355).
+    /// See [`Config::apply_global_virtual_store_derivation`] for why
+    /// pacquet keeps the two fields separate.
     #[test]
-    pub fn gvs_default_re_points_virtual_store_at_store_links() {
+    pub fn gvs_default_writes_links_into_global_virtual_store_dir() {
         let tmp = tempdir().unwrap();
-        let mut config =
+        let config =
             Config::current(|| tmp.path().to_path_buf().pipe(Ok::<_, ()>), || None, Config::new)
                 .expect("workspace yaml absent => no error");
         assert!(config.enable_global_virtual_store, "GVS defaults to true");
-        config.apply_global_virtual_store_derivation(/* explicit */ false);
-        assert_eq!(config.virtual_store_dir, config.store_dir.links());
+        // `virtual_store_dir` stays project-local. The
+        // `<cwd>/node_modules/.pnpm` default has been re-anchored to
+        // `tmp` by `Config::current` (see the cwd fixup block).
+        assert_eq!(config.virtual_store_dir, tmp.path().join("node_modules/.pnpm"));
         assert_eq!(config.global_virtual_store_dir, config.store_dir.links());
     }
 
-    /// When `enableGlobalVirtualStore: false`, the derivation leaves
-    /// `virtual_store_dir` at its `<cwd>/node_modules/.pnpm` default but
-    /// still populates `global_virtual_store_dir` at `<storeDir>/links`,
-    /// matching upstream's unconditional assignment.
+    /// When `enableGlobalVirtualStore: false`, the derivation still
+    /// populates `global_virtual_store_dir` at `<storeDir>/links` —
+    /// matching upstream's unconditional `globalVirtualStoreDir =
+    /// storeDir/links` assignment for the GVS-off branch. The frozen-
+    /// lockfile install path consults `enable_global_virtual_store`
+    /// to decide whether to consume the field.
     #[test]
     pub fn gvs_disabled_keeps_project_local_virtual_store() {
         let tmp = tempdir().unwrap();
         fs::write(tmp.path().join("pnpm-workspace.yaml"), "enableGlobalVirtualStore: false\n")
             .expect("write to pnpm-workspace.yaml");
-        let mut config =
+        let config =
             Config::current(|| tmp.path().to_path_buf().pipe(Ok::<_, ()>), || None, Config::new)
                 .expect("yaml is valid");
         assert!(!config.enable_global_virtual_store);
-        config.apply_global_virtual_store_derivation(/* explicit */ false);
-        // The path-valued default has been re-anchored to `tmp` by
-        // `Config::current` (see the cwd fixup block).
         assert_eq!(config.virtual_store_dir, tmp.path().join("node_modules/.pnpm"));
         assert_eq!(config.global_virtual_store_dir, config.store_dir.links());
     }
 
-    /// User-pinned `virtualStoreDir` survives the derivation when GVS
-    /// is on, and `globalVirtualStoreDir` mirrors the user's path.
-    /// Matches upstream's `if (virtualStoreDir == null)` guard — `true`
-    /// is passed for `explicit` to mark the field as user-pinned.
+    /// When the user pins `virtualStoreDir` *and* GVS is on,
+    /// `globalVirtualStoreDir` mirrors that path — the user gets to
+    /// pick where the shared store lives. `virtual_store_dir` itself
+    /// still holds the pinned value (it's the same field the user
+    /// configured).
     #[test]
-    pub fn gvs_user_pinned_virtual_store_overrides_default() {
+    pub fn gvs_user_pinned_virtual_store_routes_into_global_virtual_store_dir() {
         let tmp = tempdir().unwrap();
         let user_path = tmp.path().join("custom-links");
         fs::write(
@@ -925,14 +953,10 @@ mod tests {
             format!("virtualStoreDir: {}\n", user_path.display()),
         )
         .expect("write to pnpm-workspace.yaml");
-        let mut config =
+        let config =
             Config::current(|| tmp.path().to_path_buf().pipe(Ok::<_, ()>), || None, Config::new)
                 .expect("yaml is valid");
         assert!(config.enable_global_virtual_store);
-        assert_eq!(config.virtual_store_dir, user_path);
-        config.apply_global_virtual_store_derivation(/* explicit */ true);
-        // Still the user's path — the derivation must not overwrite an
-        // explicitly-set value.
         assert_eq!(config.virtual_store_dir, user_path);
         assert_eq!(config.global_virtual_store_dir, user_path);
     }

--- a/crates/package-manager/Cargo.toml
+++ b/crates/package-manager/Cargo.toml
@@ -49,6 +49,7 @@ pacquet-registry-mock = { workspace = true }
 pacquet-testing-utils = { workspace = true }
 
 node-semver       = { workspace = true }
+dunce             = { workspace = true }
 insta             = { workspace = true }
 pretty_assertions = { workspace = true }
 serde-saphyr      = { workspace = true }

--- a/crates/package-manager/src/build_modules.rs
+++ b/crates/package-manager/src/build_modules.rs
@@ -175,7 +175,12 @@ impl AllowBuildPolicy {
 /// [`BuildModules::child_concurrency`] threads — mirrors upstream's
 /// [`runGroups(getWorkspaceConcurrency(opts.childConcurrency), groups)`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/during-install/src/index.ts#L124).
 pub struct BuildModules<'a> {
-    pub virtual_store_dir: &'a Path,
+    /// Install-scoped slot-directory mapping (GVS-aware). Replaces the
+    /// previous `virtual_store_dir: &Path` field — the layout already
+    /// knows the per-snapshot subdirectory shape (legacy flat-name vs
+    /// GVS `<scope>/<name>/<version>/<hash>`). See
+    /// [`crate::VirtualStoreLayout`].
+    pub layout: &'a crate::VirtualStoreLayout,
     pub modules_dir: &'a Path,
     pub lockfile_dir: &'a Path,
     pub snapshots: Option<&'a HashMap<PackageKey, SnapshotEntry>>,
@@ -266,7 +271,7 @@ impl<'a> BuildModules<'a> {
     /// <https://github.com/pnpm/pnpm/blob/80037699fb/installing/deps-installer/src/install/index.ts#L414>.
     pub fn run<R: Reporter>(self) -> Result<Vec<String>, BuildModulesError> {
         let BuildModules {
-            virtual_store_dir,
+            layout,
             modules_dir,
             lockfile_dir,
             snapshots,
@@ -308,7 +313,7 @@ impl<'a> BuildModules<'a> {
             // optional fan-out.
             .filter(|key| !skipped.contains(key))
             .map(|key| {
-                let pkg_dir = virtual_store_dir_for_key(virtual_store_dir, key);
+                let pkg_dir = virtual_store_dir_for_key(layout, key);
                 (key.clone(), pkg_requires_build(&pkg_dir))
             })
             .collect();
@@ -417,7 +422,7 @@ impl<'a> BuildModules<'a> {
                         dep_graph.as_ref(),
                         &deps_state_cache,
                         &ignored_builds,
-                        virtual_store_dir,
+                        layout,
                         modules_dir,
                         lockfile_dir,
                         &extra_bin_paths,
@@ -463,7 +468,7 @@ fn build_one_snapshot<R: Reporter>(
     dep_graph: Option<&HashMap<PackageKey, pacquet_graph_hasher::DepsGraphNode<PackageKey>>>,
     deps_state_cache: &Mutex<pacquet_graph_hasher::DepsStateCache<PackageKey>>,
     ignored_builds: &Mutex<BTreeSet<String>>,
-    virtual_store_dir: &Path,
+    layout: &crate::VirtualStoreLayout,
     modules_dir: &Path,
     lockfile_dir: &Path,
     extra_bin_paths: &[PathBuf],
@@ -592,7 +597,7 @@ fn build_one_snapshot<R: Reporter>(
         return Ok(());
     }
 
-    let pkg_dir = virtual_store_dir_for_key(virtual_store_dir, snapshot_key);
+    let pkg_dir = virtual_store_dir_for_key(layout, snapshot_key);
     if !pkg_dir.exists() {
         return Ok(());
     }
@@ -725,7 +730,12 @@ fn build_one_snapshot<R: Reporter>(
 /// Uses `without_peer()` to strip any peer-dependency suffix before
 /// computing the path, so keys like
 /// `/@pnpm.e2e/foo@1.0.0(@pnpm.e2e/bar@2.0.0)` resolve correctly.
-fn virtual_store_dir_for_key(virtual_store_dir: &Path, key: &PackageKey) -> PathBuf {
+///
+/// Threads through the install-scoped [`crate::VirtualStoreLayout`] so
+/// the call works under both the legacy flat-name layout and the
+/// GVS-shaped `<scope>/<name>/<version>/<hash>` layout — the layout's
+/// `slot_dir` is the single switchpoint.
+fn virtual_store_dir_for_key(layout: &crate::VirtualStoreLayout, key: &PackageKey) -> PathBuf {
     let bare_key = key.without_peer();
     let key_str = bare_key.to_string();
     let name_version = key_str.strip_prefix('/').unwrap_or(&key_str);
@@ -733,9 +743,7 @@ fn virtual_store_dir_for_key(virtual_store_dir: &Path, key: &PackageKey) -> Path
     let at_idx = name_version.rfind('@').unwrap_or(name_version.len());
     let name = &name_version[..at_idx];
 
-    let store_name = name_version.replace('/', "+");
-
-    virtual_store_dir.join(&store_name).join("node_modules").join(name)
+    layout.slot_dir(&bare_key).join("node_modules").join(name)
 }
 
 /// Parse `name` and `version` from a lockfile snapshot key like

--- a/crates/package-manager/src/build_modules.rs
+++ b/crates/package-manager/src/build_modules.rs
@@ -727,14 +727,21 @@ fn build_one_snapshot<R: Reporter>(
 
 /// Compute the package directory inside the virtual store for a snapshot key.
 ///
-/// Uses `without_peer()` to strip any peer-dependency suffix before
-/// computing the path, so keys like
-/// `/@pnpm.e2e/foo@1.0.0(@pnpm.e2e/bar@2.0.0)` resolve correctly.
+/// Routes the slot-dir lookup through the install-scoped
+/// [`crate::VirtualStoreLayout`], which precomputes
+/// `<scope>/<name>/<version>/<hash>` suffixes per *full* snapshot key
+/// (with the peer-dependency suffix preserved) when GVS is enabled.
+/// Peer-resolved snapshots therefore have to look up by the full key
+/// — `slot_dir(key)` — or the GVS lookup misses, falls through to the
+/// legacy flat-name path, and points at a directory that
+/// [`crate::CreateVirtualDirBySnapshot`] never created.
+/// `slot_dir(key.without_peer())` was the pre-#432 spelling and
+/// silently dropped lifecycle scripts for peer-resolved snapshots
+/// — never use it here.
 ///
-/// Threads through the install-scoped [`crate::VirtualStoreLayout`] so
-/// the call works under both the legacy flat-name layout and the
-/// GVS-shaped `<scope>/<name>/<version>/<hash>` layout — the layout's
-/// `slot_dir` is the single switchpoint.
+/// The package-name segment still comes from the peer-stripped key,
+/// because the slot's `node_modules/<pkg>` is keyed by the bare
+/// package name regardless of peer context.
 fn virtual_store_dir_for_key(layout: &crate::VirtualStoreLayout, key: &PackageKey) -> PathBuf {
     let bare_key = key.without_peer();
     let key_str = bare_key.to_string();
@@ -743,7 +750,7 @@ fn virtual_store_dir_for_key(layout: &crate::VirtualStoreLayout, key: &PackageKe
     let at_idx = name_version.rfind('@').unwrap_or(name_version.len());
     let name = &name_version[..at_idx];
 
-    layout.slot_dir(&bare_key).join("node_modules").join(name)
+    layout.slot_dir(key).join("node_modules").join(name)
 }
 
 /// Parse `name` and `version` from a lockfile snapshot key like

--- a/crates/package-manager/src/build_modules/tests.rs
+++ b/crates/package-manager/src/build_modules/tests.rs
@@ -1,5 +1,5 @@
 use super::{AllowBuildPolicy, BuildModules, parse_name_version_from_key};
-use crate::SkippedSnapshots;
+use crate::{SkippedSnapshots, VirtualStoreLayout};
 use pacquet_config::Config;
 use pacquet_executor::ScriptsPrependNodePath;
 use pacquet_lockfile::{
@@ -290,7 +290,7 @@ fn build_modules_collects_ignored_builds() {
     create_buildable_pkg(virtual_store_dir.path(), &key("aaa", "2.0.0"));
 
     let ignored = BuildModules {
-        virtual_store_dir: virtual_store_dir.path(),
+        layout: &VirtualStoreLayout::legacy(virtual_store_dir.path()),
         modules_dir: modules_dir.path(),
         lockfile_dir: lockfile_dir.path(),
         snapshots: Some(&snapshots),
@@ -357,7 +357,7 @@ fn build_modules_collects_ignored_builds_under_concurrency() {
     create_buildable_pkg(virtual_store_dir.path(), &key("aaa", "2.0.0"));
 
     let ignored = BuildModules {
-        virtual_store_dir: virtual_store_dir.path(),
+        layout: &VirtualStoreLayout::legacy(virtual_store_dir.path()),
         modules_dir: modules_dir.path(),
         lockfile_dir: lockfile_dir.path(),
         snapshots: Some(&snapshots),
@@ -412,7 +412,7 @@ fn build_modules_excludes_explicit_deny_from_ignored() {
     create_buildable_pkg(virtual_store_dir.path(), &key("ignored", "1.0.0"));
 
     let ignored = BuildModules {
-        virtual_store_dir: virtual_store_dir.path(),
+        layout: &VirtualStoreLayout::legacy(virtual_store_dir.path()),
         modules_dir: modules_dir.path(),
         lockfile_dir: lockfile_dir.path(),
         snapshots: Some(&snapshots),
@@ -491,7 +491,7 @@ fn do_not_fail_on_optional_dep_with_failing_postinstall() {
     create_failing_postinstall_fixture(virtual_store_dir.path(), &pkg_key);
 
     let ignored = BuildModules {
-        virtual_store_dir: virtual_store_dir.path(),
+        layout: &VirtualStoreLayout::legacy(virtual_store_dir.path()),
         modules_dir: modules_dir.path(),
         lockfile_dir: lockfile_dir.path(),
         snapshots: Some(&snapshots),
@@ -618,7 +618,7 @@ fn using_side_effects_cache_skips_rebuild() {
     side_effects_maps.insert(pkg_key.clone(), std::sync::Arc::new(overlay));
 
     BuildModules {
-        virtual_store_dir: virtual_store_dir.path(),
+        layout: &VirtualStoreLayout::legacy(virtual_store_dir.path()),
         modules_dir: modules_dir.path(),
         lockfile_dir: lockfile_dir.path(),
         snapshots: Some(&snapshots),
@@ -680,7 +680,7 @@ fn side_effects_cache_disabled_bypasses_the_gate() {
     side_effects_maps.insert(pkg_key.clone(), std::sync::Arc::new(overlay));
 
     let err = BuildModules {
-        virtual_store_dir: virtual_store_dir.path(),
+        layout: &VirtualStoreLayout::legacy(virtual_store_dir.path()),
         modules_dir: modules_dir.path(),
         lockfile_dir: lockfile_dir.path(),
         snapshots: Some(&snapshots),
@@ -735,7 +735,7 @@ fn fail_when_failing_postinstall_is_required() {
     create_failing_postinstall_fixture(virtual_store_dir.path(), &pkg_key);
 
     let err = BuildModules {
-        virtual_store_dir: virtual_store_dir.path(),
+        layout: &VirtualStoreLayout::legacy(virtual_store_dir.path()),
         modules_dir: modules_dir.path(),
         lockfile_dir: lockfile_dir.path(),
         snapshots: Some(&snapshots),
@@ -967,7 +967,7 @@ async fn write_path_populates_side_effects_row() {
     );
 
     BuildModules {
-        virtual_store_dir: virtual_store_dir.path(),
+        layout: &VirtualStoreLayout::legacy(virtual_store_dir.path()),
         modules_dir: modules_dir.path(),
         lockfile_dir: lockfile_dir.path(),
         snapshots: Some(&snapshots),
@@ -1074,7 +1074,7 @@ async fn write_path_disabled_skips_upload() {
     let (writer, writer_task) = StoreIndexWriter::spawn(&store_dir);
 
     BuildModules {
-        virtual_store_dir: virtual_store_dir.path(),
+        layout: &VirtualStoreLayout::legacy(virtual_store_dir.path()),
         modules_dir: modules_dir.path(),
         lockfile_dir: lockfile_dir.path(),
         snapshots: Some(&snapshots),
@@ -1190,7 +1190,7 @@ async fn upload_error_does_not_interrupt_install() {
     let (writer, writer_task) = StoreIndexWriter::spawn(&store_dir);
 
     BuildModules {
-        virtual_store_dir: virtual_store_dir.path(),
+        layout: &VirtualStoreLayout::legacy(virtual_store_dir.path()),
         modules_dir: modules_dir.path(),
         lockfile_dir: lockfile_dir.path(),
         snapshots: Some(&snapshots),
@@ -1416,7 +1416,7 @@ new file mode 100644
     );
 
     BuildModules {
-        virtual_store_dir: virtual_store_dir.path(),
+        layout: &VirtualStoreLayout::legacy(virtual_store_dir.path()),
         modules_dir: modules_dir.path(),
         lockfile_dir: lockfile_dir.path(),
         snapshots: Some(&snapshots),
@@ -1520,7 +1520,7 @@ new file mode 100644
     let (writer, writer_task) = StoreIndexWriter::spawn(&store_dir);
 
     BuildModules {
-        virtual_store_dir: virtual_store_dir.path(),
+        layout: &VirtualStoreLayout::legacy(virtual_store_dir.path()),
         modules_dir: modules_dir.path(),
         lockfile_dir: lockfile_dir.path(),
         snapshots: Some(&snapshots),
@@ -1595,7 +1595,7 @@ async fn missing_patch_file_path_errors_with_diagnostic() {
     let (writer, writer_task) = StoreIndexWriter::spawn(&store_dir);
 
     let err = BuildModules {
-        virtual_store_dir: virtual_store_dir.path(),
+        layout: &VirtualStoreLayout::legacy(virtual_store_dir.path()),
         modules_dir: modules_dir.path(),
         lockfile_dir: lockfile_dir.path(),
         snapshots: Some(&snapshots),

--- a/crates/package-manager/src/create_symlink_layout.rs
+++ b/crates/package-manager/src/create_symlink_layout.rs
@@ -1,4 +1,4 @@
-use crate::{SymlinkPackageError, symlink_package};
+use crate::{SymlinkPackageError, VirtualStoreLayout, symlink_package};
 use pacquet_lockfile::{PkgName, SnapshotDepRef};
 use std::{collections::HashMap, path::Path};
 
@@ -8,6 +8,12 @@ use std::{collections::HashMap, path::Path};
 /// the symlink filename under `node_modules/` uses the entry key (the alias),
 /// while the virtual-store lookup uses the aliased target.
 ///
+/// Child target paths come from the install-scoped [`VirtualStoreLayout`]:
+/// `layout.slot_dir(&target)` returns either
+/// `<virtual_store_dir>/<flat-name>` (legacy) or
+/// `<global_virtual_store_dir>/<scope>/<name>/<version>/<hash>` (GVS), so
+/// the caller doesn't have to branch on which mode is in effect.
+///
 /// `virtual_node_modules_dir` does not have to exist — `symlink_package` calls
 /// `fs::create_dir_all` on the symlink path's parent before each link. Callers
 /// that already know the directory exists (e.g. `CreateVirtualStore::run`,
@@ -15,7 +21,7 @@ use std::{collections::HashMap, path::Path};
 /// stat syscalls, which is cheap and matches pnpm's own redundant-mkdir shape.
 pub fn create_symlink_layout(
     dependencies: &HashMap<PkgName, SnapshotDepRef>,
-    virtual_root: &Path,
+    layout: &VirtualStoreLayout,
     virtual_node_modules_dir: &Path,
 ) -> Result<(), SymlinkPackageError> {
     // Serial iteration: the symlink work per snapshot is small (a handful of
@@ -26,11 +32,10 @@ pub fn create_symlink_layout(
     // pnpm's `symlinkAllModules` in `worker/src/start.ts`.
     dependencies.iter().try_for_each(|(alias_name, dep_ref)| {
         let target = dep_ref.resolve(alias_name);
-        let virtual_store_name = target.to_virtual_store_name();
         let target_name_str = target.name.to_string();
         let alias_name_str = alias_name.to_string();
         symlink_package(
-            &virtual_root.join(virtual_store_name).join("node_modules").join(&target_name_str),
+            &layout.slot_dir(&target).join("node_modules").join(&target_name_str),
             &virtual_node_modules_dir.join(&alias_name_str),
         )
     })

--- a/crates/package-manager/src/create_virtual_dir_by_snapshot.rs
+++ b/crates/package-manager/src/create_virtual_dir_by_snapshot.rs
@@ -1,6 +1,6 @@
 use crate::{
-    ImportIndexedDirError, ImportIndexedDirOpts, SymlinkPackageError, create_symlink_layout,
-    import_indexed_dir,
+    ImportIndexedDirError, ImportIndexedDirOpts, SymlinkPackageError, VirtualStoreLayout,
+    create_symlink_layout, import_indexed_dir,
 };
 use derive_more::{Display, Error};
 use miette::Diagnostic;
@@ -10,12 +10,7 @@ use pacquet_reporter::{
     LogEvent, LogLevel, PackageImportMethod as WireImportMethod, ProgressLog, ProgressMessage,
     Reporter,
 };
-use std::{
-    collections::HashMap,
-    fs, io,
-    path::{Path, PathBuf},
-    sync::atomic::AtomicU8,
-};
+use std::{collections::HashMap, fs, io, path::PathBuf, sync::atomic::AtomicU8};
 
 /// This subroutine creates the virtual-store slot for one package and then
 /// runs the two post-extraction tasks — CAS file import and intra-package
@@ -27,7 +22,14 @@ use std::{
 /// install's critical-path tail.
 #[must_use]
 pub struct CreateVirtualDirBySnapshot<'a> {
-    pub virtual_store_dir: &'a Path,
+    /// Per-install precomputed slot-directory mapping. Replaces the
+    /// previous `virtual_store_dir: &Path` field — the layout already
+    /// holds the root and knows how to resolve a per-snapshot slot
+    /// (legacy `<root>/<flat-name>` vs GVS-shaped
+    /// `<root>/<scope>/<name>/<version>/<hash>`) through a single
+    /// [`VirtualStoreLayout::slot_dir`] lookup. See
+    /// [`crate::VirtualStoreLayout`] for how it's built.
+    pub layout: &'a VirtualStoreLayout,
     pub cas_paths: &'a HashMap<String, PathBuf>,
     pub import_method: PackageImportMethod,
     /// Install-scoped dedupe state for `pnpm:package-import-method`.
@@ -69,7 +71,7 @@ impl<'a> CreateVirtualDirBySnapshot<'a> {
     /// Execute the subroutine.
     pub fn run<R: Reporter>(self) -> Result<(), CreateVirtualDirError> {
         let CreateVirtualDirBySnapshot {
-            virtual_store_dir,
+            layout,
             cas_paths,
             import_method,
             logged_methods,
@@ -79,8 +81,7 @@ impl<'a> CreateVirtualDirBySnapshot<'a> {
             snapshot,
         } = self;
 
-        let virtual_node_modules_dir =
-            virtual_store_dir.join(package_key.to_virtual_store_name()).join("node_modules");
+        let virtual_node_modules_dir = layout.slot_dir(package_key).join("node_modules");
         fs::create_dir_all(&virtual_node_modules_dir).map_err(|error| {
             CreateVirtualDirError::CreateNodeModulesDir {
                 dir: virtual_node_modules_dir.clone(),
@@ -109,12 +110,10 @@ impl<'a> CreateVirtualDirBySnapshot<'a> {
                 .map_err(CreateVirtualDirError::ImportIndexedDir)
             },
             || match snapshot.dependencies.as_ref() {
-                Some(dependencies) => create_symlink_layout(
-                    dependencies,
-                    virtual_store_dir,
-                    &virtual_node_modules_dir,
-                )
-                .map_err(CreateVirtualDirError::SymlinkPackage),
+                Some(dependencies) => {
+                    create_symlink_layout(dependencies, layout, &virtual_node_modules_dir)
+                        .map_err(CreateVirtualDirError::SymlinkPackage)
+                }
                 None => Ok(()),
             },
         );

--- a/crates/package-manager/src/create_virtual_dir_by_snapshot/tests.rs
+++ b/crates/package-manager/src/create_virtual_dir_by_snapshot/tests.rs
@@ -27,14 +27,14 @@ fn optimistic_wire_method_collapses_auto_and_clone_or_copy_to_clone() {
 }
 
 /// `CreateVirtualDirBySnapshot::run` emits `pnpm:progress imported`
-/// after `create_cas_files` succeeds. Driving with an empty
+/// after `import_indexed_dir` succeeds. Driving with an empty
 /// `cas_paths` map exercises the success path without hitting the
-/// network: `create_cas_files` mkdirs the empty directory and
+/// network: `import_indexed_dir` mkdirs the empty directory and
 /// returns Ok, then the imported emit fires. Asserts the wire
 /// fields (`method`, `requester`, `to`) match what the install
 /// layer threaded down.
 #[tokio::test]
-async fn run_emits_imported_event_after_create_cas_files() {
+async fn run_emits_imported_event_after_import_indexed_dir() {
     static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
 
     struct RecordingReporter;

--- a/crates/package-manager/src/create_virtual_dir_by_snapshot/tests.rs
+++ b/crates/package-manager/src/create_virtual_dir_by_snapshot/tests.rs
@@ -60,8 +60,9 @@ async fn run_emits_imported_event_after_create_cas_files() {
     // but `#[tokio::test]` defaults to single-thread, so we run
     // `.run()` directly here. The function itself is sync — only
     // the caller's runtime flavor matters.
+    let layout = crate::VirtualStoreLayout::legacy(virtual_store_dir.clone());
     CreateVirtualDirBySnapshot {
-        virtual_store_dir: &virtual_store_dir,
+        layout: &layout,
         cas_paths: &cas_paths,
         import_method: PackageImportMethod::Hardlink,
         logged_methods: &logged_methods,

--- a/crates/package-manager/src/create_virtual_store.rs
+++ b/crates/package-manager/src/create_virtual_store.rs
@@ -294,7 +294,15 @@ impl<'a> CreateVirtualStore<'a> {
         // Run this *before* deriving cache keys so unchanged
         // directory-backed snapshots aren't tripped by
         // `snapshot_cache_key`'s `UnsupportedResolution`.
-        let virtual_store_dir = &config.virtual_store_dir;
+        //
+        // Route the slot-existence probe through `layout.slot_dir` so
+        // GVS-on installs check the correct path. The probe used to
+        // hard-code `<config.virtual_store_dir>/<flat-name>`, which is
+        // the legacy layout — under GVS, slots live at
+        // `<global_virtual_store_dir>/<scope>/<name>/<ver>/<hash>` and
+        // the legacy path is empty, so the skip gate would
+        // incorrectly mark every warm slot as "broken" and emit
+        // `BrokenModules` for the wrong path.
         let survivors: Vec<(&PackageKey, &SnapshotEntry)> = snapshots
             .iter()
             // Reason 1: installability skip. Drop entirely.
@@ -315,8 +323,8 @@ impl<'a> CreateVirtualStore<'a> {
                 if !integrity_equal(current_metadata, wanted_metadata) {
                     return true;
                 }
-                let dir = virtual_store_dir
-                    .join(snapshot_key.to_virtual_store_name())
+                let dir = layout
+                    .slot_dir(snapshot_key)
                     .join("node_modules")
                     .join(snapshot_key.name.to_string());
                 if dir.is_dir() {

--- a/crates/package-manager/src/create_virtual_store.rs
+++ b/crates/package-manager/src/create_virtual_store.rs
@@ -79,6 +79,11 @@ pub struct CreateVirtualStore<'a> {
     /// [`CreateVirtualStore::run`].
     pub current_snapshots: Option<&'a HashMap<PackageKey, SnapshotEntry>>,
     pub current_packages: Option<&'a HashMap<PackageKey, PackageMetadata>>,
+    /// Install-scoped precomputed slot-directory mapping (GVS-aware).
+    /// Used by both the warm batch and the cold batch to decide where
+    /// each snapshot's `node_modules/<pkg>` lands. See
+    /// [`crate::VirtualStoreLayout`].
+    pub layout: &'a crate::VirtualStoreLayout,
     /// Install-scoped dedupe state for `pnpm:package-import-method`.
     /// See `link_file::log_method_once`.
     pub logged_methods: &'a AtomicU8,
@@ -139,6 +144,7 @@ impl<'a> CreateVirtualStore<'a> {
             snapshots,
             current_snapshots,
             current_packages,
+            layout,
             logged_methods,
             requester,
             store_index_writer,
@@ -531,7 +537,6 @@ impl<'a> CreateVirtualStore<'a> {
             }
         }
 
-        let virtual_store_dir = &config.virtual_store_dir;
         let import_method = config.package_import_method;
         {
             use rayon::prelude::*;
@@ -554,7 +559,7 @@ impl<'a> CreateVirtualStore<'a> {
                     emit_warm_snapshot_progress::<R>(&package_id, requester);
 
                     crate::CreateVirtualDirBySnapshot {
-                        virtual_store_dir,
+                        layout,
                         cas_paths: cas_paths.as_ref(),
                         import_method,
                         logged_methods,
@@ -597,6 +602,7 @@ impl<'a> CreateVirtualStore<'a> {
                     InstallPackageBySnapshot {
                         http_client,
                         config,
+                        layout,
                         store_index: store_index_ref,
                         store_index_writer: store_index_writer_ref,
                         prefetched_cas_paths: prefetched_ref,

--- a/crates/package-manager/src/install.rs
+++ b/crates/package-manager/src/install.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, path::Path, sync::atomic::AtomicU8, time::SystemTime};
+use std::{collections::BTreeMap, sync::atomic::AtomicU8, time::SystemTime};
 
 use crate::{
     InstallFrozenLockfile, InstallFrozenLockfileError, InstallWithoutLockfile,
@@ -216,33 +216,6 @@ where
 
         tracing::info!(target: "pacquet::install", "Start all");
 
-        // Register this project against the shared store when both the
-        // frozen-lockfile dispatch and GVS are active — i.e. when the
-        // install actually places packages under `<store_dir>/links/...`.
-        // `InstallWithoutLockfile` still uses the project-local virtual
-        // store (`VirtualStoreLayout::legacy`), so a registry entry for
-        // it would point at a project that never touches the shared
-        // store. Gating on `frozen_lockfile` keeps
-        // `<store_dir>/projects/` aligned with what `pacquet store prune`
-        // (tracked separately) will need to walk.
-        //
-        // Mirrors upstream's call into `@pnpm/store.controller`'s
-        // [`registerProject`](https://github.com/pnpm/pnpm/blob/94240bc046/store/controller/src/storeController/projectRegistry.ts).
-        // Best-effort: a registry write failure shouldn't fail the
-        // install. Surface as `tracing::warn!` so the failure is
-        // diagnosable but the install carries on.
-        if frozen_lockfile && config.enable_global_virtual_store {
-            let project_dir = Path::new(&prefix);
-            if let Err(error) = pacquet_store_dir::register_project(&config.store_dir, project_dir)
-            {
-                tracing::warn!(
-                    target: "pacquet::install",
-                    ?error,
-                    "Failed to register project in the global-virtual-store registry; install continues",
-                );
-            }
-        }
-
         // Dispatch priority, matching pnpm's CLI semantics:
         //
         // 1. `--frozen-lockfile` is the strongest signal. If the user
@@ -297,6 +270,46 @@ where
             .run::<R>()
             .await
             .map_err(InstallError::FrozenLockfile)?;
+
+            // Register every importer against the shared store now
+            // that the install has materialized their `node_modules/`.
+            // Mirrors upstream's call into `@pnpm/store.controller`'s
+            // [`registerProject`](https://github.com/pnpm/pnpm/blob/94240bc046/store/controller/src/storeController/projectRegistry.ts),
+            // which runs once per importer — a workspace ends up with
+            // one symlink in `<store_dir>/projects/` per package, so
+            // `pacquet store prune` (tracked separately) can find
+            // every reachable consumer of `<store_dir>/links/...`.
+            //
+            // Gated on `frozen_lockfile && enable_global_virtual_store`:
+            // `InstallWithoutLockfile` keeps the project-local virtual
+            // store via `VirtualStoreLayout::legacy`, and a registry
+            // entry for it would point at a project that never
+            // touches the shared store.
+            //
+            // Best-effort: a registry write failure shouldn't fail
+            // the install. Surface as `tracing::warn!` so the failure
+            // is diagnosable but the install carries on. Validation
+            // of importer keys is done by
+            // [`crate::SymlinkDirectDependencies::run`] before we get
+            // here, so by this point every key is known-safe.
+            if config.enable_global_virtual_store {
+                for importer_id in importers.keys() {
+                    let project_dir = crate::symlink_direct_dependencies::importer_root_dir(
+                        &workspace_root,
+                        importer_id,
+                    );
+                    if let Err(error) =
+                        pacquet_store_dir::register_project(&config.store_dir, &project_dir)
+                    {
+                        tracing::warn!(
+                            target: "pacquet::install",
+                            ?error,
+                            importer_id = %importer_id,
+                            "Failed to register importer in the global-virtual-store registry; install continues",
+                        );
+                    }
+                }
+            }
         } else if config.lockfile {
             return Err(InstallError::UnsupportedLockfileMode);
         } else {

--- a/crates/package-manager/src/install.rs
+++ b/crates/package-manager/src/install.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, sync::atomic::AtomicU8, time::SystemTime};
+use std::{collections::BTreeMap, path::Path, sync::atomic::AtomicU8, time::SystemTime};
 
 use crate::{
     InstallFrozenLockfile, InstallFrozenLockfileError, InstallWithoutLockfile,
@@ -215,6 +215,34 @@ where
         let logged_methods = AtomicU8::new(0);
 
         tracing::info!(target: "pacquet::install", "Start all");
+
+        // Register this project against the shared store when GVS is
+        // on, so a future `pacquet store prune` (tracked separately)
+        // can discover every project that still references a
+        // `<store_dir>/links/...` slot. Mirrors upstream's call into
+        // `@pnpm/store.controller`'s
+        // [`registerProject`](https://github.com/pnpm/pnpm/blob/94240bc046/store/controller/src/storeController/projectRegistry.ts).
+        // Fires once per `Install::run`, irrespective of frozen-vs-non-
+        // frozen dispatch — the registry tracks the project, not the
+        // particular install mode.
+        //
+        // Best-effort: a registry write failure shouldn't fail the
+        // install (the legacy non-GVS path doesn't need this entry).
+        // Surface as `tracing::warn!` so the failure is diagnosable but
+        // the install carries on. Skip the call entirely when GVS is
+        // off so a `<store_dir>/projects/` directory only appears on
+        // installs that actually use the shared store.
+        if config.enable_global_virtual_store {
+            let project_dir = Path::new(&prefix);
+            if let Err(error) = pacquet_store_dir::register_project(&config.store_dir, project_dir)
+            {
+                tracing::warn!(
+                    target: "pacquet::install",
+                    ?error,
+                    "Failed to register project in the global-virtual-store registry; install continues",
+                );
+            }
+        }
 
         // Dispatch priority, matching pnpm's CLI semantics:
         //

--- a/crates/package-manager/src/install.rs
+++ b/crates/package-manager/src/install.rs
@@ -216,23 +216,22 @@ where
 
         tracing::info!(target: "pacquet::install", "Start all");
 
-        // Register this project against the shared store when GVS is
-        // on, so a future `pacquet store prune` (tracked separately)
-        // can discover every project that still references a
-        // `<store_dir>/links/...` slot. Mirrors upstream's call into
-        // `@pnpm/store.controller`'s
-        // [`registerProject`](https://github.com/pnpm/pnpm/blob/94240bc046/store/controller/src/storeController/projectRegistry.ts).
-        // Fires once per `Install::run`, irrespective of frozen-vs-non-
-        // frozen dispatch — the registry tracks the project, not the
-        // particular install mode.
+        // Register this project against the shared store when both the
+        // frozen-lockfile dispatch and GVS are active — i.e. when the
+        // install actually places packages under `<store_dir>/links/...`.
+        // `InstallWithoutLockfile` still uses the project-local virtual
+        // store (`VirtualStoreLayout::legacy`), so a registry entry for
+        // it would point at a project that never touches the shared
+        // store. Gating on `frozen_lockfile` keeps
+        // `<store_dir>/projects/` aligned with what `pacquet store prune`
+        // (tracked separately) will need to walk.
         //
+        // Mirrors upstream's call into `@pnpm/store.controller`'s
+        // [`registerProject`](https://github.com/pnpm/pnpm/blob/94240bc046/store/controller/src/storeController/projectRegistry.ts).
         // Best-effort: a registry write failure shouldn't fail the
-        // install (the legacy non-GVS path doesn't need this entry).
-        // Surface as `tracing::warn!` so the failure is diagnosable but
-        // the install carries on. Skip the call entirely when GVS is
-        // off so a `<store_dir>/projects/` directory only appears on
-        // installs that actually use the shared store.
-        if config.enable_global_virtual_store {
+        // install. Surface as `tracing::warn!` so the failure is
+        // diagnosable but the install carries on.
+        if frozen_lockfile && config.enable_global_virtual_store {
             let project_dir = Path::new(&prefix);
             if let Err(error) = pacquet_store_dir::register_project(&config.store_dir, project_dir)
             {

--- a/crates/package-manager/src/install/tests.rs
+++ b/crates/package-manager/src/install/tests.rs
@@ -783,6 +783,15 @@ async fn warm_reinstall_skips_snapshot_when_current_lockfile_matches() {
     manifest.save().unwrap();
 
     let mut config = Config::new();
+    // Opt out of the (now-default) global virtual store: the
+    // `seed_placeholder_virtual_store_slot` helper writes the legacy
+    // `<virtual_store_dir>/<flat-name>` shape, which only matches the
+    // skip-probe path when `VirtualStoreLayout` is in legacy mode.
+    // The partial-install behaviour under test (skip when the
+    // current lockfile matches + slot exists) is independent of the
+    // GVS layout; the GVS-on equivalent is exercised by the
+    // `frozen_lockfile_under_gvs_*` tests below.
+    config.enable_global_virtual_store = false;
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = virtual_store_dir.clone();
@@ -856,6 +865,12 @@ async fn warm_reinstall_emits_broken_modules_when_dir_is_missing() {
     manifest.save().unwrap();
 
     let mut config = Config::new();
+    // Opt out of the GVS layout — see the rationale on
+    // [`warm_reinstall_skips_snapshot_when_current_lockfile_matches`].
+    // The pre-seeded `<virtual_store_dir>/<flat-name>` slot is the
+    // legacy shape the probe matches; the BrokenModules emit fires
+    // identically under either layout once the slot is missing.
+    config.enable_global_virtual_store = false;
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = virtual_store_dir.clone();
@@ -1084,6 +1099,11 @@ async fn warm_reinstall_reports_added_zero_and_emits_no_imported_events() {
     manifest.save().unwrap();
 
     let mut config = Config::new();
+    // Opt out of the GVS layout — the pre-seeded
+    // `<virtual_store_dir>/<flat-name>` slot is the legacy shape the
+    // skip probe matches under
+    // [`warm_reinstall_skips_snapshot_when_current_lockfile_matches`].
+    config.enable_global_virtual_store = false;
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = virtual_store_dir.clone();

--- a/crates/package-manager/src/install/tests.rs
+++ b/crates/package-manager/src/install/tests.rs
@@ -14,7 +14,7 @@ use pacquet_reporter::{
 };
 use pacquet_testing_utils::fs::{get_all_folders, is_symlink_or_junction};
 use pipe_trait::Pipe;
-use std::sync::Mutex;
+use std::{path::PathBuf, sync::Mutex};
 use tempfile::tempdir;
 use text_block_macros::text_block;
 
@@ -1416,6 +1416,95 @@ async fn frozen_lockfile_with_gvs_off_skips_project_registry() {
         !store_dir.join("projects").exists(),
         "GVS-off install must NOT create the project-registry directory",
     );
+
+    drop(dir);
+}
+
+/// Workspace install under GVS registers each importer separately.
+/// Mirrors upstream's per-project
+/// [`registerProject`](https://github.com/pnpm/pnpm/blob/94240bc046/store/controller/src/storeController/projectRegistry.ts)
+/// call site, which fires once per workspace package — a workspace
+/// with `.` (root) and `packages/web` therefore ends up with two
+/// entries in `<store_dir>/projects/`, each resolving back to its
+/// own root dir. `pacquet store prune` (tracked separately) needs
+/// every reachable importer in the registry to keep the
+/// `<store_dir>/links/...` slots they share alive.
+#[tokio::test]
+async fn frozen_lockfile_under_gvs_registers_each_workspace_importer() {
+    let dir = tempdir().unwrap();
+    let store_dir = dir.path().join("pacquet-store");
+    let workspace_root = dir.path().join("workspace");
+    let modules_dir = workspace_root.join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pacquet");
+
+    // Workspace layout: root + one sub-importer. Both directories
+    // have to exist on disk because `register_project` canonicalises
+    // the target before writing the symlink.
+    let web_dir = workspace_root.join("packages/web");
+    std::fs::create_dir_all(&web_dir).expect("create packages/web");
+    let manifest_path = workspace_root.join("package.json");
+    let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
+    // The sub-importer needs a `package.json` too — the freshness check
+    // satisfies on the root only today, but the per-importer registry
+    // write still resolves the target on disk.
+    std::fs::write(web_dir.join("package.json"), "{}").expect("write packages/web/package.json");
+
+    let mut config = Config::new();
+    config.enable_global_virtual_store = true;
+    config.lockfile = false;
+    config.store_dir = store_dir.clone().into();
+    config.modules_dir = modules_dir.clone();
+    config.virtual_store_dir = virtual_store_dir.clone();
+    config.global_virtual_store_dir = store_dir.join("links");
+    let config = config.leak();
+
+    // Two importers: `.` and `packages/web`. Empty dep graph so the
+    // install reaches the per-importer registry-write loop without
+    // doing any actual fetch/link work.
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "importers:"
+        "  .:"
+        "    dependencies: {}"
+        "  packages/web:"
+        "    dependencies: {}"
+        "packages: {}"
+        "snapshots: {}"
+    })
+    .expect("parse minimal v9 workspace lockfile");
+
+    Install {
+        tarball_mem_cache: &Default::default(),
+        http_client: &Default::default(),
+        config,
+        manifest: &manifest,
+        lockfile: Some(&lockfile),
+        dependency_groups: [DependencyGroup::Prod],
+        frozen_lockfile: true,
+        resolved_packages: &Default::default(),
+    }
+    .run::<SilentReporter>()
+    .await
+    .expect("workspace frozen-lockfile install under GVS should succeed");
+
+    // Exactly two registry entries — one per importer. Resolve the
+    // symlink targets and confirm both project roots are present.
+    let projects_dir = store_dir.join("projects");
+    assert!(projects_dir.is_dir(), "GVS-on workspace install must create <store_dir>/projects/");
+    let mut targets: Vec<PathBuf> = std::fs::read_dir(&projects_dir)
+        .unwrap()
+        .map(|entry| {
+            let target = std::fs::read_link(entry.unwrap().path()).expect("registry entry");
+            dunce::canonicalize(&target).expect("canonicalize registry target")
+        })
+        .collect();
+    targets.sort();
+    let mut expected = [
+        dunce::canonicalize(&workspace_root).expect("canonicalize workspace root"),
+        dunce::canonicalize(&web_dir).expect("canonicalize packages/web"),
+    ];
+    expected.sort();
+    assert_eq!(targets, expected, "every importer must have a registry entry");
 
     drop(dir);
 }

--- a/crates/package-manager/src/install/tests.rs
+++ b/crates/package-manager/src/install/tests.rs
@@ -1252,3 +1252,150 @@ async fn frozen_lockfile_errors_when_lockfile_has_no_root_importer() {
 
     drop(dir);
 }
+
+/// GVS-on frozen-lockfile install. With
+/// `enable_global_virtual_store: true` (pacquet's default, matching
+/// upstream's
+/// [`config/reader/src/index.ts:392-394`](https://github.com/pnpm/pnpm/blob/94240bc046/config/reader/src/index.ts#L392-L394)),
+/// `Install::run` registers the project at
+/// `<store_dir>/projects/<short-hash>` (mirroring upstream's
+/// [`registerProject`](https://github.com/pnpm/pnpm/blob/94240bc046/store/controller/src/storeController/projectRegistry.ts))
+/// and routes every per-snapshot slot through
+/// [`crate::VirtualStoreLayout`]. The empty-snapshot lockfile here is
+/// enough to prove the wiring runs end-to-end without panicking and
+/// that the registry entry actually lands on disk; the GVS-shaped
+/// per-package path layout itself is unit-tested inside the
+/// [`crate::VirtualStoreLayout`] module, and the e2e port of
+/// upstream's `globalVirtualStore.ts` cases (with non-empty
+/// snapshots) is tracked as a follow-up.
+#[tokio::test]
+async fn frozen_lockfile_under_gvs_registers_project_and_runs_clean() {
+    let dir = tempdir().unwrap();
+    let store_dir = dir.path().join("pacquet-store");
+    let project_root = dir.path().join("project");
+    let modules_dir = project_root.join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pacquet");
+
+    // Place the manifest *inside* `project_root` — `Install::run`
+    // derives the registry target from `manifest.path().parent()`,
+    // so a manifest at `<tmp>/package.json` would register `<tmp>`
+    // and the symlink-resolves-to-project_root assertion below
+    // would silently pass for the wrong reason.
+    std::fs::create_dir_all(&project_root).expect("create project root");
+    let manifest_path = project_root.join("package.json");
+    let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
+
+    let mut config = Config::new();
+    // Pacquet's default is `true`; pin it explicitly so the test
+    // doesn't silently degrade if the default flips someday.
+    config.enable_global_virtual_store = true;
+    config.lockfile = false;
+    config.store_dir = store_dir.clone().into();
+    config.modules_dir = modules_dir.clone();
+    config.virtual_store_dir = virtual_store_dir.clone();
+    // Pin the GVS root to a known location under the test temp dir
+    // so any future assertions can target it without walking the
+    // SmartDefault'd cwd-based fallback.
+    config.global_virtual_store_dir = store_dir.join("links");
+    let config = config.leak();
+
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "importers:"
+        "  .:"
+        "    dependencies: {}"
+        "packages: {}"
+        "snapshots: {}"
+    })
+    .expect("parse minimal v9 lockfile");
+
+    Install {
+        tarball_mem_cache: &Default::default(),
+        http_client: &Default::default(),
+        config,
+        manifest: &manifest,
+        lockfile: Some(&lockfile),
+        dependency_groups: [DependencyGroup::Prod],
+        frozen_lockfile: true,
+        resolved_packages: &Default::default(),
+    }
+    .run::<SilentReporter>()
+    .await
+    .expect("frozen-lockfile install under GVS should succeed");
+
+    // `register_project` wrote `<store_dir>/projects/<short-hash>`
+    // pointing back at the project dir. Resolve the symlink and
+    // canonicalize both ends — the test temp dir may itself be a
+    // symlink (e.g. `/tmp` → `/private/tmp` on macOS), and the
+    // registry stores the absolute project path at write time.
+    let projects_dir = store_dir.join("projects");
+    assert!(projects_dir.is_dir(), "GVS-on install must create <store_dir>/projects/");
+    let entries: Vec<_> =
+        std::fs::read_dir(&projects_dir).unwrap().collect::<Result<_, _>>().unwrap();
+    assert_eq!(entries.len(), 1, "exactly one project entry per `Install::run` invocation");
+    let entry_target = std::fs::read_link(entries[0].path()).expect("registry entry is a symlink");
+    assert_eq!(
+        dunce::canonicalize(&entry_target).expect("canonicalize registry target"),
+        dunce::canonicalize(&project_root).expect("canonicalize project root"),
+        "registry symlink must resolve back to the install's project root",
+    );
+
+    drop(dir);
+}
+
+/// GVS-off frozen-lockfile install. The dispatch path is the same,
+/// but `Install::run` skips the project-registry write entirely.
+/// Pins that turning off `enable_global_virtual_store` makes the
+/// install behave like today — no `<store_dir>/projects/` directory
+/// appears.
+#[tokio::test]
+async fn frozen_lockfile_with_gvs_off_skips_project_registry() {
+    let dir = tempdir().unwrap();
+    let store_dir = dir.path().join("pacquet-store");
+    let project_root = dir.path().join("project");
+    let modules_dir = project_root.join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pacquet");
+
+    std::fs::create_dir_all(&project_root).expect("create project root");
+    let manifest_path = project_root.join("package.json");
+    let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
+
+    let mut config = Config::new();
+    config.enable_global_virtual_store = false;
+    config.lockfile = false;
+    config.store_dir = store_dir.clone().into();
+    config.modules_dir = modules_dir.clone();
+    config.virtual_store_dir = virtual_store_dir.clone();
+    let config = config.leak();
+
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "importers:"
+        "  .:"
+        "    dependencies: {}"
+        "packages: {}"
+        "snapshots: {}"
+    })
+    .expect("parse minimal v9 lockfile");
+
+    Install {
+        tarball_mem_cache: &Default::default(),
+        http_client: &Default::default(),
+        config,
+        manifest: &manifest,
+        lockfile: Some(&lockfile),
+        dependency_groups: [DependencyGroup::Prod],
+        frozen_lockfile: true,
+        resolved_packages: &Default::default(),
+    }
+    .run::<SilentReporter>()
+    .await
+    .expect("frozen-lockfile install with GVS off should succeed");
+
+    assert!(
+        !store_dir.join("projects").exists(),
+        "GVS-off install must NOT create the project-registry directory",
+    );
+
+    drop(dir);
+}

--- a/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/crates/package-manager/src/install_frozen_lockfile.rs
@@ -277,12 +277,7 @@ where
         // `slot_dir` call. Either way every downstream consumer
         // (warm batch, cold batch, direct-dep symlinks, bin linker,
         // build module) routes through this one lookup.
-        let layout = VirtualStoreLayout::new(
-            config,
-            engine_name.as_deref().unwrap_or(""),
-            snapshots,
-            packages,
-        );
+        let layout = VirtualStoreLayout::new(config, engine_name.as_deref(), snapshots, packages);
 
         let CreateVirtualStoreOutput { package_manifests, side_effects_maps_by_snapshot } =
             CreateVirtualStore {

--- a/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/crates/package-manager/src/install_frozen_lockfile.rs
@@ -2,7 +2,8 @@ use crate::{
     AllowBuildPolicy, BuildModules, BuildModulesError, CreateVirtualStore, CreateVirtualStoreError,
     CreateVirtualStoreOutput, InstallabilityHost, LinkVirtualStoreBins, LinkVirtualStoreBinsError,
     SkippedSnapshots, SymlinkDirectDependencies, SymlinkDirectDependenciesError,
-    VersionPolicyError, any_installability_constraint, compute_skipped_snapshots,
+    VersionPolicyError, VirtualStoreLayout, any_installability_constraint,
+    compute_skipped_snapshots,
 };
 use derive_more::{Display, Error};
 use miette::Diagnostic;
@@ -231,38 +232,29 @@ where
             (SkippedSnapshots::new(), None)
         };
 
-        let CreateVirtualStoreOutput { package_manifests, side_effects_maps_by_snapshot } =
-            CreateVirtualStore {
-                http_client,
-                config,
-                packages,
-                snapshots,
-                current_snapshots,
-                current_packages,
-                logged_methods,
-                requester,
-                store_index_writer: &store_index_writer,
-                allow_build_policy: &allow_build_policy,
-                skipped: &skipped,
-            }
-            .run::<R>()
-            .await
-            .map_err(InstallFrozenLockfileError::CreateVirtualStore)?;
-
-        // `engine_name` for the side-effects-cache lookup.
+        // Compute `engine_name` *before* `CreateVirtualStore::run`
+        // because the GVS-aware `VirtualStoreLayout` needs it to
+        // produce the per-snapshot
+        // `<scope>/<name>/<version>/<hash>` suffix that `pnpm` writes
+        // under `<store_dir>/links`. Same value also feeds
+        // `BuildModules`'s side-effects-cache key prefix.
         //
         // Two paths:
         // - We already detected the host for the installability
         //   check (constraint-bearing lockfile): reuse the cached
-        //   version. The synthetic-fallback case (`node_detected = false`)
-        //   yields `None` so a bogus `99999.0.0`-derived key can't
-        //   poison the cache.
+        //   version. The synthetic-fallback case (`node_detected =
+        //   false`) yields `None` so a bogus `99999.0.0`-derived key
+        //   can't poison either the cache or the GVS hash.
         // - We skipped the installability check (constraint-free
         //   lockfile, the common case): no cached version. Fall
-        //   back to the legacy `detect_node_major` spawn — run
-        //   after `CreateVirtualStore::run` so it overlaps with
-        //   nothing on the critical path. This is the same
-        //   placement upstream used to have.
+        //   back to the legacy `detect_node_major` spawn. This used
+        //   to sit *after* `CreateVirtualStore::run` to overlap the
+        //   `node --version` cost with the install I/O, but the GVS
+        //   path now needs it earlier — the trade-off is a one-time
+        //   `node --version` spawn synchronous with install setup,
+        //   which is still tens of ms on the critical path. Users
+        //   who want the old overlap can opt out via
+        //   `enable_global_virtual_store: false`.
         let engine_name: Option<String> = match &host_node {
             Some((true, ver)) => parse_major_from_version(ver)
                 .map(|major| pacquet_graph_hasher::engine_name(major, None, None)),
@@ -276,8 +268,44 @@ where
             .flatten(),
         };
 
+        // Build the install-scoped slot-directory layout. When
+        // `enable_global_virtual_store` is on the layout precomputes
+        // each snapshot's `<scope>/<name>/<version>/<hash>` suffix
+        // from [`pacquet_graph_hasher::calc_graph_node_hash`];
+        // otherwise it falls through to the legacy
+        // `to_virtual_store_name`-shaped flat name on every
+        // `slot_dir` call. Either way every downstream consumer
+        // (warm batch, cold batch, direct-dep symlinks, bin linker,
+        // build module) routes through this one lookup.
+        let layout = VirtualStoreLayout::new(
+            config,
+            engine_name.as_deref().unwrap_or(""),
+            snapshots,
+            packages,
+        );
+
+        let CreateVirtualStoreOutput { package_manifests, side_effects_maps_by_snapshot } =
+            CreateVirtualStore {
+                http_client,
+                config,
+                packages,
+                snapshots,
+                current_snapshots,
+                current_packages,
+                layout: &layout,
+                logged_methods,
+                requester,
+                store_index_writer: &store_index_writer,
+                allow_build_policy: &allow_build_policy,
+                skipped: &skipped,
+            }
+            .run::<R>()
+            .await
+            .map_err(InstallFrozenLockfileError::CreateVirtualStore)?;
+
         SymlinkDirectDependencies {
             config,
+            layout: &layout,
             importers,
             dependency_groups,
             workspace_root,
@@ -297,7 +325,7 @@ where
         // (matching pnpm's `bundledManifest`-from-CAFS path) instead
         // of re-reading every child's `package.json` from disk.
         LinkVirtualStoreBins {
-            virtual_store_dir: &config.virtual_store_dir,
+            layout: &layout,
             snapshots,
             packages,
             package_manifests: &package_manifests,
@@ -388,7 +416,7 @@ where
         };
 
         let ignored_builds = BuildModules {
-            virtual_store_dir: &config.virtual_store_dir,
+            layout: &layout,
             modules_dir: &config.modules_dir,
             lockfile_dir: manifest_dir,
             snapshots,

--- a/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/crates/package-manager/src/install_package_by_snapshot.rs
@@ -1,5 +1,5 @@
 use crate::{
-    AllowBuildPolicy, CreateVirtualDirBySnapshot, CreateVirtualDirError,
+    AllowBuildPolicy, CreateVirtualDirBySnapshot, CreateVirtualDirError, VirtualStoreLayout,
     retry_config::retry_opts_from_config,
 };
 use derive_more::{Display, Error};
@@ -28,6 +28,11 @@ use std::{
 pub struct InstallPackageBySnapshot<'a> {
     pub http_client: &'a ThrottledClient,
     pub config: &'static Config,
+    /// Install-scoped slot-directory mapping (GVS-aware). Drives the
+    /// per-snapshot directory passed to
+    /// [`CreateVirtualDirBySnapshot`] after the cold-batch download
+    /// finishes. See [`crate::VirtualStoreLayout`].
+    pub layout: &'a VirtualStoreLayout,
     pub store_index: Option<&'a SharedReadonlyStoreIndex>,
     pub store_index_writer: Option<&'a Arc<StoreIndexWriter>>,
     /// Install-scoped batched cache lookup result. See
@@ -94,6 +99,7 @@ impl<'a> InstallPackageBySnapshot<'a> {
         let InstallPackageBySnapshot {
             http_client,
             config,
+            layout,
             store_index,
             store_index_writer,
             prefetched_cas_paths,
@@ -218,7 +224,7 @@ impl<'a> InstallPackageBySnapshot<'a> {
         };
 
         CreateVirtualDirBySnapshot {
-            virtual_store_dir: &config.virtual_store_dir,
+            layout,
             cas_paths: &cas_paths,
             import_method: config.package_import_method,
             logged_methods,

--- a/crates/package-manager/src/install_without_lockfile.rs
+++ b/crates/package-manager/src/install_without_lockfile.rs
@@ -205,10 +205,18 @@ impl<'a, DependencyGroupList> InstallWithoutLockfile<'a, DependencyGroupList> {
         // by walking `<virtual_store_dir>`, child manifests read from
         // disk). The frozen-lockfile path skips both via
         // [`LinkVirtualStoreBins::snapshots`] / `package_manifests`.
+        //
+        // The bin linker also doesn't need GVS-aware slot lookups
+        // here: without snapshots there are no GVS slot directories to
+        // compute. Construct a legacy layout so the readdir path
+        // enumerates `config.virtual_store_dir` exactly as before. GVS
+        // is scoped to frozen-lockfile installs (pnpm/pacquet#432); the
+        // without-lockfile fallback stays project-local.
+        let layout = crate::VirtualStoreLayout::legacy(config.virtual_store_dir.clone());
         let empty_manifests = std::collections::HashMap::new();
         let empty_skipped = crate::SkippedSnapshots::new();
         LinkVirtualStoreBins {
-            virtual_store_dir: &config.virtual_store_dir,
+            layout: &layout,
             snapshots: None,
             packages: None,
             package_manifests: &empty_manifests,

--- a/crates/package-manager/src/link_bins.rs
+++ b/crates/package-manager/src/link_bins.rs
@@ -174,8 +174,7 @@ impl<'a> LinkVirtualStoreBins<'a> {
             + FsSetExecutable
             + FsEnsureExecutableBits,
     {
-        let LinkVirtualStoreBins { layout, snapshots, packages, package_manifests, skipped } =
-            self;
+        let LinkVirtualStoreBins { layout, snapshots, packages, package_manifests, skipped } = self;
         if let Some(snapshots) = snapshots {
             let has_bin_set = build_has_bin_set(packages);
             run_lockfile_driven::<Api>(

--- a/crates/package-manager/src/link_bins.rs
+++ b/crates/package-manager/src/link_bins.rs
@@ -115,7 +115,12 @@ pub enum LinkVirtualStoreBinsError {
 /// lockfile-driven path landed.
 #[must_use]
 pub struct LinkVirtualStoreBins<'a> {
-    pub virtual_store_dir: &'a Path,
+    /// Install-scoped slot-directory mapping (GVS-aware). Replaces the
+    /// previous `virtual_store_dir: &Path` field — the layout already
+    /// knows where each snapshot's slot lives, including under the
+    /// global-virtual-store `<scope>/<name>/<version>/<hash>` shape.
+    /// See [`crate::VirtualStoreLayout`].
+    pub layout: &'a crate::VirtualStoreLayout,
     /// `Some` when the install is lockfile-driven. Iterating the
     /// snapshot map (instead of `read_dir(virtual_store_dir)`)
     /// removes the per-slot directory enumeration and lets us walk
@@ -169,24 +174,24 @@ impl<'a> LinkVirtualStoreBins<'a> {
             + FsSetExecutable
             + FsEnsureExecutableBits,
     {
-        let LinkVirtualStoreBins {
-            virtual_store_dir,
-            snapshots,
-            packages,
-            package_manifests,
-            skipped,
-        } = self;
+        let LinkVirtualStoreBins { layout, snapshots, packages, package_manifests, skipped } =
+            self;
         if let Some(snapshots) = snapshots {
             let has_bin_set = build_has_bin_set(packages);
             run_lockfile_driven::<Api>(
-                virtual_store_dir,
+                layout,
                 snapshots,
                 has_bin_set.as_ref(),
                 package_manifests,
                 skipped,
             )
         } else {
-            run_with_readdir::<Api>(virtual_store_dir)
+            // No snapshots (lockfile absent or empty): fall back to a
+            // `read_dir` enumeration. This path only fires for non-
+            // frozen installs, which #432 doesn't activate GVS for, so
+            // reading from `layout.package_store_dir()` reproduces
+            // today's behaviour exactly when GVS is off.
+            run_with_readdir::<Api>(layout.package_store_dir())
         }
     }
 }
@@ -236,7 +241,7 @@ fn build_has_bin_set(
 /// `package.json` read through the existing symlink at
 /// `<slot>/node_modules/<alias>`.
 fn run_lockfile_driven<Api>(
-    virtual_store_dir: &Path,
+    layout: &crate::VirtualStoreLayout,
     snapshots: &HashMap<PackageKey, SnapshotEntry>,
     has_bin_set: Option<&HashSet<PackageKey>>,
     package_manifests: &PackageManifests,
@@ -305,7 +310,7 @@ where
             return Ok(());
         }
 
-        let slot_dir = virtual_store_dir.join(slot_key.to_virtual_store_name());
+        let slot_dir = layout.slot_dir(slot_key);
         let modules_dir = slot_dir.join("node_modules");
         let self_pkg_dir = slot_own_pkg_dir(&modules_dir, slot_key);
         let bins_dir = self_pkg_dir.join("node_modules/.bin");

--- a/crates/package-manager/src/link_bins/tests.rs
+++ b/crates/package-manager/src/link_bins/tests.rs
@@ -1,5 +1,5 @@
 use super::{LinkVirtualStoreBins, LinkVirtualStoreBinsError, link_direct_dep_bins};
-use crate::SkippedSnapshots;
+use crate::{SkippedSnapshots, VirtualStoreLayout};
 use pacquet_cmd_shim::is_shim_pointing_at;
 use serde_json::json;
 use std::{
@@ -41,7 +41,7 @@ fn writes_child_bins_into_slot_own_package_node_modules() {
     write_file(child_dir.join("cli.js"), "#!/usr/bin/env node\n").unwrap();
 
     LinkVirtualStoreBins {
-        virtual_store_dir: &virtual_dir,
+        layout: &VirtualStoreLayout::legacy(virtual_dir.clone()),
         snapshots: None,
         packages: None,
         package_manifests: &Default::default(),
@@ -109,7 +109,7 @@ fn skips_slot_own_package_when_walking_children() {
     write_file(other_dir.join("other.js"), "#!/usr/bin/env node\n").unwrap();
 
     LinkVirtualStoreBins {
-        virtual_store_dir: &virtual_dir,
+        layout: &VirtualStoreLayout::legacy(virtual_dir.clone()),
         snapshots: None,
         packages: None,
         package_manifests: &Default::default(),
@@ -134,7 +134,7 @@ fn link_virtual_store_bins_no_op_when_dir_missing() {
     let tmp = tempdir().unwrap();
     let nonexistent = tmp.path().join("does-not-exist");
     LinkVirtualStoreBins {
-        virtual_store_dir: &nonexistent,
+        layout: &VirtualStoreLayout::legacy(nonexistent.clone()),
         snapshots: None,
         packages: None,
         package_manifests: &Default::default(),
@@ -172,7 +172,7 @@ fn link_virtual_store_bins_handles_scoped_slot_name() {
     write_file(child_dir.join("cli.js"), "#!/usr/bin/env node\n").unwrap();
 
     LinkVirtualStoreBins {
-        virtual_store_dir: &virtual_dir,
+        layout: &VirtualStoreLayout::legacy(virtual_dir.clone()),
         snapshots: None,
         packages: None,
         package_manifests: &Default::default(),
@@ -223,7 +223,7 @@ fn link_virtual_store_bins_handles_peer_resolved_slot_name() {
     write_file(child_dir.join("cli.js"), "#!/usr/bin/env node\n").unwrap();
 
     LinkVirtualStoreBins {
-        virtual_store_dir: &virtual_dir,
+        layout: &VirtualStoreLayout::legacy(virtual_dir.clone()),
         snapshots: None,
         packages: None,
         package_manifests: &Default::default(),
@@ -273,7 +273,7 @@ fn link_virtual_store_bins_handles_unscoped_name_with_plus() {
     write_file(child_dir.join("cli.js"), "#!/usr/bin/env node\n").unwrap();
 
     LinkVirtualStoreBins {
-        virtual_store_dir: &virtual_dir,
+        layout: &VirtualStoreLayout::legacy(virtual_dir.clone()),
         snapshots: None,
         packages: None,
         package_manifests: &Default::default(),
@@ -298,7 +298,7 @@ fn link_virtual_store_bins_skips_slot_without_node_modules() {
     let virtual_dir = tmp.path().join(".pacquet");
     create_dir_all(virtual_dir.join("incomplete@1.0.0")).unwrap();
     LinkVirtualStoreBins {
-        virtual_store_dir: &virtual_dir,
+        layout: &VirtualStoreLayout::legacy(virtual_dir.clone()),
         snapshots: None,
         packages: None,
         package_manifests: &Default::default(),
@@ -325,7 +325,7 @@ fn link_virtual_store_bins_skips_slot_without_own_package_dir() {
     // is missing, so `find_slot_own_package_dir` returns `None`.
     create_dir_all(virtual_dir.join("foo@1.0.0/node_modules")).unwrap();
     LinkVirtualStoreBins {
-        virtual_store_dir: &virtual_dir,
+        layout: &VirtualStoreLayout::legacy(virtual_dir.clone()),
         snapshots: None,
         packages: None,
         package_manifests: &Default::default(),
@@ -473,7 +473,7 @@ fn link_virtual_store_bins_propagates_read_error_via_di() {
     }
 
     let err = LinkVirtualStoreBins {
-        virtual_store_dir: Path::new("/anything"),
+        layout: &VirtualStoreLayout::legacy(PathBuf::from("/anything")),
         snapshots: None,
         packages: None,
         package_manifests: &Default::default(),

--- a/crates/package-manager/src/symlink_direct_dependencies.rs
+++ b/crates/package-manager/src/symlink_direct_dependencies.rs
@@ -241,7 +241,7 @@ fn validate_importer_id(importer_id: &str) -> Result<(), SymlinkDirectDependenci
 /// keeps lockfiles written by pacquet and pnpm interchangeable. The
 /// returned path is platform-native (`Path::join` handles the
 /// conversion on Windows).
-fn importer_root_dir(workspace_root: &Path, importer_id: &str) -> PathBuf {
+pub(crate) fn importer_root_dir(workspace_root: &Path, importer_id: &str) -> PathBuf {
     if importer_id == "." {
         workspace_root.to_path_buf()
     } else {

--- a/crates/package-manager/src/symlink_direct_dependencies.rs
+++ b/crates/package-manager/src/symlink_direct_dependencies.rs
@@ -1,4 +1,7 @@
-use crate::{SkippedSnapshots, SymlinkPackageError, link_direct_dep_bins, symlink_package};
+use crate::{
+    SkippedSnapshots, SymlinkPackageError, VirtualStoreLayout, link_direct_dep_bins,
+    symlink_package,
+};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_cmd_shim::LinkBinsError;
@@ -46,6 +49,11 @@ where
     DependencyGroupList: IntoIterator<Item = DependencyGroup>,
 {
     pub config: &'static Config,
+    /// Install-scoped slot-directory mapping (GVS-aware). Drives the
+    /// per-direct-dep symlink target — `node_modules/<dep>` resolves
+    /// to `layout.slot_dir(<key>)/node_modules/<dep>`. See
+    /// [`crate::VirtualStoreLayout`].
+    pub layout: &'a VirtualStoreLayout,
     pub importers: &'a HashMap<String, ProjectSnapshot>,
     pub dependency_groups: DependencyGroupList,
     /// Workspace root. For a single-project install this is the
@@ -112,6 +120,7 @@ where
     pub fn run<R: Reporter>(self) -> Result<(), SymlinkDirectDependenciesError> {
         let SymlinkDirectDependencies {
             config,
+            layout,
             importers,
             dependency_groups,
             workspace_root,
@@ -160,7 +169,7 @@ where
 
             link_one_importer::<R>(
                 importer_id,
-                config,
+                layout,
                 project_snapshot,
                 &project_dir,
                 &modules_dir,
@@ -247,7 +256,7 @@ fn importer_root_dir(workspace_root: &Path, importer_id: &str) -> PathBuf {
 
 fn link_one_importer<R: Reporter>(
     importer_id: &str,
-    config: &Config,
+    layout: &VirtualStoreLayout,
     project_snapshot: &ProjectSnapshot,
     project_dir: &Path,
     modules_dir: &Path,
@@ -331,15 +340,18 @@ fn link_one_importer<R: Reporter>(
             let name_str = name.to_string();
             let target_path: PathBuf = match &spec.version {
                 ImporterDepVersion::Regular(ver_peer) => {
-                    // TODO: the code below is not optimal
-                    let virtual_store_name =
-                        PkgNameVerPeer::new(PkgName::clone(name), ver_peer.clone())
-                            .to_virtual_store_name();
-                    config
-                        .virtual_store_dir
-                        .join(virtual_store_name)
-                        .join("node_modules")
-                        .join(&name_str)
+                    // Route the slot-directory lookup through the
+                    // install-scoped [`VirtualStoreLayout`] so the
+                    // path works under both legacy
+                    // (`<virtual_store_dir>/<flat-name>`) and GVS
+                    // (`<global_virtual_store_dir>/<scope>/<name>/<version>/<hash>`)
+                    // layouts. The layout's GVS-suffix map is keyed by
+                    // the full snapshot key (with peer suffix), so
+                    // construct that from the importer's resolved
+                    // version-with-peer rather than from `name`+`version`
+                    // separately.
+                    let dep_key = PkgNameVerPeer::new(PkgName::clone(name), ver_peer.clone());
+                    layout.slot_dir(&dep_key).join("node_modules").join(&name_str)
                 }
                 ImporterDepVersion::Link(target) => {
                     // `link:<path>` values are relative to the

--- a/crates/package-manager/src/symlink_direct_dependencies/tests.rs
+++ b/crates/package-manager/src/symlink_direct_dependencies/tests.rs
@@ -82,6 +82,7 @@ fn emits_pnpm_root_added_per_direct_dependency() {
 
     SymlinkDirectDependencies {
         config,
+        layout: &crate::VirtualStoreLayout::legacy(config.virtual_store_dir.clone()),
         importers: &importers,
         dependency_groups: [DependencyGroup::Prod, DependencyGroup::Dev],
         workspace_root: &project_root,
@@ -200,6 +201,7 @@ fn duplicate_dep_across_groups_collapses_to_one_entry() {
 
     SymlinkDirectDependencies {
         config,
+        layout: &crate::VirtualStoreLayout::legacy(config.virtual_store_dir.clone()),
         importers: &importers,
         // Prod first → first-wins gives `dependencyType: prod`.
         dependency_groups: [DependencyGroup::Prod, DependencyGroup::Optional],
@@ -336,8 +338,10 @@ fn empty_importers_is_a_no_op() {
     let config = config.leak();
 
     let importers = HashMap::new();
+    let layout = crate::VirtualStoreLayout::legacy(config.virtual_store_dir.clone());
     let result = SymlinkDirectDependencies {
         config,
+        layout: &layout,
         importers: &importers,
         dependency_groups: [DependencyGroup::Prod],
         workspace_root: &project_root,

--- a/crates/package-manager/src/symlink_direct_dependencies/tests.rs
+++ b/crates/package-manager/src/symlink_direct_dependencies/tests.rs
@@ -281,6 +281,7 @@ fn cross_importer_link_dep_symlinks_to_sibling_rootdir() {
 
     SymlinkDirectDependencies {
         config,
+        layout: &crate::VirtualStoreLayout::legacy(config.virtual_store_dir.clone()),
         importers: &importers,
         dependency_groups: [DependencyGroup::Prod],
         workspace_root: &workspace_root,
@@ -416,6 +417,7 @@ fn per_importer_prefix_in_pnpm_root_events() {
 
     SymlinkDirectDependencies {
         config,
+        layout: &crate::VirtualStoreLayout::legacy(config.virtual_store_dir.clone()),
         importers: &importers,
         dependency_groups: [DependencyGroup::Prod],
         workspace_root: &workspace_root,
@@ -479,6 +481,7 @@ fn unsafe_importer_keys_error_before_filesystem_writes() {
 
         let result = SymlinkDirectDependencies {
             config,
+            layout: &crate::VirtualStoreLayout::legacy(config.virtual_store_dir.clone()),
             importers: &importers,
             dependency_groups: [DependencyGroup::Prod],
             workspace_root: &workspace_root,
@@ -552,6 +555,7 @@ fn custom_modules_dir_propagates_to_each_importer() {
 
     SymlinkDirectDependencies {
         config,
+        layout: &crate::VirtualStoreLayout::legacy(config.virtual_store_dir.clone()),
         importers: &importers,
         dependency_groups: [DependencyGroup::Prod],
         workspace_root: &workspace_root,

--- a/crates/package-manager/src/virtual_store_layout.rs
+++ b/crates/package-manager/src/virtual_store_layout.rs
@@ -389,8 +389,12 @@ mod tests {
         );
         let mut snapshots = HashMap::new();
         snapshots.insert(key.clone(), SnapshotEntry::default());
-        let layout =
-            VirtualStoreLayout::new(&config, Some("linux-x64-node22"), Some(&snapshots), Some(&packages));
+        let layout = VirtualStoreLayout::new(
+            &config,
+            Some("linux-x64-node22"),
+            Some(&snapshots),
+            Some(&packages),
+        );
         let slot = layout.slot_dir(&key);
         let _ = slot
             .strip_prefix("/tmp/store/links/@/foo/1.0.0/")

--- a/crates/package-manager/src/virtual_store_layout.rs
+++ b/crates/package-manager/src/virtual_store_layout.rs
@@ -63,6 +63,17 @@ pub struct VirtualStoreLayout {
 }
 
 impl VirtualStoreLayout {
+    /// Construct a layout that always uses the legacy
+    /// `<root>/<flat-name>` shape, regardless of any
+    /// `enable_global_virtual_store` setting on `Config`. The
+    /// non-frozen install path uses this — GVS is scoped to
+    /// frozen-lockfile installs (pnpm/pacquet#432), so without-lockfile
+    /// callers stay on the project-local flat layout even when
+    /// `enable_global_virtual_store: true` is configured.
+    pub fn legacy(root: impl Into<PathBuf>) -> Self {
+        VirtualStoreLayout { package_store_dir: root.into(), gvs_suffixes: None }
+    }
+
     /// Build the layout for one install. Reads
     /// [`Config::enable_global_virtual_store`] to decide whether to
     /// precompute GVS slot names, then iterates the lockfile's
@@ -90,7 +101,18 @@ impl VirtualStoreLayout {
         snapshots: Option<&HashMap<PackageKey, SnapshotEntry>>,
         packages: Option<&HashMap<PackageKey, PackageMetadata>>,
     ) -> Self {
-        let package_store_dir = config.virtual_store_dir.clone();
+        // Pacquet keeps `virtual_store_dir` and `global_virtual_store_dir`
+        // as two separate fields (see
+        // [`Config::apply_global_virtual_store_derivation`] for why).
+        // The frozen-lockfile install picks
+        // `global_virtual_store_dir` here when GVS is on so the
+        // without-lockfile path can stay on the project-local
+        // `virtual_store_dir` without colliding.
+        let package_store_dir = if config.enable_global_virtual_store {
+            config.global_virtual_store_dir.clone()
+        } else {
+            config.virtual_store_dir.clone()
+        };
         if !config.enable_global_virtual_store {
             return VirtualStoreLayout { package_store_dir, gvs_suffixes: None };
         }
@@ -236,10 +258,15 @@ mod tests {
     use pretty_assertions::assert_eq;
     use std::{collections::HashMap, path::PathBuf};
 
-    fn make_config(gvs: bool, virtual_store_dir: PathBuf) -> Config {
+    /// Build a `Config` test-double with the GVS-relevant fields
+    /// wired explicitly. `gvs_dir` populates `global_virtual_store_dir`
+    /// for the GVS-on path; `virtual_store_dir` stays at the
+    /// project-local default for the GVS-off path.
+    fn make_config(gvs: bool, virtual_store_dir: PathBuf, gvs_dir: PathBuf) -> Config {
         let mut config = Config::new();
         config.enable_global_virtual_store = gvs;
         config.virtual_store_dir = virtual_store_dir;
+        config.global_virtual_store_dir = gvs_dir;
         config
     }
 
@@ -248,7 +275,11 @@ mod tests {
     /// drop-in for the legacy path.
     #[test]
     fn slot_dir_uses_flat_name_when_gvs_off() {
-        let config = make_config(false, PathBuf::from("/tmp/proj/node_modules/.pnpm"));
+        let config = make_config(
+            false,
+            PathBuf::from("/tmp/proj/node_modules/.pnpm"),
+            PathBuf::from("/tmp/store/links"),
+        );
         let layout = VirtualStoreLayout::new(&config, "ignored", None, None);
         let key: PackageKey = "@scope/foo@1.2.3".parse().unwrap();
         assert_eq!(
@@ -263,7 +294,11 @@ mod tests {
     /// and depth.
     #[test]
     fn slot_dir_uses_gvs_layout_when_gvs_on() {
-        let config = make_config(true, PathBuf::from("/tmp/store/links"));
+        let config = make_config(
+            true,
+            PathBuf::from("/tmp/proj/node_modules/.pnpm"),
+            PathBuf::from("/tmp/store/links"),
+        );
         let key: PackageKey = "@scope/foo@1.2.3".parse().unwrap();
         let mut packages = HashMap::new();
         packages.insert(
@@ -311,7 +346,11 @@ mod tests {
     /// depth — easier `readdir`-driven traversal.
     #[test]
     fn slot_dir_prefixes_unscoped_with_at_slash_under_gvs() {
-        let config = make_config(true, PathBuf::from("/tmp/store/links"));
+        let config = make_config(
+            true,
+            PathBuf::from("/tmp/proj/node_modules/.pnpm"),
+            PathBuf::from("/tmp/store/links"),
+        );
         let key: PackageKey = "foo@1.0.0".parse().unwrap();
         let mut packages = HashMap::new();
         packages.insert(

--- a/crates/package-manager/src/virtual_store_layout.rs
+++ b/crates/package-manager/src/virtual_store_layout.rs
@@ -42,10 +42,18 @@ use std::{
 /// touch — it returns an absolute directory whose `node_modules/<name>`
 /// subdirectory holds the unpacked package.
 pub struct VirtualStoreLayout {
-    /// Root containing every per-snapshot subdirectory. Equal to
-    /// `Config::virtual_store_dir` in both GVS-on and GVS-off modes
-    /// (the field is derived to point at `<store_dir>/links` when
-    /// GVS is on; see [`Config::apply_global_virtual_store_derivation`]).
+    /// Root containing every per-snapshot subdirectory. Picked from
+    /// `Config::global_virtual_store_dir` when GVS is enabled (the
+    /// shared `<store_dir>/links` path, or the user's pinned override)
+    /// and from `Config::virtual_store_dir` when GVS is disabled (the
+    /// project-local `<modules_dir>/.pnpm`). Pacquet keeps the two
+    /// fields separate so the legacy non-frozen
+    /// [`crate::InstallWithoutLockfile`] path can keep reading
+    /// `virtual_store_dir` directly via [`Self::legacy`] without the
+    /// frozen-lockfile derivation redirecting it. See
+    /// [`Config::apply_global_virtual_store_derivation`] for the
+    /// reasoning behind the field split.
+    ///
     /// Stored separately from a `&Config` so callers don't have to
     /// thread the full config through the helpers that only need a
     /// path lookup.
@@ -90,6 +98,12 @@ impl VirtualStoreLayout {
     /// [`pacquet_graph_hasher::engine_name`] produces; threaded in
     /// instead of recomputed inside so the value matches whatever the
     /// rest of the install (notably the side-effects cache key) uses.
+    /// `None` propagates straight into
+    /// [`calc_graph_node_hash`]'s `engine` parameter — `None` and
+    /// `Some("")` produce *different* GVS hashes (the former omits
+    /// the `engine` contribution, the latter hashes the empty string),
+    /// so the call site must keep the `Option` shape rather than
+    /// flattening to `unwrap_or("")`.
     ///
     /// `snapshots` / `packages` are the lockfile fields the caller
     /// already has by the time the install dispatches to a frozen-
@@ -97,7 +111,7 @@ impl VirtualStoreLayout {
     /// [`crate::InstallFrozenLockfile::run`].
     pub fn new(
         config: &Config,
-        engine: &str,
+        engine: Option<&str>,
         snapshots: Option<&HashMap<PackageKey, SnapshotEntry>>,
         packages: Option<&HashMap<PackageKey, PackageMetadata>>,
     ) -> Self {
@@ -123,7 +137,7 @@ impl VirtualStoreLayout {
         let mut cache: DepsStateCache<PackageKey> = HashMap::new();
         let mut gvs_suffixes: HashMap<PackageKey, String> = HashMap::with_capacity(snapshots.len());
         for snapshot_key in snapshots.keys() {
-            let hex_digest = calc_graph_node_hash(&graph, &mut cache, snapshot_key, Some(engine));
+            let hex_digest = calc_graph_node_hash(&graph, &mut cache, snapshot_key, engine);
             let metadata_key = snapshot_key.without_peer();
             let name = metadata_key.name.to_string();
             let version = metadata_key.suffix.version().to_string();
@@ -280,7 +294,7 @@ mod tests {
             PathBuf::from("/tmp/proj/node_modules/.pnpm"),
             PathBuf::from("/tmp/store/links"),
         );
-        let layout = VirtualStoreLayout::new(&config, "ignored", None, None);
+        let layout = VirtualStoreLayout::new(&config, Some("ignored"), None, None);
         let key: PackageKey = "@scope/foo@1.2.3".parse().unwrap();
         assert_eq!(
             layout.slot_dir(&key),
@@ -325,7 +339,7 @@ mod tests {
         snapshots.insert(key.clone(), SnapshotEntry::default());
         let layout = VirtualStoreLayout::new(
             &config,
-            "darwin-arm64-node20",
+            Some("darwin-arm64-node20"),
             Some(&snapshots),
             Some(&packages),
         );
@@ -376,7 +390,7 @@ mod tests {
         let mut snapshots = HashMap::new();
         snapshots.insert(key.clone(), SnapshotEntry::default());
         let layout =
-            VirtualStoreLayout::new(&config, "linux-x64-node22", Some(&snapshots), Some(&packages));
+            VirtualStoreLayout::new(&config, Some("linux-x64-node22"), Some(&snapshots), Some(&packages));
         let slot = layout.slot_dir(&key);
         let _ = slot
             .strip_prefix("/tmp/store/links/@/foo/1.0.0/")

--- a/tasks/integrated-benchmark/src/fixtures/pnpm-workspace.yaml
+++ b/tasks/integrated-benchmark/src/fixtures/pnpm-workspace.yaml
@@ -1,5 +1,21 @@
 storeDir: ./store-dir
 
+# Pin the virtual-store layout to the legacy project-local shape
+# (`<project>/node_modules/.pnpm`) so the benchmark continues to
+# compare apples-to-apples across pacquet revisions.
+#
+# Pacquet's default flipped to `enableGlobalVirtualStore: true` in
+# pnpm/pacquet#432 (pnpm v11 parity), but the benchmark's job is
+# to track isolated-linker performance across `pacquet@HEAD` vs
+# `pacquet@main` vs `pnpm`. With GVS on, slot directories move to
+# `<storeDir>/links/<scope>/<name>/<version>/<hash>` — a different
+# disk layout from what pre-#432 revisions and pacquet's
+# project-local baseline produce, so leaving the default in place
+# would silently change what the numbers measure. Flip this to
+# `true` in a `--fixture-dir` override (or drop the line entirely)
+# to benchmark the GVS path on its own terms.
+enableGlobalVirtualStore: false
+
 # Force pnpm to install every optional dependency in the lockfile
 # regardless of the runner's own os/cpu/libc, so its install payload
 # matches pacquet's (which currently installs every snapshot in the

--- a/tasks/integrated-benchmark/src/workspace_manifest.rs
+++ b/tasks/integrated-benchmark/src/workspace_manifest.rs
@@ -25,6 +25,19 @@ pub struct MinimalWorkspaceManifest {
     pub ignore_scripts: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lockfile: Option<bool>,
+    /// Mirrors pnpm's
+    /// [`enableGlobalVirtualStore`](https://github.com/pnpm/pnpm/blob/94240bc046/config/reader/src/index.ts#L392-L394)
+    /// (default `true` in v11). The benchmark fixture pins this to
+    /// `false` so existing revisions can be compared apples-to-apples
+    /// against the project-local virtual-store layout pacquet shipped
+    /// before pnpm/pacquet#432 — both `pacquet@HEAD` and `pacquet@main`
+    /// then sit on the same `<project>/node_modules/.pnpm` shape, and
+    /// pnpm on the other side of the comparison honours the same
+    /// override. A separate GVS-on benchmark variant lives behind a
+    /// caller-supplied `--fixture-dir` with the flag flipped to
+    /// `true` (or omitted to inherit the default).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enable_global_virtual_store: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub supported_architectures: Option<SupportedArchitectures>,
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]


### PR DESCRIPTION
## Summary

Threads `VirtualStoreLayout` (from #444) through the frozen-lockfile install pipeline so packages installed with `enableGlobalVirtualStore: true` (pacquet's default since #444) land at the upstream-shaped `<store_dir>/links/<scope>/<name>/<version>/<hash>/node_modules/<pkg>` path. Closes the rest of #432 (Section B + C activation + D entry tests).

## Pipeline changes (frozen-lockfile path)

- `InstallFrozenLockfile::run` constructs the install-scoped `VirtualStoreLayout` from the lockfile + engine name + config, then threads `&VirtualStoreLayout` through `CreateVirtualStore`, `CreateVirtualDirBySnapshot`, `create_symlink_layout`, `SymlinkDirectDependencies`, `InstallPackageBySnapshot`, `BuildModules`, and `LinkVirtualStoreBins`. Every site that used to compute `virtual_store_dir.join(key.to_virtual_store_name())` now goes through one `layout.slot_dir(key)` lookup.
- `Install::run` calls `pacquet_store_dir::register_project` **once per importer** when `enable_global_virtual_store` is on, writing `<store_dir>/projects/<short-hash>` per workspace package so a future `pacquet store prune` can find every reachable consumer of `<store_dir>/links/...`. Best-effort: registry write failures degrade to `tracing::warn!` and the install continues. The walk runs *after* `InstallFrozenLockfile::run` succeeds so importer keys have already been validated.
- `Config::current` now applies `apply_global_virtual_store_derivation` after yaml — pacquet's variant of upstream's [`extendInstallOptions.ts:343-355`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/src/install/extendInstallOptions.ts#L343-L355). An explicit `globalVirtualStoreDir:` in yaml wins over the derivation; otherwise the field falls back to the user's pinned `virtualStoreDir` (under GVS-on) or to `<store_dir>/links`.

## Field-split deviation from upstream

Upstream pnpm *mutates* `virtualStoreDir` in place under GVS, so every consumer that reads `virtualStoreDir` sees `<storeDir>/links`. Pacquet keeps `virtual_store_dir` at its project-local value and writes the GVS path into the separate `global_virtual_store_dir` field. The frozen-lockfile path consumes `global_virtual_store_dir` through `VirtualStoreLayout`; the legacy non-frozen `InstallWithoutLockfile` keeps reading `virtual_store_dir` (now via `VirtualStoreLayout::legacy`). The split is a pacquet-only concern: upstream has no without-lockfile install path and so doesn't need the second field. See the doc on `Config::apply_global_virtual_store_derivation` for the reasoning.

## Benchmarks

The integrated-benchmark fixture pins `enableGlobalVirtualStore: false` so existing scenarios continue to compare apples-to-apples against the project-local `<modules>/.pnpm/<flat-name>` shape. Without the pin, every revision newer than this PR would silently switch to the GVS layout, while `pacquet@main` and the pnpm side of the comparison would still use the isolated layout — different shape, unfair comparison. GVS-specific benchmark runs are available by passing `--fixture-dir <dir>` at a copy of the fixture with the flag flipped.

## Tests

- `install::tests::frozen_lockfile_under_gvs_registers_project_and_runs_clean` pins the registry write under default GVS-on (single-project case).
- `install::tests::frozen_lockfile_under_gvs_registers_each_workspace_importer` pins per-importer registration: workspace root + `packages/web` each end up with their own symlink in `<store_dir>/projects/`.
- `install::tests::frozen_lockfile_with_gvs_off_skips_project_registry` pins that GVS-off opts out of the registry write.
- `config::tests::yaml_global_virtual_store_dir_wins_over_derivation` pins the yaml-override precedence.
- All **829 workspace tests** pass under the new layout-threaded path.
- Existing per-snapshot legacy tests construct `VirtualStoreLayout::legacy(...)` explicitly so they keep asserting the flat-name layout regardless of any global default. Partial-install tests from #442 pin `enable_global_virtual_store = false` so their seeded legacy-shape slots match the probe path.

End-to-end port of upstream's [`installing/deps-installer/test/install/globalVirtualStore.ts`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/test/install/globalVirtualStore.ts) is tracked as a follow-up — those tests need a small frozen-lockfile fixture against the registry-mock that doesn't exist yet.

## Test plan

- [x] `just ready` (829 tests green)
- [x] `taplo format --check` (clean)
- [x] `just dylint` (clean)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace --document-private-items` (clean)
- [x] `cargo fmt --check` (clean)

Closes #432.

---
Written by an agent (Claude Code, claude-opus-4-7).
