### PR TITLE
feat: persist .modules.yaml.skipped + headless seed-and-recompute (#434 slice 3)

### DIFF
--- a/crates/package-manager/src/install.rs
+++ b/crates/package-manager/src/install.rs
@@ -249,104 +249,111 @@ where
         //    normally generate / update a lockfile, which pacquet
         //    doesn't support yet → `UnsupportedLockfileMode`. `false`
         //    means "lockfile disabled, resolve from registry".
-        let hoisted_dependencies: HoistedDependencies = if frozen_lockfile {
-            let Some(lockfile) = lockfile else {
-                return Err(InstallError::NoLockfile);
-            };
-            let Lockfile { lockfile_version, importers, packages, snapshots, .. } = lockfile;
-            assert_eq!(lockfile_version.major, 9); // compatibility check already happens at serde, but this still helps preventing programmer mistakes.
+        let (hoisted_dependencies, frozen_skipped): (HoistedDependencies, crate::SkippedSnapshots) =
+            if frozen_lockfile {
+                let Some(lockfile) = lockfile else {
+                    return Err(InstallError::NoLockfile);
+                };
+                let Lockfile { lockfile_version, importers, packages, snapshots, .. } = lockfile;
+                assert_eq!(lockfile_version.major, 9); // compatibility check already happens at serde, but this still helps preventing programmer mistakes.
 
-            // Freshness check: verify the on-disk `package.json`
-            // still matches the lockfile's importer entry before we
-            // commit to materializing `node_modules` from it. Mirrors
-            // upstream's `satisfiesPackageManifest` gate at
-            // <https://github.com/pnpm/pnpm/blob/94240bc046/pkg-manager/core/src/install/index.ts#L808-L832>.
-            // Pacquet has only one importer today (#431 tracks
-            // workspaces), so the root project is the only thing to
-            // verify; once workspaces land this becomes a per-project
-            // loop over `importers`.
-            let importer = importers.get(Lockfile::ROOT_IMPORTER_KEY).ok_or_else(|| {
-                InstallError::NoImporter { importer_id: Lockfile::ROOT_IMPORTER_KEY.to_string() }
-            })?;
-            satisfies_package_manifest(importer, manifest, Lockfile::ROOT_IMPORTER_KEY)
-                .map_err(|reason| InstallError::OutdatedLockfile { reason })?;
+                // Freshness check: verify the on-disk `package.json`
+                // still matches the lockfile's importer entry before we
+                // commit to materializing `node_modules` from it. Mirrors
+                // upstream's `satisfiesPackageManifest` gate at
+                // <https://github.com/pnpm/pnpm/blob/94240bc046/pkg-manager/core/src/install/index.ts#L808-L832>.
+                // Pacquet has only one importer today (#431 tracks
+                // workspaces), so the root project is the only thing to
+                // verify; once workspaces land this becomes a per-project
+                // loop over `importers`.
+                let importer = importers.get(Lockfile::ROOT_IMPORTER_KEY).ok_or_else(|| {
+                    InstallError::NoImporter {
+                        importer_id: Lockfile::ROOT_IMPORTER_KEY.to_string(),
+                    }
+                })?;
+                satisfies_package_manifest(importer, manifest, Lockfile::ROOT_IMPORTER_KEY)
+                    .map_err(|reason| InstallError::OutdatedLockfile { reason })?;
 
-            let frozen_result = InstallFrozenLockfile {
-                http_client,
-                config,
-                importers,
-                packages: packages.as_ref(),
-                snapshots: snapshots.as_ref(),
-                current_snapshots: current_lockfile.as_ref().and_then(|l| l.snapshots.as_ref()),
-                current_packages: current_lockfile.as_ref().and_then(|l| l.packages.as_ref()),
-                dependency_groups,
-                logged_methods: &logged_methods,
-                workspace_root: &workspace_root,
-                requester: &prefix,
-                supported_architectures: supported_architectures.as_ref(),
-            }
-            .run::<R>()
-            .await
-            .map_err(InstallError::FrozenLockfile)?;
+                let frozen_result = InstallFrozenLockfile {
+                    http_client,
+                    config,
+                    importers,
+                    packages: packages.as_ref(),
+                    snapshots: snapshots.as_ref(),
+                    current_snapshots: current_lockfile.as_ref().and_then(|l| l.snapshots.as_ref()),
+                    current_packages: current_lockfile.as_ref().and_then(|l| l.packages.as_ref()),
+                    dependency_groups,
+                    logged_methods: &logged_methods,
+                    workspace_root: &workspace_root,
+                    requester: &prefix,
+                    supported_architectures: supported_architectures.as_ref(),
+                }
+                .run::<R>()
+                .await
+                .map_err(InstallError::FrozenLockfile)?;
 
-            // Register every importer against the shared store now
-            // that the install has materialized their `node_modules/`.
-            // Mirrors upstream's call into `@pnpm/store.controller`'s
-            // [`registerProject`](https://github.com/pnpm/pnpm/blob/94240bc046/store/controller/src/storeController/projectRegistry.ts),
-            // which runs once per importer — a workspace ends up with
-            // one symlink in `<store_dir>/projects/` per package, so
-            // `pacquet store prune` (tracked separately) can find
-            // every reachable consumer of `<store_dir>/links/...`.
-            //
-            // Gated on `frozen_lockfile && enable_global_virtual_store`:
-            // `InstallWithoutLockfile` keeps the project-local virtual
-            // store via `VirtualStoreLayout::legacy`, and a registry
-            // entry for it would point at a project that never
-            // touches the shared store.
-            //
-            // Best-effort: a registry write failure shouldn't fail
-            // the install. Surface as `tracing::warn!` so the failure
-            // is diagnosable but the install carries on. Validation
-            // of importer keys is done by
-            // [`crate::SymlinkDirectDependencies::run`] before we get
-            // here, so by this point every key is known-safe.
-            if config.enable_global_virtual_store {
-                for importer_id in importers.keys() {
-                    let project_dir = crate::symlink_direct_dependencies::importer_root_dir(
-                        &workspace_root,
-                        importer_id,
-                    );
-                    if let Err(error) =
-                        pacquet_store_dir::register_project(&config.store_dir, &project_dir)
-                    {
-                        tracing::warn!(
-                            target: "pacquet::install",
-                            ?error,
-                            importer_id = %importer_id,
-                            "Failed to register importer in the global-virtual-store registry; install continues",
+                // Register every importer against the shared store now
+                // that the install has materialized their `node_modules/`.
+                // Mirrors upstream's call into `@pnpm/store.controller`'s
+                // [`registerProject`](https://github.com/pnpm/pnpm/blob/94240bc046/store/controller/src/storeController/projectRegistry.ts),
+                // which runs once per importer — a workspace ends up with
+                // one symlink in `<store_dir>/projects/` per package, so
+                // `pacquet store prune` (tracked separately) can find
+                // every reachable consumer of `<store_dir>/links/...`.
+                //
+                // Gated on `frozen_lockfile && enable_global_virtual_store`:
+                // `InstallWithoutLockfile` keeps the project-local virtual
+                // store via `VirtualStoreLayout::legacy`, and a registry
+                // entry for it would point at a project that never
+                // touches the shared store.
+                //
+                // Best-effort: a registry write failure shouldn't fail
+                // the install. Surface as `tracing::warn!` so the failure
+                // is diagnosable but the install carries on. Validation
+                // of importer keys is done by
+                // [`crate::SymlinkDirectDependencies::run`] before we get
+                // here, so by this point every key is known-safe.
+                if config.enable_global_virtual_store {
+                    for importer_id in importers.keys() {
+                        let project_dir = crate::symlink_direct_dependencies::importer_root_dir(
+                            &workspace_root,
+                            importer_id,
                         );
+                        if let Err(error) =
+                            pacquet_store_dir::register_project(&config.store_dir, &project_dir)
+                        {
+                            tracing::warn!(
+                                target: "pacquet::install",
+                                ?error,
+                                importer_id = %importer_id,
+                                "Failed to register importer in the global-virtual-store registry; install continues",
+                            );
+                        }
                     }
                 }
-            }
 
-            frozen_result
-        } else if config.lockfile {
-            return Err(InstallError::UnsupportedLockfileMode);
-        } else {
-            InstallWithoutLockfile {
-                tarball_mem_cache,
-                resolved_packages,
-                http_client,
-                config,
-                manifest,
-                dependency_groups,
-                logged_methods: &logged_methods,
-                requester: &prefix,
-            }
-            .run::<R>()
-            .await
-            .map_err(InstallError::WithoutLockfile)?
-        };
+                (frozen_result.hoisted_dependencies, frozen_result.skipped)
+            } else if config.lockfile {
+                return Err(InstallError::UnsupportedLockfileMode);
+            } else {
+                // The no-lockfile path has no installability check (no
+                // `packages:` metadata to evaluate constraints against),
+                // so its skip set is empty by construction.
+                let hd = InstallWithoutLockfile {
+                    tarball_mem_cache,
+                    resolved_packages,
+                    http_client,
+                    config,
+                    manifest,
+                    dependency_groups,
+                    logged_methods: &logged_methods,
+                    requester: &prefix,
+                }
+                .run::<R>()
+                .await
+                .map_err(InstallError::WithoutLockfile)?;
+                (hd, crate::SkippedSnapshots::new())
+            };
 
         tracing::info!(target: "pacquet::install", "Complete all");
 
@@ -367,7 +374,7 @@ where
         // tool) can detect a layout change and prune accordingly.
         write_modules_manifest::<RealApi>(
             &config.modules_dir,
-            build_modules_manifest(config, included, hoisted_dependencies),
+            build_modules_manifest(config, included, hoisted_dependencies, &frozen_skipped),
         )
         .map_err(InstallError::WriteModules)?;
 
@@ -420,21 +427,33 @@ fn map_node_linker(linker: &NodeLinker) -> ModulesNodeLinker {
 ///
 /// Mirrors upstream's literal at
 /// <https://github.com/pnpm/pnpm/blob/086c5e91e8/installing/deps-installer/src/install/index.ts#L1608-L1630>.
-/// Fields pacquet does not populate yet (`pendingBuilds`, `skipped`,
+/// Fields pacquet does not populate yet (`pendingBuilds`,
 /// `injectedDeps`, `ignoredBuilds`, `allowBuilds`) default to empty
 /// / unset.
 ///
-/// `hoistedDependencies` is now produced by the hoist pass in
+/// `hoistedDependencies` is produced by the hoist pass in
 /// `InstallFrozenLockfile::run` and threaded in here — empty for the
 /// no-lockfile path and for installs where both hoist patterns are
 /// `None`. Persisting it lets a subsequent install detect a hoist
 /// pattern change and re-hoist appropriately (the partial-install
 /// path tracked at pnpm/pacquet#433 will consume it; today every
 /// install does the full hoist anyway).
+///
+/// `skipped` is the depPath list pnpm writes at
+/// <https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/src/install/index.ts#L1625>:
+/// each [`PackageKey`] in the install-time
+/// [`crate::SkippedSnapshots`] becomes one string entry; ordering is
+/// handled by [`write_modules_manifest`]'s sort-on-write, matching
+/// upstream's `saveModules.skipped.sort()`. An empty set produces
+/// an empty list — matching the fresh-install case.
+///
+/// [`PackageKey`]: pacquet_lockfile::PackageKey
+/// [`write_modules_manifest`]: pacquet_modules_yaml::write_modules_manifest
 fn build_modules_manifest(
     config: &Config,
     included: IncludedDependencies,
     hoisted_dependencies: HoistedDependencies,
+    skipped: &crate::SkippedSnapshots,
 ) -> Modules {
     Modules {
         hoist_pattern: config.hoist_pattern.clone(),
@@ -450,6 +469,7 @@ fn build_modules_manifest(
         // `new Date().toUTCString()` at line 1622.
         pruned_at: httpdate::fmt_http_date(SystemTime::now()),
         registries: Some(BTreeMap::from([("default".to_string(), config.registry.clone())])),
+        skipped: skipped.iter().map(ToString::to_string).collect(),
         store_dir: config.store_dir.display().to_string(),
         virtual_store_dir: config.virtual_store_dir.to_string_lossy().into_owned(),
         virtual_store_dir_max_length: DEFAULT_VIRTUAL_STORE_DIR_MAX_LENGTH,

--- a/crates/package-manager/src/install/tests.rs
+++ b/crates/package-manager/src/install/tests.rs
@@ -1528,3 +1528,79 @@ async fn frozen_lockfile_under_gvs_registers_each_workspace_importer() {
 
     drop(dir);
 }
+
+/// `build_modules_manifest` serializes the install-time
+/// [`SkippedSnapshots`] into `.modules.yaml.skipped` as a list of
+/// depPath strings. Mirrors upstream's
+/// `skipped: Array.from(ctx.skipped)` literal at
+/// <https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/src/install/index.ts#L1625>:
+/// each entry is the snapshot's [`PackageKey`] `Display` form
+/// (`name@version(peers)`), and ordering is handled by
+/// `write_modules_manifest`'s sort-on-write.
+///
+/// An empty set produces an empty list — covers the fresh-install
+/// case while pinning that the field is no longer
+/// `..Default::default()`'d away from the manifest.
+///
+/// [`SkippedSnapshots`]: super::super::SkippedSnapshots
+/// [`PackageKey`]: pacquet_lockfile::PackageKey
+#[test]
+fn build_modules_manifest_serializes_skipped_set() {
+    use crate::SkippedSnapshots;
+    use pacquet_lockfile::PackageKey;
+    use pacquet_modules_yaml::IncludedDependencies;
+    use std::collections::HashSet;
+
+    let dir = tempdir().unwrap();
+    let mut config = Config::new();
+    config.store_dir = dir.path().join("store").into();
+    config.modules_dir = dir.path().join("node_modules");
+    config.virtual_store_dir = dir.path().join("node_modules/.pacquet");
+    let config = config.leak();
+
+    let key1: PackageKey = "darwin-only-pkg@1.0.0".parse().unwrap();
+    let key2: PackageKey = "@scope/linux-only@2.3.4".parse().unwrap();
+    let mut set = HashSet::new();
+    set.insert(key1.clone());
+    set.insert(key2.clone());
+    let skipped = SkippedSnapshots::from_set(set);
+
+    let included = IncludedDependencies {
+        dependencies: true,
+        dev_dependencies: false,
+        optional_dependencies: true,
+    };
+    let manifest = super::build_modules_manifest(config, included, Default::default(), &skipped);
+
+    // Set the manifest's `skipped` matches the depPath `Display`
+    // form. Order check happens in the read-back loop below — the
+    // function itself doesn't sort (that's `write_modules_manifest`).
+    let actual: HashSet<String> = manifest.skipped.iter().cloned().collect();
+    let expected: HashSet<String> = [key1.to_string(), key2.to_string()].into_iter().collect();
+    assert_eq!(actual, expected);
+}
+
+/// Empty `SkippedSnapshots` produces an empty `Modules.skipped`. The
+/// common case — most installs have no platform-mismatched optional
+/// deps — must keep the field present-but-empty so the on-disk
+/// shape stays uniform.
+#[test]
+fn build_modules_manifest_skipped_is_empty_on_empty_set() {
+    use crate::SkippedSnapshots;
+    use pacquet_modules_yaml::IncludedDependencies;
+
+    let dir = tempdir().unwrap();
+    let mut config = Config::new();
+    config.store_dir = dir.path().join("store").into();
+    config.modules_dir = dir.path().join("node_modules");
+    config.virtual_store_dir = dir.path().join("node_modules/.pacquet");
+    let config = config.leak();
+
+    let manifest = super::build_modules_manifest(
+        config,
+        IncludedDependencies::default(),
+        Default::default(),
+        &SkippedSnapshots::new(),
+    );
+    assert!(manifest.skipped.is_empty());
+}

--- a/crates/package-manager/src/install/tests.rs
+++ b/crates/package-manager/src/install/tests.rs
@@ -3,7 +3,7 @@ use pacquet_config::Config;
 use pacquet_lockfile::Lockfile;
 use pacquet_modules_yaml::{
     DEFAULT_VIRTUAL_STORE_DIR_MAX_LENGTH, LayoutVersion, Modules, NodeLinker, RealApi,
-    read_modules_manifest,
+    read_modules_manifest, write_modules_manifest,
 };
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_registry_mock::AutoMockInstance;
@@ -1572,9 +1572,12 @@ fn build_modules_manifest_serializes_skipped_set() {
     };
     let manifest = super::build_modules_manifest(config, included, Default::default(), &skipped);
 
-    // Set the manifest's `skipped` matches the depPath `Display`
-    // form. Order check happens in the read-back loop below — the
-    // function itself doesn't sort (that's `write_modules_manifest`).
+    // Compare as sets — `build_modules_manifest` does not sort.
+    // Sort-on-write happens later inside `write_modules_manifest`,
+    // matching upstream's `saveModules.skipped.sort()` at
+    // <https://github.com/pnpm/pnpm/blob/94240bc046/installing/modules-yaml/src/index.ts#L121>;
+    // the read-after-write order is covered by the integration
+    // test on the full install path.
     let actual: HashSet<String> = manifest.skipped.iter().cloned().collect();
     let expected: HashSet<String> = [key1.to_string(), key2.to_string()].into_iter().collect();
     assert_eq!(actual, expected);
@@ -1603,4 +1606,102 @@ fn build_modules_manifest_skipped_is_empty_on_empty_set() {
         &SkippedSnapshots::new(),
     );
     assert!(manifest.skipped.is_empty());
+}
+
+/// End-to-end read → seed → write loop. Pre-write
+/// `.modules.yaml.skipped` before a frozen-lockfile install runs;
+/// confirm the install picks up the seed and re-writes the file
+/// with the same key. The lockfile here has empty `snapshots: {}` so
+/// the constraint-free fast path runs — that's the branch in
+/// [`InstallFrozenLockfile::run`] that preserves the seed verbatim
+/// without calling `compute_skipped_snapshots`. Together with the
+/// unit tests on the slow path, this pins the full plumbing between
+/// `read_modules_manifest`, `compute_skipped_snapshots`'s seed
+/// arg, the threading out of [`InstallFrozenLockfileOutput`], and
+/// `build_modules_manifest`'s serialization.
+///
+/// [`InstallFrozenLockfile::run`]: super::super::InstallFrozenLockfile::run
+/// [`InstallFrozenLockfileOutput`]: super::super::InstallFrozenLockfileOutput
+#[tokio::test]
+async fn frozen_install_preserves_seeded_skipped_across_reinstall() {
+    let dir = tempdir().unwrap();
+    let store_dir = dir.path().join("pacquet-store");
+    let project_root = dir.path().join("project");
+    let modules_dir = project_root.join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pacquet");
+
+    let manifest_path = dir.path().join("package.json");
+    let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
+
+    let mut config = Config::new();
+    config.lockfile = false;
+    config.store_dir = store_dir.clone().into();
+    config.modules_dir = modules_dir.clone();
+    config.virtual_store_dir = virtual_store_dir.clone();
+    let config = config.leak();
+
+    // Pre-write `.modules.yaml` with a non-empty `skipped` list —
+    // models the state left by a previous install that landed
+    // platform-mismatched optional deps. Two entries: one bare
+    // package and one scoped, so the parse-then-serialize round-trip
+    // covers both `name@version` and `@scope/name@version`.
+    let seeded_keys = ["previously-skipped@1.0.0", "@scope/also-skipped@2.3.4"];
+    let seed_modules = Modules {
+        layout_version: Some(LayoutVersion),
+        node_linker: Some(NodeLinker::Isolated),
+        store_dir: store_dir.display().to_string(),
+        virtual_store_dir: virtual_store_dir.to_string_lossy().into_owned(),
+        virtual_store_dir_max_length: DEFAULT_VIRTUAL_STORE_DIR_MAX_LENGTH,
+        skipped: seeded_keys.iter().map(|s| (*s).to_string()).collect(),
+        ..Default::default()
+    };
+    write_modules_manifest::<RealApi>(&modules_dir, seed_modules).expect("seed .modules.yaml");
+
+    // Empty lockfile drives the constraint-free fast path. The
+    // seed must survive verbatim.
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "importers:"
+        "  .:"
+        "    dependencies: {}"
+        "packages: {}"
+        "snapshots: {}"
+    })
+    .expect("parse minimal v9 lockfile");
+
+    Install {
+        tarball_mem_cache: &Default::default(),
+        http_client: &Default::default(),
+        config,
+        manifest: &manifest,
+        lockfile: Some(&lockfile),
+        dependency_groups: [DependencyGroup::Prod],
+        frozen_lockfile: true,
+        supported_architectures: None,
+        resolved_packages: &Default::default(),
+    }
+    .run::<SilentReporter>()
+    .await
+    .expect("frozen-lockfile install should succeed");
+
+    let written = modules_dir
+        .pipe_as_ref(read_modules_manifest::<RealApi>)
+        .expect("read .modules.yaml")
+        .expect("modules manifest exists");
+
+    // Both seed entries survive — proves the read → seed → write
+    // loop is fully wired. Order is the sort-on-write order:
+    // `@scope/...` < `previously-...` lexically, so the scoped
+    // entry leads.
+    assert_eq!(written.skipped.len(), 2, "both seeded entries must survive");
+    assert!(written.skipped.contains(&"previously-skipped@1.0.0".to_string()));
+    assert!(written.skipped.contains(&"@scope/also-skipped@2.3.4".to_string()));
+    let sorted: Vec<&str> = written.skipped.iter().map(String::as_str).collect();
+    assert_eq!(
+        sorted,
+        ["@scope/also-skipped@2.3.4", "previously-skipped@1.0.0"],
+        "write_modules_manifest must sort the list alphabetically",
+    );
+
+    drop(dir);
 }

--- a/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/crates/package-manager/src/install_frozen_lockfile.rs
@@ -13,6 +13,7 @@ use pacquet_cmd_shim::LinkBinsError;
 use pacquet_config::{Config, matcher::create_matcher};
 use pacquet_executor::ScriptsPrependNodePath as ExecScriptsPrependNodePath;
 use pacquet_lockfile::{PackageKey, PackageMetadata, ProjectSnapshot, SnapshotEntry};
+use pacquet_modules_yaml::{RealApi, read_modules_manifest};
 use pacquet_network::ThrottledClient;
 use pacquet_package_manifest::DependencyGroup;
 use pacquet_patching::{
@@ -169,13 +170,17 @@ where
 {
     /// Execute the subroutine.
     ///
-    /// Returns the [`HoistedDependencies`] map produced by the hoist
-    /// pass. The map is empty when both hoist patterns are `None`
-    /// (feature disabled) and otherwise lists every transitive that
-    /// the matchers selected. The caller (`Install::run`) feeds it
-    /// into `.modules.yaml`'s `hoistedDependencies` so a later install
-    /// observes the same hoist decisions.
-    pub async fn run<R: Reporter>(self) -> Result<HoistedDependencies, InstallFrozenLockfileError> {
+    /// Returns an [`InstallFrozenLockfileOutput`] carrying the
+    /// `HoistedDependencies` map produced by the hoist pass plus
+    /// the install-time `SkippedSnapshots` set. The caller
+    /// (`Install::run`) feeds both into `.modules.yaml` —
+    /// `hoistedDependencies` lets a later install observe the same
+    /// hoist decisions, and `skipped` lets the next install seed
+    /// the installability re-check against the previously skipped
+    /// snapshots.
+    pub async fn run<R: Reporter>(
+        self,
+    ) -> Result<InstallFrozenLockfileOutput, InstallFrozenLockfileError> {
         let InstallFrozenLockfile {
             http_client,
             config,
@@ -235,6 +240,34 @@ where
             _ => false,
         };
 
+        // Seed the skip set from the previous install's
+        // `.modules.yaml.skipped`. Each entry there is a depPath
+        // string a previous run wrote out; on this run we treat each
+        // one as already-skipped so its per-snapshot installability
+        // check is short-circuited and no
+        // `pnpm:skipped-optional-dependency` event is re-emitted for
+        // a known-skipped package. Mirrors upstream's seed-from-
+        // `modules.skipped` at
+        // <https://github.com/pnpm/pnpm/blob/94240bc046/installing/read-projects-context/src/index.ts#L79>
+        // and the early-return at
+        // <https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-builder/src/lockfileToDepGraph.ts#L194>.
+        //
+        // A read error (corrupt yaml, permissions) is degraded to
+        // an empty seed — `.modules.yaml` is a cache artifact, not
+        // an authoritative source. Missing file → empty seed.
+        let seed = match read_modules_manifest::<RealApi>(&config.modules_dir) {
+            Ok(Some(manifest)) => SkippedSnapshots::from_strings(&manifest.skipped),
+            Ok(None) => SkippedSnapshots::new(),
+            Err(error) => {
+                tracing::warn!(
+                    target: "pacquet::install",
+                    ?error,
+                    "failed to read .modules.yaml for skipped seed; starting from empty",
+                );
+                SkippedSnapshots::new()
+            }
+        };
+
         // Build the per-install [`SkippedSnapshots`] set. For every
         // lockfile snapshot, run the installability check against
         // the host triple; optional+incompatible entries land in
@@ -271,6 +304,7 @@ where
                 packages.expect("guarded by needs_installability_check"),
                 &host,
                 requester,
+                seed,
             )
             .map_err(InstallFrozenLockfileError::Installability)?;
             // Preserve `node_detected` + `node_version` for the
@@ -278,7 +312,11 @@ where
             // host struct frees the allocations early.
             (s, Some((host.node_detected, host.node_version)))
         } else {
-            (SkippedSnapshots::new(), None)
+            // Constraint-free lockfile: keep the seed verbatim so a
+            // snapshot recorded as skipped on the previous install
+            // survives the constraint having been removed from the
+            // lockfile.
+            (seed, None)
         };
 
         // Compute `engine_name` *before* `CreateVirtualStore::run`
@@ -650,8 +688,27 @@ where
             ),
         }
 
-        Ok(hoisted_dependencies)
+        Ok(InstallFrozenLockfileOutput { hoisted_dependencies, skipped })
     }
+}
+
+/// Two-field bundle returned by [`InstallFrozenLockfile::run`] so
+/// the caller can write both `.modules.yaml.hoistedDependencies`
+/// (slice tracked at pnpm/pacquet#435) and `.modules.yaml.skipped`
+/// (umbrella slice 3) from a single call. Defined as a `struct`
+/// rather than a tuple so future fields (the in-flight current
+/// lockfile in umbrella slice 6, etc.) can land without churning
+/// every call site.
+#[derive(Debug)]
+pub struct InstallFrozenLockfileOutput {
+    /// Hoisted-dependencies map produced by the hoist pass — empty
+    /// when both hoist patterns are `None`.
+    pub hoisted_dependencies: HoistedDependencies,
+    /// Install-time skip set produced by `compute_skipped_snapshots`,
+    /// seeded from the previous install's `.modules.yaml.skipped`
+    /// and augmented with snapshots that newly failed the
+    /// installability check.
+    pub skipped: SkippedSnapshots,
 }
 
 /// Pull the leading major-version digits out of a semver string like

--- a/crates/package-manager/src/installability.rs
+++ b/crates/package-manager/src/installability.rs
@@ -52,6 +52,23 @@ impl SkippedSnapshots {
         Self { set }
     }
 
+    /// Seed the set with snapshot keys recorded as skipped by a
+    /// previous install (read from `.modules.yaml.skipped`).
+    /// Unparsable strings are silently dropped — upstream tolerates
+    /// the same shape mismatch at
+    /// <https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-builder/src/lockfileToDepGraph.ts#L194>
+    /// (the seed is only consulted by `Set.has(depPath)`; a
+    /// nonsense string never matches any current snapshot, so the
+    /// orphan is harmless).
+    pub fn from_strings<I>(iter: I) -> Self
+    where
+        I: IntoIterator,
+        I::Item: AsRef<str>,
+    {
+        let set = iter.into_iter().filter_map(|s| s.as_ref().parse::<PackageKey>().ok()).collect();
+        Self { set }
+    }
+
     pub fn contains(&self, key: &PackageKey) -> bool {
         self.set.contains(key)
     }
@@ -146,6 +163,7 @@ pub fn compute_skipped_snapshots<R: Reporter>(
     packages: &HashMap<PackageKey, PackageMetadata>,
     host: &InstallabilityHost,
     prefix: &str,
+    seed: SkippedSnapshots,
 ) -> Result<SkippedSnapshots, Box<InstallabilityError>> {
     // Fast path: if no package in the lockfile declares any
     // installability constraint, every snapshot is trivially
@@ -157,6 +175,12 @@ pub fn compute_skipped_snapshots<R: Reporter>(
     // decomposing each metadata row only to find no constraints to
     // evaluate.
     //
+    // The `seed` is returned as-is on the fast path so previously
+    // skipped snapshots survive across reinstalls even when the
+    // lockfile's per-snapshot constraints have since been removed.
+    // Mirrors upstream's early-return behavior at
+    // <https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-builder/src/lockfileToDepGraph.ts#L194>.
+    //
     // Concretely on the integrated benchmark (1352 packages with no
     // platform / engine constraints): drops ~1352 `String` and
     // `PackageKey` allocations and the matching number of
@@ -165,10 +189,10 @@ pub fn compute_skipped_snapshots<R: Reporter>(
     // `Option::is_some` checks per row and short-circuits on the
     // first declared constraint.
     if !any_installability_constraint(packages) {
-        return Ok(SkippedSnapshots::new());
+        return Ok(seed);
     }
 
-    let mut skipped = SkippedSnapshots::new();
+    let mut skipped = seed;
     let mut seen_emit: HashSet<PackageKey> = HashSet::new();
 
     // Build the host-derived part of the options once. Only the
@@ -206,6 +230,18 @@ pub fn compute_skipped_snapshots<R: Reporter>(
     let mut check_cache: HashMap<PackageKey, Option<InstallabilityError>> = HashMap::new();
 
     for (snapshot_key, snapshot) in snapshots {
+        // Seeded entries short-circuit the per-snapshot re-check.
+        // Mirrors upstream's `if (opts.skipped.has(depPath)) return`
+        // at
+        // <https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-builder/src/lockfileToDepGraph.ts#L194>:
+        // a snapshot recorded as skipped on the previous install is
+        // not re-evaluated and emits no
+        // `pnpm:skipped-optional-dependency` event, so the user is
+        // not re-notified of a known skip on every reinstall.
+        if skipped.contains(snapshot_key) {
+            continue;
+        }
+
         let metadata_key = snapshot_key.without_peer();
         let Some(metadata) = packages.get(&metadata_key) else { continue };
 

--- a/crates/package-manager/src/installability/tests.rs
+++ b/crates/package-manager/src/installability/tests.rs
@@ -11,7 +11,7 @@ use pacquet_reporter::{LogEvent, Reporter, SkippedOptionalReason};
 use pretty_assertions::assert_eq;
 
 use crate::installability::{
-    InstallabilityHost, any_installability_constraint, compute_skipped_snapshots,
+    InstallabilityHost, SkippedSnapshots, any_installability_constraint, compute_skipped_snapshots,
 };
 
 // Thread-local recording so the cargo-default parallel test runner
@@ -107,6 +107,7 @@ fn skip_optional_with_wrong_os() {
         &packages,
         &host("20.10.0", "darwin", "arm64"),
         "/proj",
+        SkippedSnapshots::new(),
     )
     .unwrap();
 
@@ -142,6 +143,7 @@ fn skip_optional_with_wrong_node_engine() {
         &packages,
         &host("20.10.0", "darwin", "arm64"),
         "/proj",
+        SkippedSnapshots::new(),
     )
     .unwrap();
 
@@ -170,6 +172,7 @@ fn compatible_snapshots_are_not_skipped() {
         &packages,
         &host("20.10.0", "darwin", "arm64"),
         "/proj",
+        SkippedSnapshots::new(),
     )
     .unwrap();
 
@@ -199,6 +202,7 @@ fn non_optional_incompatible_is_not_skipped() {
         &packages,
         &host("20.10.0", "darwin", "arm64"),
         "/proj",
+        SkippedSnapshots::new(),
     )
     .unwrap();
 
@@ -231,6 +235,7 @@ fn no_constraints_skips_the_per_snapshot_pass() {
         &packages,
         &host("20.10.0", "darwin", "arm64"),
         "/proj",
+        SkippedSnapshots::new(),
     )
     .unwrap();
 
@@ -331,6 +336,7 @@ fn duplicate_metadata_dedupes_reporter_events() {
         &packages,
         &host("20.10.0", "darwin", "arm64"),
         "/proj",
+        SkippedSnapshots::new(),
     )
     .unwrap();
 
@@ -375,9 +381,14 @@ fn supported_architectures_widens_accept_set_so_optional_stays() {
         libc: None,
     });
 
-    let skipped =
-        compute_skipped_snapshots::<RecordingReporter>(&snapshots, &packages, &host, "/proj")
-            .unwrap();
+    let skipped = compute_skipped_snapshots::<RecordingReporter>(
+        &snapshots,
+        &packages,
+        &host,
+        "/proj",
+        SkippedSnapshots::new(),
+    )
+    .unwrap();
 
     assert!(skipped.is_empty(), "supportedArchitectures.os=['darwin'] should keep the package");
     let events = take_events();
@@ -408,12 +419,109 @@ fn supported_architectures_does_not_implicitly_include_host() {
         libc: None,
     });
 
-    let skipped =
-        compute_skipped_snapshots::<RecordingReporter>(&snapshots, &packages, &host, "/proj")
-            .unwrap();
+    let skipped = compute_skipped_snapshots::<RecordingReporter>(
+        &snapshots,
+        &packages,
+        &host,
+        "/proj",
+        SkippedSnapshots::new(),
+    )
+    .unwrap();
 
     assert!(
         skipped.contains(&key),
         "supportedArchitectures.os=['linux'] should still skip a darwin-only package",
     );
+}
+
+/// A seeded snapshot bypasses the per-snapshot re-check entirely
+/// and emits no `pnpm:skipped-optional-dependency` event. Mirrors
+/// upstream's early return at
+/// <https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-builder/src/lockfileToDepGraph.ts#L194>:
+/// a snapshot listed in `.modules.yaml.skipped` from the previous
+/// install is treated as already skipped without re-running
+/// `package_is_installable`, so the user is not re-notified of a
+/// known skip on every reinstall.
+#[test]
+fn seeded_snapshot_short_circuits_recheck() {
+    reset_events();
+    let key = snapshot_key("for-legacy-node@1.0.0");
+    let mut snapshots = HashMap::new();
+    snapshots.insert(key.clone(), SnapshotEntry { optional: true, ..Default::default() });
+    let mut packages = HashMap::new();
+    // Metadata is still incompatible (`engines.node: "0.10"`).
+    // Without the short-circuit a recompute would skip the package
+    // AND emit a `pnpm:skipped-optional-dependency` event; with the
+    // short-circuit the snapshot stays in the seeded set without
+    // re-emitting.
+    packages.insert(key.clone(), synthetic_metadata(Some(&[("node", "0.10")]), None, None, None));
+
+    let seed = SkippedSnapshots::from_set([key.clone()].into_iter().collect());
+    let skipped = compute_skipped_snapshots::<RecordingReporter>(
+        &snapshots,
+        &packages,
+        &host("20.10.0", "darwin", "arm64"),
+        "/proj",
+        seed,
+    )
+    .unwrap();
+
+    assert!(skipped.contains(&key), "seeded key must survive the recompute");
+    let events = take_events();
+    assert!(
+        events.iter().all(|e| !matches!(e, LogEvent::SkippedOptionalDependency(_))),
+        "no SkippedOptionalDependency event must fire for a seeded snapshot, got {events:?}",
+    );
+}
+
+/// On the fast path (no constraint anywhere in the lockfile) the
+/// seed survives verbatim. Same upstream rationale as the seeded
+/// short-circuit: a previously skipped snapshot must not re-appear
+/// just because the lockfile's per-snapshot constraints were
+/// dropped between installs.
+#[test]
+fn fast_path_preserves_seed() {
+    reset_events();
+    let key = snapshot_key("previously-skipped@1.0.0");
+    let mut snapshots = HashMap::new();
+    snapshots.insert(key.clone(), SnapshotEntry { optional: true, ..Default::default() });
+    let mut packages = HashMap::new();
+    // Constraint-free metadata so `any_installability_constraint`
+    // returns false; the per-snapshot loop is short-circuited and
+    // the seed becomes the final set.
+    packages.insert(key.clone(), synthetic_metadata(None, None, None, None));
+
+    let seed = SkippedSnapshots::from_set([key.clone()].into_iter().collect());
+    let skipped = compute_skipped_snapshots::<RecordingReporter>(
+        &snapshots,
+        &packages,
+        &host("20.10.0", "darwin", "arm64"),
+        "/proj",
+        seed,
+    )
+    .unwrap();
+
+    assert_eq!(skipped.len(), 1, "fast path must keep the seed entry");
+    assert!(skipped.contains(&key));
+}
+
+/// `from_strings` silently drops unparsable depPath entries.
+/// Orphaned strings — e.g. a snapshot that has since been removed
+/// from the lockfile, or a malformed line from a hand-edited
+/// `.modules.yaml` — must not crash the read; they simply don't
+/// match any current key and survive as no-ops in the set.
+#[test]
+fn from_strings_skips_unparsable_entries() {
+    let set = SkippedSnapshots::from_strings([
+        "valid-pkg@1.0.0",
+        "@scope/pkg@2.0.0",
+        "",
+        "not a depPath",
+        "@@@no-version",
+    ]);
+    let key1: PackageKey = "valid-pkg@1.0.0".parse().unwrap();
+    let key2: PackageKey = "@scope/pkg@2.0.0".parse().unwrap();
+    assert_eq!(set.len(), 2);
+    assert!(set.contains(&key1));
+    assert!(set.contains(&key2));
 }


### PR DESCRIPTION
## Summary

Slice 3 of the [#434 umbrella](https://github.com/pnpm/pacquet/issues/434) (`Proper optionalDependencies support`). Slice 1 (#439) computed a `SkippedSnapshots` set on every frozen-lockfile install but never serialized it; slice 2 (#456) closed the input side. This PR closes the loop by mirroring three upstream sites pinned at [pnpm/pnpm@94240bc046](https://github.com/pnpm/pnpm/tree/94240bc046):

- **Write** — `Modules.skipped` was declared at [`crates/modules-yaml/src/lib.rs:197`](https://github.com/pnpm/pacquet/blob/b13b8180/crates/modules-yaml/src/lib.rs#L197) with sort-on-write but always serialized empty. `build_modules_manifest` now takes `&SkippedSnapshots` and produces the depPath string list pnpm writes at [`installing/deps-installer/src/install/index.ts:1625`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/src/install/index.ts#L1625).

- **Seed** — `install_frozen_lockfile::run` reads `.modules.yaml.skipped` before computing the in-memory set and passes the parsed `PackageKey`s as the seed to `compute_skipped_snapshots`. Mirrors upstream's load at [`installing/read-projects-context/src/index.ts:79`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/read-projects-context/src/index.ts#L79) plus the early return at [`deps/graph-builder/src/lockfileToDepGraph.ts:194`](https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-builder/src/lockfileToDepGraph.ts#L194).

- **Short-circuit** — `compute_skipped_snapshots` returns the seed verbatim on the fast path (no constraints in the lockfile) and, on the slow path, skips the per-snapshot re-check for keys already in the seed without emitting a duplicate `pnpm:skipped-optional-dependency` event. Non-seeded snapshots still re-run `package_is_installable`, covering the \"host arch changed since last install\" case upstream guards at [`:206-215`](https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-builder/src/lockfileToDepGraph.ts#L206-L215).

`InstallFrozenLockfile::run` now returns a small `InstallFrozenLockfileOutput { hoisted_dependencies, skipped }` struct so `Install::run` can thread both into `.modules.yaml`. Read errors on `.modules.yaml` degrade to an empty seed — the file is a cache artifact, not authoritative.

## Test plan

- [x] `installability/tests::seeded_snapshot_short_circuits_recheck` — verified with test-the-test: remove the short-circuit and the test fails on the duplicate event assertion.
- [x] `installability/tests::fast_path_preserves_seed` — constraint-free path.
- [x] `installability/tests::from_strings_skips_unparsable_entries` — orphan / malformed strings.
- [x] `install/tests::build_modules_manifest_serializes_skipped_set` + `_skipped_is_empty_on_empty_set` — write path. Verified with test-the-test: replace the wire-up with `vec![]` and the former fails.
- [x] `just ready` — typos + fmt + check + nextest (192 package-manager tests + 850 across the workspace) + clippy.
- [x] `taplo format --check`.
- [x] `just dylint` (perfectionist).
- [x] `RUSTDOCFLAGS=\"-D warnings\" cargo doc --no-deps --workspace`.

## Out of scope

- Current-lockfile write (`<virtual_store_dir>/lock.yaml`) — umbrella slice 6.
- `--no-optional` plumbing — umbrella slice 5.
- `--force` bypass (pacquet doesn't expose the flag yet).

Closes #463.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Skipped optional dependencies are preserved across reinstalls, including frozen installs, preventing unnecessary rechecks or reinstalls.

* **New Features**
  * Installation metadata now records a persisted "skipped" list in the modules manifest, and writes are sorted for deterministic output.

* **Tests**
  * Added tests to verify serialization, persistence, preservation, and behavior of seeded skipped entries across installs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pacquet/pull/467)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->