### PR TITLE
feat(real-hoist): ancestor-path-aware peer-shadow refusal (#438)

### DIFF
--- a/crates/real-hoist/src/lib.rs
+++ b/crates/real-hoist/src/lib.rs
@@ -16,7 +16,7 @@ use miette::Diagnostic;
 use pacquet_lockfile::{Lockfile, PkgName, PkgNameVerPeer, ProjectSnapshot, SnapshotEntry};
 use std::{
     cell::RefCell,
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     rc::Rc,
 };
 
@@ -648,110 +648,132 @@ enum AbsorbDecision {
     PeerShadow,
 }
 
-/// Walk the result tree breadth-first and hoist every eligible
-/// descendant of `root` onto `root` itself. Single-pass: each node
-/// is visited once, and a descendant's children become hoist
-/// candidates as soon as the descendant itself is queued.
+/// Walk the result tree and hoist every eligible descendant of
+/// `root` onto `root` itself.
 ///
 /// Maintains a side `HashMap<name, RcByPtr>` mirror of root's
 /// direct deps so the per-edge "is this name taken at root?" check
 /// stays O(1). Without the index a graph with `N` packages all
 /// hoisting freely would do O(N²) `IndexSet` scans.
 ///
-/// Queue entries are `(node, ancestor_path)` — the ancestor path
-/// records how BFS reached `node`, so the peer-shadowing check
-/// can walk back through ancestors to find which ident each peer
-/// is expected to resolve to. For a DAG where the same node is
-/// reachable through multiple paths, only the BFS-discovered
-/// path is consulted; upstream's `cloneTree` produces a strict
-/// tree (per-path duplication) and gets a per-path peer decision
-/// for free, but pacquet preserves DAG sharing and accepts a
-/// more conservative ruling in the rare cross-path mismatch
-/// cases. The cost is layouts that are sometimes more nested
-/// than pnpm's, never less.
+/// Implemented as a recursive depth-first walk (see
+/// [`hoist_subtree`]) so the `ancestor_path` passed into each
+/// recursion reflects the current result-graph position of the
+/// parent. A previous BFS form computed the path at queue time
+/// and used it at dequeue time, which went stale whenever a node
+/// was hoisted to root between those two moments — the peer-
+/// shadow check then walked ex-ancestors and over-refused hoists.
+/// In the DFS form, when we recurse into a freshly-hoisted child,
+/// we pass `[root]` as the path; when we recurse into a child
+/// that stayed nested, we pass the parent's path plus the parent.
+///
+/// For a DAG where the same node is reachable through multiple
+/// paths, only the first-arrived path is consulted; upstream's
+/// `cloneTree` produces a strict tree (per-path duplication) and
+/// gets a per-path peer decision for free, but pacquet preserves
+/// DAG sharing and accepts a more conservative ruling in the
+/// rare cross-path mismatch cases. The cost is layouts that are
+/// sometimes more nested than pnpm's, never less.
 fn hoist_into_root(root: &Rc<HoisterResult>) {
-    let root_ptr = Rc::as_ptr(root);
     let mut visited: HashSet<*const HoisterResult> = HashSet::new();
-    let mut queue: VecDeque<(Rc<HoisterResult>, Vec<Rc<HoisterResult>>)> = VecDeque::new();
-    // Root has no ancestors.
-    queue.push_back((Rc::clone(root), Vec::new()));
-
     let mut root_index: HashMap<String, RcByPtr<HoisterResult>> =
         root.dependencies.borrow().iter().map(|d| (d.0.name.clone(), d.clone())).collect();
+    hoist_subtree(root, &[], root, &mut root_index, &mut visited);
+}
 
-    while let Some((node, ancestor_path)) = queue.pop_front() {
-        let node_ptr = Rc::as_ptr(&node);
-        if !visited.insert(node_ptr) {
+/// Depth-first hoist driver. `ancestor_path` is the path from
+/// `root` down to (but *excluding*) `node`, so for the root
+/// itself it is empty and for a child of root it is `[root]`.
+fn hoist_subtree(
+    node: &Rc<HoisterResult>,
+    ancestor_path: &[Rc<HoisterResult>],
+    root: &Rc<HoisterResult>,
+    root_index: &mut HashMap<String, RcByPtr<HoisterResult>>,
+    visited: &mut HashSet<*const HoisterResult>,
+) {
+    let root_ptr = Rc::as_ptr(root);
+    if !visited.insert(Rc::as_ptr(node)) {
+        return;
+    }
+
+    // Snapshot the current children so we can mutate
+    // `node.dependencies` mid-iteration without invalidating the
+    // borrow. `RcByPtr::clone` just bumps refcounts.
+    let children: Vec<RcByPtr<HoisterResult>> =
+        node.dependencies.borrow().iter().cloned().collect();
+
+    let is_root = Rc::ptr_eq(node, root);
+
+    // Path from root down to and including `node` — i.e. the
+    // ancestor path for `node`'s direct children. Used both for
+    // peer-shadow checks (children) and as the starting point
+    // for the path passed into recursion when a child stays
+    // nested.
+    let mut path_for_children: Vec<Rc<HoisterResult>> = ancestor_path.to_vec();
+    path_for_children.push(Rc::clone(node));
+
+    for child in children {
+        if Rc::as_ptr(&child.0) == root_ptr {
+            // Back-edge to root via a cycle. Nothing to hoist.
             continue;
         }
 
-        // Snapshot the current children so we can mutate
-        // `node.dependencies` mid-iteration without invalidating the
-        // borrow. `RcByPtr::clone` just bumps refcounts.
-        let children: Vec<RcByPtr<HoisterResult>> =
-            node.dependencies.borrow().iter().cloned().collect();
+        let mut decision = match root_index.get(&child.0.name) {
+            None => AbsorbDecision::Free,
+            Some(existing) if Rc::ptr_eq(&existing.0, &child.0) => AbsorbDecision::SameNode,
+            Some(_) => AbsorbDecision::Conflict,
+        };
 
-        let is_root_parent = Rc::ptr_eq(&node, root);
+        // Peer-aware refusal layered on top of the basic
+        // free / dedup / conflict decision. `Conflict` already
+        // leaves the candidate in place and `SameNode` dedups
+        // an already-hoisted shared `Rc`, so the peer check
+        // only matters when we'd otherwise hoist.
+        if matches!(decision, AbsorbDecision::Free)
+            && would_shadow_peer(&child.0, &path_for_children, root, root_index)
+        {
+            decision = AbsorbDecision::PeerShadow;
+        }
 
-        // Each child's ancestor path = the path that reached `node`,
-        // plus `node` itself. Building it once per parent visit
-        // means children share the same ancestor Vec via clone.
-        let mut child_ancestor_path = ancestor_path.clone();
-        child_ancestor_path.push(Rc::clone(&node));
-
-        for child in children {
-            let child_ptr = Rc::as_ptr(&child.0);
-            if child_ptr == root_ptr {
-                // Back-edge to root via a cycle. Nothing to hoist.
-                continue;
-            }
-
-            let mut decision = match root_index.get(&child.0.name) {
-                None => AbsorbDecision::Free,
-                Some(existing) if Rc::ptr_eq(&existing.0, &child.0) => AbsorbDecision::SameNode,
-                Some(_) => AbsorbDecision::Conflict,
-            };
-
-            // Peer-aware refusal layered on top of the basic
-            // free / dedup / conflict decision. Conflict and
-            // SameNode already leave the candidate in place or
-            // dedup it, so the peer check only matters when we'd
-            // otherwise hoist.
-            if matches!(decision, AbsorbDecision::Free)
-                && would_shadow_peer(&child.0, &child_ancestor_path, root, &root_index)
-            {
-                decision = AbsorbDecision::PeerShadow;
-            }
-
-            if !is_root_parent {
-                match decision {
-                    AbsorbDecision::Free => {
-                        node.dependencies.borrow_mut().shift_remove(&child);
-                        root.dependencies.borrow_mut().insert(child.clone());
-                        root_index.insert(child.0.name.clone(), child.clone());
-                    }
-                    AbsorbDecision::SameNode => {
-                        // The shared `Rc` is already at root; just
-                        // strip the duplicate reference at this
-                        // parent so the deeper copy disappears.
-                        node.dependencies.borrow_mut().shift_remove(&child);
-                    }
-                    AbsorbDecision::Conflict | AbsorbDecision::PeerShadow => {
-                        // Stays at the current parent. The version
-                        // already at root wins the slot, or
-                        // hoisting would shadow a peer dependency.
-                    }
+        // Apply the decision, *then* compute the path to pass
+        // into recursion based on the child's *new* position.
+        // This is the load-bearing difference from the previous
+        // BFS shape: the recursion path reflects current state.
+        let child_recursion_path: Vec<Rc<HoisterResult>> = if is_root {
+            // Root's direct children are already at root — no
+            // movement happens, and their ancestor path is
+            // simply `[root]`.
+            path_for_children.clone()
+        } else {
+            match decision {
+                AbsorbDecision::Free => {
+                    node.dependencies.borrow_mut().shift_remove(&child);
+                    root.dependencies.borrow_mut().insert(child.clone());
+                    root_index.insert(child.0.name.clone(), child.clone());
+                    // Child is now a direct dep of root; its
+                    // ancestor path collapses to `[root]`.
+                    vec![Rc::clone(root)]
+                }
+                AbsorbDecision::SameNode => {
+                    // The shared `Rc` is already at root; strip
+                    // the duplicate reference at this parent so
+                    // the deeper copy disappears. Child's actual
+                    // ancestor path is `[root]`.
+                    node.dependencies.borrow_mut().shift_remove(&child);
+                    vec![Rc::clone(root)]
+                }
+                AbsorbDecision::Conflict | AbsorbDecision::PeerShadow => {
+                    // Stays at the current parent. The version
+                    // already at root wins the slot, or
+                    // hoisting would shadow a peer dependency.
+                    // Child's ancestor path is the path through
+                    // `node`.
+                    path_for_children.clone()
                 }
             }
+        };
 
-            // Queue the child so its own descendants get a chance.
-            // This is what lets deep chains (`root → a → b → c`)
-            // flatten in a single BFS pass: by the time `b` is
-            // dequeued it's already a direct child of root, so
-            // `c` is evaluated against root's slot, not against
-            // `a`'s slot.
-            queue.push_back((Rc::clone(&child.0), child_ancestor_path.clone()));
-        }
+        hoist_subtree(&child.0, &child_recursion_path, root, root_index, visited);
     }
 }
 
@@ -841,13 +863,14 @@ fn would_shadow_peer(
                 }
                 None => {
                     // This ancestor doesn't supply the peer.
-                    // Either it peer-passes the name to its own
-                    // parent (continue walking), or the peer is
-                    // simply unsatisfied along this path (the
-                    // BFS will visit the candidate again with the
-                    // same conclusion). Continue walking up; if
-                    // we reach the root with no provider found,
-                    // the candidate has no peer to shadow.
+                    // Walk further up — the actual provider may
+                    // be a parent of this ancestor (the common
+                    // shape is `ancestor` peer-passes the name
+                    // through to its own parent). If we exhaust
+                    // the path without finding any provider,
+                    // there's no ancestor-bound peer to shadow
+                    // and the candidate may hoist freely for
+                    // this peer.
                 }
             }
         }

--- a/crates/real-hoist/src/lib.rs
+++ b/crates/real-hoist/src/lib.rs
@@ -105,12 +105,25 @@ pub struct HoisterTree {
 ///
 /// Mirrors `HoisterResult` at the [yarn source][yarn-result].
 ///
+/// Pacquet extends upstream's `HoisterResult` with a `peer_names`
+/// field copied through from [`HoisterTree::peer_names`]. The hoist
+/// algorithm reads it while deciding whether a candidate can hoist
+/// past parents that supply the peer; upstream resolves the same
+/// information against its `HoisterWorkTree` instead, but since
+/// pacquet runs the algorithm directly on `HoisterResult` (no
+/// intermediate work tree), the peer set has to ride along.
+///
 /// [yarn-result]: https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L20-L23
 #[derive(Debug, Clone)]
 pub struct HoisterResult {
     pub name: String,
     pub ident_name: String,
     pub references: RefCell<BTreeSet<String>>,
+    /// Peer-dependency names the upstream `HoisterTree` node
+    /// declared. Read by the hoist algorithm to refuse hoists that
+    /// would shadow a peer the candidate's ancestors satisfy with a
+    /// different ident.
+    pub peer_names: BTreeSet<String>,
     pub dependencies: RefCell<IndexSet<RcByPtr<HoisterResult>>>,
 }
 
@@ -159,27 +172,6 @@ pub enum HoistError {
         /// The depPath (snapshot key) the lockfile failed to
         /// resolve.
         pkg_key: String,
-    },
-    /// A package in the lockfile declares peer dependencies (or
-    /// transitive peer dependencies). The hoist algorithm doesn't
-    /// model peer-dependency constraints yet, so it would freely
-    /// hoist this node past parents that supply the peer — a
-    /// silent shadowing pnpm would reject. Refuse upfront rather
-    /// than emit a wrong layout.
-    #[display("hoister cannot yet model peer dependencies (package {ident}, peers: {peers:?})")]
-    #[diagnostic(
-        code(ERR_PACQUET_HOIST_UNSUPPORTED_PEER),
-        help(
-            "the hoister doesn't yet model peer-dependency constraints; \
-             pass a lockfile whose packages declare no `peerDependencies` \
-             (and whose snapshots carry no `transitivePeerDependencies`)."
-        )
-    )]
-    UnsupportedPeerDependency {
-        /// The snapshot key of the offending package.
-        ident: String,
-        /// The peer / transitive-peer names that block the hoist.
-        peers: BTreeSet<String>,
     },
     /// The caller passed a non-empty `hoisting_limits` map. The
     /// hoist algorithm doesn't enforce limits yet, so flattening
@@ -363,15 +355,6 @@ pub fn hoist(lockfile: &Lockfile, opts: &HoistOpts) -> Result<HoisterResult, Hoi
         hoist_priority: 0,
         dependencies: RefCell::new(root_children),
     });
-
-    // Scan the constructed tree for peer-constrained packages.
-    // `peer_names` only gets populated when the lockfile's
-    // `packages` map declares `peerDependencies` (or
-    // `transitive_peer_dependencies` on a snapshot), so a peer-
-    // free lockfile passes the guard unchanged.
-    if let Some(err) = find_first_peer_constrained(&root_node) {
-        return Err(err);
-    }
 
     let result = nm_hoist(&root_node, opts);
 
@@ -581,29 +564,6 @@ fn percent_encode_path(s: &str) -> String {
     out
 }
 
-/// Walk the constructed tree and return the first node whose
-/// `peer_names` is non-empty as an `UnsupportedPeerDependency`
-/// error. Returns `None` when the tree is peer-free.
-fn find_first_peer_constrained(root: &Rc<HoisterTree>) -> Option<HoistError> {
-    let mut visited: HashSet<*const HoisterTree> = HashSet::new();
-    let mut stack: Vec<Rc<HoisterTree>> = vec![Rc::clone(root)];
-    while let Some(node) = stack.pop() {
-        if !visited.insert(Rc::as_ptr(&node)) {
-            continue;
-        }
-        if !node.peer_names.is_empty() {
-            return Some(HoistError::UnsupportedPeerDependency {
-                ident: node.reference.clone(),
-                peers: node.peer_names.clone(),
-            });
-        }
-        for dep in node.dependencies.borrow().iter() {
-            stack.push(Rc::clone(&dep.0));
-        }
-    }
-    None
-}
-
 /// Pacquet's port of the `@yarnpkg/nm` hoist algorithm. Walks the
 /// input tree, deep-copies it into a `HoisterResult` shape, then
 /// pulls eligible descendants up to the root via single-pass BFS
@@ -623,23 +583,27 @@ fn find_first_peer_constrained(root: &Rc<HoisterTree>) -> Option<HoistError> {
 ///   share an alias but resolve to different snapshot keys, the
 ///   first one BFS reaches takes the root slot and the other
 ///   stays under its parent.
+/// * Peer-shadow refusal: a candidate whose `peer_names` would
+///   resolve against an ancestor's dep with a different ident
+///   than the root carries stays nested under its parent. See
+///   [`would_shadow_peer`] for the ancestor-path walk and how
+///   pacquet's DAG-preserving model differs from upstream's
+///   per-path tree clone in rare cross-path mismatch cases.
 ///
-/// What this does *not* model yet (each gated on later work
-/// because they require additional graph structure and tests):
+/// What this does *not* model yet:
 ///
-/// * Peer-dependency constraints (`peer_names`) — packages that
-///   refuse to hoist past parents declaring them as peers. The
-///   wrapper refuses lockfiles that contain any peer-constrained
-///   nodes via `HoistError::UnsupportedPeerDependency`, so this
-///   function only ever sees peer-free input today.
 /// * Multi-round convergence — re-walking the tree to discover
-///   newly-hoistable deps after the first pass. The BFS does
-///   handle deep chains (`root → a → b → c` flattens in one
-///   pass), so the cases requiring true multi-round are limited
-///   to peer interactions.
-/// * `hoistingLimits` / `externalDependencies` knobs.
+///   newly-hoistable deps after the first pass. The BFS handles
+///   deep chains (`root → a → b → c` flattens in one pass), so
+///   the cases requiring true multi-round are limited to
+///   peer-interactions where one hoist decision unblocks
+///   another. Today the algorithm refuses those conservatively.
+/// * `hoistingLimits` / `externalDependencies` runtime
+///   enforcement (the wrapper still refuses non-empty
+///   `hoisting_limits`).
 /// * `dependencyKind` distinctions for workspaces and external
-///   soft links.
+///   soft links (the `Workspace` guard at the wrapper boundary
+///   still refuses multi-importer lockfiles upfront).
 ///
 /// Matches the structural intent of upstream `hoistTo` at
 /// [hoist.ts:329][upstream] for the subset above.
@@ -671,6 +635,17 @@ enum AbsorbDecision {
     /// Root's name slot is taken by a different `Rc` — a version
     /// conflict. The child stays under its current parent.
     Conflict,
+    /// Hoisting would shadow a peer dependency one of the
+    /// candidate's ancestors satisfies with a different ident than
+    /// what the root provides. The child stays under its parent so
+    /// the ancestor's peer resolution still finds the intended
+    /// version. Mirrors upstream's `getNodeHoistInfo` peer checks
+    /// at [hoist.ts:414][peer-shadow-root] and
+    /// [hoist.ts:454-479][peer-path].
+    ///
+    /// [peer-shadow-root]: https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L414
+    /// [peer-path]: https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L454-L479
+    PeerShadow,
 }
 
 /// Walk the result tree breadth-first and hoist every eligible
@@ -682,16 +657,29 @@ enum AbsorbDecision {
 /// direct deps so the per-edge "is this name taken at root?" check
 /// stays O(1). Without the index a graph with `N` packages all
 /// hoisting freely would do O(N²) `IndexSet` scans.
+///
+/// Queue entries are `(node, ancestor_path)` — the ancestor path
+/// records how BFS reached `node`, so the peer-shadowing check
+/// can walk back through ancestors to find which ident each peer
+/// is expected to resolve to. For a DAG where the same node is
+/// reachable through multiple paths, only the BFS-discovered
+/// path is consulted; upstream's `cloneTree` produces a strict
+/// tree (per-path duplication) and gets a per-path peer decision
+/// for free, but pacquet preserves DAG sharing and accepts a
+/// more conservative ruling in the rare cross-path mismatch
+/// cases. The cost is layouts that are sometimes more nested
+/// than pnpm's, never less.
 fn hoist_into_root(root: &Rc<HoisterResult>) {
     let root_ptr = Rc::as_ptr(root);
     let mut visited: HashSet<*const HoisterResult> = HashSet::new();
-    let mut queue: VecDeque<Rc<HoisterResult>> = VecDeque::new();
-    queue.push_back(Rc::clone(root));
+    let mut queue: VecDeque<(Rc<HoisterResult>, Vec<Rc<HoisterResult>>)> = VecDeque::new();
+    // Root has no ancestors.
+    queue.push_back((Rc::clone(root), Vec::new()));
 
     let mut root_index: HashMap<String, RcByPtr<HoisterResult>> =
         root.dependencies.borrow().iter().map(|d| (d.0.name.clone(), d.clone())).collect();
 
-    while let Some(node) = queue.pop_front() {
+    while let Some((node, ancestor_path)) = queue.pop_front() {
         let node_ptr = Rc::as_ptr(&node);
         if !visited.insert(node_ptr) {
             continue;
@@ -705,6 +693,12 @@ fn hoist_into_root(root: &Rc<HoisterResult>) {
 
         let is_root_parent = Rc::ptr_eq(&node, root);
 
+        // Each child's ancestor path = the path that reached `node`,
+        // plus `node` itself. Building it once per parent visit
+        // means children share the same ancestor Vec via clone.
+        let mut child_ancestor_path = ancestor_path.clone();
+        child_ancestor_path.push(Rc::clone(&node));
+
         for child in children {
             let child_ptr = Rc::as_ptr(&child.0);
             if child_ptr == root_ptr {
@@ -712,11 +706,22 @@ fn hoist_into_root(root: &Rc<HoisterResult>) {
                 continue;
             }
 
-            let decision = match root_index.get(&child.0.name) {
+            let mut decision = match root_index.get(&child.0.name) {
                 None => AbsorbDecision::Free,
                 Some(existing) if Rc::ptr_eq(&existing.0, &child.0) => AbsorbDecision::SameNode,
                 Some(_) => AbsorbDecision::Conflict,
             };
+
+            // Peer-aware refusal layered on top of the basic
+            // free / dedup / conflict decision. Conflict and
+            // SameNode already leave the candidate in place or
+            // dedup it, so the peer check only matters when we'd
+            // otherwise hoist.
+            if matches!(decision, AbsorbDecision::Free)
+                && would_shadow_peer(&child.0, &child_ancestor_path, root, &root_index)
+            {
+                decision = AbsorbDecision::PeerShadow;
+            }
 
             if !is_root_parent {
                 match decision {
@@ -731,9 +736,10 @@ fn hoist_into_root(root: &Rc<HoisterResult>) {
                         // parent so the deeper copy disappears.
                         node.dependencies.borrow_mut().shift_remove(&child);
                     }
-                    AbsorbDecision::Conflict => {
+                    AbsorbDecision::Conflict | AbsorbDecision::PeerShadow => {
                         // Stays at the current parent. The version
-                        // already at root wins the slot.
+                        // already at root wins the slot, or
+                        // hoisting would shadow a peer dependency.
                     }
                 }
             }
@@ -744,9 +750,112 @@ fn hoist_into_root(root: &Rc<HoisterResult>) {
             // dequeued it's already a direct child of root, so
             // `c` is evaluated against root's slot, not against
             // `a`'s slot.
-            queue.push_back(Rc::clone(&child.0));
+            queue.push_back((Rc::clone(&child.0), child_ancestor_path.clone()));
         }
     }
+}
+
+/// Return `true` when hoisting `candidate` onto the root would
+/// shadow a peer dependency one of its ancestors already
+/// satisfies with a different ident.
+///
+/// Implements two of the three peer guards upstream's
+/// `getNodeHoistInfo` runs:
+///
+/// * **Root-shadow** — the candidate's own name appears in
+///   `root.peer_names`. The root expects to *receive* this name as
+///   a peer from its own parent, so promoting the candidate into
+///   the root's name slot would change peer resolution for
+///   anything that sees the root.
+/// * **Ancestor-path mismatch** — for each peer name `P` in
+///   `candidate.peer_names`, walk the candidate's ancestors from
+///   deepest (immediate parent) toward the root. The first
+///   ancestor that has a direct dep named `P` (and doesn't itself
+///   peer-pass `P` through) is the one whose ident the candidate
+///   resolves at runtime. If the root provides a *different*
+///   ident for `P` (or none at all), promoting the candidate
+///   would silently re-resolve its peer to the wrong package, so
+///   we leave it nested.
+///
+/// Differs from upstream's check in one DAG case: upstream's
+/// [`cloneTree`][clone] duplicates the work tree into a strict
+/// tree per parent path, so each visit has a unique ancestor
+/// chain. Pacquet preserves the DAG, and the BFS records only
+/// the path it actually used to reach the candidate; if the same
+/// candidate could be reached via a peer-compatible alternative
+/// path, we still refuse to hoist. The result is at most
+/// over-nested layouts, never under-nested ones.
+///
+/// [clone]: https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L670
+fn would_shadow_peer(
+    candidate: &HoisterResult,
+    ancestor_path: &[Rc<HoisterResult>],
+    root: &Rc<HoisterResult>,
+    root_index: &HashMap<String, RcByPtr<HoisterResult>>,
+) -> bool {
+    // Root-shadow guard. Pacquet's wrapper builds the `.` root with
+    // empty `peer_names` (it's a `Workspace`-kind node), so in
+    // practice this check never fires today — kept for parity with
+    // upstream and to stay correct if a future caller hands in a
+    // root with declared peers.
+    if root.peer_names.contains(&candidate.name) {
+        return true;
+    }
+
+    'peer_loop: for peer_name in &candidate.peer_names {
+        // Walk ancestors deepest-first so the closest provider
+        // wins. An ancestor whose own `peer_names` includes this
+        // name *and* doesn't carry it as a direct dep is just
+        // passing the peer through — keep walking past it.
+        for ancestor in ancestor_path.iter().rev() {
+            // Clone before dropping the borrow so the Rc outlives
+            // the `Ref` we'd otherwise hold.
+            let provider_rc = ancestor
+                .dependencies
+                .borrow()
+                .iter()
+                .find(|d| d.0.name == *peer_name)
+                .map(|d| d.0.clone());
+
+            match provider_rc {
+                Some(provider) => {
+                    // Found a concrete provider in the ancestor
+                    // chain. Compare its identity against root's
+                    // current slot for the same name.
+                    match root_index.get(peer_name) {
+                        Some(at_root) if Rc::ptr_eq(&at_root.0, &provider) => {
+                            // Root already carries this exact
+                            // provider — promoting the candidate
+                            // doesn't change resolution. Move to
+                            // the next peer.
+                            continue 'peer_loop;
+                        }
+                        _ => {
+                            // Root either has a different ident
+                            // for this peer or doesn't have one
+                            // at all. Either way, hoisting would
+                            // shadow.
+                            return true;
+                        }
+                    }
+                }
+                None => {
+                    // This ancestor doesn't supply the peer.
+                    // Either it peer-passes the name to its own
+                    // parent (continue walking), or the peer is
+                    // simply unsatisfied along this path (the
+                    // BFS will visit the candidate again with the
+                    // same conclusion). Continue walking up; if
+                    // we reach the root with no provider found,
+                    // the candidate has no peer to shadow.
+                }
+            }
+        }
+        // No ancestor (excluding root) provides the peer; the
+        // candidate either resolves it at root or leaves it
+        // unsatisfied. Either case is "no shadow" — keep going.
+    }
+    false
 }
 
 fn convert(
@@ -768,6 +877,7 @@ fn convert(
         name: tree.name.clone(),
         ident_name: tree.ident_name.clone(),
         references: RefCell::new(refs),
+        peer_names: tree.peer_names.clone(),
         dependencies: RefCell::new(IndexSet::new()),
     });
     memo.insert(ptr, Rc::clone(&node));

--- a/crates/real-hoist/src/tests.rs
+++ b/crates/real-hoist/src/tests.rs
@@ -425,52 +425,68 @@ fn transitive_npm_alias_resolves_target_snapshot() {
     assert!(host.dependencies.borrow().is_empty(), "host stripped of its aliased dep: {host:#?}");
 }
 
-/// A package with `peer_dependencies` declared in the lockfile's
-/// `packages:` map must surface `UnsupportedPeerDependency` rather
-/// than silently hoist past parents that supply the peer. The
-/// algorithm doesn't model peer constraints today; refusing
-/// upfront keeps a future caller from getting a wrong layout.
-#[test]
-fn peer_dependency_in_lockfile_surfaces_unsupported() {
+/// Helper for the peer-aware tests: build a `PackageMetadata`
+/// whose `packages:`-level `peer_dependencies` claims one peer.
+fn pkg_metadata_with_peer(peer_name: &str) -> pacquet_lockfile::PackageMetadata {
     use pacquet_lockfile::{LockfileResolution, PackageMetadata, TarballResolution};
+    let mut peer_deps = HashMap::new();
+    peer_deps.insert(peer_name.to_string(), "*".to_string());
+    PackageMetadata {
+        resolution: LockfileResolution::Tarball(TarballResolution {
+            tarball: format!("https://example.invalid/{peer_name}-host.tgz"),
+            integrity: None,
+            git_hosted: None,
+            path: None,
+        }),
+        engines: None,
+        cpu: None,
+        os: None,
+        libc: None,
+        deprecated: None,
+        has_bin: None,
+        prepare: None,
+        bundled_dependencies: None,
+        peer_dependencies: Some(peer_deps),
+        peer_dependencies_meta: None,
+    }
+}
+
+/// Peer-shadow refusal: `app → widget (peer: react) + widget → react@17`
+/// and `root → react@18`. `widget` declares `react` as a peer, its
+/// only ancestor (`app`) supplies `react@17`, and the root carries
+/// `react@18`. Hoisting `widget` to root would silently re-resolve
+/// its peer to react@18 instead of the ancestor-supplied react@17,
+/// so the algorithm leaves `widget` nested under `app`.
+#[test]
+fn peer_constrained_node_stays_under_parent_when_root_provides_different_ident() {
     let mut importers = HashMap::new();
     let mut root_deps = ResolvedDependencyMap::new();
-    root_deps.insert(pkg_name("widget"), resolved_dep("1.0.0"));
+    root_deps.insert(pkg_name("app"), resolved_dep("1.0.0"));
+    root_deps.insert(pkg_name("react"), resolved_dep("18.0.0"));
     importers.insert(
         Lockfile::ROOT_IMPORTER_KEY.to_string(),
         ProjectSnapshot { dependencies: Some(root_deps), ..ProjectSnapshot::default() },
     );
 
-    // `widget@1.0.0` declares `react` as a peer dep — the
-    // `packages:` map carries that information at the
-    // `name@version` (peer-stripped) key.
-    let mut packages = HashMap::new();
-    let mut peer_deps = HashMap::new();
-    peer_deps.insert("react".to_string(), "^18".to_string());
-    packages.insert(
-        dep_key("widget", "1.0.0").without_peer(),
-        PackageMetadata {
-            resolution: LockfileResolution::Tarball(TarballResolution {
-                tarball: "https://example.invalid/widget-1.0.0.tgz".to_string(),
-                integrity: None,
-                git_hosted: None,
-                path: None,
-            }),
-            engines: None,
-            cpu: None,
-            os: None,
-            libc: None,
-            deprecated: None,
-            has_bin: None,
-            prepare: None,
-            bundled_dependencies: None,
-            peer_dependencies: Some(peer_deps),
-            peer_dependencies_meta: None,
-        },
-    );
-
+    // `app@1.0.0` brings in both `widget` and `react@17`.
+    // `widget@1.0.0` declares `react` as a peer dependency. The
+    // snapshot graph itself doesn't list `react` under `widget`
+    // (peers aren't snapshot edges), so `widget`'s ancestor for
+    // peer resolution is `app`.
     let mut snapshots = HashMap::new();
+    let mut app_deps = HashMap::new();
+    app_deps.insert(pkg_name("widget"), SnapshotDepRef::Plain(ver_peer("1.0.0")));
+    app_deps.insert(pkg_name("react"), SnapshotDepRef::Plain(ver_peer("17.0.0")));
+    snapshots.insert(
+        dep_key("app", "1.0.0"),
+        SnapshotEntry { dependencies: Some(app_deps), ..SnapshotEntry::default() },
+    );
     snapshots.insert(dep_key("widget", "1.0.0"), SnapshotEntry::default());
+    snapshots.insert(dep_key("react", "17.0.0"), SnapshotEntry::default());
+    snapshots.insert(dep_key("react", "18.0.0"), SnapshotEntry::default());
+
+    let mut packages = HashMap::new();
+    packages.insert(dep_key("widget", "1.0.0").without_peer(), pkg_metadata_with_peer("react"));
 
     let lockfile = Lockfile {
         lockfile_version: lockfile_version(),
@@ -481,14 +497,76 @@ fn peer_dependency_in_lockfile_surfaces_unsupported() {
         snapshots: Some(snapshots),
     };
 
-    let err = hoist(&lockfile, &HoistOpts::default()).expect_err("peer dep should bail");
-    match err {
-        HoistError::UnsupportedPeerDependency { ident, peers } => {
-            assert_eq!(ident, "widget@1.0.0", "carries the offending ident: {ident}");
-            assert!(peers.contains("react"), "carries the peer name set: {peers:?}");
-        }
-        other => panic!("expected UnsupportedPeerDependency, got {other:?}"),
-    }
+    let result = hoist(&lockfile, &HoistOpts::default()).expect("peer-aware hoist should succeed");
+    let root_children = result.dependencies.borrow();
+    let mut names: Vec<&str> = root_children.iter().map(|d| d.0.name.as_str()).collect();
+    names.sort();
+    // Root has the two direct deps; `widget` is NOT at root.
+    assert_eq!(names, ["app", "react"], "widget stays under app: {result:#?}");
+    let app = root_children.iter().find(|d| d.0.name == "app").unwrap().0.clone();
+    let app_kids = app.dependencies.borrow();
+    let app_names: Vec<&str> = app_kids.iter().map(|d| d.0.name.as_str()).collect();
+    assert!(
+        app_names.contains(&"widget"),
+        "widget nested under app to keep ancestor peer resolution: {app_names:?}",
+    );
+    // The conflicting react@17 also stays nested under app
+    // (parent-wins kicked in because root already has react@18).
+    assert!(app_names.contains(&"react"), "app keeps its own react@17: {app_names:?}");
+}
+
+/// Peer-friendly hoist: `app → widget (peer: react)`, `app → react@18`,
+/// `root → react@18`. The peer name `react` is provided by both
+/// `app` and the root with the *same* ident (`react@18`, shared `Rc`
+/// thanks to the wrapper's identity dedup), so hoisting `widget` to
+/// root doesn't change its peer resolution — the algorithm allows
+/// the hoist.
+#[test]
+fn peer_constrained_node_hoists_when_ancestor_and_root_agree() {
+    let mut importers = HashMap::new();
+    let mut root_deps = ResolvedDependencyMap::new();
+    root_deps.insert(pkg_name("app"), resolved_dep("1.0.0"));
+    root_deps.insert(pkg_name("react"), resolved_dep("18.0.0"));
+    importers.insert(
+        Lockfile::ROOT_IMPORTER_KEY.to_string(),
+        ProjectSnapshot { dependencies: Some(root_deps), ..ProjectSnapshot::default() },
+    );
+
+    let mut snapshots = HashMap::new();
+    let mut app_deps = HashMap::new();
+    app_deps.insert(pkg_name("widget"), SnapshotDepRef::Plain(ver_peer("1.0.0")));
+    app_deps.insert(pkg_name("react"), SnapshotDepRef::Plain(ver_peer("18.0.0")));
+    snapshots.insert(
+        dep_key("app", "1.0.0"),
+        SnapshotEntry { dependencies: Some(app_deps), ..SnapshotEntry::default() },
+    );
+    snapshots.insert(dep_key("widget", "1.0.0"), SnapshotEntry::default());
+    snapshots.insert(dep_key("react", "18.0.0"), SnapshotEntry::default());
+
+    let mut packages = HashMap::new();
+    packages.insert(dep_key("widget", "1.0.0").without_peer(), pkg_metadata_with_peer("react"));
+
+    let lockfile = Lockfile {
+        lockfile_version: lockfile_version(),
+        settings: None,
+        overrides: None,
+        importers,
+        packages: Some(packages),
+        snapshots: Some(snapshots),
+    };
+
+    let result = hoist(&lockfile, &HoistOpts::default()).expect("peer-aware hoist should succeed");
+    let root_children = result.dependencies.borrow();
+    let mut names: Vec<&str> = root_children.iter().map(|d| d.0.name.as_str()).collect();
+    names.sort();
+    // widget hoists to root because the peer resolves identically
+    // at root and at app.
+    assert_eq!(names, ["app", "react", "widget"], "widget hoists past app: {result:#?}");
+    let app = root_children.iter().find(|d| d.0.name == "app").unwrap().0.clone();
+    assert!(
+        app.dependencies.borrow().is_empty(),
+        "app stripped of its hoisted widget + dedup'd react: {app:#?}",
+    );
 }
 
 /// Non-empty `hoisting_limits` surfaces `UnsupportedHoistingLimits`.

--- a/crates/real-hoist/src/tests.rs
+++ b/crates/real-hoist/src/tests.rs
@@ -515,6 +515,92 @@ fn peer_constrained_node_stays_under_parent_when_root_provides_different_ident()
     assert!(app_names.contains(&"react"), "app keeps its own react@17: {app_names:?}");
 }
 
+/// Regression for the stale-ancestor-path bug: a peer-constrained
+/// leaf whose intermediate parent hoists to the root must be
+/// evaluated against the parent's *post-hoist* ancestor chain, not
+/// against the (now-irrelevant) original chain. The previous BFS
+/// captured the path at queue time, so when an intermediate node
+/// got hoisted between being queued and dequeued, the leaf would
+/// be checked against ex-ancestors and over-refused.
+///
+/// Setup: `root → {app, react@18}`, `app → {react@17, mid}`,
+/// `mid → terminal (peer: react)`. After hoist:
+/// - `app` and `react@18` are direct deps of root.
+/// - `react@17` stays under `app` because root's `react` slot is
+///   already taken by `react@18` (parent-wins).
+/// - `mid` has no name conflict at root, so it hoists.
+/// - `terminal` has peer `react`. With the *post-hoist* path
+///   `[root, mid]`, neither `mid` nor `root` provides a peer
+///   ident that disagrees with what `root` carries
+///   (`root.react@18` is consistent with itself), so `terminal`
+///   hoists too. The previous BFS would have used the stale path
+///   `[root, app, mid]`, seen `app.react@17 ≠ root.react@18`, and
+///   refused — leaving terminal nested under `mid` for no real
+///   reason.
+#[test]
+fn peer_check_uses_post_hoist_ancestor_path_not_queue_time_path() {
+    let mut importers = HashMap::new();
+    let mut root_deps = ResolvedDependencyMap::new();
+    root_deps.insert(pkg_name("app"), resolved_dep("1.0.0"));
+    root_deps.insert(pkg_name("react"), resolved_dep("18.0.0"));
+    importers.insert(
+        Lockfile::ROOT_IMPORTER_KEY.to_string(),
+        ProjectSnapshot { dependencies: Some(root_deps), ..ProjectSnapshot::default() },
+    );
+
+    let mut snapshots = HashMap::new();
+    let mut app_deps = HashMap::new();
+    app_deps.insert(pkg_name("react"), SnapshotDepRef::Plain(ver_peer("17.0.0")));
+    app_deps.insert(pkg_name("mid"), SnapshotDepRef::Plain(ver_peer("1.0.0")));
+    snapshots.insert(
+        dep_key("app", "1.0.0"),
+        SnapshotEntry { dependencies: Some(app_deps), ..SnapshotEntry::default() },
+    );
+    let mut mid_deps = HashMap::new();
+    mid_deps.insert(pkg_name("terminal"), SnapshotDepRef::Plain(ver_peer("1.0.0")));
+    snapshots.insert(
+        dep_key("mid", "1.0.0"),
+        SnapshotEntry { dependencies: Some(mid_deps), ..SnapshotEntry::default() },
+    );
+    snapshots.insert(dep_key("react", "17.0.0"), SnapshotEntry::default());
+    snapshots.insert(dep_key("react", "18.0.0"), SnapshotEntry::default());
+    snapshots.insert(dep_key("terminal", "1.0.0"), SnapshotEntry::default());
+
+    let mut packages = HashMap::new();
+    packages.insert(dep_key("terminal", "1.0.0").without_peer(), pkg_metadata_with_peer("react"));
+
+    let lockfile = Lockfile {
+        lockfile_version: lockfile_version(),
+        settings: None,
+        overrides: None,
+        importers,
+        packages: Some(packages),
+        snapshots: Some(snapshots),
+    };
+
+    let result = hoist(&lockfile, &HoistOpts::default()).expect("hoist should succeed");
+    let root_children = result.dependencies.borrow();
+    let mut names: Vec<&str> = root_children.iter().map(|d| d.0.name.as_str()).collect();
+    names.sort();
+    // The whole chain flattens: mid (no name conflict) hoists to
+    // root, and terminal (peer-friendly along its post-hoist
+    // path) hoists past mid.
+    assert_eq!(
+        names,
+        ["app", "mid", "react", "terminal"],
+        "mid and terminal hoist freely: {result:#?}",
+    );
+    let app = root_children.iter().find(|d| d.0.name == "app").unwrap().0.clone();
+    let app_deps = app.dependencies.borrow();
+    let app_names: Vec<&str> = app_deps.iter().map(|d| d.0.name.as_str()).collect();
+    // app keeps its conflicting react@17 (parent-wins), but mid
+    // has moved to root so app no longer carries it.
+    assert_eq!(app_names, ["react"], "app retains conflicting react@17: {app_names:?}");
+    drop(app_deps);
+    let mid = root_children.iter().find(|d| d.0.name == "mid").unwrap().0.clone();
+    assert!(mid.dependencies.borrow().is_empty(), "mid stripped of terminal: {mid:#?}");
+}
+
 /// Peer-friendly hoist: `app → widget (peer: react)`, `app → react@18`,
 /// `root → react@18`. The peer name `react` is provided by both
 /// `app` and the root with the *same* ident (`react@18`, shared `Rc`


### PR DESCRIPTION
## Summary

Lifts the previous `UnsupportedPeerDependency` upfront guard and replaces it with the real peer check from upstream's `getNodeHoistInfo`. The hoister now accepts lockfiles whose packages declare peer dependencies and produces the layout pnpm would: a peer-constrained dep only floats up to the root when doing so doesn't change which package its peers resolve to.

## How it works

- `HoisterResult` carries the input `peer_names` set forward. Upstream's `HoisterResult` doesn't (peer info lives on its intermediate `HoisterWorkTree`); pacquet runs the algorithm on `HoisterResult` directly, so the peer set rides along.

- The hoist driver is a recursive `hoist_subtree` that walks the result graph depth-first. Each recursion receives the candidate parent's *current* ancestor path (`Vec<Rc<HoisterResult>>` exclusive of the parent). After a child's hoist decision is applied, the path passed into the child's recursion reflects its *new* position — a freshly-hoisted child recurses with `[root]`, a child that stayed nested recurses with `parent_path + [parent]`. (An earlier version of this PR used BFS with paths captured at queue time; that path went stale whenever a node was hoisted between being queued and dequeued, leading to over-refused hoists. The recursive form was Copilot's recommendation in code review; the bug regression is pinned by `peer_check_uses_post_hoist_ancestor_path_not_queue_time_path`.)

- `would_shadow_peer` walks that path to decide whether a candidate hoist would change its own peer resolution.

- New `AbsorbDecision::PeerShadow` variant alongside `Free` / `SameNode` / `Conflict`. Fires when:
  1. Root declares the candidate's own name as a peer (root-shadow guard — vacuous today since the wrapper's `.` root has empty `peer_names`, kept for parity).
  2. For each peer name `P` the candidate declares, the closest ancestor providing `P` does so with a different ident than the root's `P`. Promoting the candidate would silently re-resolve the peer.

- The previous `UnsupportedPeerDependency` error variant and `find_first_peer_constrained` upfront scan are gone. The `#[non_exhaustive]` tag stays so future variants can be added without breaking callers.

## DAG-vs-tree caveat

Upstream's `cloneTree` duplicates the work tree into a strict tree per parent path, so each candidate visit has a unique ancestor chain. Pacquet preserves the DAG (its identity-dedup is a feature) and records only the path DFS actually used to reach the candidate. In the rare case where the same `Rc` is reachable through both a peer-compatible and a peer-shadowing path, pacquet refuses to hoist — the layout ends up at most over-nested, never under-nested. The trade-off is documented on `would_shadow_peer`.

## Upstream reference

- [`hoist.ts:414`](https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L414) — root-shadow guard.
- [`hoist.ts:454-479`](https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L454-L479) — ancestor-path peer check.
- [`hoist.ts:670`](https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L670) — `cloneTree`, the per-path-tree shape pacquet skips.

## Test plan

- [x] `peer_constrained_node_stays_under_parent_when_root_provides_different_ident` — `app → widget (peer: react) + react@17`, `root → react@18`. widget cannot hoist because hoisting would change its peer to react@18.
- [x] `peer_constrained_node_hoists_when_ancestor_and_root_agree` — same shape but `app → react@18` matches root's `react@18` (shared `Rc` via wrapper dedup), so widget hoists freely.
- [x] `peer_check_uses_post_hoist_ancestor_path_not_queue_time_path` — regression for the BFS-stale-path bug Copilot caught. `root → app → mid → terminal` (peer: `react`) where `mid` hoists past a conflicting `app.react@17`. Under the previous BFS the stale path `[root, app, mid]` made `terminal`'s peer check trip on `app.react@17 ≠ root.react@18` and refuse the hoist; under DFS the actual post-hoist path `[root, mid]` finds no provider mismatch and `terminal` correctly flattens to root.
- [x] All 10 pre-existing tests still pass (`one_transitive_dep_hoists_to_root`, `diamond_dep_hoists_once_to_root`, `version_conflict_keeps_loser_at_parent`, `deep_chain_flattens_in_one_pass`, `transitive_npm_alias_resolves_target_snapshot`, `non_empty_hoisting_limits_surfaces_unsupported`, `multi_importer_lockfile_surfaces_unsupported_workspace`, `external_dependencies_are_stripped_from_the_result`, `empty_lockfile_yields_empty_root`, `hoist_throws_on_broken_lockfile`).
- [x] The previously-failing `peer_dependency_in_lockfile_surfaces_unsupported` test from #452 is replaced (peers are no longer an unsupported input).
- [x] All Copilot review threads addressed and resolved (stale ancestor path, misleading comment).
- [x] `just ready` (836 tests pass), `cargo doc --document-private-items`, `taplo format --check`, `just dylint` all clean.

---
Written by an agent (Claude Code, claude-opus-4-7).
