### PR TITLE
feat(lockfile): BinaryResolution + VariationsResolution (#437 slice A)

### DIFF
--- a/crates/lockfile/src/resolution.rs
+++ b/crates/lockfile/src/resolution.rs
@@ -2,6 +2,7 @@ use derive_more::{From, TryInto};
 use pipe_trait::Pipe;
 use serde::{Deserialize, Serialize};
 use ssri::Integrity;
+use std::collections::BTreeMap;
 
 /// For tarball hosted remotely or locally.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
@@ -61,6 +62,117 @@ pub struct GitResolution {
     pub path: Option<String>,
 }
 
+/// One of the named executables a [`BinaryResolution`] exposes. Pnpm
+/// writes either a single string (one binary, named after the
+/// package) or a map of `{ bin_name -> path_inside_archive }` so a
+/// runtime archive can expose several launchers (e.g. `node` and
+/// `node-mips`). Mirrors pnpm's
+/// [`BinaryResolution.bin`](https://github.com/pnpm/pnpm/blob/94240bc046/resolving/resolver-base/src/index.ts#L46-L48)
+/// type union.
+///
+/// `BTreeMap` (not `HashMap`) keeps the serialised order stable so a
+/// round-trip through pacquet doesn't churn the lockfile diff.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum BinarySpec {
+    /// Single executable. The bin name defaults to the package name
+    /// at install time; this string is the path *inside the archive*
+    /// to the executable.
+    Single(String),
+    /// Named map of `bin_name -> path_inside_archive`.
+    Map(BTreeMap<String, String>),
+}
+
+/// Archive format for a [`BinaryResolution`].
+///
+/// Mirrors pnpm's `BinaryResolution.archive` discriminator at
+/// <https://github.com/pnpm/pnpm/blob/94240bc046/resolving/resolver-base/src/index.ts#L47>.
+/// `tarball` is the common shape for nodejs.org's `.tar.gz` artifacts
+/// (Linux / macOS); `zip` is what Windows Node ships as.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum BinaryArchive {
+    Tarball,
+    Zip,
+}
+
+/// For a downloaded binary archive (a JavaScript runtime: Node, Deno,
+/// or Bun). Mirrors pnpm's
+/// [`BinaryResolution`](https://github.com/pnpm/pnpm/blob/94240bc046/resolving/resolver-base/src/index.ts#L41-L49).
+///
+/// The install path extracts the archive into the CAS (with optional
+/// per-package `ignoreFilePattern` filtering — Node strips bundled
+/// `npm` / `corepack`) and links the executables named in `bin` into
+/// the importer's `node_modules/.bin/`.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct BinaryResolution {
+    pub url: String,
+    pub integrity: Integrity,
+    pub bin: BinarySpec,
+    pub archive: BinaryArchive,
+    /// Basename of the archive's top-level directory (e.g.
+    /// `node-v22.0.0-darwin-arm64`). Only emitted for zip archives —
+    /// see
+    /// [`engine/runtime/node-resolver/src/index.ts`](https://github.com/pnpm/pnpm/blob/94240bc046/engine/runtime/node-resolver/src/index.ts)
+    /// where the resolver sets `resolution.prefix = address.basename`
+    /// only for the `.zip` branch. The zip extractor strips this
+    /// prefix when applying `ignoreFilePattern` and renames the
+    /// resulting `<temp>/<basename>/` directory to the CAS target.
+    /// Tarball entries already carry the prefix in their tar header,
+    /// so this stays `None` for them.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prefix: Option<String>,
+}
+
+/// One `(os, cpu, libc?)` triple a [`PlatformAssetResolution`] covers.
+/// Mirrors pnpm's
+/// [`PlatformAssetTarget`](https://github.com/pnpm/pnpm/blob/94240bc046/resolving/resolver-base/src/index.ts#L60-L64).
+///
+/// Pnpm only writes `libc` for musl-built variants; glibc is the
+/// implicit default on Linux and the field is omitted everywhere
+/// else. `Option<String>` (rather than `Option<Libc>` enum) keeps
+/// future libc values future-compatible without a churning serde
+/// migration if upstream adds one.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct PlatformAssetTarget {
+    pub os: String,
+    pub cpu: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub libc: Option<String>,
+}
+
+/// One variant of a [`VariationsResolution`]: an inner [`LockfileResolution`]
+/// paired with the host triples it covers. Mirrors pnpm's
+/// [`PlatformAssetResolution`](https://github.com/pnpm/pnpm/blob/94240bc046/resolving/resolver-base/src/index.ts#L66-L69).
+///
+/// The inner resolution is *atomic* upstream — a `BinaryResolution`,
+/// `TarballResolution`, etc. — never another `VariationsResolution`.
+/// Pacquet keeps it typed as the full `LockfileResolution` for
+/// serde-round-trip uniformity; the variant picker checks at runtime
+/// that the resolved inner is atomic.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct PlatformAssetResolution {
+    pub resolution: LockfileResolution,
+    pub targets: Vec<PlatformAssetTarget>,
+}
+
+/// For a runtime (or any platform-conditioned binary) that has more
+/// than one downloadable artifact, one per `(os, cpu, libc?)` combo.
+/// Mirrors pnpm's
+/// [`VariationsResolution`](https://github.com/pnpm/pnpm/blob/94240bc046/resolving/resolver-base/src/index.ts#L73-L76).
+///
+/// At install time, the dispatcher walks `variants` in declaration
+/// order and picks the first whose `targets[]` includes the host
+/// triple — see `pick_variant` in `pacquet-package-manager`.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct VariationsResolution {
+    pub variants: Vec<PlatformAssetResolution>,
+}
+
 /// Represent the resolution object.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, From, TryInto)]
 #[serde(from = "ResolutionSerde", into = "ResolutionSerde")]
@@ -69,6 +181,8 @@ pub enum LockfileResolution {
     Registry(RegistryResolution),
     Directory(DirectoryResolution),
     Git(GitResolution),
+    Binary(BinaryResolution),
+    Variations(VariationsResolution),
 }
 
 impl LockfileResolution {
@@ -77,7 +191,14 @@ impl LockfileResolution {
         match self {
             LockfileResolution::Tarball(resolution) => resolution.integrity.as_ref(),
             LockfileResolution::Registry(resolution) => Some(&resolution.integrity),
-            LockfileResolution::Directory(_) | LockfileResolution::Git(_) => None,
+            LockfileResolution::Binary(resolution) => Some(&resolution.integrity),
+            // Directory / Git resolutions have no integrity.
+            // Variations is a meta-shape — the integrity lives on the
+            // picked variant's inner resolution, so callers must
+            // resolve through `pick_variant` first.
+            LockfileResolution::Directory(_)
+            | LockfileResolution::Git(_)
+            | LockfileResolution::Variations(_) => None,
         }
     }
 }
@@ -88,6 +209,8 @@ impl LockfileResolution {
 enum TaggedResolution {
     Directory(DirectoryResolution),
     Git(GitResolution),
+    Binary(BinaryResolution),
+    Variations(VariationsResolution),
 }
 
 /// Intermediate helper type for serde.
@@ -116,6 +239,8 @@ impl From<ResolutionSerde> for LockfileResolution {
             ResolutionSerde::Registry(resolution) => resolution.into(),
             ResolutionSerde::Tagged(TaggedResolution::Directory(resolution)) => resolution.into(),
             ResolutionSerde::Tagged(TaggedResolution::Git(resolution)) => resolution.into(),
+            ResolutionSerde::Tagged(TaggedResolution::Binary(resolution)) => resolution.into(),
+            ResolutionSerde::Tagged(TaggedResolution::Variations(resolution)) => resolution.into(),
         }
     }
 }
@@ -140,6 +265,12 @@ impl From<LockfileResolution> for ResolutionSerde {
                 resolution.pipe(TaggedResolution::from).into()
             }
             LockfileResolution::Git(resolution) => resolution.pipe(TaggedResolution::from).into(),
+            LockfileResolution::Binary(resolution) => {
+                resolution.pipe(TaggedResolution::from).into()
+            }
+            LockfileResolution::Variations(resolution) => {
+                resolution.pipe(TaggedResolution::from).into()
+            }
         }
     }
 }

--- a/crates/lockfile/src/resolution/tests.rs
+++ b/crates/lockfile/src/resolution/tests.rs
@@ -1,9 +1,12 @@
 use super::{
-    DirectoryResolution, GitResolution, LockfileResolution, RegistryResolution, TarballResolution,
+    BinaryArchive, BinaryResolution, BinarySpec, DirectoryResolution, GitResolution,
+    LockfileResolution, PlatformAssetResolution, PlatformAssetTarget, RegistryResolution,
+    TarballResolution, VariationsResolution,
 };
 use crate::serialize_yaml;
 use pretty_assertions::assert_eq;
 use ssri::Integrity;
+use std::collections::BTreeMap;
 use text_block_macros::text_block;
 
 fn integrity(integrity_str: &str) -> Integrity {
@@ -353,6 +356,178 @@ fn serialize_git_resolution_with_path() {
         "repo: https://github.com/ksxnodemodules/ts-pipe-compose.git"
         "commit: e63c09e460269b0c535e4c34debf69bb91d57b22"
         "path: packages/sub"
+    };
+    assert_eq!(received, expected);
+}
+
+/// A `BinaryResolution` for a tarball-shape runtime (Linux / macOS
+/// Node), `bin` as a single string, no `prefix`. Mirrors what pnpm's
+/// node-resolver writes for the `.tar.gz` branch.
+#[test]
+fn deserialize_binary_resolution_tarball() {
+    let yaml = text_block! {
+        "type: binary"
+        "url: https://nodejs.org/dist/v22.0.0/node-v22.0.0-darwin-arm64.tar.gz"
+        "integrity: sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg=="
+        "bin: bin/node"
+        "archive: tarball"
+    };
+    let received: LockfileResolution = serde_saphyr::from_str(yaml).unwrap();
+    dbg!(&received);
+    let expected = LockfileResolution::Binary(BinaryResolution {
+        url: "https://nodejs.org/dist/v22.0.0/node-v22.0.0-darwin-arm64.tar.gz".to_string(),
+        integrity: integrity(
+            "sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==",
+        ),
+        bin: BinarySpec::Single("bin/node".to_string()),
+        archive: BinaryArchive::Tarball,
+        prefix: None,
+    });
+    assert_eq!(received, expected);
+}
+
+/// A `BinaryResolution` for a zip-shape runtime (Windows Node), `bin`
+/// as a name map, and `prefix` carrying the archive's top-level
+/// directory name. Mirrors what pnpm's node-resolver writes for the
+/// `.zip` branch at
+/// <https://github.com/pnpm/pnpm/blob/94240bc046/engine/runtime/node-resolver/src/index.ts>.
+#[test]
+fn deserialize_binary_resolution_zip_with_map_and_prefix() {
+    let yaml = text_block! {
+        "type: binary"
+        "url: https://nodejs.org/dist/v22.0.0/node-v22.0.0-win-x64.zip"
+        "integrity: sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg=="
+        "bin:"
+        "  node: node.exe"
+        "archive: zip"
+        "prefix: node-v22.0.0-win-x64"
+    };
+    let received: LockfileResolution = serde_saphyr::from_str(yaml).unwrap();
+    dbg!(&received);
+    let bin = BinarySpec::Map(BTreeMap::from([("node".to_string(), "node.exe".to_string())]));
+    let expected = LockfileResolution::Binary(BinaryResolution {
+        url: "https://nodejs.org/dist/v22.0.0/node-v22.0.0-win-x64.zip".to_string(),
+        integrity: integrity(
+            "sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==",
+        ),
+        bin,
+        archive: BinaryArchive::Zip,
+        prefix: Some("node-v22.0.0-win-x64".to_string()),
+    });
+    assert_eq!(received, expected);
+}
+
+/// Round-trip a `BinaryResolution` so the serialized form pacquet
+/// emits matches the shape upstream's resolver writes. Guards the
+/// field ordering (and `prefix` omission for the tarball case) so a
+/// lockfile pacquet round-trips stays diff-stable against pnpm.
+#[test]
+fn serialize_binary_resolution_tarball() {
+    let resolution = LockfileResolution::Binary(BinaryResolution {
+        url: "https://nodejs.org/dist/v22.0.0/node-v22.0.0-darwin-arm64.tar.gz".to_string(),
+        integrity: integrity(
+            "sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==",
+        ),
+        bin: BinarySpec::Single("bin/node".to_string()),
+        archive: BinaryArchive::Tarball,
+        prefix: None,
+    });
+    let received = serialize_yaml::to_string(&resolution).unwrap();
+    let received = received.trim();
+    eprintln!("RECEIVED:\n{received}");
+    // Field order follows the struct declaration; `prefix: None`
+    // skips serialization.
+    let expected = text_block! {
+        "type: binary"
+        "url: https://nodejs.org/dist/v22.0.0/node-v22.0.0-darwin-arm64.tar.gz"
+        "integrity: sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg=="
+        "bin: bin/node"
+        "archive: tarball"
+    };
+    assert_eq!(received, expected);
+}
+
+/// A `VariationsResolution` wrapping two `BinaryResolution` variants
+/// — the typical Node runtime shape: one variant per `(os, cpu)`
+/// pair. `libc` only set on the linux-musl variant (when present);
+/// omitted everywhere else.
+#[test]
+fn deserialize_variations_resolution() {
+    let yaml = text_block! {
+        "type: variations"
+        "variants:"
+        "  - resolution:"
+        "      type: binary"
+        "      url: https://nodejs.org/dist/v22.0.0/node-v22.0.0-darwin-arm64.tar.gz"
+        "      integrity: sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg=="
+        "      bin: bin/node"
+        "      archive: tarball"
+        "    targets:"
+        "      - os: darwin"
+        "        cpu: arm64"
+        "  - resolution:"
+        "      type: binary"
+        "      url: https://nodejs.org/dist/v22.0.0/node-v22.0.0-linux-x64-musl.tar.gz"
+        "      integrity: sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg=="
+        "      bin: bin/node"
+        "      archive: tarball"
+        "    targets:"
+        "      - os: linux"
+        "        cpu: x64"
+        "        libc: musl"
+    };
+    let received: LockfileResolution = serde_saphyr::from_str(yaml).unwrap();
+    dbg!(&received);
+    let LockfileResolution::Variations(variations) = received else {
+        panic!("expected Variations, got {received:?}");
+    };
+    assert_eq!(variations.variants.len(), 2);
+    assert_eq!(variations.variants[0].targets.len(), 1);
+    assert_eq!(variations.variants[0].targets[0].os, "darwin");
+    assert_eq!(variations.variants[0].targets[0].cpu, "arm64");
+    assert_eq!(variations.variants[0].targets[0].libc, None);
+    assert_eq!(variations.variants[1].targets[0].libc.as_deref(), Some("musl"));
+}
+
+/// Round-trip a single-variant `VariationsResolution`. Pinning the
+/// emitted shape so the variant list, the inner resolution
+/// discriminator, and the targets array all serialise in the same
+/// order pnpm writes.
+#[test]
+fn serialize_variations_resolution() {
+    let resolution = LockfileResolution::Variations(VariationsResolution {
+        variants: vec![PlatformAssetResolution {
+            resolution: LockfileResolution::Binary(BinaryResolution {
+                url: "https://nodejs.org/dist/v22.0.0/node-v22.0.0-darwin-arm64.tar.gz".to_string(),
+                integrity: integrity(
+                    "sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==",
+                ),
+                bin: BinarySpec::Single("bin/node".to_string()),
+                archive: BinaryArchive::Tarball,
+                prefix: None,
+            }),
+            targets: vec![PlatformAssetTarget {
+                os: "darwin".to_string(),
+                cpu: "arm64".to_string(),
+                libc: None,
+            }],
+        }],
+    });
+    let received = serialize_yaml::to_string(&resolution).unwrap();
+    let received = received.trim();
+    eprintln!("RECEIVED:\n{received}");
+    let expected = text_block! {
+        "type: variations"
+        "variants:"
+        "- resolution:"
+        "    type: binary"
+        "    url: https://nodejs.org/dist/v22.0.0/node-v22.0.0-darwin-arm64.tar.gz"
+        "    integrity: sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg=="
+        "    bin: bin/node"
+        "    archive: tarball"
+        "  targets:"
+        "  - os: darwin"
+        "    cpu: arm64"
     };
     assert_eq!(received, expected);
 }

--- a/crates/package-manager/src/create_virtual_store.rs
+++ b/crates/package-manager/src/create_virtual_store.rs
@@ -729,13 +729,13 @@ fn snapshot_cache_key(
         // store-index key for `Binary` will compose through the same
         // `store_index_key(integrity, pkg_id)` shape the registry /
         // tarball arms use once Slice D wires the fetcher.
-        // `Variations` has no integrity of its own — the picked
-        // variant carries it — and the install dispatcher unwraps it
-        // before this helper sees it, so the warm path never observes
-        // a `Variations` directly. Surface both as "cold install" for
-        // now by returning `Ok(None)`; cold dispatch in
+        // `Variations` is a meta-shape: its integrity (and target
+        // platforms) live on the picked variant, so a warm key only
+        // makes sense after variant selection has run. Treat both as
+        // cold by returning `Ok(None)` until Slice D adds variant
+        // selection + fetcher dispatch; the cold path in
         // [`InstallPackageBySnapshot`] then raises the typed
-        // `UnsupportedResolution` until Slice D wires the fetcher.
+        // `UnsupportedResolution` for either kind.
         LockfileResolution::Binary(_) | LockfileResolution::Variations(_) => Ok(None),
     }
 }

--- a/crates/package-manager/src/create_virtual_store.rs
+++ b/crates/package-manager/src/create_virtual_store.rs
@@ -725,6 +725,18 @@ fn snapshot_cache_key(
             // whether the snapshot is already in `index.db`.
             Ok(Some(git_hosted_store_index_key(&pkg_id, true)))
         }
+        // Slice A of #437 wires the lockfile types; the warm-batch
+        // store-index key for `Binary` will compose through the same
+        // `store_index_key(integrity, pkg_id)` shape the registry /
+        // tarball arms use once Slice D wires the fetcher.
+        // `Variations` has no integrity of its own — the picked
+        // variant carries it — and the install dispatcher unwraps it
+        // before this helper sees it, so the warm path never observes
+        // a `Variations` directly. Surface both as "cold install" for
+        // now by returning `Ok(None)`; cold dispatch in
+        // [`InstallPackageBySnapshot`] then raises the typed
+        // `UnsupportedResolution` until Slice D wires the fetcher.
+        LockfileResolution::Binary(_) | LockfileResolution::Variations(_) => Ok(None),
     }
 }
 

--- a/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/crates/package-manager/src/install_package_by_snapshot.rs
@@ -211,6 +211,23 @@ impl<'a> InstallPackageBySnapshot<'a> {
                     resolution_kind: "directory",
                 });
             }
+            // Slice A of #437 wires the lockfile types; the install
+            // dispatch for `Binary` / `Variations` lands in Slice D.
+            // Until then, surface the kind so a v11 lockfile with a
+            // runtime entry fails with a clear message rather than
+            // a non-exhaustive-match panic.
+            LockfileResolution::Binary(_) => {
+                return Err(InstallPackageBySnapshotError::UnsupportedResolution {
+                    package_key: package_key.to_string(),
+                    resolution_kind: "binary",
+                });
+            }
+            LockfileResolution::Variations(_) => {
+                return Err(InstallPackageBySnapshotError::UnsupportedResolution {
+                    package_key: package_key.to_string(),
+                    resolution_kind: "variations",
+                });
+            }
             LockfileResolution::Git(git_resolution) => {
                 // Same `built = true` rationale as the git-hosted
                 // tarball branch above — key shape stays in lock-step
@@ -286,10 +303,14 @@ fn tarball_url_and_integrity<'a>(
             Ok((Cow::Owned(tarball_url), &registry_resolution.integrity))
         }
         // Caller (`run`) only invokes this helper for the tarball /
-        // registry arms; git and directory resolutions never reach
-        // here. Return an unreachable-style error so a future caller
-        // that forgets to gate gets a clear panic in debug.
-        LockfileResolution::Directory(_) | LockfileResolution::Git(_) => {
+        // registry arms; git, directory, binary, and variations
+        // resolutions never reach here. Return an unreachable-style
+        // error so a future caller that forgets to gate gets a
+        // clear panic in debug.
+        LockfileResolution::Directory(_)
+        | LockfileResolution::Git(_)
+        | LockfileResolution::Binary(_)
+        | LockfileResolution::Variations(_) => {
             unreachable!("tarball_url_and_integrity called with non-tarball resolution");
         }
     }

--- a/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/crates/package-manager/src/install_package_by_snapshot.rs
@@ -213,9 +213,13 @@ impl<'a> InstallPackageBySnapshot<'a> {
             }
             // Slice A of #437 wires the lockfile types; the install
             // dispatch for `Binary` / `Variations` lands in Slice D.
-            // Until then, surface the kind so a v11 lockfile with a
-            // runtime entry fails with a clear message rather than
-            // a non-exhaustive-match panic.
+            // Until then, surface the kind via the typed
+            // `UnsupportedResolution` error so a v11 lockfile with a
+            // runtime entry fails with a clear, structured message.
+            // (Without these arms, adding the new `LockfileResolution`
+            // variants would surface as a compile-time
+            // non-exhaustive-match error rather than building cleanly
+            // — these arms are what makes Slice A standalone.)
             LockfileResolution::Binary(_) => {
                 return Err(InstallPackageBySnapshotError::UnsupportedResolution {
                     package_key: package_key.to_string(),


### PR DESCRIPTION
## Summary

Slice A of #437. Adds the lockfile types pnpm v11 writes for runtime dependencies (`node@runtime:`, `deno@runtime:`, `bun@runtime:`); the install pipeline doesn't dispatch them yet (subsequent slices). No new workspace deps.

- **`BinaryResolution { url, integrity, bin, archive, prefix? }`** — mirrors upstream's [`BinaryResolution`](https://github.com/pnpm/pnpm/blob/94240bc046/resolving/resolver-base/src/index.ts#L41-L49). `bin` is `BinarySpec::Single(String) | BinarySpec::Map(BTreeMap)` (untagged); `archive` is the lowercase `BinaryArchive::Tarball | BinaryArchive::Zip` discriminator; `prefix` (only set on the `.zip` branch upstream) skips serialization when `None`.
- **`PlatformAssetTarget { os, cpu, libc? }`** + **`PlatformAssetResolution { resolution, targets }`** per [`resolver-base`](https://github.com/pnpm/pnpm/blob/94240bc046/resolving/resolver-base/src/index.ts#L60-L69). `libc` is `Option<String>` (not an enum) so an upstream addition beyond the current `musl` value lands without a serde migration.
- **`VariationsResolution { variants }`** + the `LockfileResolution`/`TaggedResolution` arms routing both new shapes through the existing `from/into ResolutionSerde` round-trip.
- **Lockfile major stays at 9** — confirmed against [`core/constants/src/index.ts`](https://github.com/pnpm/pnpm/blob/94240bc046/core/constants/src/index.ts) (`LOCKFILE_MAJOR_VERSION = '9'`), so the existing `lockfile_version.major == 9` assertion holds for v11 lockfiles carrying runtime entries.

**Install-dispatch stubs.** `install_package_by_snapshot.rs` and `create_virtual_store.rs` raise `InstallPackageBySnapshotError::UnsupportedResolution { kind: "binary" | "variations" }` until Slice D wires the fetcher. Adding these arms keeps the workspace compiling without forcing the full install path to land in this slice. The warm-prefetch path returns `Ok(None)` for `Variations`, routing through the cold dispatcher where the unsupported-kind error fires; upstream unwraps `Variations` before this layer ever sees one, so the branch is unreachable on well-formed input.

## Test plan

- [x] `just ready` — 830 tests pass (2 skipped)
- [x] `taplo format --check` — clean
- [x] `just dylint` (perfectionist) — clean
- [x] 4 new serde round-trip tests: tarball-shape `BinaryResolution` with `bin: <string>` and no `prefix`; zip-shape `BinaryResolution` with `bin: <map>` and `prefix`; two-variant `VariationsResolution` covering `(darwin, arm64)` and `(linux, x64, musl)` to pin the `libc?` omission rule; single-variant `VariationsResolution` serialise.

## Follow-up slices on #437

- **B**: `pick_variant(variants, host_target)` + host platform plumbing.
- **C**: Binary fetcher (tarball path through `pacquet-tarball` with `ignore_file_pattern`; zip path with `zip = "5"` workspace dep + path-traversal validation + `NODE_EXTRAS_IGNORE_PATTERN`).
- **D**: Install-pipeline dispatch for `Binary` / `Variations` + bin linking via `pacquet-cmd-shim`.
- **E**: `--no-runtime` CLI flag + `Config.skip_runtimes`.
- **F**: Integration tests with recorded fixture archives + the 12 entries from `plans/TEST_PORTING.md` Installation Of Runtimes section.

## Upstream

pnpm/pnpm@[`94240bc046`](https://github.com/pnpm/pnpm/tree/94240bc046).

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lockfiles now record downloaded runtime binaries and platform-specific variant entries, with stable serialization ordering for reliable cross-platform installs.
* **Tests**
  * Added round-trip serialization tests for binary and platform-variant lockfile entries to ensure format and field ordering stability.
* **Chores**
  * Installation/cache logic treats these new resolution types as cold installs; installers will surface “unsupported” for them until fetcher integration is implemented.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pacquet/pull/457)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->