### PR TITLE
feat(real-hoist): multi-round convergence + hoistingLimits (#438 slice 3 close-out)

### DIFF
--- a/crates/real-hoist/src/lib.rs
+++ b/crates/real-hoist/src/lib.rs
@@ -82,10 +82,13 @@ pub struct HoisterTree {
     /// hoister moves freely).
     pub peer_names: BTreeSet<String>,
     pub dependency_kind: HoisterDependencyKind,
-    /// Tiebreaker the hoister consults when ranking candidates.
-    /// Pacquet always builds with `0`; pnpm and yarn-berry use
-    /// higher values for packages that declare a high
-    /// `hoistPriority` to bias them toward the root.
+    /// Tiebreaker used upstream when ranking competing hoist
+    /// candidates. Carried through the type for parity with
+    /// `@yarnpkg/nm`'s `HoisterTree.hoistPriority` but currently
+    /// unread by pacquet's algorithm — pacquet builds every node
+    /// with `0` and the popularity-based preference pass that
+    /// would consume it isn't ported yet (see the "popularity-
+    /// based ident preference" gap on `nm_hoist`).
     pub hoist_priority: u32,
     /// Children of this node. Order matches insertion order — the
     /// hoister depends on it.
@@ -245,16 +248,16 @@ impl<T> From<Rc<T>> for RcByPtr<T> {
     }
 }
 
-/// Build the [`HoisterTree`] for `lockfile`'s root importer (plus
-/// any non-root importers as workspace children) and run the
-/// `@yarnpkg/nm` hoister over it. Ports
+/// Build the [`HoisterTree`] for `lockfile`'s root importer and
+/// run the `@yarnpkg/nm` hoister over it. Ports
 /// [`installing/linking/real-hoist/src/index.ts`][upstream].
 ///
-/// The inner hoist algorithm is currently stubbed: it returns the
-/// input tree shape converted to `HoisterResult` without moving
-/// anything. The lockfile-to-tree translation and the
-/// `LockfileMissingDependencyError` surface are what this function
-/// pins today.
+/// The inner hoist is a recursive DFS with multi-round
+/// convergence over the result graph (peer-aware, with
+/// `hoistingLimits` enforced as `Border` decisions). Gaps that
+/// remain — popularity-based ident preference, multi-importer
+/// workspace trees, and `ExternalSoftLink` descendants — are
+/// documented on the private `nm_hoist` driver.
 ///
 /// [upstream]: https://github.com/pnpm/pnpm/blob/94240bc0464196bd52f7006b97f6d9a43df34633/installing/linking/real-hoist/src/index.ts
 pub fn hoist(lockfile: &Lockfile, opts: &HoistOpts) -> Result<HoisterResult, HoistError> {
@@ -613,9 +616,17 @@ fn percent_encode_path(s: &str) -> String {
 ///
 /// [upstream]: https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L329
 fn nm_hoist(tree: &HoisterTree, opts: &HoistOpts) -> HoisterResult {
+    // Compute the root locator from the input tree, where each
+    // node carries a single unambiguous `reference`. The result
+    // graph collects references into a `BTreeSet` (one
+    // `HoisterResult` can absorb several `HoisterTree` nodes with
+    // the same ident), so deriving the locator from a result
+    // node would mean picking an arbitrary entry from the set;
+    // doing it here keeps the lookup well-defined.
+    let root_locator = format!("{}@{}", tree.ident_name, tree.reference);
     let mut memo: HashMap<*const HoisterTree, Rc<HoisterResult>> = HashMap::new();
     let root = convert(tree, &mut memo);
-    hoist_into_root(&root, opts);
+    hoist_into_root(&root, &root_locator, opts);
     // Returning an owned `HoisterResult` (rather than
     // `Rc<HoisterResult>`) keeps the wrapper's post-hoist
     // `external_dependencies` filter from mutating the shared graph.
@@ -693,7 +704,7 @@ enum AbsorbDecision {
 /// DAG sharing and accepts a more conservative ruling in the
 /// rare cross-path mismatch cases. The cost is layouts that are
 /// sometimes more nested than pnpm's, never less.
-fn hoist_into_root(root: &Rc<HoisterResult>, opts: &HoistOpts) {
+fn hoist_into_root(root: &Rc<HoisterResult>, root_locator: &str, opts: &HoistOpts) {
     let mut root_index: HashMap<String, RcByPtr<HoisterResult>> =
         root.dependencies.borrow().iter().map(|d| (d.0.name.clone(), d.clone())).collect();
 
@@ -703,10 +714,9 @@ fn hoist_into_root(root: &Rc<HoisterResult>, opts: &HoistOpts) {
     // names up by-name at decision time, which is equivalent since
     // there's only one root locator. An empty fallback set means
     // the check is effectively a no-op when no limits are configured.
-    let root_locator = make_locator(root);
     let empty_set: BTreeSet<String> = BTreeSet::new();
     let border_names: &BTreeSet<String> =
-        opts.hoisting_limits.get(&root_locator).unwrap_or(&empty_set);
+        opts.hoisting_limits.get(root_locator).unwrap_or(&empty_set);
 
     loop {
         let mut visited: HashSet<*const HoisterResult> = HashSet::new();
@@ -715,16 +725,6 @@ fn hoist_into_root(root: &Rc<HoisterResult>, opts: &HoistOpts) {
             break;
         }
     }
-}
-
-/// Build the upstream locator key (`identName@reference`) for a
-/// result node. The wrapper builds the root with
-/// `ident_name = "."` and `reference = ""`, so the root locator is
-/// `".@"` — the same form pnpm uses for `hoistingLimits` keys.
-fn make_locator(node: &Rc<HoisterResult>) -> String {
-    let refs = node.references.borrow();
-    let r = refs.iter().next().map(|s| s.as_str()).unwrap_or("");
-    format!("{}@{}", node.ident_name, r)
 }
 
 /// Depth-first hoist driver. `ancestor_path` is the path from

--- a/crates/real-hoist/src/lib.rs
+++ b/crates/real-hoist/src/lib.rs
@@ -173,23 +173,6 @@ pub enum HoistError {
         /// resolve.
         pkg_key: String,
     },
-    /// The caller passed a non-empty `hoisting_limits` map. The
-    /// hoist algorithm doesn't enforce limits yet, so flattening
-    /// would violate the borders the caller asked to keep. Refuse
-    /// upfront.
-    #[display(
-        "hoister cannot yet enforce `hoisting_limits`; the supplied map is non-empty ({len} entries)"
-    )]
-    #[diagnostic(
-        code(ERR_PACQUET_HOIST_UNSUPPORTED_HOISTING_LIMITS),
-        help("the hoister doesn't yet enforce `hoistingLimits`; pass an empty map.")
-    )]
-    UnsupportedHoistingLimits {
-        /// How many entries the caller supplied. Carries no
-        /// semantic value beyond debug; if zero we wouldn't have
-        /// fired.
-        len: usize,
-    },
     /// The lockfile contains more than one importer. The hoist
     /// algorithm doesn't yet support workspace projects (multi-
     /// importer hoist trees with `workspace:` references). Refuse
@@ -276,10 +259,9 @@ impl<T> From<Rc<T>> for RcByPtr<T> {
 pub fn hoist(lockfile: &Lockfile, opts: &HoistOpts) -> Result<HoisterResult, HoistError> {
     // Refuse upfront for inputs the algorithm doesn't yet model.
     // Better an explicit error than a silently-invented layout
-    // pnpm would reject.
-    if !opts.hoisting_limits.is_empty() {
-        return Err(HoistError::UnsupportedHoistingLimits { len: opts.hoisting_limits.len() });
-    }
+    // pnpm would reject. `hoisting_limits` is enforced by the
+    // algorithm itself (see `hoist_into_root`), so no upfront
+    // guard is needed here.
     let extra_importers: Vec<String> = lockfile
         .importers
         .keys()
@@ -597,23 +579,41 @@ fn percent_encode_path(s: &str) -> String {
 ///   iterates until a round makes no moves. Bounded by O(N)
 ///   rounds since each move is one-way (parent → root).
 ///
+/// What this models today (continued):
+///
+/// * `hoistingLimits` borders. Names in
+///   `opts.hoisting_limits[root_locator]` are kept out of the
+///   root's `node_modules` (`AbsorbDecision::Border`). Mirrors
+///   upstream's `isHoistBorder` flag.
+/// * `externalDependencies` placeholders — the wrapper adds them
+///   as zero-children `ExternalSoftLink` nodes at the root, and
+///   strips them from the result post-hoist. Same observable
+///   shape as upstream.
+///
 /// What this does *not* model yet:
 ///
-/// * `hoistingLimits` / `externalDependencies` runtime
-///   enforcement (the wrapper still refuses non-empty
-///   `hoisting_limits`).
-/// * `dependencyKind` distinctions for workspaces and external
-///   soft links (the `Workspace` guard at the wrapper boundary
-///   still refuses multi-importer lockfiles upfront).
+/// * Popularity-based ident preference (upstream's
+///   `buildPreferenceMap`). When two distinct deps share an
+///   alias, pacquet picks the first-visited; upstream picks the
+///   one with more incoming references. Outcome differs for the
+///   handful of upstream test cases that exercise the tie-break.
+/// * Multi-importer (workspace) hoist trees — pacquet's wrapper
+///   refuses lockfiles with non-root importers upfront via
+///   `UnsupportedWorkspace`. Workspace-aware hoisting requires
+///   per-importer roots and a different output shape.
+/// * `ExternalSoftLink` descendants — pacquet creates soft-links
+///   only as zero-children placeholders, so upstream's
+///   "only-hoist-when-all-descendants-hoist" rule has nothing to
+///   delay today.
 ///
 /// Matches the structural intent of upstream `hoistTo` at
 /// [hoist.ts:329][upstream] for the subset above.
 ///
 /// [upstream]: https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L329
-fn nm_hoist(tree: &HoisterTree, _opts: &HoistOpts) -> HoisterResult {
+fn nm_hoist(tree: &HoisterTree, opts: &HoistOpts) -> HoisterResult {
     let mut memo: HashMap<*const HoisterTree, Rc<HoisterResult>> = HashMap::new();
     let root = convert(tree, &mut memo);
-    hoist_into_root(&root);
+    hoist_into_root(&root, opts);
     // Returning an owned `HoisterResult` (rather than
     // `Rc<HoisterResult>`) keeps the wrapper's post-hoist
     // `external_dependencies` filter from mutating the shared graph.
@@ -647,6 +647,15 @@ enum AbsorbDecision {
     /// [peer-shadow-root]: https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L414
     /// [peer-path]: https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L454-L479
     PeerShadow,
+    /// The candidate's name is in `opts.hoisting_limits` for the
+    /// current root locator. The caller asked us to keep this name
+    /// out of the root's `node_modules`, so the candidate stays
+    /// nested under its parent. Mirrors upstream's `isHoistBorder`
+    /// flag set during `cloneTree` from
+    /// [`hoist.ts:707`][hoist-border].
+    ///
+    /// [hoist-border]: https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L707
+    Border,
 }
 
 /// Walk the result tree and hoist every eligible descendant of
@@ -682,16 +691,38 @@ enum AbsorbDecision {
 /// DAG sharing and accepts a more conservative ruling in the
 /// rare cross-path mismatch cases. The cost is layouts that are
 /// sometimes more nested than pnpm's, never less.
-fn hoist_into_root(root: &Rc<HoisterResult>) {
+fn hoist_into_root(root: &Rc<HoisterResult>, opts: &HoistOpts) {
     let mut root_index: HashMap<String, RcByPtr<HoisterResult>> =
         root.dependencies.borrow().iter().map(|d| (d.0.name.clone(), d.clone())).collect();
+
+    // Look up the names the caller asked us not to hoist to *this*
+    // root. Upstream stores this on each child as `isHoistBorder`
+    // during `cloneTree`; pacquet stays DAG-shaped and looks the
+    // names up by-name at decision time, which is equivalent since
+    // there's only one root locator. An empty fallback set means
+    // the check is effectively a no-op when no limits are configured.
+    let root_locator = make_locator(root);
+    let empty_set: BTreeSet<String> = BTreeSet::new();
+    let border_names: &BTreeSet<String> =
+        opts.hoisting_limits.get(&root_locator).unwrap_or(&empty_set);
+
     loop {
         let mut visited: HashSet<*const HoisterResult> = HashSet::new();
-        let changed = hoist_subtree(root, &[], root, &mut root_index, &mut visited);
+        let changed = hoist_subtree(root, &[], root, &mut root_index, &mut visited, border_names);
         if !changed {
             break;
         }
     }
+}
+
+/// Build the upstream locator key (`identName@reference`) for a
+/// result node. The wrapper builds the root with
+/// `ident_name = "."` and `reference = ""`, so the root locator is
+/// `".@"` — the same form pnpm uses for `hoistingLimits` keys.
+fn make_locator(node: &Rc<HoisterResult>) -> String {
+    let refs = node.references.borrow();
+    let r = refs.iter().next().map(|s| s.as_str()).unwrap_or("");
+    format!("{}@{}", node.ident_name, r)
 }
 
 /// Depth-first hoist driver. `ancestor_path` is the path from
@@ -706,6 +737,7 @@ fn hoist_subtree(
     root: &Rc<HoisterResult>,
     root_index: &mut HashMap<String, RcByPtr<HoisterResult>>,
     visited: &mut HashSet<*const HoisterResult>,
+    border_names: &BTreeSet<String>,
 ) -> bool {
     let root_ptr = Rc::as_ptr(root);
     if !visited.insert(Rc::as_ptr(node)) {
@@ -740,6 +772,13 @@ fn hoist_subtree(
             Some(existing) if Rc::ptr_eq(&existing.0, &child.0) => AbsorbDecision::SameNode,
             Some(_) => AbsorbDecision::Conflict,
         };
+
+        // Hoisting limits ride on top of the basic decision: even
+        // if the slot is free and no peer would shadow, the caller
+        // may have asked us to keep this name out of the root.
+        if matches!(decision, AbsorbDecision::Free) && border_names.contains(&child.0.name) {
+            decision = AbsorbDecision::Border;
+        }
 
         // Peer-aware refusal layered on top of the basic
         // free / dedup / conflict decision. `Conflict` already
@@ -781,21 +820,22 @@ fn hoist_subtree(
                     changed_in_subtree = true;
                     vec![Rc::clone(root)]
                 }
-                AbsorbDecision::Conflict | AbsorbDecision::PeerShadow => {
+                AbsorbDecision::Conflict | AbsorbDecision::PeerShadow | AbsorbDecision::Border => {
                     // Stays at the current parent. The version
-                    // already at root wins the slot, or
-                    // hoisting would shadow a peer dependency.
-                    // Child's ancestor path is the path through
-                    // `node`. A later round may revisit this
-                    // candidate with a different peer / conflict
-                    // context.
+                    // already at root wins the slot, hoisting would
+                    // shadow a peer dependency, or the caller's
+                    // `hoisting_limits` blocked the name. Child's
+                    // ancestor path is the path through `node`; a
+                    // later round may revisit this candidate with a
+                    // different peer / conflict context (limits are
+                    // fixed so the Border verdict won't change).
                     path_for_children.clone()
                 }
             }
         };
 
         let child_changed =
-            hoist_subtree(&child.0, &child_recursion_path, root, root_index, visited);
+            hoist_subtree(&child.0, &child_recursion_path, root, root_index, visited, border_names);
         changed_in_subtree |= child_changed;
     }
     changed_in_subtree

--- a/crates/real-hoist/src/lib.rs
+++ b/crates/real-hoist/src/lib.rs
@@ -82,9 +82,10 @@ pub struct HoisterTree {
     /// hoister moves freely).
     pub peer_names: BTreeSet<String>,
     pub dependency_kind: HoisterDependencyKind,
-    /// Tiebreaker for the hoister's BFS. Pacquet always builds with
-    /// `0`; pnpm and yarn-berry use higher values for packages that
-    /// declare a high `hoistPriority` to bias them toward the root.
+    /// Tiebreaker the hoister consults when ranking candidates.
+    /// Pacquet always builds with `0`; pnpm and yarn-berry use
+    /// higher values for packages that declare a high
+    /// `hoistPriority` to bias them toward the root.
     pub hoist_priority: u32,
     /// Children of this node. Order matches insertion order — the
     /// hoister depends on it.
@@ -548,8 +549,9 @@ fn percent_encode_path(s: &str) -> String {
 
 /// Pacquet's port of the `@yarnpkg/nm` hoist algorithm. Walks the
 /// input tree, deep-copies it into a `HoisterResult` shape, then
-/// pulls eligible descendants up to the root via single-pass BFS
-/// with parent-wins conflict resolution. Models the common case
+/// pulls eligible descendants up to the root via a depth-first
+/// recursion run to a fixed point (see [`hoist_into_root`]) with
+/// parent-wins conflict resolution. Models the common case
 /// of pnpm's `nodeLinker: hoisted` install — every transitive
 /// dependency that doesn't collide with an already-hoisted name
 /// surfaces at the root, just like a flat `node_modules`.
@@ -793,8 +795,10 @@ fn hoist_subtree(
 
         // Apply the decision, *then* compute the path to pass
         // into recursion based on the child's *new* position.
-        // This is the load-bearing difference from the previous
-        // BFS shape: the recursion path reflects current state.
+        // Computing post-decision is the load-bearing detail:
+        // the recursion path always reflects the child's current
+        // position in the result graph, so peer checks deeper
+        // down see ancestors that are actually ancestors.
         let child_recursion_path: Vec<Rc<HoisterResult>> = if is_root {
             // Root's direct children are already at root — no
             // movement happens, and their ancestor path is
@@ -866,7 +870,7 @@ fn hoist_subtree(
 /// Differs from upstream's check in one DAG case: upstream's
 /// [`cloneTree`][clone] duplicates the work tree into a strict
 /// tree per parent path, so each visit has a unique ancestor
-/// chain. Pacquet preserves the DAG, and the BFS records only
+/// chain. Pacquet preserves the DAG, and the DFS records only
 /// the path it actually used to reach the candidate; if the same
 /// candidate could be reached via a peer-compatible alternative
 /// path, we still refuse to hoist. The result is at most

--- a/crates/real-hoist/src/lib.rs
+++ b/crates/real-hoist/src/lib.rs
@@ -581,7 +581,7 @@ fn percent_encode_path(s: &str) -> String {
 ///   to one node at root.
 /// * Parent-wins on version conflict: when two distinct deps
 ///   share an alias but resolve to different snapshot keys, the
-///   first one BFS reaches takes the root slot and the other
+///   first one the DFS reaches takes the root slot and the other
 ///   stays under its parent.
 /// * Peer-shadow refusal: a candidate whose `peer_names` would
 ///   resolve against an ancestor's dep with a different ident
@@ -589,15 +589,16 @@ fn percent_encode_path(s: &str) -> String {
 ///   [`would_shadow_peer`] for the ancestor-path walk and how
 ///   pacquet's DAG-preserving model differs from upstream's
 ///   per-path tree clone in rare cross-path mismatch cases.
+/// * Multi-round convergence: when a round refuses a hoist
+///   because of a peer mismatch and a subsequent move shifts the
+///   blocking ident out of the ancestor chain (or into a
+///   compatible root slot), the next round reconsiders the
+///   refused candidate. The outer loop in [`hoist_into_root`]
+///   iterates until a round makes no moves. Bounded by O(N)
+///   rounds since each move is one-way (parent → root).
 ///
 /// What this does *not* model yet:
 ///
-/// * Multi-round convergence — re-walking the tree to discover
-///   newly-hoistable deps after the first pass. The BFS handles
-///   deep chains (`root → a → b → c` flattens in one pass), so
-///   the cases requiring true multi-round are limited to
-///   peer-interactions where one hoist decision unblocks
-///   another. Today the algorithm refuses those conservatively.
 /// * `hoistingLimits` / `externalDependencies` runtime
 ///   enforcement (the wrapper still refuses non-empty
 ///   `hoisting_limits`).
@@ -649,23 +650,30 @@ enum AbsorbDecision {
 }
 
 /// Walk the result tree and hoist every eligible descendant of
-/// `root` onto `root` itself.
+/// `root` onto `root` itself, iterating until the graph reaches a
+/// fixed point.
 ///
 /// Maintains a side `HashMap<name, RcByPtr>` mirror of root's
 /// direct deps so the per-edge "is this name taken at root?" check
 /// stays O(1). Without the index a graph with `N` packages all
 /// hoisting freely would do O(N²) `IndexSet` scans.
 ///
-/// Implemented as a recursive depth-first walk (see
-/// [`hoist_subtree`]) so the `ancestor_path` passed into each
-/// recursion reflects the current result-graph position of the
-/// parent. A previous BFS form computed the path at queue time
-/// and used it at dequeue time, which went stale whenever a node
-/// was hoisted to root between those two moments — the peer-
-/// shadow check then walked ex-ancestors and over-refused hoists.
-/// In the DFS form, when we recurse into a freshly-hoisted child,
-/// we pass `[root]` as the path; when we recurse into a child
-/// that stayed nested, we pass the parent's path plus the parent.
+/// Each round is a recursive depth-first walk (see
+/// [`hoist_subtree`]) whose `ancestor_path` reflects the current
+/// result-graph position of each node — a freshly-hoisted child
+/// recurses with `[root]`, a child that stayed nested recurses
+/// with `parent_path + [parent]`. The outer loop re-runs the DFS
+/// whenever a round made at least one move, because that move can
+/// unlock further hoists: a previously-blocking peer ident may
+/// have shifted out of the ancestor chain (a sibling's dep moved
+/// to root), or a previously-empty root slot may now carry a
+/// compatible ident.
+///
+/// Termination is bounded by O(N) rounds since each move is
+/// one-way (parent → root) and the graph has finite size.
+/// Mirrors upstream `hoistTo`'s
+/// `do { hoistGraph(); } while (anotherRoundNeeded)` shape, just
+/// with the DFS-by-round simplification described above.
 ///
 /// For a DAG where the same node is reachable through multiple
 /// paths, only the first-arrived path is consulted; upstream's
@@ -675,26 +683,35 @@ enum AbsorbDecision {
 /// rare cross-path mismatch cases. The cost is layouts that are
 /// sometimes more nested than pnpm's, never less.
 fn hoist_into_root(root: &Rc<HoisterResult>) {
-    let mut visited: HashSet<*const HoisterResult> = HashSet::new();
     let mut root_index: HashMap<String, RcByPtr<HoisterResult>> =
         root.dependencies.borrow().iter().map(|d| (d.0.name.clone(), d.clone())).collect();
-    hoist_subtree(root, &[], root, &mut root_index, &mut visited);
+    loop {
+        let mut visited: HashSet<*const HoisterResult> = HashSet::new();
+        let changed = hoist_subtree(root, &[], root, &mut root_index, &mut visited);
+        if !changed {
+            break;
+        }
+    }
 }
 
 /// Depth-first hoist driver. `ancestor_path` is the path from
 /// `root` down to (but *excluding*) `node`, so for the root
 /// itself it is empty and for a child of root it is `[root]`.
+/// Returns whether this subtree moved at least one node in the
+/// current round — the outer multi-round loop uses that to
+/// decide whether another round can unlock further hoists.
 fn hoist_subtree(
     node: &Rc<HoisterResult>,
     ancestor_path: &[Rc<HoisterResult>],
     root: &Rc<HoisterResult>,
     root_index: &mut HashMap<String, RcByPtr<HoisterResult>>,
     visited: &mut HashSet<*const HoisterResult>,
-) {
+) -> bool {
     let root_ptr = Rc::as_ptr(root);
     if !visited.insert(Rc::as_ptr(node)) {
-        return;
+        return false;
     }
+    let mut changed_in_subtree = false;
 
     // Snapshot the current children so we can mutate
     // `node.dependencies` mid-iteration without invalidating the
@@ -750,6 +767,7 @@ fn hoist_subtree(
                     node.dependencies.borrow_mut().shift_remove(&child);
                     root.dependencies.borrow_mut().insert(child.clone());
                     root_index.insert(child.0.name.clone(), child.clone());
+                    changed_in_subtree = true;
                     // Child is now a direct dep of root; its
                     // ancestor path collapses to `[root]`.
                     vec![Rc::clone(root)]
@@ -760,6 +778,7 @@ fn hoist_subtree(
                     // the deeper copy disappears. Child's actual
                     // ancestor path is `[root]`.
                     node.dependencies.borrow_mut().shift_remove(&child);
+                    changed_in_subtree = true;
                     vec![Rc::clone(root)]
                 }
                 AbsorbDecision::Conflict | AbsorbDecision::PeerShadow => {
@@ -767,14 +786,19 @@ fn hoist_subtree(
                     // already at root wins the slot, or
                     // hoisting would shadow a peer dependency.
                     // Child's ancestor path is the path through
-                    // `node`.
+                    // `node`. A later round may revisit this
+                    // candidate with a different peer / conflict
+                    // context.
                     path_for_children.clone()
                 }
             }
         };
 
-        hoist_subtree(&child.0, &child_recursion_path, root, root_index, visited);
+        let child_changed =
+            hoist_subtree(&child.0, &child_recursion_path, root, root_index, visited);
+        changed_in_subtree |= child_changed;
     }
+    changed_in_subtree
 }
 
 /// Return `true` when hoisting `candidate` onto the root would

--- a/crates/real-hoist/src/tests.rs
+++ b/crates/real-hoist/src/tests.rs
@@ -655,6 +655,80 @@ fn peer_constrained_node_hoists_when_ancestor_and_root_agree() {
     );
 }
 
+/// Multi-round convergence: a peer-constrained candidate that
+/// gets refused in round 1 because a sibling provides the peer
+/// with no matching root slot. Once round 1 hoists the sibling
+/// out, round 2 reconsiders the candidate against the new state
+/// and lets it through.
+///
+/// Setup: `root → app → {widget (peer: x), x@1}`. Root has no
+/// `x` of its own. Iteration order over `app`'s children is
+/// alphabetical, so `widget` is visited *before* `x` in round 1:
+///
+/// - Round 1: `widget`'s peer check sees `app.x@1` and root with
+///   no `x` → mismatch → `PeerShadow`, leave at `app`. Then `x`
+///   gets evaluated: free at root → hoist. End of round 1:
+///   `root.deps = {app, x@1}`, `app.deps = {widget}`.
+/// - Round 2: walk again. `widget`'s peer check now sees `app`
+///   without `x` (it moved out in round 1) and root with `x@1`.
+///   No ancestor disagrees with root's slot → no shadow →
+///   `Free` → hoist. End of round 2: `root.deps = {app, x@1,
+///   widget}`, `app.deps = {}`.
+/// - Round 3: no moves, loop terminates.
+///
+/// The previous single-pass DFS would have left `widget` nested
+/// forever; multi-round converges to the correct flat layout.
+#[test]
+fn multi_round_unlocks_peer_friendly_hoist_after_blocker_moves() {
+    let mut importers = HashMap::new();
+    let mut root_deps = ResolvedDependencyMap::new();
+    root_deps.insert(pkg_name("app"), resolved_dep("1.0.0"));
+    importers.insert(
+        Lockfile::ROOT_IMPORTER_KEY.to_string(),
+        ProjectSnapshot { dependencies: Some(root_deps), ..ProjectSnapshot::default() },
+    );
+
+    // app@1 depends on widget@1 and x@1. widget@1 declares x as a
+    // peer (via the `packages:` map). Root carries no x of its
+    // own, so the only x in scope before hoisting is the one
+    // under app — exactly the multi-round trigger.
+    let mut snapshots = HashMap::new();
+    let mut app_deps = HashMap::new();
+    app_deps.insert(pkg_name("widget"), SnapshotDepRef::Plain(ver_peer("1.0.0")));
+    app_deps.insert(pkg_name("x"), SnapshotDepRef::Plain(ver_peer("1.0.0")));
+    snapshots.insert(
+        dep_key("app", "1.0.0"),
+        SnapshotEntry { dependencies: Some(app_deps), ..SnapshotEntry::default() },
+    );
+    snapshots.insert(dep_key("widget", "1.0.0"), SnapshotEntry::default());
+    snapshots.insert(dep_key("x", "1.0.0"), SnapshotEntry::default());
+
+    let mut packages = HashMap::new();
+    packages.insert(dep_key("widget", "1.0.0").without_peer(), pkg_metadata_with_peer("x"));
+
+    let lockfile = Lockfile {
+        lockfile_version: lockfile_version(),
+        settings: None,
+        overrides: None,
+        importers,
+        packages: Some(packages),
+        snapshots: Some(snapshots),
+    };
+
+    let result = hoist(&lockfile, &HoistOpts::default()).expect("multi-round should converge");
+    let root_children = result.dependencies.borrow();
+    let mut names: Vec<&str> = root_children.iter().map(|d| d.0.name.as_str()).collect();
+    names.sort();
+    // All three at root after multi-round convergence.
+    assert_eq!(
+        names,
+        ["app", "widget", "x"],
+        "widget hoists in round 2 after x clears app in round 1: {result:#?}",
+    );
+    let app = root_children.iter().find(|d| d.0.name == "app").unwrap().0.clone();
+    assert!(app.dependencies.borrow().is_empty(), "app stripped after multi-round: {app:#?}");
+}
+
 /// Non-empty `hoisting_limits` surfaces `UnsupportedHoistingLimits`.
 /// The algorithm doesn't honor limits today, so flattening past
 /// them would silently violate the borders the caller asked to

--- a/crates/real-hoist/src/tests.rs
+++ b/crates/real-hoist/src/tests.rs
@@ -204,7 +204,7 @@ fn diamond_dep_hoists_once_to_root() {
 }
 
 /// Version conflict: `root → {a, c}` with `a → b@1` and
-/// `c → b@2`. The first BFS reach wins root's `b` slot; the
+/// `c → b@2`. The first DFS reach wins root's `b` slot; the
 /// other version stays under its declaring parent.
 #[test]
 fn version_conflict_keeps_loser_at_parent() {
@@ -249,14 +249,14 @@ fn version_conflict_keeps_loser_at_parent() {
     names.sort();
     assert_eq!(names, ["a", "b", "c"], "root has a, c, and one b");
     let b_at_root = root_children.iter().find(|d| d.0.name == "b").unwrap().0.clone();
-    // The first BFS visit from root iterates root's direct deps in
-    // alias order (`a` then `c`), so `a@1`'s `b@1.0.0` reaches
-    // root first and wins the slot. Assert membership (not
-    // iteration-order-derived equality) so the test stays focused
-    // on which reference is present, not on which one happens to
-    // come back first from the set.
+    // DFS visits root's direct deps in alias order (`a` then
+    // `c`), so `a@1`'s `b@1.0.0` reaches root first and wins the
+    // slot. Assert membership (not iteration-order-derived
+    // equality) so the test stays focused on which reference is
+    // present, not on which one happens to come back first from
+    // the set.
     let b_refs = b_at_root.references.borrow();
-    assert!(b_refs.contains("b@1.0.0"), "first BFS visitor wins root slot: {b_refs:?}");
+    assert!(b_refs.contains("b@1.0.0"), "first DFS visitor wins root slot: {b_refs:?}");
     assert_eq!(b_refs.len(), 1, "no other reference accumulated yet: {b_refs:?}");
     // `c`'s `b@2` remains under `c`.
     let c = root_children.iter().find(|d| d.0.name == "c").unwrap().0.clone();
@@ -268,9 +268,9 @@ fn version_conflict_keeps_loser_at_parent() {
 }
 
 /// Deep linear chain `root → a → b → c → d` flattens to
-/// `root → {a, b, c, d}` in a single BFS pass: each node, once
-/// queued, sees the previously-hoisted nodes as direct children
-/// of root, so its own children evaluate against root's slots
+/// `root → {a, b, c, d}` in a single hoist round: each node, by
+/// the time DFS descends into it, has already been moved up to
+/// root, so its own children evaluate against root's slots
 /// (which are all free).
 #[test]
 fn deep_chain_flattens_in_one_pass() {
@@ -887,7 +887,8 @@ fn hoisting_limits_keyed_on_unrelated_importer_is_inert() {
 /// self-dependencies` in `@yarnpkg/nm/tests/hoist.test.ts`).
 /// The wrapper's dedup-by-cache keeps a single `Rc` for `a@1`,
 /// and the hoist sees the back-edge to itself as a cycle that
-/// the BFS/DFS skips. No infinite loop, sane output.
+/// the DFS skips via its `visited` set. No infinite loop, sane
+/// output.
 #[test]
 fn self_dependency_does_not_loop() {
     let mut importers = HashMap::new();

--- a/crates/real-hoist/src/tests.rs
+++ b/crates/real-hoist/src/tests.rs
@@ -4,7 +4,10 @@ use pacquet_lockfile::{
     ProjectSnapshot, ResolvedDependencyMap, ResolvedDependencySpec, SnapshotDepRef, SnapshotEntry,
 };
 use pretty_assertions::assert_eq;
-use std::{collections::HashMap, rc::Rc};
+use std::{
+    collections::{BTreeSet, HashMap},
+    rc::Rc,
+};
 
 fn lockfile_version() -> LockfileVersion<9> {
     LockfileVersion::<9>::try_from(ComVer::new(9, 0)).expect("lockfileVersion 9.0 is compatible")
@@ -729,21 +732,252 @@ fn multi_round_unlocks_peer_friendly_hoist_after_blocker_moves() {
     assert!(app.dependencies.borrow().is_empty(), "app stripped after multi-round: {app:#?}");
 }
 
-/// Non-empty `hoisting_limits` surfaces `UnsupportedHoistingLimits`.
-/// The algorithm doesn't honor limits today, so flattening past
-/// them would silently violate the borders the caller asked to
-/// keep.
+/// `hoisting_limits` blocks a single name from hoisting to root.
+/// Ports the spirit of upstream's `should not hoist packages past
+/// hoist boundary`. Setup: `root → a → b`. With no limits, `b`
+/// would flatten to root (see `one_transitive_dep_hoists_to_root`).
+/// With `hoisting_limits[".@"] = {b}`, `b` stays under `a`.
 #[test]
-fn non_empty_hoisting_limits_surfaces_unsupported() {
-    let lockfile = empty_lockfile();
-    let mut opts = HoistOpts::default();
-    opts.hoisting_limits.insert(".@".to_string(), Default::default());
+fn hoisting_limits_keeps_blocked_name_at_parent() {
+    let mut importers = HashMap::new();
+    let mut root_deps = ResolvedDependencyMap::new();
+    root_deps.insert(pkg_name("a"), resolved_dep("1.0.0"));
+    importers.insert(
+        Lockfile::ROOT_IMPORTER_KEY.to_string(),
+        ProjectSnapshot { dependencies: Some(root_deps), ..ProjectSnapshot::default() },
+    );
 
-    let err = hoist(&lockfile, &opts).expect_err("hoisting_limits should bail");
-    match err {
-        HoistError::UnsupportedHoistingLimits { len } => assert_eq!(len, 1),
-        other => panic!("expected UnsupportedHoistingLimits, got {other:?}"),
-    }
+    let mut snapshots = HashMap::new();
+    let mut a_deps = HashMap::new();
+    a_deps.insert(pkg_name("b"), SnapshotDepRef::Plain(ver_peer("1.0.0")));
+    snapshots.insert(
+        dep_key("a", "1.0.0"),
+        SnapshotEntry { dependencies: Some(a_deps), ..SnapshotEntry::default() },
+    );
+    snapshots.insert(dep_key("b", "1.0.0"), SnapshotEntry::default());
+
+    let lockfile = Lockfile {
+        lockfile_version: lockfile_version(),
+        settings: None,
+        overrides: None,
+        importers,
+        packages: None,
+        snapshots: Some(snapshots),
+    };
+
+    let mut blocked = BTreeSet::new();
+    blocked.insert("b".to_string());
+    let mut opts = HoistOpts::default();
+    opts.hoisting_limits.insert(".@".to_string(), blocked);
+
+    let result = hoist(&lockfile, &opts).expect("hoist with limits should succeed");
+    let root_children = result.dependencies.borrow();
+    let mut names: Vec<&str> = root_children.iter().map(|d| d.0.name.as_str()).collect();
+    names.sort();
+    assert_eq!(names, ["a"], "b stayed below the limit: {result:#?}");
+    let a = root_children.iter().find(|d| d.0.name == "a").unwrap().0.clone();
+    let a_deps = a.dependencies.borrow();
+    let a_names: Vec<&str> = a_deps.iter().map(|d| d.0.name.as_str()).collect();
+    assert_eq!(a_names, ["b"], "b remains under a: {a_names:?}");
+}
+
+/// Multiple blocked names work the same way — each one stays at
+/// its declaring parent. Ports the spirit of upstream's `should
+/// not hoist multiple package past nohoist root`.
+#[test]
+fn hoisting_limits_blocks_multiple_names() {
+    let mut importers = HashMap::new();
+    let mut root_deps = ResolvedDependencyMap::new();
+    root_deps.insert(pkg_name("a"), resolved_dep("1.0.0"));
+    importers.insert(
+        Lockfile::ROOT_IMPORTER_KEY.to_string(),
+        ProjectSnapshot { dependencies: Some(root_deps), ..ProjectSnapshot::default() },
+    );
+
+    let mut snapshots = HashMap::new();
+    let mut a_deps = HashMap::new();
+    a_deps.insert(pkg_name("b"), SnapshotDepRef::Plain(ver_peer("1.0.0")));
+    a_deps.insert(pkg_name("c"), SnapshotDepRef::Plain(ver_peer("1.0.0")));
+    a_deps.insert(pkg_name("d"), SnapshotDepRef::Plain(ver_peer("1.0.0")));
+    snapshots.insert(
+        dep_key("a", "1.0.0"),
+        SnapshotEntry { dependencies: Some(a_deps), ..SnapshotEntry::default() },
+    );
+    snapshots.insert(dep_key("b", "1.0.0"), SnapshotEntry::default());
+    snapshots.insert(dep_key("c", "1.0.0"), SnapshotEntry::default());
+    snapshots.insert(dep_key("d", "1.0.0"), SnapshotEntry::default());
+
+    let lockfile = Lockfile {
+        lockfile_version: lockfile_version(),
+        settings: None,
+        overrides: None,
+        importers,
+        packages: None,
+        snapshots: Some(snapshots),
+    };
+
+    let mut blocked = BTreeSet::new();
+    blocked.insert("b".to_string());
+    blocked.insert("c".to_string());
+    let mut opts = HoistOpts::default();
+    opts.hoisting_limits.insert(".@".to_string(), blocked);
+
+    let result = hoist(&lockfile, &opts).expect("hoist with limits should succeed");
+    let root_children = result.dependencies.borrow();
+    let mut names: Vec<&str> = root_children.iter().map(|d| d.0.name.as_str()).collect();
+    names.sort();
+    // Only `a` (direct dep) and `d` (not blocked) sit at root; b
+    // and c stay nested under a.
+    assert_eq!(names, ["a", "d"], "blocked names stayed at a: {result:#?}");
+    let a = root_children.iter().find(|d| d.0.name == "a").unwrap().0.clone();
+    let a_deps = a.dependencies.borrow();
+    let mut a_names: Vec<&str> = a_deps.iter().map(|d| d.0.name.as_str()).collect();
+    a_names.sort();
+    assert_eq!(a_names, ["b", "c"], "a kept its blocked deps: {a_names:?}");
+}
+
+/// `hoisting_limits` keyed on a different importer (one we don't
+/// hoist into) is silently ignored. The wrapper passes the whole
+/// map through, and the algorithm only consults entries matching
+/// the current root locator. Sanity test for non-interference.
+#[test]
+fn hoisting_limits_keyed_on_unrelated_importer_is_inert() {
+    let mut importers = HashMap::new();
+    let mut root_deps = ResolvedDependencyMap::new();
+    root_deps.insert(pkg_name("a"), resolved_dep("1.0.0"));
+    importers.insert(
+        Lockfile::ROOT_IMPORTER_KEY.to_string(),
+        ProjectSnapshot { dependencies: Some(root_deps), ..ProjectSnapshot::default() },
+    );
+
+    let mut snapshots = HashMap::new();
+    let mut a_deps = HashMap::new();
+    a_deps.insert(pkg_name("b"), SnapshotDepRef::Plain(ver_peer("1.0.0")));
+    snapshots.insert(
+        dep_key("a", "1.0.0"),
+        SnapshotEntry { dependencies: Some(a_deps), ..SnapshotEntry::default() },
+    );
+    snapshots.insert(dep_key("b", "1.0.0"), SnapshotEntry::default());
+
+    let lockfile = Lockfile {
+        lockfile_version: lockfile_version(),
+        settings: None,
+        overrides: None,
+        importers,
+        packages: None,
+        snapshots: Some(snapshots),
+    };
+
+    let mut blocked = BTreeSet::new();
+    blocked.insert("b".to_string());
+    let mut opts = HoistOpts::default();
+    // Wrong key — `packages/foo@workspace:packages/foo`, not `.@`.
+    opts.hoisting_limits.insert("packages/foo@workspace:packages/foo".to_string(), blocked);
+
+    let result = hoist(&lockfile, &opts).expect("hoist should succeed");
+    let root_children = result.dependencies.borrow();
+    let mut names: Vec<&str> = root_children.iter().map(|d| d.0.name.as_str()).collect();
+    names.sort();
+    // b still hoists because the limits don't apply to `.@`.
+    assert_eq!(names, ["a", "b"], "limits keyed elsewhere don't affect root hoist: {result:#?}");
+}
+
+/// Self-dependency: a package that lists itself as a transitive
+/// dep. Upstream tolerates this (see `should tolerate
+/// self-dependencies` in `@yarnpkg/nm/tests/hoist.test.ts`).
+/// The wrapper's dedup-by-cache keeps a single `Rc` for `a@1`,
+/// and the hoist sees the back-edge to itself as a cycle that
+/// the BFS/DFS skips. No infinite loop, sane output.
+#[test]
+fn self_dependency_does_not_loop() {
+    let mut importers = HashMap::new();
+    let mut root_deps = ResolvedDependencyMap::new();
+    root_deps.insert(pkg_name("a"), resolved_dep("1.0.0"));
+    importers.insert(
+        Lockfile::ROOT_IMPORTER_KEY.to_string(),
+        ProjectSnapshot { dependencies: Some(root_deps), ..ProjectSnapshot::default() },
+    );
+
+    // a@1 depends on itself.
+    let mut snapshots = HashMap::new();
+    let mut a_deps = HashMap::new();
+    a_deps.insert(pkg_name("a"), SnapshotDepRef::Plain(ver_peer("1.0.0")));
+    snapshots.insert(
+        dep_key("a", "1.0.0"),
+        SnapshotEntry { dependencies: Some(a_deps), ..SnapshotEntry::default() },
+    );
+
+    let lockfile = Lockfile {
+        lockfile_version: lockfile_version(),
+        settings: None,
+        overrides: None,
+        importers,
+        packages: None,
+        snapshots: Some(snapshots),
+    };
+
+    let result = hoist(&lockfile, &HoistOpts::default()).expect("self-dep should not loop");
+    let root_children = result.dependencies.borrow();
+    let names: Vec<&str> = root_children.iter().map(|d| d.0.name.as_str()).collect();
+    assert_eq!(names, ["a"], "single a at root: {result:#?}");
+    let a = root_children.iter().find(|d| d.0.name == "a").unwrap().0.clone();
+    // The self-edge is dedup'd by the wrapper's identity cache to
+    // the same Rc as the root's `a`. During hoist, the back-edge
+    // to root is skipped; the self-edge under a is dedup'd as
+    // SameNode (a is at root via the same Rc) and stripped.
+    assert!(a.dependencies.borrow().is_empty(), "self-edge stripped: {a:#?}");
+}
+
+/// Basic two-node cycle: `a → b → a`. Both packages share the
+/// `Rc` for `a` and `b` thanks to the wrapper's dedup, so the
+/// hoist back-edge is skipped and the algorithm terminates.
+/// Ports the spirit of upstream's `should support basic cyclic
+/// dependencies`.
+#[test]
+fn basic_cyclic_dependency_terminates() {
+    let mut importers = HashMap::new();
+    let mut root_deps = ResolvedDependencyMap::new();
+    root_deps.insert(pkg_name("a"), resolved_dep("1.0.0"));
+    importers.insert(
+        Lockfile::ROOT_IMPORTER_KEY.to_string(),
+        ProjectSnapshot { dependencies: Some(root_deps), ..ProjectSnapshot::default() },
+    );
+
+    // a → b → a (cycle).
+    let mut snapshots = HashMap::new();
+    let mut a_deps = HashMap::new();
+    a_deps.insert(pkg_name("b"), SnapshotDepRef::Plain(ver_peer("1.0.0")));
+    let mut b_deps = HashMap::new();
+    b_deps.insert(pkg_name("a"), SnapshotDepRef::Plain(ver_peer("1.0.0")));
+    snapshots.insert(
+        dep_key("a", "1.0.0"),
+        SnapshotEntry { dependencies: Some(a_deps), ..SnapshotEntry::default() },
+    );
+    snapshots.insert(
+        dep_key("b", "1.0.0"),
+        SnapshotEntry { dependencies: Some(b_deps), ..SnapshotEntry::default() },
+    );
+
+    let result = hoist(
+        &Lockfile {
+            lockfile_version: lockfile_version(),
+            settings: None,
+            overrides: None,
+            importers,
+            packages: None,
+            snapshots: Some(snapshots),
+        },
+        &HoistOpts::default(),
+    )
+    .expect("cycle should not loop");
+    let root_children = result.dependencies.borrow();
+    let mut names: Vec<&str> = root_children.iter().map(|d| d.0.name.as_str()).collect();
+    names.sort();
+    assert_eq!(names, ["a", "b"], "both a and b flatten to root: {result:#?}");
+    let a = root_children.iter().find(|d| d.0.name == "a").unwrap().0.clone();
+    let b = root_children.iter().find(|d| d.0.name == "b").unwrap().0.clone();
+    assert!(a.dependencies.borrow().is_empty(), "a's b hoisted away: {a:#?}");
+    assert!(b.dependencies.borrow().is_empty(), "b's back-edge to a stripped: {b:#?}");
 }
 
 /// A lockfile with importers beyond `.` (a workspace) surfaces


### PR DESCRIPTION
## Summary

Closes out the Slice 3 hoist-algorithm port. Two additions on top of slice 3c's peer-aware hoist:

1. **Multi-round convergence.** The DFS runs in a fixed-point loop — a peer-shadow refusal in one round can be reconsidered in a later round once the blocking ident has moved out of the ancestor chain (or a previously-empty root slot has been filled with a compatible version). Bounded by O(N) rounds since every move is one-way.
2. **`hoistingLimits` enforcement.** The upfront `UnsupportedHoistingLimits` guard is gone; the algorithm now reads `opts.hoisting_limits[root_locator]` and refuses to hoist names listed there. New `AbsorbDecision::Border` variant alongside `Free` / `SameNode` / `Conflict` / `PeerShadow`.

Plus a backfill of behavior-pinning tests ported from `@yarnpkg/nm/tests/hoist.test.ts`.

## How multi-round works

- `hoist_subtree` returns `bool` for whether it moved any node in the current round.
- `hoist_into_root` wraps it in a `loop` that resets `visited` each iteration and exits when a round makes no moves.
- Mirrors upstream `hoistTo`'s `do { hoistGraph(); } while (anotherRoundNeeded)` without the per-candidate `dependsOn` bookkeeping; pacquet's coarse re-walk catches the same unlock cases at the cost of revisiting unchanged nodes.

Canonical case (`multi_round_unlocks_peer_friendly_hoist_after_blocker_moves`): `root → app → {widget(peer: x), x@1}` with root carrying no `x`.

- **Round 1.** Alphabetical iteration visits `widget` first. App supplies `x@1`, root has no `x` → mismatch → `PeerShadow`, widget stays at app. Then `x` is evaluated: `Free`, hoist to root.
- **Round 2.** Reconsider widget. App no longer has `x`; root has `x@1`. No ancestor disagreement → `Free`. Widget hoists.
- **Round 3.** No moves; loop exits.

## How hoistingLimits works

- Computed locator: `"{ident_name}@{reference}"` — for the wrapper's root that's `".@"`, matching pnpm's keying convention.
- Border-name set: `opts.hoisting_limits.get(root_locator)`, defaulting to empty when absent.
- New `AbsorbDecision::Border` is layered between the basic decision and the peer check. Names in the set never hoist; they stay where the lockfile placed them.
- Mirrors upstream's `isHoistBorder` flag set during `cloneTree`.

## Upstream test ports

From `yarnpkg/berry@4287909fa6` `packages/yarnpkg-nm/tests/hoist.test.ts`, expressed via lockfile fixtures so they exercise the wrapper too:

- **`hoisting_limits_keeps_blocked_name_at_parent`** — `should not hoist packages past hoist boundary`.
- **`hoisting_limits_blocks_multiple_names`** — `should not hoist multiple package past nohoist root`.
- **`hoisting_limits_keyed_on_unrelated_importer_is_inert`** — non-interference sanity check.
- **`self_dependency_does_not_loop`** — `should tolerate self-dependencies`.
- **`basic_cyclic_dependency_terminates`** — `should support basic cyclic dependencies`.

## Documented gaps

The `nm_hoist` doc-comment now lists what's deferred *intentionally* rather than "not done yet":

- **Popularity-based ident preference.** Upstream's `buildPreferenceMap` picks the ident with more incoming references when two distinct deps share an alias; pacquet picks the first-visited. Affects the handful of upstream test cases that exercise the tie-break (`should honor package popularity when hoisting`, etc.).
- **Multi-importer workspace hoist trees.** Still guarded upfront by `HoistError::UnsupportedWorkspace`. Workspace-aware hoisting needs per-importer roots and a different output shape.
- **`ExternalSoftLink` descendants.** The wrapper only creates soft-links as zero-children placeholders, so upstream's "only-hoist-when-all-descendants-hoist" rule has nothing to delay today. Tests for `should not hoist portal with unhoistable dependencies` and similar were skipped.

## Upstream reference

Aligned with `yarnpkg/berry@4287909fa6`:

- [`hoist.ts:109-119`](https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L109-L119) — outer round loop in `hoist`.
- [`hoist.ts:352-367`](https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L352-L367) — inner round loop in `hoistTo`.
- [`hoist.ts:707`](https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L707) — `isHoistBorder` flag during `cloneTree`.

## Test plan

- [x] `multi_round_unlocks_peer_friendly_hoist_after_blocker_moves` — the canonical multi-round case.
- [x] `hoisting_limits_keeps_blocked_name_at_parent` — single-name limit.
- [x] `hoisting_limits_blocks_multiple_names` — multi-name limit.
- [x] `hoisting_limits_keyed_on_unrelated_importer_is_inert` — non-interference.
- [x] `self_dependency_does_not_loop` — port of `should tolerate self-dependencies`.
- [x] `basic_cyclic_dependency_terminates` — port of `should support basic cyclic dependencies`.
- [x] All 13 pre-existing tests still pass (free hoist, diamond, version conflict, deep chain, npm-alias, peer-shadow/peer-friendly, stale-path regression from #461, externals stripped, broken-lockfile, empty-lockfile, workspace guard).
- [x] The previous `non_empty_hoisting_limits_surfaces_unsupported` test is replaced by the three positive limits tests.
- [x] `just ready` runs **857 tests** workspace-wide, all green.
- [x] `cargo doc --document-private-items`, `taplo format --check`, `just dylint` all clean.

---
Written by an agent (Claude Code, claude-opus-4-7).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hoisting now enforces limits at decision time and runs repeated passes until no further moves, allowing peer-constrained packages to become hoistable across rounds.
  * Removed the prior upfront rejection for certain hoisting limits.

* **Tests**
  * Added regression tests covering multi-round convergence, hoisting-limits behavior, and cycle termination.
  * Removed an outdated test that treated non-empty hoisting limits as unsupported.

* **Documentation**
  * Updated hoisting docs to describe multi-round convergence and DFS-based decisions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pacquet/pull/465)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->