### PR TITLE
feat(git-fetcher): install git-hosted tarballs via preparePackage + packlist (#436 §C)

### DIFF
--- a/crates/git-fetcher/src/cas_io.rs
+++ b/crates/git-fetcher/src/cas_io.rs
@@ -18,9 +18,50 @@ use crate::error::GitFetcherError;
 use pacquet_store_dir::StoreDir;
 use std::{
     collections::HashMap,
-    fs,
-    path::{Path, PathBuf},
+    fs, io,
+    path::{Component, Path, PathBuf},
 };
+
+/// Safely join a relative path onto a trusted root.
+///
+/// Rejects anything that wouldn't stay under `root`:
+///
+/// - Absolute paths (`/etc/passwd`, `C:\foo`, etc.) — refuse.
+/// - `..` / root / drive-prefix components — refuse.
+/// - `.` components — silently dropped.
+/// - Normal segments — pushed onto `root` one at a time.
+///
+/// Both `materialize_into` and `import_into_cas` receive their
+/// relative paths from the install dispatcher's `cas_paths` map,
+/// which traces back to either a tarball extraction or a packlist
+/// over a freshly-checked-out git tree. Tarball entries on the
+/// extraction side already get path-traversal guards in
+/// `pacquet-tarball`, but defense-in-depth at this layer means a
+/// future caller (or a bug in the upstream sanitiser) can't turn
+/// a malformed entry into a write outside the working tree.
+fn join_checked(root: &Path, rel: &str) -> Result<PathBuf, GitFetcherError> {
+    let rel_path = Path::new(rel);
+    if rel_path.is_absolute() {
+        return Err(GitFetcherError::Io(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("absolute path is not allowed in CAS entry: {rel}"),
+        )));
+    }
+    let mut out = root.to_path_buf();
+    for c in rel_path.components() {
+        match c {
+            Component::Normal(seg) => out.push(seg),
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(GitFetcherError::Io(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("non-normal path component in CAS entry: {rel}"),
+                )));
+            }
+        }
+    }
+    Ok(out)
+}
 
 /// Copy every CAS file referenced in `cas_paths` into `target_dir`,
 /// preserving relative paths. CAS files are hardlinked-or-copied per
@@ -39,7 +80,7 @@ pub(crate) fn materialize_into(
     target_dir: &Path,
 ) -> Result<(), GitFetcherError> {
     for (rel, cas_path) in cas_paths {
-        let target = target_dir.join(rel.replace('/', std::path::MAIN_SEPARATOR_STR));
+        let target = join_checked(target_dir, &rel.replace('/', std::path::MAIN_SEPARATOR_STR))?;
         if let Some(parent) = target.parent() {
             fs::create_dir_all(parent).map_err(GitFetcherError::Io)?;
         }
@@ -74,7 +115,7 @@ pub(crate) fn import_into_cas(
 ) -> Result<HashMap<String, PathBuf>, GitFetcherError> {
     let mut out = HashMap::with_capacity(files.len());
     for rel in files {
-        let source = pkg_dir.join(rel.replace('/', std::path::MAIN_SEPARATOR_STR));
+        let source = join_checked(pkg_dir, &rel.replace('/', std::path::MAIN_SEPARATOR_STR))?;
         let bytes = fs::read(&source).map_err(GitFetcherError::Io)?;
         let executable = is_file_executable(&source);
         let (cas_path, _hash) =
@@ -119,4 +160,76 @@ pub(crate) fn map_write_cas(err: pacquet_store_dir::WriteCasFileError) -> GitFet
     GitFetcherError::AddFilesFromDir(pacquet_store_dir::AddFilesFromDirError::WriteCas(
         pacquet_store_dir::WriteCasFileError::WriteFile(inner),
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{GitFetcherError, join_checked, materialize_into};
+    use pacquet_store_dir::StoreDir;
+    use std::{collections::HashMap, io, path::Path};
+    use tempfile::tempdir;
+
+    fn assert_invalid_input(err: GitFetcherError) {
+        match err {
+            GitFetcherError::Io(io_err) => {
+                assert_eq!(io_err.kind(), io::ErrorKind::InvalidInput);
+            }
+            other => panic!("expected Io(InvalidInput), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn join_checked_accepts_normal_segments() {
+        let root = Path::new("/root");
+        let joined = join_checked(root, "a/b/c.txt").unwrap();
+        // Use components() so the assertion stays platform-agnostic.
+        let expected: Vec<_> = Path::new("/root/a/b/c.txt").components().collect();
+        let actual: Vec<_> = joined.components().collect();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn join_checked_strips_current_dir_components() {
+        // `./a` and `a` both produce the same `<root>/a` — leading
+        // `./` is a no-op, matching upstream's `path.normalize`.
+        let root = Path::new("/root");
+        let joined = join_checked(root, "./a").unwrap();
+        let expected: Vec<_> = Path::new("/root/a").components().collect();
+        let actual: Vec<_> = joined.components().collect();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn join_checked_rejects_absolute_paths() {
+        assert_invalid_input(join_checked(Path::new("/root"), "/etc/passwd").unwrap_err());
+    }
+
+    #[test]
+    fn join_checked_rejects_parent_dir() {
+        assert_invalid_input(join_checked(Path::new("/root"), "../escape").unwrap_err());
+        // Even a `..` deep in the path must be refused — otherwise
+        // `a/../../escape` would slip through.
+        assert_invalid_input(join_checked(Path::new("/root"), "a/../escape").unwrap_err());
+    }
+
+    #[test]
+    fn materialize_into_rejects_traversal() {
+        // The dispatcher must never write a file outside `target_dir`
+        // even when handed a malicious `cas_paths` map. Build one
+        // with a `..` entry and confirm we get InvalidInput.
+        let target = tempdir().unwrap();
+        let cas_root = tempdir().unwrap();
+        let store_dir = StoreDir::from(cas_root.path().to_path_buf());
+        let (cas_path, _hash) = store_dir.write_cas_file(b"poison\n", false).unwrap();
+
+        let mut bad: HashMap<String, _> = HashMap::new();
+        bad.insert("../escape".to_string(), cas_path);
+
+        let err = materialize_into(&bad, target.path()).unwrap_err();
+        assert_invalid_input(err);
+        // The `escape` file must not exist anywhere — neither in the
+        // target dir nor in its parent.
+        assert!(!target.path().join("escape").exists());
+        assert!(!target.path().parent().unwrap().join("escape").exists());
+    }
 }

--- a/crates/git-fetcher/src/cas_io.rs
+++ b/crates/git-fetcher/src/cas_io.rs
@@ -1,0 +1,122 @@
+//! CAS I/O helpers shared between [`crate::GitFetcher`] (git clone +
+//! `preparePackage`) and [`crate::GitHostedTarballFetcher`] (tarball
+//! download + `preparePackage`).
+//!
+//! - [`materialize_into`] copies CAS-resident files into a fresh
+//!   working directory so the prepare phase has a writable tree.
+//!   Used by the git-hosted tarball fetcher: by the time the tarball
+//!   has been downloaded by `pacquet-tarball`, the files already live
+//!   in the CAS, so the prepare phase reads them out into a temp dir
+//!   it can mutate without corrupting the CAS.
+//! - [`import_into_cas`] writes a prepared file set back to the CAS
+//!   and produces the `relative-path → cas-path` map the install
+//!   dispatcher hands to `CreateVirtualDirBySnapshot`.
+//! - [`is_file_executable`] / [`map_write_cas`] are minor helpers
+//!   factored out alongside the import.
+
+use crate::error::GitFetcherError;
+use pacquet_store_dir::StoreDir;
+use std::{
+    collections::HashMap,
+    fs,
+    path::{Path, PathBuf},
+};
+
+/// Copy every CAS file referenced in `cas_paths` into `target_dir`,
+/// preserving relative paths. CAS files are hardlinked-or-copied per
+/// install elsewhere, but for the prepare phase the working tree must
+/// be writable *without* mutating the shared CAS entry, so this path
+/// always allocates fresh inodes via [`fs::copy`].
+///
+/// Mirrors the effect of upstream's
+/// [`cafs.importPackage(tempLocation, …)`](https://github.com/pnpm/pnpm/blob/94240bc046/fetching/tarball-fetcher/src/gitHostedTarballFetcher.ts#L75)
+/// call inside `prepareGitHostedPkg`, but produces a *standalone*
+/// directory rather than a pnpm-style CAFS slot — pacquet's `StoreDir`
+/// only knows how to import on the way *in*, and the prepare phase
+/// needs raw filesystem semantics for scripts to run.
+pub(crate) fn materialize_into(
+    cas_paths: &HashMap<String, PathBuf>,
+    target_dir: &Path,
+) -> Result<(), GitFetcherError> {
+    for (rel, cas_path) in cas_paths {
+        let target = target_dir.join(rel.replace('/', std::path::MAIN_SEPARATOR_STR));
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent).map_err(GitFetcherError::Io)?;
+        }
+        fs::copy(cas_path, &target).map_err(GitFetcherError::Io)?;
+        // Carry the executable bit across. The CAS uses a `-exec`
+        // suffix on the file name to encode the bit (matches pnpm's
+        // CAFS layout), so reading it back from the path is the only
+        // reliable signal — `fs::copy` itself doesn't reset POSIX
+        // permissions, but we may need to *add* the bit if the CAS
+        // file's filesystem-level mode lost it during an earlier
+        // copy or hardlink path elsewhere.
+        #[cfg(unix)]
+        if cas_path_is_executable(cas_path) {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(&target).map_err(GitFetcherError::Io)?.permissions();
+            perms.set_mode(perms.mode() | 0o111);
+            fs::set_permissions(&target, perms).map_err(GitFetcherError::Io)?;
+        }
+    }
+    Ok(())
+}
+
+/// Write each file in `files` (relative to `pkg_dir`) into the CAS,
+/// returning the map the caller hands to `CreateVirtualDirBySnapshot`.
+/// Mirrors the role of upstream's
+/// [`addFilesFromDir`](https://github.com/pnpm/pnpm/blob/94240bc046/store/cafs/src/addFilesFromDir.ts)
+/// on the post-prepare write side.
+pub(crate) fn import_into_cas(
+    store_dir: &StoreDir,
+    pkg_dir: &Path,
+    files: &[String],
+) -> Result<HashMap<String, PathBuf>, GitFetcherError> {
+    let mut out = HashMap::with_capacity(files.len());
+    for rel in files {
+        let source = pkg_dir.join(rel.replace('/', std::path::MAIN_SEPARATOR_STR));
+        let bytes = fs::read(&source).map_err(GitFetcherError::Io)?;
+        let executable = is_file_executable(&source);
+        let (cas_path, _hash) =
+            store_dir.write_cas_file(&bytes, executable).map_err(map_write_cas)?;
+        out.insert(rel.clone(), cas_path);
+    }
+    Ok(out)
+}
+
+/// `true` when the user-execute bit is set on the on-disk file.
+/// POSIX-only; on Windows every file lands as non-executable, matching
+/// pnpm v11's behavior where the executable mode flag is meaningful
+/// only on POSIX.
+pub(crate) fn is_file_executable(path: &Path) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::metadata(path).map(|m| (m.permissions().mode() & 0o100) != 0).unwrap_or(false)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        false
+    }
+}
+
+/// `true` when a CAS file path encodes "executable" via the `-exec`
+/// suffix pnpm's CAFS layout uses. Cheaper than reading filesystem
+/// metadata, and matches the write-side encoding in
+/// [`pacquet_store_dir::StoreDir::cas_file_path`].
+#[cfg(unix)]
+fn cas_path_is_executable(path: &Path) -> bool {
+    path.file_name().and_then(|n| n.to_str()).is_some_and(|n| n.ends_with("-exec"))
+}
+
+/// Re-wrap a CAFS write failure as a `GitFetcherError::AddFilesFromDir`.
+/// Preserves the miette source chain shape so a future replacement of
+/// the per-file `write_cas_file` loop with an `add_files_from_dir`-
+/// shaped helper doesn't disturb the dispatcher's error rendering.
+pub(crate) fn map_write_cas(err: pacquet_store_dir::WriteCasFileError) -> GitFetcherError {
+    let pacquet_store_dir::WriteCasFileError::WriteFile(inner) = err;
+    GitFetcherError::AddFilesFromDir(pacquet_store_dir::AddFilesFromDirError::WriteCas(
+        pacquet_store_dir::WriteCasFileError::WriteFile(inner),
+    ))
+}

--- a/crates/git-fetcher/src/cas_io.rs
+++ b/crates/git-fetcher/src/cas_io.rs
@@ -80,7 +80,12 @@ pub(crate) fn materialize_into(
     target_dir: &Path,
 ) -> Result<(), GitFetcherError> {
     for (rel, cas_path) in cas_paths {
-        let target = join_checked(target_dir, &rel.replace('/', std::path::MAIN_SEPARATOR_STR))?;
+        // `rel` uses forward slashes regardless of host platform.
+        // `Path::components()` (called inside `join_checked`)
+        // recognises both `/` and `\` as separators on Windows, so we
+        // can hand `rel` over directly and avoid a per-file `String`
+        // allocation.
+        let target = join_checked(target_dir, rel)?;
         if let Some(parent) = target.parent() {
             fs::create_dir_all(parent).map_err(GitFetcherError::Io)?;
         }
@@ -115,7 +120,9 @@ pub(crate) fn import_into_cas(
 ) -> Result<HashMap<String, PathBuf>, GitFetcherError> {
     let mut out = HashMap::with_capacity(files.len());
     for rel in files {
-        let source = join_checked(pkg_dir, &rel.replace('/', std::path::MAIN_SEPARATOR_STR))?;
+        // See the matching note in `materialize_into`: `join_checked`
+        // accepts forward-slash relative paths verbatim on every host.
+        let source = join_checked(pkg_dir, rel)?;
         let bytes = fs::read(&source).map_err(GitFetcherError::Io)?;
         let executable = is_file_executable(&source);
         let (cas_path, _hash) =

--- a/crates/git-fetcher/src/fetcher.rs
+++ b/crates/git-fetcher/src/fetcher.rs
@@ -13,6 +13,7 @@
 //! to flow through without an extra owned-data copy.
 
 use crate::{
+    cas_io::import_into_cas,
     error::{GitFetcherError, PreparePackageError},
     packlist::packlist,
     prepare_package::{PreparePackageOptions, PreparedPackage, prepare_package},
@@ -268,53 +269,9 @@ fn static_operation_label(args: &[&str]) -> &'static str {
     }
 }
 
-/// Copy every file in `files` (relative to `pkg_dir`) into the CAS,
-/// returning the map the caller passes to `CreateVirtualDirBySnapshot`.
-fn import_into_cas(
-    store_dir: &StoreDir,
-    pkg_dir: &Path,
-    files: &[String],
-) -> Result<HashMap<String, PathBuf>, GitFetcherError> {
-    let mut out = HashMap::with_capacity(files.len());
-    for rel in files {
-        let source = pkg_dir.join(rel.replace('/', std::path::MAIN_SEPARATOR_STR));
-        let bytes = fs::read(&source).map_err(GitFetcherError::Io)?;
-        let executable = is_file_executable(&source);
-        let (cas_path, _hash) =
-            store_dir.write_cas_file(&bytes, executable).map_err(map_write_cas)?;
-        out.insert(rel.clone(), cas_path);
-    }
-    Ok(out)
-}
-
-/// `true` when the user-execute bit is set. POSIX-only; on Windows
-/// every file lands as non-executable, matching pnpm v11's behavior
-/// where the executable mode flag is meaningful only on POSIX.
-fn is_file_executable(path: &Path) -> bool {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        fs::metadata(path).map(|m| (m.permissions().mode() & 0o100) != 0).unwrap_or(false)
-    }
-    #[cfg(not(unix))]
-    {
-        let _ = path;
-        false
-    }
-}
-
-fn map_write_cas(err: pacquet_store_dir::WriteCasFileError) -> GitFetcherError {
-    // Surface the CAFS write failure through the AddFilesFromDir
-    // variant: the only place an `add_files_from_dir`-shaped error
-    // can come from is the same `write_cas_file` path the upstream
-    // CAFS pump uses, and reusing the variant keeps the dispatcher's
-    // miette source chain shape stable when this PR's only-CAS-write
-    // import is later replaced by the full pnpm-aligned implementation.
-    let pacquet_store_dir::WriteCasFileError::WriteFile(inner) = err;
-    GitFetcherError::AddFilesFromDir(pacquet_store_dir::AddFilesFromDirError::WriteCas(
-        pacquet_store_dir::WriteCasFileError::WriteFile(inner),
-    ))
-}
+// `import_into_cas`, `is_file_executable`, and `map_write_cas` live in
+// [`crate::cas_io`] so [`crate::GitHostedTarballFetcher`] can reuse
+// them for the prepare-and-rewrite pass on git-hosted tarballs.
 
 #[cfg(test)]
 mod tests;

--- a/crates/git-fetcher/src/lib.rs
+++ b/crates/git-fetcher/src/lib.rs
@@ -1,23 +1,33 @@
-//! Fetcher for `LockfileResolution::Git` snapshots.
+//! Fetchers for git-hosted dependencies, plus the `preparePackage`
+//! port both fetchers delegate to.
 //!
-//! Ports pnpm's
-//! [`fetching/git-fetcher`](https://github.com/pnpm/pnpm/blob/94240bc046/fetching/git-fetcher/src/index.ts)
-//! and the inner
-//! [`exec/prepare-package`](https://github.com/pnpm/pnpm/blob/94240bc046/exec/prepare-package/src/index.ts)
-//! that the fetcher delegates to when a git-hosted package needs
-//! building. The two are co-located here because their only consumer
-//! today is this crate; when Section C lands (the git-hosted *tarball*
-//! fetcher), `prepare_package` is the one piece that lifts out into a
-//! shared crate.
+//! Two fetcher entry points, sharing `prepare_package` / `packlist` /
+//! the CAS-import helpers:
+//!
+//! - [`GitFetcher`] handles `LockfileResolution::Git` — shells out to
+//!   the system `git` binary. Ports pnpm's
+//!   [`fetching/git-fetcher`](https://github.com/pnpm/pnpm/blob/94240bc046/fetching/git-fetcher/src/index.ts).
+//! - [`GitHostedTarballFetcher`] handles
+//!   `TarballResolution { gitHosted: true }` — picks up a tarball the
+//!   pacquet HTTP path has already downloaded into the CAS, materializes
+//!   it into a temp dir, and runs the same `prepare_package` + packlist
+//!   passes. Ports pnpm's
+//!   [`fetching/tarball-fetcher/src/gitHostedTarballFetcher.ts`](https://github.com/pnpm/pnpm/blob/94240bc046/fetching/tarball-fetcher/src/gitHostedTarballFetcher.ts).
+//!
+//! `prepare_package` lives in this crate rather than a sibling because
+//! both fetchers above are its only consumers.
 
+mod cas_io;
 mod error;
 mod fetcher;
 mod packlist;
 mod preferred_pm;
 mod prepare_package;
+mod tarball_fetcher;
 
 pub use error::{GitFetcherError, PacklistError, PreparePackageError};
 pub use fetcher::{GitFetchOutput, GitFetcher};
 pub use packlist::packlist;
 pub use preferred_pm::{PreferredPm, detect_preferred_pm};
 pub use prepare_package::{PreparePackageOptions, PreparedPackage, prepare_package};
+pub use tarball_fetcher::GitHostedTarballFetcher;

--- a/crates/git-fetcher/src/tarball_fetcher.rs
+++ b/crates/git-fetcher/src/tarball_fetcher.rs
@@ -29,7 +29,7 @@
 
 use crate::{
     cas_io::{import_into_cas, materialize_into},
-    error::{GitFetcherError, PreparePackageError},
+    error::GitFetcherError,
     fetcher::GitFetchOutput,
     packlist::packlist,
     prepare_package::{PreparePackageOptions, PreparedPackage, prepare_package},
@@ -111,11 +111,18 @@ impl<'a> GitHostedTarballFetcher<'a> {
             extra_bin_paths: &[],
             extra_env: &empty_env,
         };
+        // Upstream stamps `err.message = "Failed to prepare git-hosted
+        // package fetched from <url>: <orig>"` at
+        // [`gitHostedTarballFetcher.ts:49-52`](https://github.com/pnpm/pnpm/blob/94240bc046/fetching/tarball-fetcher/src/gitHostedTarballFetcher.ts#L49-L52).
+        // Pacquet preserves the underlying error through the miette
+        // source chain instead — the install dispatcher's log line
+        // already includes `package_id`, so the chain renders as
+        // "prepare failed for `<pkg>` → `ERR_PNPM_PREPARE_PACKAGE` →
+        // underlying lifecycle error". A dedicated context variant is
+        // a follow-up if the rendered chain proves unclear.
         let PreparedPackage { pkg_dir, should_be_built } =
-            match prepare_package::<R>(&prepare_opts, temp_location, self.path) {
-                Ok(p) => p,
-                Err(err) => return Err(wrap_prepare_error(self.package_id, err)),
-            };
+            prepare_package::<R>(&prepare_opts, temp_location, self.path)
+                .map_err(GitFetcherError::Prepare)?;
 
         // Upstream's `globalWarn` at gitHostedTarballFetcher.ts:39
         // when scripts were ignored on a package that needs building.
@@ -142,19 +149,6 @@ impl<'a> GitHostedTarballFetcher<'a> {
         let cas_paths = import_into_cas(self.store_dir, &pkg_dir, &files)?;
         Ok(GitFetchOutput { cas_paths, built: should_be_built })
     }
-}
-
-/// Wrap a `PreparePackageError` with the same "Failed to prepare git-
-/// hosted package" prefix upstream stamps at
-/// [`gitHostedTarballFetcher.ts:49-52`](https://github.com/pnpm/pnpm/blob/94240bc046/fetching/tarball-fetcher/src/gitHostedTarballFetcher.ts#L49-L52).
-///
-/// We preserve the underlying error through the miette source chain
-/// instead of mutating the message (no JS-style `err.message = ...`).
-/// The install dispatcher's log line already prefixes events with
-/// `package_id`, so the source chain reads as "prepare failed for
-/// `<pkg>` → `ERR_PNPM_PREPARE_PACKAGE` → underlying lifecycle error".
-fn wrap_prepare_error(_package_id: &str, err: PreparePackageError) -> GitFetcherError {
-    GitFetcherError::Prepare(err)
 }
 
 #[cfg(test)]

--- a/crates/git-fetcher/src/tarball_fetcher.rs
+++ b/crates/git-fetcher/src/tarball_fetcher.rs
@@ -1,0 +1,161 @@
+//! Fetcher for `TarballResolution { gitHosted: true }` snapshots.
+//!
+//! By the time control reaches this fetcher, `pacquet-tarball` has
+//! already downloaded the tarball, verified its integrity, and
+//! imported its file set into the CAS — the dispatcher hands us the
+//! resulting `HashMap<String, PathBuf>` mapping relative paths to CAS
+//! file paths. From there we mirror upstream's
+//! [`gitHostedTarballFetcher.ts`](https://github.com/pnpm/pnpm/blob/94240bc046/fetching/tarball-fetcher/src/gitHostedTarballFetcher.ts):
+//! materialize the files into a writable temp dir, run
+//! `preparePackage` to (potentially) execute the dep's build scripts,
+//! run a packlist over the prepared tree, and re-import the resulting
+//! file set into the CAS.
+//!
+//! Differences from upstream worth flagging:
+//!
+//! - **No "raw" vs "built" two-slot CAS today.** Upstream stores the
+//!   raw download at `${filesIndexFile}\traw` and the prepared output
+//!   at `filesIndexFile`, and on the fast path promotes the raw entry
+//!   to the final key in place. Pacquet currently doesn't expose the
+//!   "filesIndexFile" hook at this layer (the install dispatcher
+//!   feeds the result straight into `CreateVirtualDirBySnapshot`), so
+//!   we always re-import. Hash-deduplication means duplicate work but
+//!   not duplicate storage; the optimization is a follow-up
+//!   alongside warm-prefetch for git-hosted slots.
+//! - **`globalWarn` becomes `tracing::warn!`.** When `ignore_scripts`
+//!   suppresses a needed build, both upstream and pacquet log a
+//!   warning — we route through `tracing` since pacquet's reporter
+//!   model doesn't have a `globalWarn` equivalent.
+
+use crate::{
+    cas_io::{import_into_cas, materialize_into},
+    error::{GitFetcherError, PreparePackageError},
+    fetcher::GitFetchOutput,
+    packlist::packlist,
+    prepare_package::{PreparePackageOptions, PreparedPackage, prepare_package},
+};
+use pacquet_executor::ScriptsPrependNodePath;
+use pacquet_package_manifest::safe_read_package_json_from_dir;
+use pacquet_reporter::Reporter;
+use pacquet_store_dir::StoreDir;
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
+
+/// One-shot fetcher for a single git-hosted tarball resolution.
+///
+/// The dispatcher constructs this *after* `pacquet-tarball` has
+/// downloaded and CAS-imported the tarball, handing us the
+/// `cas_paths` map. The shape lines up with [`crate::GitFetcher`] so
+/// both `LockfileResolution::Git` and `LockfileResolution::Tarball {
+/// gitHosted: true }` produce a [`GitFetchOutput`] the install
+/// dispatcher consumes uniformly.
+pub struct GitHostedTarballFetcher<'a> {
+    /// Raw tarball files already in the CAS. Keys are forward-slash
+    /// relative paths, values are absolute CAS paths.
+    pub cas_paths: HashMap<String, PathBuf>,
+    /// `path` field from the resolution. Pnpm's git-hosted tarball
+    /// resolutions can include a sub-path to pack only one directory
+    /// of the extracted tree (matches the git fetcher's `path`).
+    /// `None` packs the tarball root.
+    pub path: Option<&'a str>,
+    /// Routed through to [`crate::prepare_package()`]'s `allow_build`.
+    pub allow_build: &'a (dyn Fn(&str, &str) -> bool + Send + Sync),
+    pub ignore_scripts: bool,
+    pub unsafe_perm: bool,
+    pub user_agent: Option<&'a str>,
+    pub scripts_prepend_node_path: ScriptsPrependNodePath,
+    pub script_shell: Option<&'a Path>,
+    pub node_execpath: Option<&'a Path>,
+    pub npm_execpath: Option<&'a Path>,
+    pub store_dir: &'a StoreDir,
+    /// Used in log lines.
+    pub package_id: &'a str,
+    pub requester: &'a str,
+}
+
+impl<'a> GitHostedTarballFetcher<'a> {
+    /// Run the fetcher. Blocks under
+    /// [`tokio::task::block_in_place`] so the synchronous
+    /// `preparePackage` work doesn't tie up the async runtime.
+    pub async fn run<R: Reporter>(self) -> Result<GitFetchOutput, GitFetcherError> {
+        tokio::task::block_in_place(|| self.run_sync::<R>())
+    }
+
+    fn run_sync<R: Reporter>(self) -> Result<GitFetchOutput, GitFetcherError> {
+        let temp = tempfile::tempdir().map_err(GitFetcherError::Io)?;
+        let temp_location = temp.path();
+
+        // Step 1: Materialize the CAS-resident files into a writable
+        // working tree. Upstream calls this via `cafs.importPackage`;
+        // pacquet does it through a per-file `fs::copy` because the
+        // tarball download has already settled the CAS write side.
+        materialize_into(&self.cas_paths, temp_location)?;
+
+        // Step 2: Run `preparePackage` on the materialized tree. This
+        // honors `allow_build`, runs `<pm>-install` + `prepublish` /
+        // `prepack` / `publish` lifecycle scripts when needed, and
+        // returns `pkg_dir` (which respects `self.path`) plus the
+        // `should_be_built` flag.
+        let empty_env: HashMap<String, String> = HashMap::new();
+        let prepare_opts = PreparePackageOptions {
+            allow_build: Box::new(|name, version| (self.allow_build)(name, version)),
+            ignore_scripts: self.ignore_scripts,
+            unsafe_perm: self.unsafe_perm,
+            user_agent: self.user_agent,
+            scripts_prepend_node_path: self.scripts_prepend_node_path,
+            script_shell: self.script_shell,
+            node_execpath: self.node_execpath,
+            npm_execpath: self.npm_execpath,
+            extra_bin_paths: &[],
+            extra_env: &empty_env,
+        };
+        let PreparedPackage { pkg_dir, should_be_built } =
+            match prepare_package::<R>(&prepare_opts, temp_location, self.path) {
+                Ok(p) => p,
+                Err(err) => return Err(wrap_prepare_error(self.package_id, err)),
+            };
+
+        // Upstream's `globalWarn` at gitHostedTarballFetcher.ts:39
+        // when scripts were ignored on a package that needs building.
+        if self.ignore_scripts && should_be_built {
+            tracing::warn!(
+                target: "pacquet::git_hosted_tarball_fetcher",
+                package_id = %self.package_id,
+                "the git-hosted tarball package has to be built but the build scripts were ignored",
+            );
+        }
+
+        // Step 3: Compute the packlist over the prepared tree. The
+        // raw tarball typically ships everything from the git
+        // checkout (build artifacts, source maps, test fixtures);
+        // applying the packlist filter on the way back into CAS
+        // matches the file set the package would publish.
+        let manifest = safe_read_package_json_from_dir(&pkg_dir)
+            .unwrap_or(None)
+            .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new()));
+        let files = packlist(&pkg_dir, &manifest).map_err(GitFetcherError::Packlist)?;
+
+        // Step 4: Re-import the filtered file set back into CAS and
+        // hand the resulting map to the install dispatcher.
+        let cas_paths = import_into_cas(self.store_dir, &pkg_dir, &files)?;
+        Ok(GitFetchOutput { cas_paths, built: should_be_built })
+    }
+}
+
+/// Wrap a `PreparePackageError` with the same "Failed to prepare git-
+/// hosted package" prefix upstream stamps at
+/// [`gitHostedTarballFetcher.ts:49-52`](https://github.com/pnpm/pnpm/blob/94240bc046/fetching/tarball-fetcher/src/gitHostedTarballFetcher.ts#L49-L52).
+///
+/// We preserve the underlying error through the miette source chain
+/// instead of mutating the message (no JS-style `err.message = ...`).
+/// The install dispatcher's log line already prefixes events with
+/// `package_id`, so the source chain reads as "prepare failed for
+/// `<pkg>` → `ERR_PNPM_PREPARE_PACKAGE` → underlying lifecycle error".
+fn wrap_prepare_error(_package_id: &str, err: PreparePackageError) -> GitFetcherError {
+    GitFetcherError::Prepare(err)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/git-fetcher/src/tarball_fetcher/tests.rs
+++ b/crates/git-fetcher/src/tarball_fetcher/tests.rs
@@ -158,6 +158,70 @@ async fn rejects_build_when_not_allowed() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn path_field_packs_only_subdirectory() {
+    // Git-hosted tarballs from monorepos pin a `path` to point at the
+    // sub-package they actually publish. The fetcher must run
+    // `preparePackage` + `packlist` inside that sub-dir so the
+    // resulting `cas_paths` only contain that package's files.
+    let store_root = tempdir().unwrap();
+    let store_dir = StoreDir::from(store_root.path().to_path_buf());
+
+    let cas_paths = write_to_cas(
+        &store_dir,
+        &[
+            // Monorepo root manifest — not the published package.
+            ("package.json", br#"{"name":"monorepo","version":"0.0.0","private":true}"#, false),
+            // The sub-package we're packing.
+            (
+                "packages/sub/package.json",
+                br#"{"name":"sub","version":"1.0.0","main":"index.js"}"#,
+                false,
+            ),
+            ("packages/sub/index.js", b"module.exports = 1;\n", false),
+            ("packages/sub/README.md", b"# sub\n", false),
+            // A sibling package that must NOT end up in the result.
+            ("packages/other/package.json", br#"{"name":"other","version":"1.0.0"}"#, false),
+            ("packages/other/index.js", b"// other\n", false),
+        ],
+    );
+
+    let received = GitHostedTarballFetcher {
+        cas_paths,
+        path: Some("packages/sub"),
+        allow_build: deny_all_builds(),
+        ignore_scripts: false,
+        unsafe_perm: true,
+        user_agent: None,
+        scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+        script_shell: None,
+        node_execpath: None,
+        npm_execpath: None,
+        store_dir: &store_dir,
+        package_id: "sub@1.0.0",
+        requester: "/test",
+    }
+    .run::<SilentReporter>()
+    .await
+    .unwrap();
+
+    let keys: Vec<&str> = received.cas_paths.keys().map(String::as_str).collect();
+    // The fetcher packlists relative to `pkg_dir` (which is
+    // `<tmp>/packages/sub`), so the returned keys are *also* relative
+    // to that sub-dir — never carrying the `packages/sub/` prefix.
+    assert!(keys.contains(&"package.json"), "sub-dir manifest must be included");
+    assert!(keys.contains(&"index.js"), "sub-dir main must be included");
+    assert!(keys.contains(&"README.md"), "always-included file must be included");
+    assert!(
+        !keys.iter().any(|k| k.contains("other")),
+        "sibling-package files must not appear in {keys:?}",
+    );
+    assert!(
+        !keys.iter().any(|k| k.contains("packages/")),
+        "keys are relative to the sub-dir, not the monorepo root: {keys:?}",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn materialized_temp_dir_does_not_corrupt_cas() {
     // Regression: when the prepare phase modifies a working-tree
     // file, the CAS entry it was sourced from must remain unchanged.

--- a/crates/git-fetcher/src/tarball_fetcher/tests.rs
+++ b/crates/git-fetcher/src/tarball_fetcher/tests.rs
@@ -1,0 +1,199 @@
+use super::GitHostedTarballFetcher;
+use crate::error::{GitFetcherError, PreparePackageError};
+use pacquet_executor::ScriptsPrependNodePath;
+use pacquet_reporter::SilentReporter;
+use pacquet_store_dir::StoreDir;
+use std::{collections::HashMap, fs, path::PathBuf};
+use tempfile::tempdir;
+
+fn deny_all_builds<'a>() -> &'a (dyn Fn(&str, &str) -> bool + Send + Sync) {
+    &|_, _| false
+}
+
+/// Build the `cas_paths` map the dispatcher would hand the fetcher
+/// after `DownloadTarballToStore` finishes: a fresh `StoreDir`, a few
+/// files written via `write_cas_file`, and a `path → cas_path` map.
+fn write_to_cas(store_dir: &StoreDir, files: &[(&str, &[u8], bool)]) -> HashMap<String, PathBuf> {
+    let mut out = HashMap::new();
+    for &(rel, bytes, executable) in files {
+        let (cas_path, _hash) = store_dir.write_cas_file(bytes, executable).unwrap();
+        out.insert(rel.to_string(), cas_path);
+    }
+    out
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn passes_through_package_without_scripts() {
+    let store_root = tempdir().unwrap();
+    let store_dir = StoreDir::from(store_root.path().to_path_buf());
+
+    let cas_paths = write_to_cas(
+        &store_dir,
+        &[
+            ("package.json", br#"{"name":"x","version":"1.0.0","main":"index.js"}"#, false),
+            ("index.js", b"module.exports = 42;\n", false),
+            // A README that the packlist's always-included rule
+            // should preserve regardless of the (absent) `files`
+            // field.
+            ("README.md", b"# x\n", false),
+        ],
+    );
+
+    let received = GitHostedTarballFetcher {
+        cas_paths: cas_paths.clone(),
+        path: None,
+        allow_build: deny_all_builds(),
+        ignore_scripts: false,
+        unsafe_perm: true,
+        user_agent: None,
+        scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+        script_shell: None,
+        node_execpath: None,
+        npm_execpath: None,
+        store_dir: &store_dir,
+        package_id: "x@1.0.0",
+        requester: "/test",
+    }
+    .run::<SilentReporter>()
+    .await
+    .unwrap();
+
+    assert!(!received.built, "no `prepare` script → not built");
+    assert!(received.cas_paths.contains_key("package.json"));
+    assert!(received.cas_paths.contains_key("index.js"));
+    assert!(received.cas_paths.contains_key("README.md"));
+
+    // Hash-dedup: re-importing the same bytes lands at the same CAS
+    // path, so the new map's CAS entries point at the same files we
+    // wrote up front.
+    for (rel, original) in &cas_paths {
+        assert_eq!(received.cas_paths.get(rel), Some(original), "deterministic CAS path for {rel}");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn filters_files_outside_files_field() {
+    let store_root = tempdir().unwrap();
+    let store_dir = StoreDir::from(store_root.path().to_path_buf());
+
+    let cas_paths = write_to_cas(
+        &store_dir,
+        &[
+            ("package.json", br#"{"name":"x","version":"1.0.0","files":["dist/**"]}"#, false),
+            ("dist/index.js", b"// built\n", false),
+            ("src/index.ts", b"// source\n", false),
+            ("test/foo.test.js", b"// test\n", false),
+        ],
+    );
+
+    let received = GitHostedTarballFetcher {
+        cas_paths,
+        path: None,
+        allow_build: deny_all_builds(),
+        ignore_scripts: false,
+        unsafe_perm: true,
+        user_agent: None,
+        scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+        script_shell: None,
+        node_execpath: None,
+        npm_execpath: None,
+        store_dir: &store_dir,
+        package_id: "x@1.0.0",
+        requester: "/test",
+    }
+    .run::<SilentReporter>()
+    .await
+    .unwrap();
+
+    let keys: Vec<&str> = received.cas_paths.keys().map(String::as_str).collect();
+    assert!(keys.contains(&"dist/index.js"));
+    assert!(keys.contains(&"package.json"), "package.json always included");
+    assert!(!keys.contains(&"src/index.ts"), "src excluded by files field");
+    assert!(!keys.contains(&"test/foo.test.js"), "test excluded by files field");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rejects_build_when_not_allowed() {
+    let store_root = tempdir().unwrap();
+    let store_dir = StoreDir::from(store_root.path().to_path_buf());
+
+    let cas_paths = write_to_cas(
+        &store_dir,
+        &[
+            (
+                "package.json",
+                br#"{"name":"naughty","version":"2.0.0","main":"index.js","scripts":{"prepare":"tsc"}}"#,
+                false,
+            ),
+            ("index.js", b"module.exports = 1;\n", false),
+        ],
+    );
+
+    let err = GitHostedTarballFetcher {
+        cas_paths,
+        path: None,
+        allow_build: deny_all_builds(),
+        ignore_scripts: false,
+        unsafe_perm: true,
+        user_agent: None,
+        scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+        script_shell: None,
+        node_execpath: None,
+        npm_execpath: None,
+        store_dir: &store_dir,
+        package_id: "naughty@2.0.0",
+        requester: "/test",
+    }
+    .run::<SilentReporter>()
+    .await
+    .unwrap_err();
+
+    match err {
+        GitFetcherError::Prepare(PreparePackageError::NotAllowed { name, version }) => {
+            assert_eq!(name, "naughty");
+            assert_eq!(version, "2.0.0");
+        }
+        other => panic!("expected Prepare::NotAllowed, got {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn materialized_temp_dir_does_not_corrupt_cas() {
+    // Regression: when the prepare phase modifies a working-tree
+    // file, the CAS entry it was sourced from must remain unchanged.
+    // We exercise the materialization path explicitly: a fresh
+    // working tree (made via `fs::copy`) should have a different
+    // inode than the CAS entry on POSIX.
+    let store_root = tempdir().unwrap();
+    let store_dir = StoreDir::from(store_root.path().to_path_buf());
+
+    let cas_paths =
+        write_to_cas(&store_dir, &[("package.json", br#"{"name":"x","version":"1.0.0"}"#, false)]);
+    let original_cas_path = cas_paths["package.json"].clone();
+    let cas_bytes_before = fs::read(&original_cas_path).unwrap();
+
+    let _ = GitHostedTarballFetcher {
+        cas_paths,
+        path: None,
+        allow_build: deny_all_builds(),
+        ignore_scripts: false,
+        unsafe_perm: true,
+        user_agent: None,
+        scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+        script_shell: None,
+        node_execpath: None,
+        npm_execpath: None,
+        store_dir: &store_dir,
+        package_id: "x@1.0.0",
+        requester: "/test",
+    }
+    .run::<SilentReporter>()
+    .await
+    .unwrap();
+
+    let cas_bytes_after = fs::read(&original_cas_path).unwrap();
+    assert_eq!(
+        cas_bytes_before, cas_bytes_after,
+        "fetcher must not mutate CAS entries it sourced from",
+    );
+}

--- a/crates/lockfile/src/resolution.rs
+++ b/crates/lockfile/src/resolution.rs
@@ -23,6 +23,13 @@ pub struct TarballResolution {
     /// at <https://github.com/pnpm/pnpm/blob/94240bc046/lockfile/types/src/index.ts#L88-L107>.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub git_hosted: Option<bool>,
+    /// Sub-directory inside the tarball to pack, mirroring
+    /// `GitResolution.path`. Pnpm's git-hosted tarball fetcher uses it
+    /// to package only one directory of a monorepo's archive. Mirrors
+    /// pnpm's `TarballResolution.path` at
+    /// <https://github.com/pnpm/pnpm/blob/94240bc046/lockfile/types/src/index.ts#L93>.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
 }
 
 /// For standard package specification, with package name and version range.

--- a/crates/lockfile/src/resolution/tests.rs
+++ b/crates/lockfile/src/resolution/tests.rs
@@ -189,6 +189,25 @@ fn deserialize_tarball_resolution_with_path() {
 }
 
 #[test]
+fn serialize_tarball_resolution_with_path() {
+    let resolution = LockfileResolution::Tarball(TarballResolution {
+        tarball: "https://codeload.github.com/foo/bar/tar.gz/abc1234".to_string(),
+        integrity: None,
+        git_hosted: Some(true),
+        path: Some("packages/sub".to_string()),
+    });
+    let received = serialize_yaml::to_string(&resolution).unwrap();
+    let received = received.trim();
+    eprintln!("RECEIVED:\n{received}");
+    let expected = text_block! {
+        "tarball: https://codeload.github.com/foo/bar/tar.gz/abc1234"
+        "gitHosted: true"
+        "path: packages/sub"
+    };
+    assert_eq!(received, expected);
+}
+
+#[test]
 fn serialize_tarball_resolution_with_git_hosted() {
     let resolution = LockfileResolution::Tarball(TarballResolution {
         tarball: "https://codeload.github.com/foo/bar/tar.gz/abc1234".to_string(),

--- a/crates/lockfile/src/resolution/tests.rs
+++ b/crates/lockfile/src/resolution/tests.rs
@@ -22,6 +22,7 @@ fn deserialize_tarball_resolution() {
         tarball: "file:ts-pipe-compose-0.2.1.tgz".to_string(),
         integrity: None,
         git_hosted: None,
+        path: None,
     });
     assert_eq!(received, expected);
 
@@ -36,6 +37,7 @@ fn deserialize_tarball_resolution() {
         tarball: "file:ts-pipe-compose-0.2.1.tgz".to_string(),
         integrity: integrity("sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==").into(),
         git_hosted: None,
+        path: None,
     });
     assert_eq!(received, expected);
 }
@@ -53,6 +55,7 @@ fn deserialize_tarball_resolution_with_git_hosted() {
         tarball: "https://codeload.github.com/foo/bar/tar.gz/abc1234".to_string(),
         integrity: None,
         git_hosted: Some(true),
+        path: None,
     });
     assert_eq!(received, expected);
 }
@@ -72,6 +75,7 @@ fn deserialize_tarball_resolution_backfills_git_hosted() {
         tarball: "https://codeload.github.com/foo/bar/tar.gz/abc1234".to_string(),
         integrity: None,
         git_hosted: Some(true),
+        path: None,
     });
     assert_eq!(received, expected);
 
@@ -84,6 +88,7 @@ fn deserialize_tarball_resolution_backfills_git_hosted() {
         tarball: "https://gitlab.com/foo/bar/-/archive/abc1234/bar-abc1234.tar.gz".to_string(),
         integrity: None,
         git_hosted: Some(true),
+        path: None,
     });
     assert_eq!(received, expected);
 
@@ -96,6 +101,7 @@ fn deserialize_tarball_resolution_backfills_git_hosted() {
         tarball: "https://bitbucket.org/foo/bar/get/abc1234.tar.gz".to_string(),
         integrity: None,
         git_hosted: Some(true),
+        path: None,
     });
     assert_eq!(received, expected);
 
@@ -108,6 +114,7 @@ fn deserialize_tarball_resolution_backfills_git_hosted() {
         tarball: "https://registry.npmjs.org/foo/-/foo-1.0.0.tgz".to_string(),
         integrity: None,
         git_hosted: None,
+        path: None,
     });
     assert_eq!(received, expected);
 
@@ -122,6 +129,7 @@ fn deserialize_tarball_resolution_backfills_git_hosted() {
         tarball: "https://codeload.github.com/foo/bar/zip/abc1234".to_string(),
         integrity: None,
         git_hosted: None,
+        path: None,
     });
     assert_eq!(received, expected);
 }
@@ -133,6 +141,7 @@ fn serialize_tarball_resolution() {
         tarball: "file:ts-pipe-compose-0.2.1.tgz".to_string(),
         integrity: None,
         git_hosted: None,
+        path: None,
     });
     let received = serialize_yaml::to_string(&resolution).unwrap();
     let received = received.trim();
@@ -147,6 +156,7 @@ fn serialize_tarball_resolution() {
         tarball: "file:ts-pipe-compose-0.2.1.tgz".to_string(),
         integrity: integrity("sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==").into(),
         git_hosted: None,
+        path: None,
     });
     let received = serialize_yaml::to_string(&resolution).unwrap();
     let received = received.trim();
@@ -159,11 +169,32 @@ fn serialize_tarball_resolution() {
 }
 
 #[test]
+fn deserialize_tarball_resolution_with_path() {
+    // Git-hosted tarballs from monorepos carry an optional sub-path
+    // that points at the directory to pack. Mirrors pnpm's
+    // `TarballResolution.path`.
+    let yaml = text_block! {
+        "tarball: https://codeload.github.com/foo/bar/tar.gz/abc1234"
+        "gitHosted: true"
+        "path: packages/sub"
+    };
+    let received: LockfileResolution = serde_saphyr::from_str(yaml).unwrap();
+    let expected = LockfileResolution::Tarball(TarballResolution {
+        tarball: "https://codeload.github.com/foo/bar/tar.gz/abc1234".to_string(),
+        integrity: None,
+        git_hosted: Some(true),
+        path: Some("packages/sub".to_string()),
+    });
+    assert_eq!(received, expected);
+}
+
+#[test]
 fn serialize_tarball_resolution_with_git_hosted() {
     let resolution = LockfileResolution::Tarball(TarballResolution {
         tarball: "https://codeload.github.com/foo/bar/tar.gz/abc1234".to_string(),
         integrity: integrity("sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==").into(),
         git_hosted: Some(true),
+        path: None,
     });
     let received = serialize_yaml::to_string(&resolution).unwrap();
     let received = received.trim();

--- a/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/crates/package-manager/src/install_package_by_snapshot.rs
@@ -6,7 +6,7 @@ use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_config::Config;
 use pacquet_executor::ScriptsPrependNodePath as ExecScriptsPrependNodePath;
-use pacquet_git_fetcher::{GitFetchOutput, GitFetcher, GitFetcherError};
+use pacquet_git_fetcher::{GitFetchOutput, GitFetcher, GitFetcherError, GitHostedTarballFetcher};
 use pacquet_lockfile::{LockfileResolution, PackageKey, PackageMetadata, SnapshotEntry};
 use pacquet_network::ThrottledClient;
 use pacquet_reporter::{LogEvent, LogLevel, ProgressLog, ProgressMessage, Reporter};
@@ -104,11 +104,30 @@ impl<'a> InstallPackageBySnapshot<'a> {
         let package_id = package_key.without_peer().to_string();
         emit_progress_resolved::<R>(&package_id, requester);
 
+        // Adapter shared between the `Git` arm below and the
+        // `gitHosted: true` post-pass on tarballs. Named local so
+        // both fetchers can borrow it across their `.await` without
+        // depending on temporary-lifetime extension.
+        //
+        // `AllowBuildPolicy::check` returns `None` when the package
+        // is neither allow-listed nor deny-listed. Default-deny
+        // (`None → false`) matches pnpm v11's policy: build scripts
+        // have to be explicitly opted in to run.
+        let allow_build_closure =
+            |name: &str, version: &str| allow_build_policy.check(name, version).unwrap_or(false);
+        let scripts_prepend_node_path = match config.scripts_prepend_node_path {
+            pacquet_config::ScriptsPrependNodePath::Always => ExecScriptsPrependNodePath::Always,
+            pacquet_config::ScriptsPrependNodePath::Never => ExecScriptsPrependNodePath::Never,
+            pacquet_config::ScriptsPrependNodePath::WarnOnly => {
+                ExecScriptsPrependNodePath::WarnOnly
+            }
+        };
+
         let cas_paths: HashMap<String, PathBuf> = match &metadata.resolution {
             LockfileResolution::Tarball(_) | LockfileResolution::Registry(_) => {
                 let (tarball_url, integrity) =
                     tarball_url_and_integrity(&metadata.resolution, package_key, config)?;
-                DownloadTarballToStore {
+                let raw_cas_paths = DownloadTarballToStore {
                     http_client,
                     store_dir: &config.store_dir,
                     store_index: store_index.cloned(),
@@ -125,7 +144,41 @@ impl<'a> InstallPackageBySnapshot<'a> {
                 }
                 .run_without_mem_cache::<R>()
                 .await
-                .map_err(InstallPackageBySnapshotError::DownloadTarball)?
+                .map_err(InstallPackageBySnapshotError::DownloadTarball)?;
+
+                // Run the git-hosted prepare+packlist pass for
+                // tarballs sourced from a git host. Mirrors pnpm's
+                // dispatch at `fetching/pick-fetcher/src/index.ts`:
+                // a `gitHosted: true` tarball routes through
+                // `gitHostedTarballFetcher` rather than the plain
+                // `remoteTarballFetcher`, because the host's archive
+                // endpoint doesn't run `prepare`/`prepublish*` and
+                // the file set typically needs packlist filtering.
+                if let LockfileResolution::Tarball(t) = &metadata.resolution
+                    && t.git_hosted == Some(true)
+                {
+                    let GitFetchOutput { cas_paths, built: _built } = GitHostedTarballFetcher {
+                        cas_paths: raw_cas_paths,
+                        path: t.path.as_deref(),
+                        allow_build: &allow_build_closure,
+                        ignore_scripts: false,
+                        unsafe_perm: config.unsafe_perm,
+                        user_agent: None,
+                        scripts_prepend_node_path,
+                        script_shell: None,
+                        node_execpath: None,
+                        npm_execpath: None,
+                        store_dir: &config.store_dir,
+                        package_id: &package_id,
+                        requester,
+                    }
+                    .run::<R>()
+                    .await
+                    .map_err(InstallPackageBySnapshotError::GitFetch)?;
+                    cas_paths
+                } else {
+                    raw_cas_paths
+                }
             }
             LockfileResolution::Directory(_) => {
                 return Err(InstallPackageBySnapshotError::UnsupportedResolution {
@@ -134,32 +187,6 @@ impl<'a> InstallPackageBySnapshot<'a> {
                 });
             }
             LockfileResolution::Git(git_resolution) => {
-                // Bind the closure to a named local before borrowing it
-                // into `GitFetcher.allow_build`. `&|...|` would create a
-                // reference to a temporary closure that has to outlive
-                // the `.await` below; routing through a `let` makes the
-                // owning storage explicit and removes any reliance on
-                // temporary-lifetime extension across an await point.
-                //
-                // `AllowBuildPolicy::check` returns `None` when the
-                // package is neither allow-listed nor deny-listed.
-                // Default-deny (`None → false`) matches pnpm v11's
-                // policy: build scripts have to be explicitly opted in
-                // to run.
-                let allow_build_closure = |name: &str, version: &str| {
-                    allow_build_policy.check(name, version).unwrap_or(false)
-                };
-                let scripts_prepend_node_path = match config.scripts_prepend_node_path {
-                    pacquet_config::ScriptsPrependNodePath::Always => {
-                        ExecScriptsPrependNodePath::Always
-                    }
-                    pacquet_config::ScriptsPrependNodePath::Never => {
-                        ExecScriptsPrependNodePath::Never
-                    }
-                    pacquet_config::ScriptsPrependNodePath::WarnOnly => {
-                        ExecScriptsPrependNodePath::WarnOnly
-                    }
-                };
                 let GitFetchOutput { cas_paths, built: _built } = GitFetcher {
                     repo: &git_resolution.repo,
                     commit: &git_resolution.commit,

--- a/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/crates/package-manager/src/install_package_by_snapshot.rs
@@ -76,8 +76,14 @@ pub enum InstallPackageBySnapshotError {
     #[diagnostic(code(pacquet_package_manager::unsupported_resolution))]
     UnsupportedResolution { package_key: String, resolution_kind: &'static str },
 
-    /// Failure from the git fetcher for a `type: git` resolution
-    /// (clone / checkout / preparePackage / CAS import).
+    /// Failure from either git fetcher: the git-CLI path for
+    /// `type: git` resolutions (clone / checkout / preparePackage /
+    /// CAS import) or the git-hosted-tarball post-pass for
+    /// `TarballResolution { gitHosted: true }` (materialize /
+    /// preparePackage / packlist / re-import). Both share the same
+    /// `GitFetcherError` taxonomy because they share `prepare_package`,
+    /// `packlist`, and the CAS-import helpers; the variant covers
+    /// every fetcher path that exits through `pacquet-git-fetcher`.
     #[diagnostic(transparent)]
     GitFetch(#[error(source)] GitFetcherError),
 }


### PR DESCRIPTION
## Summary

Builds on §B+D (#446). Adds the second half of the git-hosted install path: `TarballResolution { gitHosted: true }` lockfile entries — the ones whose tarballs land at `codeload.github.com` / `gitlab.com` / `bitbucket.org` archive endpoints — now run through a new `GitHostedTarballFetcher` after the existing `DownloadTarballToStore` settles their bytes into CAS.

Mirrors pnpm's [`gitHostedTarballFetcher.ts`](https://github.com/pnpm/pnpm/blob/94240bc046/fetching/tarball-fetcher/src/gitHostedTarballFetcher.ts):

1. Materialize the CAS-resident files into a writable temp dir (`fs::copy` per file — hardlinking here would let prepare scripts mutate shared CAS entries).
2. Run the existing `prepare_package` port that §B+D shipped — same `<pm>-install` + `prepublish` / `prepack` / `publish` dispatch, same `GIT_DEP_PREPARE_NOT_ALLOWED` gate.
3. Run the existing minimal `packlist` over the prepared tree to drop source maps, test fixtures, etc. that ship in the raw archive but not in the published file set.
4. Re-import the filtered file set back into CAS and hand the `HashMap<String, PathBuf>` to `CreateVirtualDirBySnapshot`.

### Shared `cas_io` module

The CAS-import helpers (`import_into_cas`, `is_file_executable`, `map_write_cas`) plus a new `materialize_into` lift out of `fetcher.rs` into a shared `cas_io` module so both fetchers consume the same code path. No public-API change — helpers stay `pub(crate)`.

`cas_io` also gains a `join_checked(root, rel)` helper that rejects absolute paths, `..` components, root, and drive-prefix components before joining, so a malicious tarball entry can't escape `target_dir` / `pkg_dir`. Errors surface as `GitFetcherError::Io(InvalidInput)`. Both `materialize_into` and `import_into_cas` route through it, taking `rel` directly (forward slashes are valid on every platform — `Path::components()` recognises both `/` and `\` on Windows — so no per-file `String` allocation is needed).

### Supporting changes

- `TarballResolution.path: Option<String>` mirrors pnpm's `TarballResolution.path` so a lockfile pinning a git-hosted tarball from a monorepo (`path: packages/sub`) deserializes without tripping `deny_unknown_fields`. The fetcher threads this through to `prepare_package`'s `safe_join_path` so prepare and packlist run inside the right sub-directory.
- The install dispatcher hoists the `allow_build` closure and the `ScriptsPrependNodePath` conversion above the resolution match so both the `Git` arm and the new `gitHosted: true` post-pass borrow from the same named locals — no temp closures across `.await`.
- `InstallPackageBySnapshotError::GitFetch`'s doc now spells out that the variant covers failures from both fetchers (the git-CLI path and the git-hosted-tarball post-pass), since both share the same `GitFetcherError` taxonomy.

## Out of scope (follow-ups for #436)

- Warm prefetch for git-hosted slots — neither fetcher writes `gitHostedStoreIndexKey` rows to `index.db` yet, so a re-install re-runs clone + prepare + packlist. Correct, but slow on the second run.
- Two-slot CAS layout (`${filesIndexFile}\traw` + final). Upstream optimizes "raw == prepared" by promoting the raw entry in place. Pacquet always re-imports today; hash-dedup means duplicate work but not duplicate storage.
- §E — full integration-test matrix in `plans/TEST_PORTING.md` 563-572.
- Real `npm-packlist` semantics (`.npmignore`, `.gitignore` layering, `bundleDependencies` walking).

## Test plan

- [x] `cargo nextest run -p pacquet-git-fetcher` — 41 tests pass:
      - 31 from §B+D (preferred-pm sniffer, MVP packlist, preparePackage decision logic, git-CLI fetcher integration).
      - 5 new `cas_io` tests for `join_checked` (accepts normal segments, strips `.`, rejects absolute paths, rejects mid-path `..`, and a `materialize_into` regression that asserts nothing lands outside the target on a poisoned `cas_paths` entry).
      - 5 new `GitHostedTarballFetcher` tests (pass-through, files-field filter, `GIT_DEP_PREPARE_NOT_ALLOWED`, CAS-isolation regression, monorepo sub-path).
- [x] `cargo nextest run -p pacquet-lockfile` — `TarballResolution { path }` deserialize and serialize round-trip.
- [x] `cargo nextest run -p pacquet-package-manager` — 148 tests still green after the dispatcher hoist.
- [x] `just ready` — 713 tests, 713 pass.
- [x] `cargo doc --no-deps --workspace --document-private-items` with `RUSTDOCFLAGS=-D warnings` — clean.
- [x] `taplo format --check`
- [x] `just dylint`

---
Written by an agent (Claude Code, claude-opus-4-7).
