### PR TITLE
test(git-fetcher): port §E git-fetcher and tarball-fetcher tests from upstream (#436 §E)

### DIFF
--- a/crates/git-fetcher/src/fetcher/tests.rs
+++ b/crates/git-fetcher/src/fetcher/tests.rs
@@ -419,13 +419,25 @@ async fn fetcher_skips_build_when_ignore_scripts() {
         package_id: "x@1.0.0",
         requester: "/test",
         store_index_writer: None,
-        files_index_file: "x@1.0.0\tnot-built",
+        // The key's `built` dimension reflects what the *dispatcher*
+        // would pass for `ignore_scripts: false`. Upstream's
+        // `pickStoreIndexKey` would flip this to `\tnot-built` when
+        // ignore-scripts is honored at the dispatcher layer; pacquet's
+        // dispatcher hardcodes `built=true` today (see
+        // `install_package_by_snapshot.rs`), so we mirror that here.
+        // `received.built` is the unrelated `should_be_built` flag from
+        // `prepare_package` (does the manifest declare a build?) — it
+        // can be `true` even when scripts were skipped.
+        files_index_file: "x@1.0.0\tbuilt",
     }
     .run::<SilentReporter>()
     .await
     .unwrap();
 
-    assert!(received.built, "package with prepare script still reports built when ignored");
+    assert!(
+        received.built,
+        "should_be_built must still report `true` when the manifest declares prepare scripts, even if ignore_scripts blocked them",
+    );
     assert!(received.cas_paths.contains_key("package.json"));
     assert!(received.cas_paths.contains_key("index.js"));
 }

--- a/crates/git-fetcher/src/fetcher/tests.rs
+++ b/crates/git-fetcher/src/fetcher/tests.rs
@@ -220,3 +220,212 @@ async fn fetcher_blocks_build_when_not_allowed() {
         other => panic!("expected Prepare::NotAllowed, got {other:?}"),
     }
 }
+
+/// Variant of `make_bare_repo` for monorepo-style fixtures: commits
+/// a `packages/sub/package.json` + `packages/sub/index.js` and a
+/// sibling `packages/other/index.js` that must NOT end up in the
+/// fetcher's output when `path: Some("packages/sub")` is set.
+/// Returns `(bare_repo_path, commit_sha)` like `make_bare_repo`.
+fn make_monorepo_bare_repo(tmp: &Path) -> (PathBuf, String) {
+    let work = tmp.join("work");
+    let bare = tmp.join("repo.git");
+    fs::create_dir_all(work.join("packages/sub")).unwrap();
+    fs::create_dir_all(work.join("packages/other")).unwrap();
+
+    exec_git(&["init", "-q", "-b", "main"], Some(&work)).unwrap();
+    exec_git(&["config", "user.email", "test@example.invalid"], Some(&work)).unwrap();
+    exec_git(&["config", "user.name", "Test"], Some(&work)).unwrap();
+    fs::write(work.join("package.json"), r#"{"name":"monorepo","version":"0.0.0","private":true}"#)
+        .unwrap();
+    fs::write(
+        work.join("packages/sub/package.json"),
+        r#"{"name":"sub","version":"1.0.0","main":"index.js"}"#,
+    )
+    .unwrap();
+    fs::write(work.join("packages/sub/index.js"), "module.exports = 'sub';\n").unwrap();
+    fs::write(work.join("packages/other/package.json"), r#"{"name":"other","version":"1.0.0"}"#)
+        .unwrap();
+    fs::write(work.join("packages/other/index.js"), "module.exports = 'other';\n").unwrap();
+    exec_git(&["add", "-A"], Some(&work)).unwrap();
+    exec_git(&["-c", "commit.gpgsign=false", "commit", "-q", "-m", "init"], Some(&work)).unwrap();
+    let commit = exec_git(&["rev-parse", "HEAD"], Some(&work)).unwrap().trim().to_string();
+    exec_git(&["clone", "--bare", "-q", &work.to_string_lossy(), &bare.to_string_lossy()], None)
+        .unwrap();
+    (bare, commit)
+}
+
+/// Bare repo with no `package.json` at root. Used to confirm the
+/// fetcher tolerates packages whose archive lacks a manifest — the
+/// install dispatcher rejects such packages downstream, but the
+/// fetcher itself must not crash.
+fn make_bare_repo_without_manifest(tmp: &Path) -> (PathBuf, String) {
+    let work = tmp.join("work");
+    let bare = tmp.join("repo.git");
+    fs::create_dir_all(&work).unwrap();
+    exec_git(&["init", "-q", "-b", "main"], Some(&work)).unwrap();
+    exec_git(&["config", "user.email", "test@example.invalid"], Some(&work)).unwrap();
+    exec_git(&["config", "user.name", "Test"], Some(&work)).unwrap();
+    fs::write(work.join("README.md"), "# bare\n").unwrap();
+    fs::write(work.join("index.js"), "module.exports = 1;\n").unwrap();
+    exec_git(&["add", "-A"], Some(&work)).unwrap();
+    exec_git(&["-c", "commit.gpgsign=false", "commit", "-q", "-m", "init"], Some(&work)).unwrap();
+    let commit = exec_git(&["rev-parse", "HEAD"], Some(&work)).unwrap().trim().to_string();
+    exec_git(&["clone", "--bare", "-q", &work.to_string_lossy(), &bare.to_string_lossy()], None)
+        .unwrap();
+    (bare, commit)
+}
+
+/// Ports pnpm's `fetch a package from Git sub folder` at
+/// <https://github.com/pnpm/pnpm/blob/94240bc046/fetching/git-fetcher/test/index.ts#L69>.
+/// The fetcher must pack only the files under `resolution.path`, not
+/// the monorepo root or sibling packages.
+#[tokio::test(flavor = "multi_thread")]
+async fn fetcher_packs_subfolder_when_path_set() {
+    if skip_if_no_git() {
+        return;
+    }
+    let tmp = tempdir().unwrap();
+    let (bare, commit) = make_monorepo_bare_repo(tmp.path());
+    let store_root = tempdir().unwrap();
+    let store_dir = StoreDir::from(store_root.path().to_path_buf());
+
+    let repo_url = format!("file://{}", bare.display());
+    let received = GitFetcher {
+        repo: &repo_url,
+        commit: &commit,
+        path: Some("packages/sub"),
+        git_shallow_hosts: &[],
+        allow_build: deny_all_builds(),
+        ignore_scripts: false,
+        unsafe_perm: true,
+        user_agent: None,
+        scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+        script_shell: None,
+        node_execpath: None,
+        npm_execpath: None,
+        store_dir: &store_dir,
+        package_id: "sub@1.0.0",
+        requester: "/test",
+        store_index_writer: None,
+        files_index_file: "sub@1.0.0\tbuilt",
+    }
+    .run::<SilentReporter>()
+    .await
+    .unwrap();
+
+    let keys: Vec<&str> = received.cas_paths.keys().map(String::as_str).collect();
+    assert!(keys.contains(&"package.json"), "sub-dir manifest must be included: {keys:?}");
+    assert!(keys.contains(&"index.js"), "sub-dir main must be included: {keys:?}");
+    assert!(
+        !keys.iter().any(|k| k.contains("other") || k.contains("packages/")),
+        "sibling-package files must not appear; keys are relative to the sub-dir: {keys:?}",
+    );
+}
+
+/// Ports pnpm's `fetch a package without a package.json` at
+/// <https://github.com/pnpm/pnpm/blob/94240bc046/fetching/git-fetcher/test/index.ts#L150>.
+/// `prepare_package` returns `should_be_built: false` when no manifest
+/// is present, and the fetcher imports whatever files the packlist
+/// finds — the install dispatcher rejects manifest-less packages
+/// downstream, but the fetcher itself must not crash.
+#[tokio::test(flavor = "multi_thread")]
+async fn fetcher_handles_repo_without_package_json() {
+    if skip_if_no_git() {
+        return;
+    }
+    let tmp = tempdir().unwrap();
+    let (bare, commit) = make_bare_repo_without_manifest(tmp.path());
+    let store_root = tempdir().unwrap();
+    let store_dir = StoreDir::from(store_root.path().to_path_buf());
+
+    let repo_url = format!("file://{}", bare.display());
+    let received = GitFetcher {
+        repo: &repo_url,
+        commit: &commit,
+        path: None,
+        git_shallow_hosts: &[],
+        allow_build: deny_all_builds(),
+        ignore_scripts: false,
+        unsafe_perm: true,
+        user_agent: None,
+        scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+        script_shell: None,
+        node_execpath: None,
+        npm_execpath: None,
+        store_dir: &store_dir,
+        package_id: "anon@0.0.0",
+        requester: "/test",
+        store_index_writer: None,
+        files_index_file: "anon@0.0.0\tbuilt",
+    }
+    .run::<SilentReporter>()
+    .await
+    .unwrap();
+
+    assert!(!received.built, "no manifest → not built");
+    assert!(received.cas_paths.contains_key("README.md"));
+    assert!(received.cas_paths.contains_key("index.js"));
+}
+
+/// Ports pnpm's `do not build the package when scripts are ignored`
+/// at <https://github.com/pnpm/pnpm/blob/94240bc046/fetching/git-fetcher/test/index.ts#L247>.
+/// A repo with `scripts.prepare` set must NOT run the script when
+/// `ignore_scripts: true`; the fetcher still reports
+/// `should_be_built: true` so the caller knows the package wanted a
+/// build (matches upstream's `shouldBeBuilt = true` short-circuit).
+#[tokio::test(flavor = "multi_thread")]
+async fn fetcher_skips_build_when_ignore_scripts() {
+    if skip_if_no_git() {
+        return;
+    }
+    let tmp = tempdir().unwrap();
+    // A repo whose `prepare` script would fail if it ran — observing
+    // success proves the lifecycle runner never spawned anything.
+    let work = tmp.path().join("work");
+    let bare = tmp.path().join("repo.git");
+    fs::create_dir_all(&work).unwrap();
+    exec_git(&["init", "-q", "-b", "main"], Some(&work)).unwrap();
+    exec_git(&["config", "user.email", "test@example.invalid"], Some(&work)).unwrap();
+    exec_git(&["config", "user.name", "Test"], Some(&work)).unwrap();
+    fs::write(
+        work.join("package.json"),
+        r#"{"name":"x","version":"1.0.0","main":"index.js","scripts":{"prepare":"exit 1"}}"#,
+    )
+    .unwrap();
+    fs::write(work.join("index.js"), "module.exports = 1;\n").unwrap();
+    exec_git(&["add", "-A"], Some(&work)).unwrap();
+    exec_git(&["-c", "commit.gpgsign=false", "commit", "-q", "-m", "init"], Some(&work)).unwrap();
+    let commit = exec_git(&["rev-parse", "HEAD"], Some(&work)).unwrap().trim().to_string();
+    exec_git(&["clone", "--bare", "-q", &work.to_string_lossy(), &bare.to_string_lossy()], None)
+        .unwrap();
+
+    let store_root = tempdir().unwrap();
+    let store_dir = StoreDir::from(store_root.path().to_path_buf());
+    let repo_url = format!("file://{}", bare.display());
+    let received = GitFetcher {
+        repo: &repo_url,
+        commit: &commit,
+        path: None,
+        git_shallow_hosts: &[],
+        allow_build: deny_all_builds(),
+        ignore_scripts: true,
+        unsafe_perm: true,
+        user_agent: None,
+        scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+        script_shell: None,
+        node_execpath: None,
+        npm_execpath: None,
+        store_dir: &store_dir,
+        package_id: "x@1.0.0",
+        requester: "/test",
+        store_index_writer: None,
+        files_index_file: "x@1.0.0\tnot-built",
+    }
+    .run::<SilentReporter>()
+    .await
+    .unwrap();
+
+    assert!(received.built, "package with prepare script still reports built when ignored");
+    assert!(received.cas_paths.contains_key("package.json"));
+    assert!(received.cas_paths.contains_key("index.js"));
+}

--- a/crates/git-fetcher/src/tarball_fetcher/tests.rs
+++ b/crates/git-fetcher/src/tarball_fetcher/tests.rs
@@ -349,3 +349,88 @@ async fn writes_index_row_when_writer_provided() {
         "freshly imported entries have no integrity-check timestamp yet",
     );
 }
+
+/// Ports pnpm's `prevent directory traversal attack when path is
+/// present` at
+/// <https://github.com/pnpm/pnpm/blob/94240bc046/fetching/tarball-fetcher/test/fetch.ts#L610>.
+/// A `..`-laden `resolution.path` must be rejected by
+/// `prepare_package`'s `safe_join_path` with `INVALID_PATH` before
+/// any extraction happens.
+#[tokio::test(flavor = "multi_thread")]
+async fn tarball_path_traversal_attack_is_rejected() {
+    let store_root = tempdir().unwrap();
+    let store_dir = StoreDir::from(store_root.path().to_path_buf());
+
+    let cas_paths =
+        write_to_cas(&store_dir, &[("package.json", br#"{"name":"x","version":"1.0.0"}"#, false)]);
+
+    let err = GitHostedTarballFetcher {
+        cas_paths,
+        path: Some("../escape"),
+        allow_build: deny_all_builds(),
+        ignore_scripts: false,
+        unsafe_perm: true,
+        user_agent: None,
+        scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+        script_shell: None,
+        node_execpath: None,
+        npm_execpath: None,
+        store_dir: &store_dir,
+        package_id: "x@1.0.0",
+        requester: "/test",
+        store_index_writer: None,
+        files_index_file: "x@1.0.0\tbuilt",
+    }
+    .run::<SilentReporter>()
+    .await
+    .unwrap_err();
+
+    match err {
+        GitFetcherError::Prepare(PreparePackageError::InvalidPath { path }) => {
+            assert_eq!(path, "../escape");
+        }
+        other => panic!("expected Prepare::InvalidPath, got {other:?}"),
+    }
+}
+
+/// Ports pnpm's `fail when path is not exists` at
+/// <https://github.com/pnpm/pnpm/blob/94240bc046/fetching/tarball-fetcher/test/fetch.ts#L637>.
+/// A `path` pointing at a sub-directory the tarball doesn't contain
+/// must surface as `INVALID_PATH` — silently packing the root would
+/// produce a working install for the wrong package.
+#[tokio::test(flavor = "multi_thread")]
+async fn tarball_path_to_missing_subdir_is_rejected() {
+    let store_root = tempdir().unwrap();
+    let store_dir = StoreDir::from(store_root.path().to_path_buf());
+
+    let cas_paths =
+        write_to_cas(&store_dir, &[("package.json", br#"{"name":"x","version":"1.0.0"}"#, false)]);
+
+    let err = GitHostedTarballFetcher {
+        cas_paths,
+        path: Some("does/not/exist"),
+        allow_build: deny_all_builds(),
+        ignore_scripts: false,
+        unsafe_perm: true,
+        user_agent: None,
+        scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+        script_shell: None,
+        node_execpath: None,
+        npm_execpath: None,
+        store_dir: &store_dir,
+        package_id: "x@1.0.0",
+        requester: "/test",
+        store_index_writer: None,
+        files_index_file: "x@1.0.0\tbuilt",
+    }
+    .run::<SilentReporter>()
+    .await
+    .unwrap_err();
+
+    match err {
+        GitFetcherError::Prepare(PreparePackageError::InvalidPath { path }) => {
+            assert_eq!(path, "does/not/exist");
+        }
+        other => panic!("expected Prepare::InvalidPath, got {other:?}"),
+    }
+}

--- a/plans/TEST_PORTING.md
+++ b/plans/TEST_PORTING.md
@@ -566,46 +566,46 @@ Install tests:
 - [ ] `TypeScript repo: installing/deps-installer/test/install/fromRepo.ts:105` `from a github repo with different name`
 - [ ] `TypeScript repo: installing/deps-installer/test/install/fromRepo.ts:150` `a subdependency is from a github repo with different name`
 - [ ] `TypeScript repo: installing/deps-installer/test/install/fromRepo.ts:174` `from a git repo`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/fromRepo.ts:206` `from a github repo that has no package.json file`
+- [x] `TypeScript repo: installing/deps-installer/test/install/fromRepo.ts:206` `from a github repo that has no package.json file` — covered at fetcher level by `crates/git-fetcher/src/fetcher/tests.rs::fetcher_handles_repo_without_package_json`. Full install-level test deferred until a non-resolver lockfile fixture lands.
 - [ ] `TypeScript repo: installing/deps-installer/test/install/fromRepo.ts:276` `re-adding a git repo with a different tag`
 - [ ] `TypeScript repo: installing/deps-installer/test/install/fromRepo.ts:323` `should not update when adding unrelated dependency`
 - [ ] `TypeScript repo: installing/deps-installer/test/install/fromRepo.ts:354` `git-hosted repository is not added to the store if it fails to be built`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/fromRepo.ts:366` `from subdirectories of a git repo`
+- [x] `TypeScript repo: installing/deps-installer/test/install/fromRepo.ts:366` `from subdirectories of a git repo` — covered at fetcher level by `fetcher_packs_subfolder_when_path_set`. Full install-level test deferred (Stage 2 resolver dependency).
 - [ ] `TypeScript repo: installing/deps-installer/test/install/fromRepo.ts:389` `no hash character for github subdirectory install`
 - [ ] `TypeScript repo: installing/deps-installer/test/install/lifecycleScripts.ts:311` `run prepare script for git-hosted dependencies`
 
 Fetcher/resolver/store tests:
 
-- [ ] `TypeScript repo: fetching/git-fetcher/test/index.ts:50` `fetch`
-- [ ] `TypeScript repo: fetching/git-fetcher/test/index.ts:69` `fetch a package from Git sub folder`
-- [ ] `TypeScript repo: fetching/git-fetcher/test/index.ts:87` `prevent directory traversal attack when using Git sub folder`
-- [ ] `TypeScript repo: fetching/git-fetcher/test/index.ts:108` `prevent directory traversal attack when using Git sub folder #2`
-- [ ] `TypeScript repo: fetching/git-fetcher/test/index.ts:129` `fetch a package from Git that has a prepare script`
-- [ ] `TypeScript repo: fetching/git-fetcher/test/index.ts:150` `fetch a package without a package.json`
-- [ ] `TypeScript repo: fetching/git-fetcher/test/index.ts:169` `fetch a big repository`
-- [ ] `TypeScript repo: fetching/git-fetcher/test/index.ts:183` `still able to shallow fetch for allowed hosts`
-- [ ] `TypeScript repo: fetching/git-fetcher/test/index.ts:212` `fail when preparing a git-hosted package`
-- [ ] `TypeScript repo: fetching/git-fetcher/test/index.ts:230` `fail when preparing a git-hosted package with a partial commit`
-- [ ] `TypeScript repo: fetching/git-fetcher/test/index.ts:247` `do not build the package when scripts are ignored`
-- [ ] `TypeScript repo: fetching/git-fetcher/test/index.ts:263` `block git package with prepare script`
-- [ ] `TypeScript repo: fetching/git-fetcher/test/index.ts:280` `allow git package with prepare script`
-- [ ] `TypeScript repo: fetching/git-fetcher/test/index.ts:304` `fetch only the included files`
-- [ ] `TypeScript repo: fetching/tarball-fetcher/test/fetch.ts:455` `fetch a big repository`
-- [ ] `TypeScript repo: fetching/tarball-fetcher/test/fetch.ts:472` `fail when preparing a git-hosted package`
-- [ ] `TypeScript repo: fetching/tarball-fetcher/test/fetch.ts:490` `take only the files included in the package, when fetching a git-hosted package`
-- [ ] `TypeScript repo: fetching/tarball-fetcher/test/fetch.ts:534` `do not build the package when scripts are ignored`
-- [ ] `TypeScript repo: fetching/tarball-fetcher/test/fetch.ts:580` `use the subfolder when path is present`
-- [ ] `TypeScript repo: fetching/tarball-fetcher/test/fetch.ts:610` `prevent directory traversal attack when path is present`
-- [ ] `TypeScript repo: fetching/tarball-fetcher/test/fetch.ts:637` `fail when path is not exists`
+- [x] `TypeScript repo: fetching/git-fetcher/test/index.ts:50` `fetch` — `crates/git-fetcher/src/fetcher/tests.rs::fetcher_imports_package_into_cas`.
+- [x] `TypeScript repo: fetching/git-fetcher/test/index.ts:69` `fetch a package from Git sub folder` — `fetcher_packs_subfolder_when_path_set`.
+- [x] `TypeScript repo: fetching/git-fetcher/test/index.ts:87` `prevent directory traversal attack when using Git sub folder` — `prepare_package::tests::safe_join_path_rejects_escapes` + `cas_io::tests::materialize_into_rejects_traversal`.
+- [x] `TypeScript repo: fetching/git-fetcher/test/index.ts:108` `prevent directory traversal attack when using Git sub folder #2` — same coverage as above (`join_checked` rejects every non-`Normal` component variant).
+- [ ] `TypeScript repo: fetching/git-fetcher/test/index.ts:129` `fetch a package from Git that has a prepare script` — needs a real package manager on the test host to actually run the script. Defer until a `skip-if-no-npm` test helper exists.
+- [x] `TypeScript repo: fetching/git-fetcher/test/index.ts:150` `fetch a package without a package.json` — `fetcher_handles_repo_without_package_json`.
+- [ ] `TypeScript repo: fetching/git-fetcher/test/index.ts:169` `fetch a big repository` — perf benchmark, not a correctness test; skip from the porting plan.
+- [ ] `TypeScript repo: fetching/git-fetcher/test/index.ts:183` `still able to shallow fetch for allowed hosts` — requires a PATH-shimmed `git` to spy on argv. `should_use_shallow_matches_known_host` covers the predicate; the end-to-end `fetch --depth 1` assertion is deferred.
+- [ ] `TypeScript repo: fetching/git-fetcher/test/index.ts:212` `fail when preparing a git-hosted package` — needs a real failing prepare script (and thus a real package manager). Deferred alongside `index.ts:129`.
+- [ ] `TypeScript repo: fetching/git-fetcher/test/index.ts:230` `fail when preparing a git-hosted package with a partial commit` — Stage 2 (resolver concern).
+- [x] `TypeScript repo: fetching/git-fetcher/test/index.ts:247` `do not build the package when scripts are ignored` — `fetcher_skips_build_when_ignore_scripts`.
+- [x] `TypeScript repo: fetching/git-fetcher/test/index.ts:263` `block git package with prepare script` — `fetcher_blocks_build_when_not_allowed`.
+- [ ] `TypeScript repo: fetching/git-fetcher/test/index.ts:280` `allow git package with prepare script` — needs a real package manager. Deferred.
+- [x] `TypeScript repo: fetching/git-fetcher/test/index.ts:304` `fetch only the included files` — `tarball_fetcher::tests::filters_files_outside_files_field` (same packlist code path).
+- [ ] `TypeScript repo: fetching/tarball-fetcher/test/fetch.ts:455` `fetch a big repository` — perf benchmark, not a correctness test; skip.
+- [ ] `TypeScript repo: fetching/tarball-fetcher/test/fetch.ts:472` `fail when preparing a git-hosted package` — needs a real failing prepare script. Deferred.
+- [x] `TypeScript repo: fetching/tarball-fetcher/test/fetch.ts:490` `take only the files included in the package, when fetching a git-hosted package` — `tarball_fetcher::tests::filters_files_outside_files_field`.
+- [ ] `TypeScript repo: fetching/tarball-fetcher/test/fetch.ts:534` `do not build the package when scripts are ignored` — git-fetcher equivalent covered (`fetcher_skips_build_when_ignore_scripts`); a tarball-side mirror is straightforward but not yet written.
+- [x] `TypeScript repo: fetching/tarball-fetcher/test/fetch.ts:580` `use the subfolder when path is present` — `tarball_fetcher::tests::path_field_packs_only_subdirectory`.
+- [x] `TypeScript repo: fetching/tarball-fetcher/test/fetch.ts:610` `prevent directory traversal attack when path is present` — `tarball_path_traversal_attack_is_rejected`.
+- [x] `TypeScript repo: fetching/tarball-fetcher/test/fetch.ts:637` `fail when path is not exists` — `tarball_path_to_missing_subdir_is_rejected`.
 - [ ] `TypeScript repo: resolving/git-resolver/test/index.ts:188` `resolveFromGit() with sub folder`
 - [ ] `TypeScript repo: resolving/git-resolver/test/index.ts:211` `resolveFromGit() with both sub folder and branch`
 - [ ] `TypeScript repo: resolving/git-resolver/test/index.ts:482` `resolve a private repository using the HTTPS protocol without auth token`
 - [ ] `TypeScript repo: resolving/git-resolver/test/index.ts:526` `resolve a private repository using the HTTPS protocol and an auth token`
-- [ ] `TypeScript repo: installing/package-requester/test/index.ts:884` `fetch a git package without a package.json`
+- [x] `TypeScript repo: installing/package-requester/test/index.ts:884` `fetch a git package without a package.json` — covered alongside `fetching/git-fetcher/test/index.ts:150` via `fetcher_handles_repo_without_package_json`.
 - [ ] `TypeScript repo: installing/deps-installer/test/install/peerDependencies.ts:30` `don't fail when peer dependency is fetched from GitHub`
 - [ ] `TypeScript repo: installing/deps-installer/test/lockfile.ts:600` `updating package that has a github-hosted dependency`
-- [ ] `TypeScript repo: store/pkg-finder/test/readPackageFileMap.test.ts:67` `should resolve git-hosted tarball packages (no type, has tarball)`
-- [ ] `TypeScript repo: store/pkg-finder/test/readPackageFileMap.test.ts:84` `should resolve git dependencies with type "git" and return readable file paths`
+- [x] `TypeScript repo: store/pkg-finder/test/readPackageFileMap.test.ts:67` `should resolve git-hosted tarball packages (no type, has tarball)` — write side covered by `tarball_fetcher::tests::writes_index_row_when_writer_provided`; read side reuses the existing tarball-warm prefetch (no git-specific code path).
+- [x] `TypeScript repo: store/pkg-finder/test/readPackageFileMap.test.ts:84` `should resolve git dependencies with type "git" and return readable file paths` — same coverage: the write side produces a `gitHostedStoreIndexKey` row at `pkg_id\tbuilt` (see `create_virtual_store::tests::snapshot_cache_key_for_git_resolution_uses_git_hosted_key` for the read-side key shape pin).
 
 Skipped upstream tests to track:
 


### PR DESCRIPTION
## Summary

Ports five new tests against the local-bare-repo and write-to-CAS fixtures already established by §B+D and §C, plus the `plans/TEST_PORTING.md` checkbox updates for the §E subset that ships today (15 items checked off; the rest carry concrete deferral reasons — Stage 2 resolver work, real-npm requirements, perf benchmarks, or follow-up tests that need a PATH-shim helper).

### New tests in `crates/git-fetcher/src/fetcher/tests.rs`

- `fetcher_packs_subfolder_when_path_set` — ports [`fetching/git-fetcher/test/index.ts:69`](https://github.com/pnpm/pnpm/blob/94240bc046/fetching/git-fetcher/test/index.ts#L69). Builds a tiny monorepo bare repo, runs `GitFetcher` with `path: Some("packages/sub")`, asserts the returned `cas_paths` only contain files relative to the sub-dir (never sibling packages, never carrying the `packages/` prefix).
- `fetcher_handles_repo_without_package_json` — ports [`fetching/git-fetcher/test/index.ts:150`](https://github.com/pnpm/pnpm/blob/94240bc046/fetching/git-fetcher/test/index.ts#L150). A repo with no `package.json` at root still imports cleanly: `prepare_package` returns `should_be_built: false`, and the fetcher hands the install dispatcher the files the packlist found.
- `fetcher_skips_build_when_ignore_scripts` — ports [`fetching/git-fetcher/test/index.ts:247`](https://github.com/pnpm/pnpm/blob/94240bc046/fetching/git-fetcher/test/index.ts#L247). A repo whose `scripts.prepare` would fail if it ran (`exit 1`) still produces a successful fetcher run when `ignore_scripts: true`; observing success proves the lifecycle runner never spawned. Pins the `should_be_built: true` short-circuit so callers know the package wanted a build.

### New tests in `crates/git-fetcher/src/tarball_fetcher/tests.rs`

- `tarball_path_traversal_attack_is_rejected` — ports [`fetching/tarball-fetcher/test/fetch.ts:610`](https://github.com/pnpm/pnpm/blob/94240bc046/fetching/tarball-fetcher/test/fetch.ts#L610). `path: Some("../escape")` must surface as `INVALID_PATH` from `prepare_package`'s `safe_join_path` before any extraction.
- `tarball_path_to_missing_subdir_is_rejected` — ports [`fetching/tarball-fetcher/test/fetch.ts:637`](https://github.com/pnpm/pnpm/blob/94240bc046/fetching/tarball-fetcher/test/fetch.ts#L637). `path: Some("does/not/exist")` for a tarball that doesn't contain the sub-dir must surface as `INVALID_PATH` rather than silently packing the root.

### `plans/TEST_PORTING.md` updates

15 §E items moved from `[ ]` to `[x]` with the covering pacquet test name. Deferrals carry concrete reasons:

- **Real-npm dependency** (3 items): `fetch a package from Git that has a prepare script`, `fail when preparing a git-hosted package`, `allow git package with prepare script`. Defer until a `skip-if-no-npm` test helper exists.
- **PATH-shim helper required** (1 item): `still able to shallow fetch for allowed hosts`. The predicate is unit-tested; the end-to-end `fetch --depth 1` assertion needs a `git`-binary spy.
- **Stage 2 resolver work** (most install-level fromRepo tests + the 4 git-resolver tests).
- **Perf benchmarks** (2 items): `fetch a big repository`.

## Out of scope (still on #436)

- Two-slot CAS layout (`${filesIndexFile}\traw` + final).
- Real `npm-packlist` semantics (`.npmignore`, `.gitignore`, `bundleDependencies` walking).
- The Stage 2 / real-npm / PATH-shim deferrals noted above.

## Test plan

- [x] `cargo nextest run -p pacquet-git-fetcher` — 47 tests pass (42 from previous PRs + 5 new).
- [x] `just ready` — 842 tests run, 842 pass.
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace --document-private-items` — clean.
- [x] `taplo format --check`
- [x] `just dylint`

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for fetching only a configured subdirectory.
  * Added tests for repos without a package manifest.
  * Added tests ensuring build scripts can be skipped when requested.
  * Added path-validation tests, including protection against directory traversal and missing-subpath errors.

* **Documentation**
  * Updated test-porting checklist to mark multiple git-fetcher/tarball-fetcher cases as completed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pacquet/pull/462)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->