### PR TITLE
fix(package-manager): add missing TarballResolution.path in installability test fixture

### DIFF
--- a/crates/package-manager/src/installability/tests.rs
+++ b/crates/package-manager/src/installability/tests.rs
@@ -57,6 +57,7 @@ fn synthetic_metadata(
             integrity: None,
             tarball: "https://example.test/pkg.tgz".to_string(),
             git_hosted: None,
+            path: None,
         }),
         engines: engines
             .map(|e| e.iter().map(|(k, v)| ((*k).to_string(), (*v).to_string())).collect()),


### PR DESCRIPTION
## Summary

Fixes the CI break on `main`. Landrace between two recently-merged PRs:

- **#439** (Tier-1 installability check, slice 1 of #434) introduced `crates/package-manager/src/installability/tests.rs` with a `TarballResolution { integrity, tarball, git_hosted }` struct literal.
- **#451** (#436 §C, git-hosted tarballs via `preparePackage` + `packlist`) added a new field `path: Option<String>` to `TarballResolution` to mirror upstream's [`TarballResolution.path`](https://github.com/pnpm/pnpm/blob/94240bc046/lockfile/types/src/index.ts#L93).

Both PRs were green against their own bases, but main's tip — where they're both applied — doesn't compile:

```
error[E0063]: missing field `path` in initializer of `TarballResolution`
  --> crates/package-manager/src/installability/tests.rs:56:49
```

Affected CI jobs on `main`: `Lint and Test (macos-latest)`, `Lint and Test (ubuntu-latest)`, `Lint and Test (windows-latest)`, `Dylint` — all hitting the same `cargo test --no-run` failure.

Fix: add `path: None` to the struct literal. The installability check ignores the resolution shape (per the existing comment in the test fixture), so `None` is the truthful value.

## Test plan

- [x] `cargo nextest run -p pacquet-package-manager --locked installability` — all 11 tests pass.

---
Written by an agent (Claude Code, claude-opus-4-7).