### PR TITLE
feat(git-fetcher): warm prefetch for git-hosted snapshots (#436 follow-up)

### DIFF
--- a/crates/git-fetcher/src/cas_io.rs
+++ b/crates/git-fetcher/src/cas_io.rs
@@ -11,16 +11,25 @@
 //! - [`import_into_cas`] writes a prepared file set back to the CAS
 //!   and produces the `relative-path → cas-path` map the install
 //!   dispatcher hands to `CreateVirtualDirBySnapshot`.
-//! - [`is_file_executable`] / [`map_write_cas`] are minor helpers
-//!   factored out alongside the import.
+//! - [`map_write_cas`] is a minor helper factored out alongside the
+//!   import.
 
 use crate::error::GitFetcherError;
-use pacquet_store_dir::StoreDir;
+use pacquet_store_dir::{CafsFileInfo, StoreDir};
 use std::{
     collections::HashMap,
     fs, io,
     path::{Component, Path, PathBuf},
 };
+
+/// Result of [`import_into_cas`]. The dispatcher uses `cas_paths` to
+/// build the virtual-store layout; `files_index` is the
+/// [`pacquet_store_dir::PackageFilesIndex::files`] payload the warm
+/// prefetch on a future install reads to skip re-fetching.
+pub(crate) struct ImportedFiles {
+    pub cas_paths: HashMap<String, PathBuf>,
+    pub files_index: HashMap<String, CafsFileInfo>,
+}
 
 /// Safely join a relative path onto a trusted root.
 ///
@@ -109,44 +118,66 @@ pub(crate) fn materialize_into(
 }
 
 /// Write each file in `files` (relative to `pkg_dir`) into the CAS,
-/// returning the map the caller hands to `CreateVirtualDirBySnapshot`.
-/// Mirrors the role of upstream's
+/// returning both the install-dispatcher map and the
+/// [`pacquet_store_dir::PackageFilesIndex::files`] payload the fetcher
+/// queues to `index.db` so a future install's warm prefetch can skip
+/// the re-fetch. Mirrors the role of upstream's
 /// [`addFilesFromDir`](https://github.com/pnpm/pnpm/blob/94240bc046/store/cafs/src/addFilesFromDir.ts)
 /// on the post-prepare write side.
 pub(crate) fn import_into_cas(
     store_dir: &StoreDir,
     pkg_dir: &Path,
     files: &[String],
-) -> Result<HashMap<String, PathBuf>, GitFetcherError> {
-    let mut out = HashMap::with_capacity(files.len());
+) -> Result<ImportedFiles, GitFetcherError> {
+    let mut cas_paths = HashMap::with_capacity(files.len());
+    let mut files_index = HashMap::with_capacity(files.len());
     for rel in files {
         // See the matching note in `materialize_into`: `join_checked`
         // accepts forward-slash relative paths verbatim on every host.
         let source = join_checked(pkg_dir, rel)?;
+        let metadata = fs::metadata(&source).map_err(GitFetcherError::Io)?;
+        let mode = file_mode_from(&metadata);
+        // `add_files_from_dir` reads the full POSIX mode and routes
+        // the executable bit through `is_executable(mode)`. Match
+        // that so a git-hosted snapshot's `PackageFilesIndex.files`
+        // round-trips through pacquet's read side at
+        // `cas_file_path_by_mode` exactly like a tarball entry would.
         let bytes = fs::read(&source).map_err(GitFetcherError::Io)?;
-        let executable = is_file_executable(&source);
-        let (cas_path, _hash) =
+        let size = bytes.len() as u64;
+        let executable = (mode & 0o111) != 0;
+        let (cas_path, hash) =
             store_dir.write_cas_file(&bytes, executable).map_err(map_write_cas)?;
-        out.insert(rel.clone(), cas_path);
+        cas_paths.insert(rel.clone(), cas_path);
+        files_index.insert(
+            rel.clone(),
+            CafsFileInfo {
+                digest: format!("{hash:x}"),
+                mode,
+                size,
+                // `None` matches `add_files_from_dir`: the first
+                // integrity-check pass populates this. Staying
+                // consistent with the existing CAFS write path means
+                // the warm prefetch's verify logic exercises the
+                // same code path it does for tarball entries.
+                checked_at: None,
+            },
+        );
     }
-    Ok(out)
+    Ok(ImportedFiles { cas_paths, files_index })
 }
 
-/// `true` when the user-execute bit is set on the on-disk file.
-/// POSIX-only; on Windows every file lands as non-executable, matching
-/// pnpm v11's behavior where the executable mode flag is meaningful
-/// only on POSIX.
-pub(crate) fn is_file_executable(path: &Path) -> bool {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        fs::metadata(path).map(|m| (m.permissions().mode() & 0o100) != 0).unwrap_or(false)
-    }
-    #[cfg(not(unix))]
-    {
-        let _ = path;
-        false
-    }
+/// POSIX file mode (`meta.mode() & 0o777`) on Unix; a fixed `0o644`
+/// on Windows where the OS has no analog. Mirrors
+/// `pacquet_store_dir::add_files_from_dir::file_mode_from`.
+#[cfg(unix)]
+fn file_mode_from(meta: &fs::Metadata) -> u32 {
+    use std::os::unix::fs::PermissionsExt;
+    meta.permissions().mode() & 0o777
+}
+
+#[cfg(not(unix))]
+fn file_mode_from(_meta: &fs::Metadata) -> u32 {
+    0o644
 }
 
 /// `true` when a CAS file path encodes "executable" via the `-exec`

--- a/crates/git-fetcher/src/fetcher.rs
+++ b/crates/git-fetcher/src/fetcher.rs
@@ -13,7 +13,7 @@
 //! to flow through without an extra owned-data copy.
 
 use crate::{
-    cas_io::import_into_cas,
+    cas_io::{ImportedFiles, import_into_cas},
     error::{GitFetcherError, PreparePackageError},
     packlist::packlist,
     prepare_package::{PreparePackageOptions, PreparedPackage, prepare_package},
@@ -21,12 +21,13 @@ use crate::{
 use pacquet_executor::ScriptsPrependNodePath;
 use pacquet_package_manifest::safe_read_package_json_from_dir;
 use pacquet_reporter::Reporter;
-use pacquet_store_dir::StoreDir;
+use pacquet_store_dir::{PackageFilesIndex, StoreDir, StoreIndexWriter};
 use std::{
     collections::HashMap,
     fs,
     path::{Path, PathBuf},
     process::Command,
+    sync::Arc,
 };
 
 /// One-shot fetcher for a single git resolution. Holds borrows for the
@@ -56,6 +57,20 @@ pub struct GitFetcher<'a> {
     /// install dispatcher uses (`<name>@<version>(<peer-suffix>)`).
     pub package_id: &'a str,
     pub requester: &'a str,
+    /// Install-scoped store-index writer. When provided, the fetcher
+    /// queues a `PackageFilesIndex` row at [`Self::files_index_file`]
+    /// after import so a future install's warm prefetch finds the
+    /// snapshot in `index.db` and skips the clone/checkout/prepare/
+    /// packlist re-run. Passing `None` (e.g., from tests) silently
+    /// skips the write — the install is still correct, just slower
+    /// on the next run.
+    pub store_index_writer: Option<&'a Arc<StoreIndexWriter>>,
+    /// Cache key the row lands at. Mirrors upstream's
+    /// `pickStoreIndexKey(resolution, pkgId, { built })` shape — for
+    /// git resolutions this is always the `gitHostedStoreIndexKey`
+    /// form (`pkg_id\t{built|not-built}`). The dispatcher computes
+    /// it once and threads it in.
+    pub files_index_file: &'a str,
 }
 
 /// Output of [`GitFetcher::run`]. Mirrors the shape of
@@ -154,7 +169,27 @@ impl<'a> GitFetcher<'a> {
             .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new()));
         let files = packlist(&pkg_dir, &manifest).map_err(GitFetcherError::Packlist)?;
 
-        let cas_paths = import_into_cas(self.store_dir, &pkg_dir, &files)?;
+        let ImportedFiles { cas_paths, files_index } =
+            import_into_cas(self.store_dir, &pkg_dir, &files)?;
+
+        // Queue a `PackageFilesIndex` row so a future install's warm
+        // prefetch finds the snapshot in `index.db` and skips the
+        // clone+checkout+prepare+packlist re-run. Mirrors the role
+        // of `addFilesFromDir`'s store-index write inside upstream's
+        // `fetching/git-fetcher` at index.ts:65-73.
+        if let Some(writer) = self.store_index_writer {
+            writer.queue(
+                self.files_index_file.to_string(),
+                PackageFilesIndex {
+                    manifest: None,
+                    requires_build: Some(should_be_built),
+                    algo: "sha512".to_string(),
+                    files: files_index,
+                    side_effects: None,
+                },
+            );
+        }
+
         Ok(GitFetchOutput { cas_paths, built: should_be_built })
     }
 }

--- a/crates/git-fetcher/src/fetcher/tests.rs
+++ b/crates/git-fetcher/src/fetcher/tests.rs
@@ -94,6 +94,8 @@ async fn fetcher_imports_package_into_cas() {
         store_dir: &store_dir,
         package_id: "pkg@1.0.0",
         requester: "/test",
+        store_index_writer: None,
+        files_index_file: "pkg@1.0.0\tbuilt",
     }
     .run::<SilentReporter>()
     .await
@@ -139,6 +141,8 @@ async fn fetcher_rejects_commit_mismatch() {
         store_dir: &store_dir,
         package_id: "pkg@1.0.0",
         requester: "/test",
+        store_index_writer: None,
+        files_index_file: "pkg@1.0.0\tbuilt",
     }
     .run::<SilentReporter>()
     .await
@@ -198,6 +202,8 @@ async fn fetcher_blocks_build_when_not_allowed() {
         store_dir: &store_dir,
         package_id: "naughty@2.0.0",
         requester: "/test",
+        store_index_writer: None,
+        files_index_file: "naughty@2.0.0\tbuilt",
     }
     .run::<SilentReporter>()
     .await

--- a/crates/git-fetcher/src/tarball_fetcher.rs
+++ b/crates/git-fetcher/src/tarball_fetcher.rs
@@ -28,7 +28,7 @@
 //!   model doesn't have a `globalWarn` equivalent.
 
 use crate::{
-    cas_io::{import_into_cas, materialize_into},
+    cas_io::{ImportedFiles, import_into_cas, materialize_into},
     error::GitFetcherError,
     fetcher::GitFetchOutput,
     packlist::packlist,
@@ -37,10 +37,11 @@ use crate::{
 use pacquet_executor::ScriptsPrependNodePath;
 use pacquet_package_manifest::safe_read_package_json_from_dir;
 use pacquet_reporter::Reporter;
-use pacquet_store_dir::StoreDir;
+use pacquet_store_dir::{PackageFilesIndex, StoreDir, StoreIndexWriter};
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
+    sync::Arc,
 };
 
 /// One-shot fetcher for a single git-hosted tarball resolution.
@@ -73,6 +74,12 @@ pub struct GitHostedTarballFetcher<'a> {
     /// Used in log lines.
     pub package_id: &'a str,
     pub requester: &'a str,
+    /// Install-scoped store-index writer; see the matching field on
+    /// [`crate::GitFetcher`] for the rationale.
+    pub store_index_writer: Option<&'a Arc<StoreIndexWriter>>,
+    /// Cache key the row lands at; always the git-hosted shape for
+    /// this fetcher. See [`crate::GitFetcher::files_index_file`].
+    pub files_index_file: &'a str,
 }
 
 impl<'a> GitHostedTarballFetcher<'a> {
@@ -146,7 +153,28 @@ impl<'a> GitHostedTarballFetcher<'a> {
 
         // Step 4: Re-import the filtered file set back into CAS and
         // hand the resulting map to the install dispatcher.
-        let cas_paths = import_into_cas(self.store_dir, &pkg_dir, &files)?;
+        let ImportedFiles { cas_paths, files_index } =
+            import_into_cas(self.store_dir, &pkg_dir, &files)?;
+
+        // Step 5: Queue a `PackageFilesIndex` row so a future install's
+        // warm prefetch skips the materialize+prepare+packlist+re-import
+        // pass entirely. Upstream writes the final row at
+        // `gitHostedStoreIndexKey(pkgId, { built: shouldBeBuilt })` in
+        // `addFilesFromDir`; the dispatcher already builds the same
+        // key and passes it via `files_index_file`.
+        if let Some(writer) = self.store_index_writer {
+            writer.queue(
+                self.files_index_file.to_string(),
+                PackageFilesIndex {
+                    manifest: None,
+                    requires_build: Some(should_be_built),
+                    algo: "sha512".to_string(),
+                    files: files_index,
+                    side_effects: None,
+                },
+            );
+        }
+
         Ok(GitFetchOutput { cas_paths, built: should_be_built })
     }
 }

--- a/crates/git-fetcher/src/tarball_fetcher/tests.rs
+++ b/crates/git-fetcher/src/tarball_fetcher/tests.rs
@@ -325,4 +325,27 @@ async fn writes_index_row_when_writer_provided() {
     let keys: Vec<&str> = row.files.keys().map(String::as_str).collect();
     assert!(keys.contains(&"package.json"), "package.json missing from row.files: {keys:?}");
     assert!(keys.contains(&"index.js"), "index.js missing from row.files: {keys:?}");
+
+    // Per-file metadata must round-trip cleanly — the warm prefetch
+    // reconstructs the CAS file path from `digest` + `mode`, and the
+    // verify pass compares `size` against the on-disk file. If any
+    // of these drift, a follow-up install would miss the cache and
+    // silently fall through to the cold path.
+    let pj = row.files.get("package.json").expect("package.json entry");
+    assert!(!pj.digest.is_empty(), "digest must be populated");
+    assert!(
+        pj.digest.bytes().all(|b| b.is_ascii_hexdigit()),
+        "digest must be hex: {:?}",
+        pj.digest,
+    );
+    // The exec bit is captured via the POSIX mode. `package.json` is
+    // a regular file, so on POSIX the mode lands as `0o644`; on
+    // Windows pacquet writes a fixed `0o644` (matching
+    // `add_files_from_dir`).
+    assert_eq!(pj.mode & 0o777, 0o644, "package.json must be a non-executable regular-mode file");
+    assert_eq!(pj.size as usize, br#"{"name":"x","version":"1.0.0","main":"index.js"}"#.len());
+    assert_eq!(
+        pj.checked_at, None,
+        "freshly imported entries have no integrity-check timestamp yet",
+    );
 }

--- a/crates/git-fetcher/src/tarball_fetcher/tests.rs
+++ b/crates/git-fetcher/src/tarball_fetcher/tests.rs
@@ -322,6 +322,7 @@ async fn writes_index_row_when_writer_provided() {
     let row = index.get(key).unwrap().expect("row must exist at the git-hosted key");
     assert_eq!(row.algo, "sha512");
     assert_eq!(row.requires_build, Some(received.built));
-    assert!(row.files.contains_key("package.json"));
-    assert!(row.files.contains_key("index.js"));
+    let keys: Vec<&str> = row.files.keys().map(String::as_str).collect();
+    assert!(keys.contains(&"package.json"), "package.json missing from row.files: {keys:?}");
+    assert!(keys.contains(&"index.js"), "index.js missing from row.files: {keys:?}");
 }

--- a/crates/git-fetcher/src/tarball_fetcher/tests.rs
+++ b/crates/git-fetcher/src/tarball_fetcher/tests.rs
@@ -2,8 +2,8 @@ use super::GitHostedTarballFetcher;
 use crate::error::{GitFetcherError, PreparePackageError};
 use pacquet_executor::ScriptsPrependNodePath;
 use pacquet_reporter::SilentReporter;
-use pacquet_store_dir::StoreDir;
-use std::{collections::HashMap, fs, path::PathBuf};
+use pacquet_store_dir::{StoreDir, StoreIndex, StoreIndexWriter};
+use std::{collections::HashMap, fs, path::PathBuf, sync::Arc};
 use tempfile::tempdir;
 
 fn deny_all_builds<'a>() -> &'a (dyn Fn(&str, &str) -> bool + Send + Sync) {
@@ -53,6 +53,8 @@ async fn passes_through_package_without_scripts() {
         store_dir: &store_dir,
         package_id: "x@1.0.0",
         requester: "/test",
+        store_index_writer: None,
+        files_index_file: "x@1.0.0\tbuilt",
     }
     .run::<SilentReporter>()
     .await
@@ -100,6 +102,8 @@ async fn filters_files_outside_files_field() {
         store_dir: &store_dir,
         package_id: "x@1.0.0",
         requester: "/test",
+        store_index_writer: None,
+        files_index_file: "x@1.0.0\tbuilt",
     }
     .run::<SilentReporter>()
     .await
@@ -143,6 +147,8 @@ async fn rejects_build_when_not_allowed() {
         store_dir: &store_dir,
         package_id: "naughty@2.0.0",
         requester: "/test",
+        store_index_writer: None,
+        files_index_file: "naughty@2.0.0\tbuilt",
     }
     .run::<SilentReporter>()
     .await
@@ -199,6 +205,8 @@ async fn path_field_packs_only_subdirectory() {
         store_dir: &store_dir,
         package_id: "sub@1.0.0",
         requester: "/test",
+        store_index_writer: None,
+        files_index_file: "sub@1.0.0\tbuilt",
     }
     .run::<SilentReporter>()
     .await
@@ -250,6 +258,8 @@ async fn materialized_temp_dir_does_not_corrupt_cas() {
         store_dir: &store_dir,
         package_id: "x@1.0.0",
         requester: "/test",
+        store_index_writer: None,
+        files_index_file: "x@1.0.0\tbuilt",
     }
     .run::<SilentReporter>()
     .await
@@ -260,4 +270,58 @@ async fn materialized_temp_dir_does_not_corrupt_cas() {
         cas_bytes_before, cas_bytes_after,
         "fetcher must not mutate CAS entries it sourced from",
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn writes_index_row_when_writer_provided() {
+    // Round-trip check: when the fetcher receives a `StoreIndexWriter`,
+    // it queues a `PackageFilesIndex` row at the given key. A future
+    // installs warm prefetch reads the same key and rebuilds the
+    // `cas_paths` map without re-running the fetcher.
+    let store_root = tempdir().unwrap();
+    let store_dir = StoreDir::from(store_root.path().to_path_buf());
+    let (writer, writer_task) = StoreIndexWriter::spawn(&store_dir);
+
+    let cas_paths = write_to_cas(
+        &store_dir,
+        &[
+            ("package.json", br#"{"name":"x","version":"1.0.0","main":"index.js"}"#, false),
+            ("index.js", b"module.exports = 7;\n", false),
+        ],
+    );
+
+    let key = "x@1.0.0\tbuilt";
+    let received = GitHostedTarballFetcher {
+        cas_paths,
+        path: None,
+        allow_build: deny_all_builds(),
+        ignore_scripts: false,
+        unsafe_perm: true,
+        user_agent: None,
+        scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+        script_shell: None,
+        node_execpath: None,
+        npm_execpath: None,
+        store_dir: &store_dir,
+        package_id: "x@1.0.0",
+        requester: "/test",
+        store_index_writer: Some(&Arc::clone(&writer)),
+        files_index_file: key,
+    }
+    .run::<SilentReporter>()
+    .await
+    .unwrap();
+
+    // Drop the producer handle so the writer task drains the channel
+    // and exits; await its join so the row is committed before we
+    // open a reader.
+    drop(writer);
+    writer_task.await.unwrap().unwrap();
+
+    let index = StoreIndex::open_in(&store_dir).unwrap();
+    let row = index.get(key).unwrap().expect("row must exist at the git-hosted key");
+    assert_eq!(row.algo, "sha512");
+    assert_eq!(row.requires_build, Some(received.built));
+    assert!(row.files.contains_key("package.json"));
+    assert!(row.files.contains_key("index.js"));
 }

--- a/crates/package-manager/src/create_virtual_store.rs
+++ b/crates/package-manager/src/create_virtual_store.rs
@@ -14,7 +14,10 @@ use pacquet_reporter::{
     BrokenModulesLog, LogEvent, LogLevel, ProgressLog, ProgressMessage, Reporter, StatsLog,
     StatsMessage,
 };
-use pacquet_store_dir::{SharedVerifiedFilesCache, StoreIndex, StoreIndexWriter, store_index_key};
+use pacquet_store_dir::{
+    SharedVerifiedFilesCache, StoreIndex, StoreIndexWriter, git_hosted_store_index_key,
+    store_index_key,
+};
 use pacquet_tarball::{PrefetchResult, prefetch_cas_paths};
 use pipe_trait::Pipe;
 use std::{collections::HashMap, path::PathBuf, sync::atomic::AtomicU8};
@@ -661,45 +664,54 @@ fn snapshot_cache_key(
             metadata_key: metadata_key.to_string(),
         }
     })?;
-    let integrity = match &metadata.resolution {
-        LockfileResolution::Tarball(t) => t
-            .integrity
-            .as_ref()
-            .ok_or_else(|| {
-                CreateVirtualStoreError::InstallPackageBySnapshot(
-                    InstallPackageBySnapshotError::MissingTarballIntegrity {
-                        package_key: snapshot_key.to_string(),
-                    },
-                )
-            })?
-            .to_string(),
-        LockfileResolution::Registry(r) => r.integrity.to_string(),
-        LockfileResolution::Directory(_) => {
-            return Err(CreateVirtualStoreError::InstallPackageBySnapshot(
-                InstallPackageBySnapshotError::UnsupportedResolution {
-                    package_key: snapshot_key.to_string(),
-                    resolution_kind: "directory",
-                },
-            ));
-        }
-        LockfileResolution::Git(_) => {
-            // Git resolutions don't participate in the warm prefetch
-            // batch in this PR — the fetcher decides the
-            // `gitHostedStoreIndexKey` `built` bit at fetch time
-            // (`preparePackage` returns `shouldBeBuilt`) and writes
-            // no store-index row, so there's nothing for the warm
-            // path to read back yet. Returning `Ok(None)` routes the
-            // snapshot through the cold-batch
-            // [`InstallPackageBySnapshot`], where
-            // [`pacquet_git_fetcher::GitFetcher`] handles the
-            // clone + checkout + import. Wiring warm caching for
-            // git-hosted entries is a follow-up tracked alongside
-            // Section C (the git-hosted *tarball* path) in #436.
-            return Ok(None);
-        }
-    };
     let pkg_id = metadata_key.to_string();
-    Ok(Some(store_index_key(&integrity, &pkg_id)))
+    match &metadata.resolution {
+        LockfileResolution::Tarball(t) if t.git_hosted == Some(true) => {
+            // Git-hosted tarballs land in the CAS via
+            // `pacquet_git_fetcher::GitHostedTarballFetcher` and the
+            // row is written under `gitHostedStoreIndexKey(pkg_id,
+            // built)` rather than the integrity-based key. Use the
+            // same key shape here so the warm prefetch finds the
+            // row on a re-install. `built = true` matches the
+            // dispatcher's `!ignore_scripts` default — when ignore-
+            // scripts becomes configurable both sites flip together.
+            Ok(Some(git_hosted_store_index_key(&pkg_id, true)))
+        }
+        LockfileResolution::Tarball(t) => {
+            let integrity = t
+                .integrity
+                .as_ref()
+                .ok_or_else(|| {
+                    CreateVirtualStoreError::InstallPackageBySnapshot(
+                        InstallPackageBySnapshotError::MissingTarballIntegrity {
+                            package_key: snapshot_key.to_string(),
+                        },
+                    )
+                })?
+                .to_string();
+            Ok(Some(store_index_key(&integrity, &pkg_id)))
+        }
+        LockfileResolution::Registry(r) => {
+            Ok(Some(store_index_key(&r.integrity.to_string(), &pkg_id)))
+        }
+        LockfileResolution::Directory(_) => Err(CreateVirtualStoreError::InstallPackageBySnapshot(
+            InstallPackageBySnapshotError::UnsupportedResolution {
+                package_key: snapshot_key.to_string(),
+                resolution_kind: "directory",
+            },
+        )),
+        LockfileResolution::Git(_) => {
+            // `Git` resolutions land in CAS via
+            // `pacquet_git_fetcher::GitFetcher`, which writes the
+            // row under the same `gitHostedStoreIndexKey` shape as
+            // the git-hosted tarball path. Returning the key here
+            // lets the warm prefetch reuse a previous install's
+            // clone + checkout + prepare + packlist work — without
+            // this, every git install cold-paths regardless of
+            // whether the snapshot is already in `index.db`.
+            Ok(Some(git_hosted_store_index_key(&pkg_id, true)))
+        }
+    }
 }
 
 /// Two snapshots agree on dependency wiring when both their

--- a/crates/package-manager/src/create_virtual_store/tests.rs
+++ b/crates/package-manager/src/create_virtual_store/tests.rs
@@ -1,6 +1,9 @@
-use super::{emit_warm_snapshot_progress, integrity_equal, snapshot_deps_equal};
+use super::{
+    emit_warm_snapshot_progress, integrity_equal, snapshot_cache_key, snapshot_deps_equal,
+};
 use pacquet_lockfile::{
-    LockfileResolution, PackageMetadata, PkgName, RegistryResolution, SnapshotDepRef, SnapshotEntry,
+    GitResolution, LockfileResolution, PackageKey, PackageMetadata, PkgName, PkgVerPeer,
+    RegistryResolution, SnapshotDepRef, SnapshotEntry, TarballResolution,
 };
 use pacquet_reporter::{LogEvent, ProgressMessage, Reporter};
 use std::{collections::HashMap, sync::Mutex};
@@ -165,4 +168,88 @@ fn integrity_equal_treats_one_sided_missing_as_unequal() {
     );
     assert!(!integrity_equal(None, Some(&with_integrity)));
     assert!(!integrity_equal(Some(&with_integrity), None));
+}
+
+fn ver(s: &str) -> PkgVerPeer {
+    s.parse().expect("parse PkgVerPeer")
+}
+
+fn key(n: &str, v: &str) -> PackageKey {
+    PackageKey::new(name(n), ver(v))
+}
+
+fn git_metadata() -> PackageMetadata {
+    PackageMetadata {
+        resolution: LockfileResolution::Git(GitResolution {
+            repo: "https://github.com/ksxnodemodules/ts-pipe-compose.git".to_string(),
+            commit: "e63c09e460269b0c535e4c34debf69bb91d57b22".to_string(),
+            path: None,
+        }),
+        engines: None,
+        cpu: None,
+        os: None,
+        libc: None,
+        deprecated: None,
+        has_bin: None,
+        prepare: None,
+        bundled_dependencies: None,
+        peer_dependencies: None,
+        peer_dependencies_meta: None,
+    }
+}
+
+fn git_hosted_tarball_metadata() -> PackageMetadata {
+    PackageMetadata {
+        resolution: LockfileResolution::Tarball(TarballResolution {
+            tarball: "https://codeload.github.com/foo/bar/tar.gz/abc1234".to_string(),
+            integrity: None,
+            git_hosted: Some(true),
+            path: None,
+        }),
+        engines: None,
+        cpu: None,
+        os: None,
+        libc: None,
+        deprecated: None,
+        has_bin: None,
+        prepare: None,
+        bundled_dependencies: None,
+        peer_dependencies: None,
+        peer_dependencies_meta: None,
+    }
+}
+
+/// `Git` resolutions go through the warm batch under a
+/// `gitHostedStoreIndexKey`-shaped key (`pkg_id\tbuilt|not-built`),
+/// not under the integrity-based key. This is the read-side mirror
+/// of what both fetchers write at install time — a drift between
+/// the two would silently degrade every git-hosted re-install to
+/// the cold path.
+#[test]
+fn snapshot_cache_key_for_git_resolution_uses_git_hosted_key() {
+    let pkg = key("ts-pipe-compose", "0.2.1");
+    let packages = HashMap::from([(pkg.clone(), git_metadata())]);
+
+    let received = snapshot_cache_key(&pkg, &packages).expect("snapshot_cache_key must not error");
+    assert_eq!(
+        received,
+        Some(format!("{pkg}\tbuilt")),
+        "git resolutions must route through gitHostedStoreIndexKey",
+    );
+}
+
+/// `Tarball { gitHosted: true }` mirrors the bare-`Git` arm — same
+/// key shape, so the warm prefetch picks up both fetchers' rows
+/// the same way.
+#[test]
+fn snapshot_cache_key_for_git_hosted_tarball_uses_git_hosted_key() {
+    let pkg = key("foo", "1.0.0");
+    let packages = HashMap::from([(pkg.clone(), git_hosted_tarball_metadata())]);
+
+    let received = snapshot_cache_key(&pkg, &packages).expect("snapshot_cache_key must not error");
+    assert_eq!(
+        received,
+        Some(format!("{pkg}\tbuilt")),
+        "git-hosted tarball resolutions must route through gitHostedStoreIndexKey",
+    );
 }

--- a/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/crates/package-manager/src/install_package_by_snapshot.rs
@@ -10,7 +10,10 @@ use pacquet_git_fetcher::{GitFetchOutput, GitFetcher, GitFetcherError, GitHosted
 use pacquet_lockfile::{LockfileResolution, PackageKey, PackageMetadata, SnapshotEntry};
 use pacquet_network::ThrottledClient;
 use pacquet_reporter::{LogEvent, LogLevel, ProgressLog, ProgressMessage, Reporter};
-use pacquet_store_dir::{SharedReadonlyStoreIndex, SharedVerifiedFilesCache, StoreIndexWriter};
+use pacquet_store_dir::{
+    SharedReadonlyStoreIndex, SharedVerifiedFilesCache, StoreIndexWriter,
+    git_hosted_store_index_key,
+};
 use pacquet_tarball::{DownloadTarballToStore, PrefetchedCasPaths, TarballError};
 use pipe_trait::Pipe;
 use std::{
@@ -163,6 +166,14 @@ impl<'a> InstallPackageBySnapshot<'a> {
                 if let LockfileResolution::Tarball(t) = &metadata.resolution
                     && t.git_hosted == Some(true)
                 {
+                    // `built = true` matches the dispatcher's default
+                    // (`ignore_scripts: false` everywhere). When
+                    // pacquet adds a configurable ignore-scripts mode
+                    // this `true` flips to `!ignore_scripts`, in lock-
+                    // step with the key shape `snapshot_cache_key`
+                    // produces — otherwise the prefetch and the write
+                    // would address different slots.
+                    let files_index_file = git_hosted_store_index_key(&package_id, true);
                     let GitFetchOutput { cas_paths, built: _built } = GitHostedTarballFetcher {
                         cas_paths: raw_cas_paths,
                         path: t.path.as_deref(),
@@ -177,6 +188,8 @@ impl<'a> InstallPackageBySnapshot<'a> {
                         store_dir: &config.store_dir,
                         package_id: &package_id,
                         requester,
+                        store_index_writer,
+                        files_index_file: &files_index_file,
                     }
                     .run::<R>()
                     .await
@@ -193,6 +206,10 @@ impl<'a> InstallPackageBySnapshot<'a> {
                 });
             }
             LockfileResolution::Git(git_resolution) => {
+                // Same `built = true` rationale as the git-hosted
+                // tarball branch above — key shape stays in lock-step
+                // with `snapshot_cache_key`.
+                let files_index_file = git_hosted_store_index_key(&package_id, true);
                 let GitFetchOutput { cas_paths, built: _built } = GitFetcher {
                     repo: &git_resolution.repo,
                     commit: &git_resolution.commit,
@@ -209,6 +226,8 @@ impl<'a> InstallPackageBySnapshot<'a> {
                     store_dir: &config.store_dir,
                     package_id: &package_id,
                     requester,
+                    store_index_writer,
+                    files_index_file: &files_index_file,
                 }
                 .run::<R>()
                 .await

--- a/crates/package-manager/src/installability/tests.rs
+++ b/crates/package-manager/src/installability/tests.rs
@@ -57,6 +57,7 @@ fn synthetic_metadata(
             integrity: None,
             tarball: "https://example.test/pkg.tgz".to_string(),
             git_hosted: None,
+            path: None,
         }),
         engines: engines
             .map(|e| e.iter().map(|(k, v)| ((*k).to_string(), (*v).to_string())).collect()),


### PR DESCRIPTION
## Summary

Wires git-hosted installs into pacquet's existing `index.db` warm-cache path. Before this PR every git install cold-pathed, even when the snapshot was already in the store from a previous install. Now the second install of an unchanged lockfile reuses the previous install's clone + checkout + prepare + packlist work and skips the fetcher entirely — same as registry-tarball installs do today.

### Three pieces

1. **Both fetchers now write `PackageFilesIndex` rows.** `cas_io::import_into_cas` returns the full `HashMap<String, CafsFileInfo>` payload alongside the existing `cas_paths` map; the fetchers wrap that into a `PackageFilesIndex` and queue it on the shared `StoreIndexWriter` at the cache key the dispatcher passed in.
   - `algo: "sha512"`, `manifest: None`, `requires_build` reflects `should_be_built`.
   - `add_files_from_dir`'s `file_mode_from` is duplicated locally so the cache row encodes the same POSIX-mode shape pnpm's tarball entries use.
2. **`create_virtual_store::snapshot_cache_key` routes git arms through the warm batch.** For `Tarball { gitHosted: true }` and `Git` resolutions it now returns `Some(gitHostedStoreIndexKey(pkg_id, built=true))` (matches upstream's `pickStoreIndexKey` shape) instead of the previous `None` cold-batch shortcut. `built = true` matches the dispatcher's `ignore_scripts: false` default; both sites will flip together when an `ignore-scripts` config knob lands.
3. **Dispatcher threads writer + key into both fetchers.** `install_package_by_snapshot.rs` builds the same `gitHostedStoreIndexKey(package_id, built=true)` the warm path reads and hands it to `GitFetcher.files_index_file` / `GitHostedTarballFetcher.files_index_file`, plus the shared `store_index_writer` clone.

The warm prefetch's existing file-verification (`check_pkg_files_integrity`) runs unchanged — if any CAS file referenced by the row has been pruned, the snapshot falls through to cold and the fetcher re-runs.

## Out of scope

- Two-slot CAS layout (`${filesIndexFile}\traw` + final) for skipping the re-import when packlist == raw. Pure perf optimization on top of this PR. Tracked on #436.
- §E full integration-test matrix.
- Real `npm-packlist` semantics.

## Test plan

- [x] `cargo nextest run -p pacquet-git-fetcher` — 42 tests, including a new `writes_index_row_when_writer_provided` round-trip that spawns a real `StoreIndexWriter`, runs the tarball fetcher with it, awaits the writer's join handle, and re-opens the store to confirm the row landed at `pkg_id\tbuilt` with the right `algo`, `requires_build`, and a non-empty `files` map.
- [x] `cargo nextest run -p pacquet-package-manager` — 245 tests still green after `snapshot_cache_key` is rewritten.
- [x] `just ready` — 765 tests, 765 pass.
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace --document-private-items` — clean.
- [x] `taplo format --check`
- [x] `just dylint`

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Faster installs for git-hosted packages via caching of per-package file indexes and reuse of prior checkout/packlist work (warm prefetch), reducing repeated prepare/pack steps.
* **New Features**
  * Optional recording of package file indexes into the store index to enable future prefetch/skip-materialize behavior.
  * Per-file metadata (digest, size, POSIX mode/executability) included in recorded indexes.
* **Tests**
  * Updated tests and a new integration test validating index-writing and per-file metadata round-trip.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pacquet/pull/454)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->