### PR TITLE
feat(real-hoist): single-pass parent-wins hoist (#438)

### DIFF
--- a/crates/real-hoist/src/lib.rs
+++ b/crates/real-hoist/src/lib.rs
@@ -16,7 +16,7 @@ use miette::Diagnostic;
 use pacquet_lockfile::{Lockfile, PkgName, PkgNameVerPeer, ProjectSnapshot, SnapshotEntry};
 use std::{
     cell::RefCell,
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque},
     rc::Rc,
 };
 
@@ -498,19 +498,143 @@ fn percent_encode_path(s: &str) -> String {
     out
 }
 
-/// Stub for the `@yarnpkg/nm` hoist algorithm. Walks the input tree
-/// and returns it in `HoisterResult` shape unchanged — no actual
-/// hoisting happens. The real algorithm replaces this body.
+/// Pacquet's port of the `@yarnpkg/nm` hoist algorithm. Walks the
+/// input tree, deep-copies it into a `HoisterResult` shape, then
+/// pulls eligible descendants up to the root via single-pass BFS
+/// with parent-wins conflict resolution. Models the common case
+/// of pnpm's `nodeLinker: hoisted` install — every transitive
+/// dependency that doesn't collide with an already-hoisted name
+/// surfaces at the root, just like a flat `node_modules`.
+///
+/// What this models today:
+///
+/// * Free hoist: a transitive dep with no name collision at the
+///   root surfaces at the root.
+/// * Identity dedup: a dep reachable through multiple parents
+///   (same `Rc` thanks to the wrapper's `nodes` cache) collapses
+///   to one node at root.
+/// * Parent-wins on version conflict: when two distinct deps
+///   share an alias but resolve to different snapshot keys, the
+///   first one BFS reaches takes the root slot and the other
+///   stays under its parent.
+///
+/// What this does *not* model yet (each gated on later work
+/// because they require additional graph structure and tests):
+///
+/// * Peer-dependency constraints (`peer_names`) — packages that
+///   refuse to hoist past parents declaring them as peers.
+/// * Multi-round convergence — re-walking the tree to discover
+///   newly-hoistable deps after the first pass. The BFS does
+///   handle deep chains (`root → a → b → c` flattens in one
+///   pass), so the cases requiring true multi-round are limited
+///   to peer interactions.
+/// * `hoistingLimits` / `externalDependencies` knobs.
+/// * `dependencyKind` distinctions for workspaces and external
+///   soft links.
+///
+/// Matches the structural intent of upstream `hoistTo` at
+/// [hoist.ts:329][upstream] for the subset above.
+///
+/// [upstream]: https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L329
 fn nm_hoist(tree: &HoisterTree, _opts: &HoistOpts) -> HoisterResult {
     let mut memo: HashMap<*const HoisterTree, Rc<HoisterResult>> = HashMap::new();
-    // The root is fresh (no caller holds another Rc to it yet), so
-    // cloning the outer struct is cheap and only duplicates the
-    // top-level fields — the subtree children remain shared via the
-    // cloned RcByPtr values. Returning an owned `HoisterResult`
-    // (rather than `Rc<HoisterResult>`) keeps the wrapper's
-    // post-hoist `external_dependencies` filter from mutating the
-    // shared graph.
-    (*convert(tree, &mut memo)).clone()
+    let root = convert(tree, &mut memo);
+    hoist_into_root(&root);
+    // Returning an owned `HoisterResult` (rather than
+    // `Rc<HoisterResult>`) keeps the wrapper's post-hoist
+    // `external_dependencies` filter from mutating the shared graph.
+    // Cloning the outer struct duplicates only the top-level fields —
+    // the subtree children remain shared via the cloned `RcByPtr`
+    // values, so deep deps stay deduplicated.
+    (*root).clone()
+}
+
+/// Outcome of the per-child hoist decision at the root.
+enum AbsorbDecision {
+    /// Root's name slot is free; the child should be moved up to
+    /// the root.
+    Free,
+    /// Root already holds *this exact `Rc`* (the same node was
+    /// reachable through another parent path and got hoisted
+    /// earlier). The duplicate reference in the current parent
+    /// just needs to be removed.
+    SameNode,
+    /// Root's name slot is taken by a different `Rc` — a version
+    /// conflict. The child stays under its current parent.
+    Conflict,
+}
+
+/// Walk the result tree breadth-first and hoist every eligible
+/// descendant of `root` onto `root` itself. Single-pass: each node
+/// is visited once, and a descendant's children become hoist
+/// candidates as soon as the descendant itself is queued.
+fn hoist_into_root(root: &Rc<HoisterResult>) {
+    let root_ptr = Rc::as_ptr(root);
+    let mut visited: HashSet<*const HoisterResult> = HashSet::new();
+    let mut queue: VecDeque<Rc<HoisterResult>> = VecDeque::new();
+    queue.push_back(Rc::clone(root));
+
+    while let Some(node) = queue.pop_front() {
+        let node_ptr = Rc::as_ptr(&node);
+        if !visited.insert(node_ptr) {
+            continue;
+        }
+
+        // Snapshot the current children so we can mutate
+        // `node.dependencies` mid-iteration without invalidating the
+        // borrow. `RcByPtr::clone` just bumps refcounts.
+        let children: Vec<RcByPtr<HoisterResult>> =
+            node.dependencies.borrow().iter().cloned().collect();
+
+        let is_root_parent = Rc::ptr_eq(&node, root);
+
+        for child in children {
+            let child_ptr = Rc::as_ptr(&child.0);
+            if child_ptr == root_ptr {
+                // Back-edge to root via a cycle. Nothing to hoist.
+                continue;
+            }
+
+            // Decide what to do with this child by inspecting root's
+            // current direct deps. Read in its own scope so the
+            // borrow drops before any subsequent mutation.
+            let decision = {
+                let root_deps = root.dependencies.borrow();
+                match root_deps.iter().find(|d| d.0.name == child.0.name) {
+                    None => AbsorbDecision::Free,
+                    Some(existing) if Rc::ptr_eq(&existing.0, &child.0) => AbsorbDecision::SameNode,
+                    Some(_) => AbsorbDecision::Conflict,
+                }
+            };
+
+            if !is_root_parent {
+                match decision {
+                    AbsorbDecision::Free => {
+                        node.dependencies.borrow_mut().shift_remove(&child);
+                        root.dependencies.borrow_mut().insert(child.clone());
+                    }
+                    AbsorbDecision::SameNode => {
+                        // The shared `Rc` is already at root; just
+                        // strip the duplicate reference at this
+                        // parent so the deeper copy disappears.
+                        node.dependencies.borrow_mut().shift_remove(&child);
+                    }
+                    AbsorbDecision::Conflict => {
+                        // Stays at the current parent. The version
+                        // already at root wins the slot.
+                    }
+                }
+            }
+
+            // Queue the child so its own descendants get a chance.
+            // This is what lets deep chains (`root → a → b → c`)
+            // flatten in a single BFS pass: by the time `b` is
+            // dequeued it's already a direct child of root, so
+            // `c` is evaluated against root's slot, not against
+            // `a`'s slot.
+            queue.push_back(Rc::clone(&child.0));
+        }
+    }
 }
 
 fn convert(

--- a/crates/real-hoist/src/lib.rs
+++ b/crates/real-hoist/src/lib.rs
@@ -581,6 +581,29 @@ fn percent_encode_path(s: &str) -> String {
     out
 }
 
+/// Walk the constructed tree and return the first node whose
+/// `peer_names` is non-empty as an `UnsupportedPeerDependency`
+/// error. Returns `None` when the tree is peer-free.
+fn find_first_peer_constrained(root: &Rc<HoisterTree>) -> Option<HoistError> {
+    let mut visited: HashSet<*const HoisterTree> = HashSet::new();
+    let mut stack: Vec<Rc<HoisterTree>> = vec![Rc::clone(root)];
+    while let Some(node) = stack.pop() {
+        if !visited.insert(Rc::as_ptr(&node)) {
+            continue;
+        }
+        if !node.peer_names.is_empty() {
+            return Some(HoistError::UnsupportedPeerDependency {
+                ident: node.reference.clone(),
+                peers: node.peer_names.clone(),
+            });
+        }
+        for dep in node.dependencies.borrow().iter() {
+            stack.push(Rc::clone(&dep.0));
+        }
+    }
+    None
+}
+
 /// Pacquet's port of the `@yarnpkg/nm` hoist algorithm. Walks the
 /// input tree, deep-copies it into a `HoisterResult` shape, then
 /// pulls eligible descendants up to the root via single-pass BFS
@@ -605,7 +628,10 @@ fn percent_encode_path(s: &str) -> String {
 /// because they require additional graph structure and tests):
 ///
 /// * Peer-dependency constraints (`peer_names`) — packages that
-///   refuse to hoist past parents declaring them as peers.
+///   refuse to hoist past parents declaring them as peers. The
+///   wrapper refuses lockfiles that contain any peer-constrained
+///   nodes via `HoistError::UnsupportedPeerDependency`, so this
+///   function only ever sees peer-free input today.
 /// * Multi-round convergence — re-walking the tree to discover
 ///   newly-hoistable deps after the first pass. The BFS does
 ///   handle deep chains (`root → a → b → c` flattens in one
@@ -619,29 +645,6 @@ fn percent_encode_path(s: &str) -> String {
 /// [hoist.ts:329][upstream] for the subset above.
 ///
 /// [upstream]: https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L329
-/// Walk the constructed tree and return the first node whose
-/// `peer_names` is non-empty as an `UnsupportedPeerDependency`
-/// error. Returns `None` when the tree is peer-free.
-fn find_first_peer_constrained(root: &Rc<HoisterTree>) -> Option<HoistError> {
-    let mut visited: HashSet<*const HoisterTree> = HashSet::new();
-    let mut stack: Vec<Rc<HoisterTree>> = vec![Rc::clone(root)];
-    while let Some(node) = stack.pop() {
-        if !visited.insert(Rc::as_ptr(&node)) {
-            continue;
-        }
-        if !node.peer_names.is_empty() {
-            return Some(HoistError::UnsupportedPeerDependency {
-                ident: node.reference.clone(),
-                peers: node.peer_names.clone(),
-            });
-        }
-        for dep in node.dependencies.borrow().iter() {
-            stack.push(Rc::clone(&dep.0));
-        }
-    }
-    None
-}
-
 fn nm_hoist(tree: &HoisterTree, _opts: &HoistOpts) -> HoisterResult {
     let mut memo: HashMap<*const HoisterTree, Rc<HoisterResult>> = HashMap::new();
     let root = convert(tree, &mut memo);

--- a/crates/real-hoist/src/lib.rs
+++ b/crates/real-hoist/src/lib.rs
@@ -160,6 +160,64 @@ pub enum HoistError {
         /// resolve.
         pkg_key: String,
     },
+    /// A package in the lockfile declares peer dependencies (or
+    /// transitive peer dependencies). The hoist algorithm doesn't
+    /// model peer-dependency constraints yet, so it would freely
+    /// hoist this node past parents that supply the peer — a
+    /// silent shadowing pnpm would reject. Refuse upfront rather
+    /// than emit a wrong layout.
+    #[display("hoister cannot yet model peer dependencies (package {ident}, peers: {peers:?})")]
+    #[diagnostic(
+        code(ERR_PACQUET_HOIST_UNSUPPORTED_PEER),
+        help(
+            "the hoisted node-linker requires peer-aware hoisting; \
+             this support is staged for a later sub-slice of #438."
+        )
+    )]
+    UnsupportedPeerDependency {
+        /// The snapshot key of the offending package.
+        ident: String,
+        /// The peer / transitive-peer names that block the hoist.
+        peers: BTreeSet<String>,
+    },
+    /// The caller passed a non-empty `hoisting_limits` map. The
+    /// hoist algorithm doesn't enforce limits yet, so flattening
+    /// would violate the borders the caller asked to keep. Refuse
+    /// upfront.
+    #[display(
+        "hoister cannot yet enforce `hoisting_limits`; the supplied map is non-empty ({len} entries)"
+    )]
+    #[diagnostic(
+        code(ERR_PACQUET_HOIST_UNSUPPORTED_HOISTING_LIMITS),
+        help(
+            "support for `hoistingLimits` is staged for a later sub-slice of #438; \
+             pass an empty map for now."
+        )
+    )]
+    UnsupportedHoistingLimits {
+        /// How many entries the caller supplied. Carries no
+        /// semantic value beyond debug; if zero we wouldn't have
+        /// fired.
+        len: usize,
+    },
+    /// The lockfile contains more than one importer. The hoist
+    /// algorithm doesn't yet support workspace projects (multi-
+    /// importer hoist trees with `workspace:` references). Refuse
+    /// upfront rather than build a single-importer layout that
+    /// pnpm would reject.
+    #[display("hoister cannot yet model workspace lockfiles; extra importers: {extra_importers:?}")]
+    #[diagnostic(
+        code(ERR_PACQUET_HOIST_UNSUPPORTED_WORKSPACE),
+        help(
+            "multi-importer (workspace) lockfile support is staged for a later sub-slice of #438; \
+             single-importer lockfiles with only the `.` importer key work today."
+        )
+    )]
+    UnsupportedWorkspace {
+        /// The importer IDs the lockfile carries beyond the root
+        /// `.` importer.
+        extra_importers: Vec<String>,
+    },
 }
 
 /// Identity-hashed wrapper around `Rc<T>`. Two `RcByPtr` values are
@@ -224,6 +282,22 @@ impl<T> From<Rc<T>> for RcByPtr<T> {
 ///
 /// [upstream]: https://github.com/pnpm/pnpm/blob/94240bc0464196bd52f7006b97f6d9a43df34633/installing/linking/real-hoist/src/index.ts
 pub fn hoist(lockfile: &Lockfile, opts: &HoistOpts) -> Result<HoisterResult, HoistError> {
+    // Refuse upfront for inputs the algorithm doesn't yet model.
+    // Better an explicit error than a silently-invented layout
+    // pnpm would reject.
+    if !opts.hoisting_limits.is_empty() {
+        return Err(HoistError::UnsupportedHoistingLimits { len: opts.hoisting_limits.len() });
+    }
+    let extra_importers: Vec<String> = lockfile
+        .importers
+        .keys()
+        .filter(|k| k.as_str() != Lockfile::ROOT_IMPORTER_KEY)
+        .cloned()
+        .collect();
+    if !extra_importers.is_empty() {
+        return Err(HoistError::UnsupportedWorkspace { extra_importers });
+    }
+
     let mut nodes: HashMap<String, Rc<HoisterTree>> = HashMap::new();
 
     let mut root_children: IndexSet<RcByPtr<HoisterTree>> = IndexSet::new();
@@ -289,6 +363,15 @@ pub fn hoist(lockfile: &Lockfile, opts: &HoistOpts) -> Result<HoisterResult, Hoi
         hoist_priority: 0,
         dependencies: RefCell::new(root_children),
     });
+
+    // Scan the constructed tree for peer-constrained packages.
+    // `peer_names` only gets populated when the lockfile's
+    // `packages` map declares `peerDependencies` (or
+    // `transitive_peer_dependencies` on a snapshot), so a peer-
+    // free lockfile passes the guard unchanged.
+    if let Some(err) = find_first_peer_constrained(&root_node) {
+        return Err(err);
+    }
 
     let result = nm_hoist(&root_node, opts);
 
@@ -536,6 +619,29 @@ fn percent_encode_path(s: &str) -> String {
 /// [hoist.ts:329][upstream] for the subset above.
 ///
 /// [upstream]: https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L329
+/// Walk the constructed tree and return the first node whose
+/// `peer_names` is non-empty as an `UnsupportedPeerDependency`
+/// error. Returns `None` when the tree is peer-free.
+fn find_first_peer_constrained(root: &Rc<HoisterTree>) -> Option<HoistError> {
+    let mut visited: HashSet<*const HoisterTree> = HashSet::new();
+    let mut stack: Vec<Rc<HoisterTree>> = vec![Rc::clone(root)];
+    while let Some(node) = stack.pop() {
+        if !visited.insert(Rc::as_ptr(&node)) {
+            continue;
+        }
+        if !node.peer_names.is_empty() {
+            return Some(HoistError::UnsupportedPeerDependency {
+                ident: node.reference.clone(),
+                peers: node.peer_names.clone(),
+            });
+        }
+        for dep in node.dependencies.borrow().iter() {
+            stack.push(Rc::clone(&dep.0));
+        }
+    }
+    None
+}
+
 fn nm_hoist(tree: &HoisterTree, _opts: &HoistOpts) -> HoisterResult {
     let mut memo: HashMap<*const HoisterTree, Rc<HoisterResult>> = HashMap::new();
     let root = convert(tree, &mut memo);

--- a/crates/real-hoist/src/lib.rs
+++ b/crates/real-hoist/src/lib.rs
@@ -568,11 +568,19 @@ enum AbsorbDecision {
 /// descendant of `root` onto `root` itself. Single-pass: each node
 /// is visited once, and a descendant's children become hoist
 /// candidates as soon as the descendant itself is queued.
+///
+/// Maintains a side `HashMap<name, RcByPtr>` mirror of root's
+/// direct deps so the per-edge "is this name taken at root?" check
+/// stays O(1). Without the index a graph with `N` packages all
+/// hoisting freely would do O(N²) `IndexSet` scans.
 fn hoist_into_root(root: &Rc<HoisterResult>) {
     let root_ptr = Rc::as_ptr(root);
     let mut visited: HashSet<*const HoisterResult> = HashSet::new();
     let mut queue: VecDeque<Rc<HoisterResult>> = VecDeque::new();
     queue.push_back(Rc::clone(root));
+
+    let mut root_index: HashMap<String, RcByPtr<HoisterResult>> =
+        root.dependencies.borrow().iter().map(|d| (d.0.name.clone(), d.clone())).collect();
 
     while let Some(node) = queue.pop_front() {
         let node_ptr = Rc::as_ptr(&node);
@@ -595,16 +603,10 @@ fn hoist_into_root(root: &Rc<HoisterResult>) {
                 continue;
             }
 
-            // Decide what to do with this child by inspecting root's
-            // current direct deps. Read in its own scope so the
-            // borrow drops before any subsequent mutation.
-            let decision = {
-                let root_deps = root.dependencies.borrow();
-                match root_deps.iter().find(|d| d.0.name == child.0.name) {
-                    None => AbsorbDecision::Free,
-                    Some(existing) if Rc::ptr_eq(&existing.0, &child.0) => AbsorbDecision::SameNode,
-                    Some(_) => AbsorbDecision::Conflict,
-                }
+            let decision = match root_index.get(&child.0.name) {
+                None => AbsorbDecision::Free,
+                Some(existing) if Rc::ptr_eq(&existing.0, &child.0) => AbsorbDecision::SameNode,
+                Some(_) => AbsorbDecision::Conflict,
             };
 
             if !is_root_parent {
@@ -612,6 +614,7 @@ fn hoist_into_root(root: &Rc<HoisterResult>) {
                     AbsorbDecision::Free => {
                         node.dependencies.borrow_mut().shift_remove(&child);
                         root.dependencies.borrow_mut().insert(child.clone());
+                        root_index.insert(child.0.name.clone(), child.clone());
                     }
                     AbsorbDecision::SameNode => {
                         // The shared `Rc` is already at root; just

--- a/crates/real-hoist/src/lib.rs
+++ b/crates/real-hoist/src/lib.rs
@@ -170,8 +170,9 @@ pub enum HoistError {
     #[diagnostic(
         code(ERR_PACQUET_HOIST_UNSUPPORTED_PEER),
         help(
-            "the hoisted node-linker requires peer-aware hoisting; \
-             this support is staged for a later sub-slice of #438."
+            "the hoister doesn't yet model peer-dependency constraints; \
+             pass a lockfile whose packages declare no `peerDependencies` \
+             (and whose snapshots carry no `transitivePeerDependencies`)."
         )
     )]
     UnsupportedPeerDependency {
@@ -189,10 +190,7 @@ pub enum HoistError {
     )]
     #[diagnostic(
         code(ERR_PACQUET_HOIST_UNSUPPORTED_HOISTING_LIMITS),
-        help(
-            "support for `hoistingLimits` is staged for a later sub-slice of #438; \
-             pass an empty map for now."
-        )
+        help("the hoister doesn't yet enforce `hoistingLimits`; pass an empty map.")
     )]
     UnsupportedHoistingLimits {
         /// How many entries the caller supplied. Carries no
@@ -209,8 +207,10 @@ pub enum HoistError {
     #[diagnostic(
         code(ERR_PACQUET_HOIST_UNSUPPORTED_WORKSPACE),
         help(
-            "multi-importer (workspace) lockfile support is staged for a later sub-slice of #438; \
-             single-importer lockfiles with only the `.` importer key work today."
+            "the hoister doesn't yet model multi-importer (workspace) lockfiles; \
+             pass a lockfile that carries only the `.` importer. \
+             pacquet's wider install path supports workspaces — see \
+             `SymlinkDirectDependencies` for the isolated-linker case."
         )
     )]
     UnsupportedWorkspace {

--- a/crates/real-hoist/src/tests.rs
+++ b/crates/real-hoist/src/tests.rs
@@ -115,7 +115,8 @@ fn one_transitive_dep_hoists_to_root() {
     let result = hoist(&lockfile, &HoistOpts::default()).expect("happy hoist should succeed");
     assert_eq!(result.name, ".");
     let root_children = result.dependencies.borrow();
-    let names: Vec<&str> = root_children.iter().map(|d| d.0.name.as_str()).collect();
+    let mut names: Vec<&str> = root_children.iter().map(|d| d.0.name.as_str()).collect();
+    names.sort();
     assert_eq!(names, ["a", "b"], "both a and b sit at root: {result:#?}");
     let a = root_children.iter().find(|d| d.0.name == "a").unwrap().0.clone();
     assert!(a.dependencies.borrow().is_empty(), "a's b moved to root: {a:#?}");
@@ -167,18 +168,34 @@ fn diamond_dep_hoists_once_to_root() {
     let mut names: Vec<&str> = root_children.iter().map(|d| d.0.name.as_str()).collect();
     names.sort();
     assert_eq!(names, ["a", "b", "c"], "diamond flattens at root: {result:#?}");
-    // Count the unique `b` allocations: exactly one because the
-    // wrapper deduped by identity and the hoist preserved that
-    // identity instead of allocating a second copy.
-    let mut all_bs: Vec<Rc<HoisterResult>> = Vec::new();
-    if let Some(b) = root_children.iter().find(|d| d.0.name == "b") {
-        all_bs.push(b.0.clone());
-    }
     let a = root_children.iter().find(|d| d.0.name == "a").unwrap().0.clone();
     let c = root_children.iter().find(|d| d.0.name == "c").unwrap().0.clone();
     assert!(a.dependencies.borrow().is_empty(), "a stripped of its b: {a:#?}");
     assert!(c.dependencies.borrow().is_empty(), "c stripped of its b: {c:#?}");
-    assert_eq!(all_bs.len(), 1, "b is unique");
+
+    // Walk the whole result graph and collect every distinct
+    // allocation whose `name == "b"`. The wrapper deduped a@1's b
+    // and c@1's b into one `Rc<HoisterResult>` (the diamond shares
+    // by identity), and the hoist must preserve that identity
+    // rather than allocating a second copy somewhere — so the set
+    // of pointers we collect has exactly one entry.
+    let mut b_ptrs: std::collections::HashSet<*const HoisterResult> =
+        std::collections::HashSet::new();
+    let mut stack: Vec<Rc<HoisterResult>> = root_children.iter().map(|d| d.0.clone()).collect();
+    let mut walked: std::collections::HashSet<*const HoisterResult> =
+        std::collections::HashSet::new();
+    while let Some(node) = stack.pop() {
+        if !walked.insert(Rc::as_ptr(&node)) {
+            continue;
+        }
+        if node.name == "b" {
+            b_ptrs.insert(Rc::as_ptr(&node));
+        }
+        for d in node.dependencies.borrow().iter() {
+            stack.push(d.0.clone());
+        }
+    }
+    assert_eq!(b_ptrs.len(), 1, "exactly one `b` allocation across the entire result graph");
 }
 
 /// Version conflict: `root → {a, c}` with `a → b@1` and
@@ -227,17 +244,22 @@ fn version_conflict_keeps_loser_at_parent() {
     names.sort();
     assert_eq!(names, ["a", "b", "c"], "root has a, c, and one b");
     let b_at_root = root_children.iter().find(|d| d.0.name == "b").unwrap().0.clone();
-    let b_ref = b_at_root.references.borrow().iter().next().cloned();
     // The first BFS visit from root iterates root's direct deps in
     // alias order (`a` then `c`), so `a@1`'s `b@1.0.0` reaches
-    // root first and wins the slot.
-    assert_eq!(b_ref.as_deref(), Some("b@1.0.0"), "first BFS visitor wins root slot");
+    // root first and wins the slot. Assert membership (not
+    // iteration-order-derived equality) so the test stays focused
+    // on which reference is present, not on which one happens to
+    // come back first from the set.
+    let b_refs = b_at_root.references.borrow();
+    assert!(b_refs.contains("b@1.0.0"), "first BFS visitor wins root slot: {b_refs:?}");
+    assert_eq!(b_refs.len(), 1, "no other reference accumulated yet: {b_refs:?}");
     // `c`'s `b@2` remains under `c`.
     let c = root_children.iter().find(|d| d.0.name == "c").unwrap().0.clone();
     let c_kids = c.dependencies.borrow();
     assert_eq!(c_kids.len(), 1, "c kept its conflicting b@2");
-    let b_under_c = &c_kids[0];
-    assert_eq!(b_under_c.0.references.borrow().iter().next().cloned().as_deref(), Some("b@2.0.0"));
+    let b_under_c_refs = c_kids[0].0.references.borrow();
+    assert!(b_under_c_refs.contains("b@2.0.0"), "loser stays under c: {b_under_c_refs:?}");
+    assert_eq!(b_under_c_refs.len(), 1);
 }
 
 /// Deep linear chain `root → a → b → c → d` flattens to
@@ -391,11 +413,12 @@ fn transitive_npm_alias_resolves_target_snapshot() {
         .clone();
     assert_eq!(aliased.name, "aliased-name");
     assert_eq!(aliased.ident_name, "real-pkg");
-    assert_eq!(
-        aliased.references.borrow().iter().next().map(String::as_str),
-        Some("real-pkg@2.0.0"),
-        "reference is the resolved snapshot key, not the alias",
+    let refs = aliased.references.borrow();
+    assert!(
+        refs.contains("real-pkg@2.0.0"),
+        "reference is the resolved snapshot key, not the alias: {refs:?}",
     );
+    assert_eq!(refs.len(), 1);
     let host = root_children.iter().find(|d| d.0.name == "host").unwrap().0.clone();
     assert!(host.dependencies.borrow().is_empty(), "host stripped of its aliased dep: {host:#?}");
 }

--- a/crates/real-hoist/src/tests.rs
+++ b/crates/real-hoist/src/tests.rs
@@ -64,8 +64,10 @@ fn hoist_throws_on_broken_lockfile() {
     };
 
     let err = hoist(&lockfile, &HoistOpts::default()).expect_err("missing snapshot should error");
-    let HoistError::LockfileMissingDependency { pkg_key } = err;
-    assert_eq!(pkg_key, "foo@1.0.0");
+    match err {
+        HoistError::LockfileMissingDependency { pkg_key } => assert_eq!(pkg_key, "foo@1.0.0"),
+        other => panic!("expected LockfileMissingDependency, got {other:?}"),
+    }
 }
 
 /// An empty lockfile (no importers at all) hoists to an empty
@@ -421,4 +423,115 @@ fn transitive_npm_alias_resolves_target_snapshot() {
     assert_eq!(refs.len(), 1);
     let host = root_children.iter().find(|d| d.0.name == "host").unwrap().0.clone();
     assert!(host.dependencies.borrow().is_empty(), "host stripped of its aliased dep: {host:#?}");
+}
+
+/// A package with `peer_dependencies` declared in the lockfile's
+/// `packages:` map must surface `UnsupportedPeerDependency` rather
+/// than silently hoist past parents that supply the peer. The
+/// algorithm doesn't model peer constraints today; refusing
+/// upfront keeps a future caller from getting a wrong layout.
+#[test]
+fn peer_dependency_in_lockfile_surfaces_unsupported() {
+    use pacquet_lockfile::{LockfileResolution, PackageMetadata, TarballResolution};
+    let mut importers = HashMap::new();
+    let mut root_deps = ResolvedDependencyMap::new();
+    root_deps.insert(pkg_name("widget"), resolved_dep("1.0.0"));
+    importers.insert(
+        Lockfile::ROOT_IMPORTER_KEY.to_string(),
+        ProjectSnapshot { dependencies: Some(root_deps), ..ProjectSnapshot::default() },
+    );
+
+    // `widget@1.0.0` declares `react` as a peer dep — the
+    // `packages:` map carries that information at the
+    // `name@version` (peer-stripped) key.
+    let mut packages = HashMap::new();
+    let mut peer_deps = HashMap::new();
+    peer_deps.insert("react".to_string(), "^18".to_string());
+    packages.insert(
+        dep_key("widget", "1.0.0").without_peer(),
+        PackageMetadata {
+            resolution: LockfileResolution::Tarball(TarballResolution {
+                tarball: "https://example.invalid/widget-1.0.0.tgz".to_string(),
+                integrity: None,
+                git_hosted: None,
+            }),
+            engines: None,
+            cpu: None,
+            os: None,
+            libc: None,
+            deprecated: None,
+            has_bin: None,
+            prepare: None,
+            bundled_dependencies: None,
+            peer_dependencies: Some(peer_deps),
+            peer_dependencies_meta: None,
+        },
+    );
+
+    let mut snapshots = HashMap::new();
+    snapshots.insert(dep_key("widget", "1.0.0"), SnapshotEntry::default());
+
+    let lockfile = Lockfile {
+        lockfile_version: lockfile_version(),
+        settings: None,
+        overrides: None,
+        importers,
+        packages: Some(packages),
+        snapshots: Some(snapshots),
+    };
+
+    let err = hoist(&lockfile, &HoistOpts::default()).expect_err("peer dep should bail");
+    match err {
+        HoistError::UnsupportedPeerDependency { ident, peers } => {
+            assert_eq!(ident, "widget@1.0.0", "carries the offending ident: {ident}");
+            assert!(peers.contains("react"), "carries the peer name set: {peers:?}");
+        }
+        other => panic!("expected UnsupportedPeerDependency, got {other:?}"),
+    }
+}
+
+/// Non-empty `hoisting_limits` surfaces `UnsupportedHoistingLimits`.
+/// The algorithm doesn't honor limits today, so flattening past
+/// them would silently violate the borders the caller asked to
+/// keep.
+#[test]
+fn non_empty_hoisting_limits_surfaces_unsupported() {
+    let lockfile = empty_lockfile();
+    let mut opts = HoistOpts::default();
+    opts.hoisting_limits.insert(".@".to_string(), Default::default());
+
+    let err = hoist(&lockfile, &opts).expect_err("hoisting_limits should bail");
+    match err {
+        HoistError::UnsupportedHoistingLimits { len } => assert_eq!(len, 1),
+        other => panic!("expected UnsupportedHoistingLimits, got {other:?}"),
+    }
+}
+
+/// A lockfile with importers beyond `.` (a workspace) surfaces
+/// `UnsupportedWorkspace`. Multi-importer hoisting requires
+/// workspace-aware traversal and a different output shape.
+#[test]
+fn multi_importer_lockfile_surfaces_unsupported_workspace() {
+    let mut importers = HashMap::new();
+    importers.insert(Lockfile::ROOT_IMPORTER_KEY.to_string(), ProjectSnapshot::default());
+    importers.insert("packages/foo".to_string(), ProjectSnapshot::default());
+    importers.insert("packages/bar".to_string(), ProjectSnapshot::default());
+
+    let lockfile = Lockfile {
+        lockfile_version: lockfile_version(),
+        settings: None,
+        overrides: None,
+        importers,
+        packages: None,
+        snapshots: None,
+    };
+
+    let err = hoist(&lockfile, &HoistOpts::default()).expect_err("workspace should bail");
+    match err {
+        HoistError::UnsupportedWorkspace { mut extra_importers } => {
+            extra_importers.sort();
+            assert_eq!(extra_importers, vec!["packages/bar", "packages/foo"]);
+        }
+        other => panic!("expected UnsupportedWorkspace, got {other:?}"),
+    }
 }

--- a/crates/real-hoist/src/tests.rs
+++ b/crates/real-hoist/src/tests.rs
@@ -1,4 +1,4 @@
-use super::{HoistError, HoistOpts, hoist};
+use super::{HoistError, HoistOpts, HoisterResult, hoist};
 use pacquet_lockfile::{
     ComVer, Lockfile, LockfileSettings, LockfileVersion, PkgName, PkgNameVerPeer, PkgVerPeer,
     ProjectSnapshot, ResolvedDependencyMap, ResolvedDependencySpec, SnapshotDepRef, SnapshotEntry,
@@ -80,15 +80,12 @@ fn empty_lockfile_yields_empty_root() {
     assert!(result.dependencies.borrow().is_empty(), "no importers means no children at the root");
 }
 
-/// A minimal lockfile with one direct dependency and one
-/// transitive: `root → a@1 → b@1`. With the stub `nm_hoist` no
-/// hoisting happens, so the result must have `a` as the only
-/// root child and `b` under it. Pins the current shape so that
-/// when the stub is replaced with the real algorithm the tree
-/// changing to `root → {a, b}` is an observable diff in this
-/// test rather than a silent behaviour change elsewhere.
+/// `root → a → b` collapses to `root → {a, b}` because `b` has no
+/// name conflict at root. Pins the simplest hoisting case: a
+/// single transitive dep surfaces at the root and its old parent
+/// no longer carries it.
 #[test]
-fn one_transitive_dep_appears_under_its_parent_in_the_stub() {
+fn one_transitive_dep_hoists_to_root() {
     let mut importers = HashMap::new();
     let mut root_deps = ResolvedDependencyMap::new();
     root_deps.insert(pkg_name("a"), resolved_dep("1.0.0"));
@@ -118,23 +115,18 @@ fn one_transitive_dep_appears_under_its_parent_in_the_stub() {
     let result = hoist(&lockfile, &HoistOpts::default()).expect("happy hoist should succeed");
     assert_eq!(result.name, ".");
     let root_children = result.dependencies.borrow();
-    assert_eq!(root_children.len(), 1, "root has one child: {result:#?}");
-    let a = root_children[0].0.clone();
-    assert_eq!(a.name, "a");
-    let a_children = a.dependencies.borrow();
-    assert_eq!(a_children.len(), 1, "a has one child under the stub: {a:#?}");
-    let b = a_children[0].0.clone();
-    assert_eq!(b.name, "b");
-    assert!(b.dependencies.borrow().is_empty(), "b has no transitive deps");
+    let names: Vec<&str> = root_children.iter().map(|d| d.0.name.as_str()).collect();
+    assert_eq!(names, ["a", "b"], "both a and b sit at root: {result:#?}");
+    let a = root_children.iter().find(|d| d.0.name == "a").unwrap().0.clone();
+    assert!(a.dependencies.borrow().is_empty(), "a's b moved to root: {a:#?}");
 }
 
-/// Two importers pointing at the same package version share a
-/// single `HoisterTree` node by identity — same as JS's
-/// `Set<HoisterTree>` semantics. Pinning this stops a future
-/// refactor of `build_dep_node`'s `nodes` cache from silently
-/// breaking the dedup that the real hoist algorithm relies on.
+/// Diamond dependency `root → {a, c}` with both `a → b@1` and
+/// `c → b@1` (same `Rc` thanks to the wrapper's identity dedup).
+/// After hoist, `b` appears once at root and its old parents
+/// `a` and `c` carry no transitive deps.
 #[test]
-fn shared_dep_via_two_root_paths_is_one_node() {
+fn diamond_dep_hoists_once_to_root() {
     let mut importers = HashMap::new();
     let mut root_deps = ResolvedDependencyMap::new();
     root_deps.insert(pkg_name("a"), resolved_dep("1.0.0"));
@@ -144,7 +136,8 @@ fn shared_dep_via_two_root_paths_is_one_node() {
         ProjectSnapshot { dependencies: Some(root_deps), ..ProjectSnapshot::default() },
     );
 
-    // Both a@1 and c@1 depend on b@1.
+    // Both a@1 and c@1 depend on b@1 — same dep_key → same Rc in
+    // the input HoisterTree, same Rc in the result graph.
     let mut snapshots = HashMap::new();
     let mut a_deps = HashMap::new();
     a_deps.insert(pkg_name("b"), SnapshotDepRef::Plain(ver_peer("1.0.0")));
@@ -171,16 +164,135 @@ fn shared_dep_via_two_root_paths_is_one_node() {
 
     let result = hoist(&lockfile, &HoistOpts::default()).expect("hoist should succeed");
     let root_children = result.dependencies.borrow();
-    let a = root_children.iter().find(|d| d.name == "a").expect("a present").0.clone();
-    let c = root_children.iter().find(|d| d.name == "c").expect("c present").0.clone();
-    let a_kids = a.dependencies.borrow();
+    let mut names: Vec<&str> = root_children.iter().map(|d| d.0.name.as_str()).collect();
+    names.sort();
+    assert_eq!(names, ["a", "b", "c"], "diamond flattens at root: {result:#?}");
+    // Count the unique `b` allocations: exactly one because the
+    // wrapper deduped by identity and the hoist preserved that
+    // identity instead of allocating a second copy.
+    let mut all_bs: Vec<Rc<HoisterResult>> = Vec::new();
+    if let Some(b) = root_children.iter().find(|d| d.0.name == "b") {
+        all_bs.push(b.0.clone());
+    }
+    let a = root_children.iter().find(|d| d.0.name == "a").unwrap().0.clone();
+    let c = root_children.iter().find(|d| d.0.name == "c").unwrap().0.clone();
+    assert!(a.dependencies.borrow().is_empty(), "a stripped of its b: {a:#?}");
+    assert!(c.dependencies.borrow().is_empty(), "c stripped of its b: {c:#?}");
+    assert_eq!(all_bs.len(), 1, "b is unique");
+}
+
+/// Version conflict: `root → {a, c}` with `a → b@1` and
+/// `c → b@2`. The first BFS reach wins root's `b` slot; the
+/// other version stays under its declaring parent.
+#[test]
+fn version_conflict_keeps_loser_at_parent() {
+    let mut importers = HashMap::new();
+    let mut root_deps = ResolvedDependencyMap::new();
+    root_deps.insert(pkg_name("a"), resolved_dep("1.0.0"));
+    root_deps.insert(pkg_name("c"), resolved_dep("1.0.0"));
+    importers.insert(
+        Lockfile::ROOT_IMPORTER_KEY.to_string(),
+        ProjectSnapshot { dependencies: Some(root_deps), ..ProjectSnapshot::default() },
+    );
+
+    // a@1 → b@1, c@1 → b@2.
+    let mut snapshots = HashMap::new();
+    let mut a_deps = HashMap::new();
+    a_deps.insert(pkg_name("b"), SnapshotDepRef::Plain(ver_peer("1.0.0")));
+    let mut c_deps = HashMap::new();
+    c_deps.insert(pkg_name("b"), SnapshotDepRef::Plain(ver_peer("2.0.0")));
+    snapshots.insert(
+        dep_key("a", "1.0.0"),
+        SnapshotEntry { dependencies: Some(a_deps), ..SnapshotEntry::default() },
+    );
+    snapshots.insert(
+        dep_key("c", "1.0.0"),
+        SnapshotEntry { dependencies: Some(c_deps), ..SnapshotEntry::default() },
+    );
+    snapshots.insert(dep_key("b", "1.0.0"), SnapshotEntry::default());
+    snapshots.insert(dep_key("b", "2.0.0"), SnapshotEntry::default());
+
+    let lockfile = Lockfile {
+        lockfile_version: lockfile_version(),
+        settings: None,
+        overrides: None,
+        importers,
+        packages: None,
+        snapshots: Some(snapshots),
+    };
+
+    let result = hoist(&lockfile, &HoistOpts::default()).expect("hoist should succeed");
+    let root_children = result.dependencies.borrow();
+    let mut names: Vec<&str> = root_children.iter().map(|d| d.0.name.as_str()).collect();
+    names.sort();
+    assert_eq!(names, ["a", "b", "c"], "root has a, c, and one b");
+    let b_at_root = root_children.iter().find(|d| d.0.name == "b").unwrap().0.clone();
+    let b_ref = b_at_root.references.borrow().iter().next().cloned();
+    // The first BFS visit from root iterates root's direct deps in
+    // alias order (`a` then `c`), so `a@1`'s `b@1.0.0` reaches
+    // root first and wins the slot.
+    assert_eq!(b_ref.as_deref(), Some("b@1.0.0"), "first BFS visitor wins root slot");
+    // `c`'s `b@2` remains under `c`.
+    let c = root_children.iter().find(|d| d.0.name == "c").unwrap().0.clone();
     let c_kids = c.dependencies.borrow();
-    let b_under_a = a_kids[0].0.clone();
-    let b_under_c = c_kids[0].0.clone();
-    // Identity comparison: two `b` references surfaced through
-    // different paths must point at the same allocation — proving
-    // the cache shared the node.
-    assert!(Rc::ptr_eq(&b_under_a, &b_under_c), "b should be the same Rc'd HoisterResult node");
+    assert_eq!(c_kids.len(), 1, "c kept its conflicting b@2");
+    let b_under_c = &c_kids[0];
+    assert_eq!(b_under_c.0.references.borrow().iter().next().cloned().as_deref(), Some("b@2.0.0"));
+}
+
+/// Deep linear chain `root → a → b → c → d` flattens to
+/// `root → {a, b, c, d}` in a single BFS pass: each node, once
+/// queued, sees the previously-hoisted nodes as direct children
+/// of root, so its own children evaluate against root's slots
+/// (which are all free).
+#[test]
+fn deep_chain_flattens_in_one_pass() {
+    let mut importers = HashMap::new();
+    let mut root_deps = ResolvedDependencyMap::new();
+    root_deps.insert(pkg_name("a"), resolved_dep("1.0.0"));
+    importers.insert(
+        Lockfile::ROOT_IMPORTER_KEY.to_string(),
+        ProjectSnapshot { dependencies: Some(root_deps), ..ProjectSnapshot::default() },
+    );
+
+    let mut snapshots = HashMap::new();
+    let mut a_deps = HashMap::new();
+    a_deps.insert(pkg_name("b"), SnapshotDepRef::Plain(ver_peer("1.0.0")));
+    let mut b_deps = HashMap::new();
+    b_deps.insert(pkg_name("c"), SnapshotDepRef::Plain(ver_peer("1.0.0")));
+    let mut c_deps = HashMap::new();
+    c_deps.insert(pkg_name("d"), SnapshotDepRef::Plain(ver_peer("1.0.0")));
+    snapshots.insert(
+        dep_key("a", "1.0.0"),
+        SnapshotEntry { dependencies: Some(a_deps), ..SnapshotEntry::default() },
+    );
+    snapshots.insert(
+        dep_key("b", "1.0.0"),
+        SnapshotEntry { dependencies: Some(b_deps), ..SnapshotEntry::default() },
+    );
+    snapshots.insert(
+        dep_key("c", "1.0.0"),
+        SnapshotEntry { dependencies: Some(c_deps), ..SnapshotEntry::default() },
+    );
+    snapshots.insert(dep_key("d", "1.0.0"), SnapshotEntry::default());
+
+    let lockfile = Lockfile {
+        lockfile_version: lockfile_version(),
+        settings: None,
+        overrides: None,
+        importers,
+        packages: None,
+        snapshots: Some(snapshots),
+    };
+
+    let result = hoist(&lockfile, &HoistOpts::default()).expect("hoist should succeed");
+    let root_children = result.dependencies.borrow();
+    let mut names: Vec<&str> = root_children.iter().map(|d| d.0.name.as_str()).collect();
+    names.sort();
+    assert_eq!(names, ["a", "b", "c", "d"], "depth-4 chain flattens: {result:#?}");
+    for entry in root_children.iter() {
+        assert!(entry.0.dependencies.borrow().is_empty(), "{} has no nested deps", entry.0.name);
+    }
 }
 
 /// `external_dependencies` are added as `link:` placeholders at the
@@ -262,17 +374,28 @@ fn transitive_npm_alias_resolves_target_snapshot() {
 
     let result =
         hoist(&lockfile, &HoistOpts::default()).expect("aliased transitive should resolve");
+    // After hoist, both `host` and `aliased-name` sit at root —
+    // `aliased-name` had no conflict so it floats up. The npm-
+    // alias indirection is observable on the hoisted node itself:
+    // `name` is the exposed alias, `ident_name` and `references`
+    // carry the resolved target's identity.
     let root_children = result.dependencies.borrow();
-    let host = root_children.iter().find(|d| d.name == "host").expect("host present").0.clone();
-    let host_kids = host.dependencies.borrow();
-    let aliased = host_kids[0].0.clone();
-    // The exposed name stays the alias the parent uses...
+    let mut names: Vec<&str> = root_children.iter().map(|d| d.0.name.as_str()).collect();
+    names.sort();
+    assert_eq!(names, ["aliased-name", "host"]);
+    let aliased = root_children
+        .iter()
+        .find(|d| d.0.name == "aliased-name")
+        .expect("aliased-name hoisted")
+        .0
+        .clone();
     assert_eq!(aliased.name, "aliased-name");
-    // ...but the underlying identity is the target package.
     assert_eq!(aliased.ident_name, "real-pkg");
     assert_eq!(
         aliased.references.borrow().iter().next().map(String::as_str),
         Some("real-pkg@2.0.0"),
         "reference is the resolved snapshot key, not the alias",
     );
+    let host = root_children.iter().find(|d| d.0.name == "host").unwrap().0.clone();
+    assert!(host.dependencies.borrow().is_empty(), "host stripped of its aliased dep: {host:#?}");
 }

--- a/crates/real-hoist/src/tests.rs
+++ b/crates/real-hoist/src/tests.rs
@@ -454,6 +454,7 @@ fn peer_dependency_in_lockfile_surfaces_unsupported() {
                 tarball: "https://example.invalid/widget-1.0.0.tgz".to_string(),
                 integrity: None,
                 git_hosted: None,
+                path: None,
             }),
             engines: None,
             cpu: None,


### PR DESCRIPTION
## Summary

Replaces the stub `nm_hoist` (landed in #448) with a working hoister and the surrounding guardrails: BFS over the result graph pulling every eligible descendant up to the root, plus upfront refusal of inputs the algorithm doesn't yet model.

### What the algorithm models

- **Free hoist.** A transitive dep with no name collision at the root surfaces at the root.
- **Identity dedup.** A dep reachable through multiple parents shares one `Rc` thanks to the wrapper's cache; the hoist preserves that identity and strips the duplicate reference at the other parent path.
- **Parent-wins on version conflict.** When two distinct deps share an alias but resolve to different snapshot keys, the first BFS visitor takes the root slot and the other stays under its declaring parent. Visit order matches the wrapper's alias-sorted insertion order, so the outcome is deterministic.
- **Deep chains flatten in one pass.** `root → a → b → c → d` becomes `root → {a, b, c, d}` — each node, once hoisted, is queued for further descent; its own children evaluate against root's slots rather than against the (now-empty) intermediate parent.
- **O(1) root-slot lookup.** A side `HashMap<String, RcByPtr<HoisterResult>>` mirrors root's direct deps, so the per-edge "is this name taken?" check doesn't degrade to O(N²) `IndexSet` scans on flat graphs.

### Fail-fast guards

The algorithm doesn't yet model peers, hoisting limits, or multi-importer (workspace) hoist trees. Rather than emit a layout pnpm would reject, the wrapper refuses these inputs upfront with three new `HoistError` variants:

- `UnsupportedPeerDependency { ident, peers }` — fires when scanning the constructed `HoisterTree` finds any node with non-empty `peer_names` (either `peerDependencies` from the `packages:` map or `transitive_peer_dependencies` on a `snapshots:` entry).
- `UnsupportedHoistingLimits { len }` — non-empty `opts.hoisting_limits`.
- `UnsupportedWorkspace { extra_importers }` — any importer beyond the root `.`.

Each carries enough context for an operator to identify what triggered it. The `UnsupportedWorkspace` help points at `SymlinkDirectDependencies` — workspaces *do* work in pacquet's wider install path (workspace support landed in #443 for the isolated linker); only the hoister is restricted.

### Rebase pickup

`collect_importer_deps` carries the `Link`-variant skip introduced by #443 (workspace support) — `spec.version.as_regular()` extracts the snapshot key for `Regular` deps and `continue`s past `Link` deps, since workspace siblings are direct symlinks materialised by `SymlinkDirectDependencies` and have no snapshot to hoist.

### Performance

Nothing in this PR is reachable from `pacquet install` today (`crates/package-manager/src/install*.rs` doesn't import `pacquet-real-hoist` — the crate is dead code from the install pipeline's perspective until the hoisted-linker wiring lands in later slices). The benchmark results bear that out: cold Frozen Lockfile is within CI variance (+3.2% mean, +3.5% median, driven by one outlier), Hot Cache is 6% *faster* (same `stat → lstat` improvement that shipped in slice 1's `import_indexed_dir`), micro is identical. No code path explains a real regression.

## What's deferred

- Peer-dependency-aware hoisting (`peer_names` constraints, peer-promise satisfaction).
- Multi-round convergence — the BFS handles deep chains in one pass, so the cases requiring true multi-round are limited to peer interactions.
- `hoistingLimits` runtime enforcement.
- `dependencyKind` distinctions for workspaces and external soft links (today only `ExternalSoftLink` placeholders are added by the wrapper and stripped post-hoist; `Workspace`-kind nodes are blocked by the `UnsupportedWorkspace` guard upfront).

## Upstream reference

- [`hoist.ts` algorithm overview](https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L1-L51) — the recipe pacquet's single-pass BFS approximates.
- [`hoistTo` main loop](https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L329) — the structural intent the port mirrors for the subset above.

## Test plan

- [x] `one_transitive_dep_hoists_to_root` — `root → a → b` flattens.
- [x] `diamond_dep_hoists_once_to_root` — `root → {a, c} → b` keeps one shared `b` at root; a DFS over the post-hoist graph asserts exactly one allocation with `name == "b"` (proves identity dedup observably, not via a tautological `find`).
- [x] `version_conflict_keeps_loser_at_parent` — `a → b@1, c → b@2` puts the first-visited at root and leaves the other under its parent. Reference assertions use `.contains()` + explicit `.len()`, not `iter().next()`.
- [x] `deep_chain_flattens_in_one_pass` — depth-4 chain in one BFS pass.
- [x] `transitive_npm_alias_resolves_target_snapshot` — aliased hoist with the resolved target's identity intact.
- [x] `peer_dependency_in_lockfile_surfaces_unsupported` — `packages.peerDependencies` triggers `UnsupportedPeerDependency`.
- [x] `non_empty_hoisting_limits_surfaces_unsupported` — `opts.hoisting_limits` triggers `UnsupportedHoistingLimits`.
- [x] `multi_importer_lockfile_surfaces_unsupported_workspace` — extra importers trigger `UnsupportedWorkspace`.
- [x] All 3 wrapper tests from #448 still pass (broken-lockfile error, empty lockfile, externalDependencies stripped).
- [x] `just ready`, `cargo doc --document-private-items`, `taplo format --check`, `just dylint` all clean.
- [x] All Copilot review threads addressed and resolved (order-fragile assertions, tautological identity check, references iter ordering, O(1) root-slot lookup, doc-comment misplacement, fail-fast guards from CodeRabbit).

---
Written by an agent (Claude Code, claude-opus-4-7).
