### PR TITLE
feat(git-fetcher): real npm-packlist semantics with .npmignore + bundleDependencies (#436 follow-up)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1322,6 +1322,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2000,6 +2016,7 @@ name = "pacquet-git-fetcher"
 version = "0.0.1"
 dependencies = [
  "derive_more",
+ "ignore",
  "miette 7.6.0",
  "pacquet-diagnostics",
  "pacquet-executor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ diffy = { version = "0.5.0" }
 dunce = { version = "1.0.5" }
 home = { version = "0.5.12" }
 httpdate = { version = "1.0.3" }
+ignore = { version = "0.4.25" }
 indexmap = { version = "2.14.0", features = ["serde"] }
 insta = { version = "1.47.2", features = ["yaml", "glob", "walkdir"] }
 itertools = { version = "0.14.0" }

--- a/crates/git-fetcher/Cargo.toml
+++ b/crates/git-fetcher/Cargo.toml
@@ -18,6 +18,7 @@ pacquet-reporter         = { workspace = true }
 pacquet-store-dir        = { workspace = true }
 
 derive_more = { workspace = true }
+ignore      = { workspace = true }
 miette      = { workspace = true }
 pipe-trait  = { workspace = true }
 serde_json  = { workspace = true }

--- a/crates/git-fetcher/src/packlist.rs
+++ b/crates/git-fetcher/src/packlist.rs
@@ -1,47 +1,64 @@
 //! Decide which files inside an extracted git-hosted package end up in
-//! the CAS. MVP port of [`npm-packlist`](https://github.com/npm/npm-packlist)
-//! / pnpm's
-//! [`fs/packlist`](https://github.com/pnpm/pnpm/blob/94240bc046/fs/packlist/src/index.ts):
+//! the CAS. Port of [`npm-packlist`](https://github.com/npm/npm-packlist)
+//! and pnpm's
+//! [`fs/packlist`](https://github.com/pnpm/pnpm/blob/94240bc046/fs/packlist/src/index.ts).
 //!
-//! - When `manifest.files` is a non-empty array, only its glob entries
-//!   plus the always-included files (`package.json`, `README*`,
-//!   `LICEN[SC]E*`, `CHANGES*`, `CHANGELOG*`, `HISTORY*`, `NOTICE*`)
-//!   and any file referenced by `manifest.main` / `manifest.bin` make it
-//!   into the result.
-//! - When `manifest.files` is absent, every regular file under
-//!   `pkg_dir` is included *except* the always-excluded set
-//!   (`.git/`, `node_modules/`, lockfiles for other package managers,
-//!   common cruft like `.DS_Store` / `npm-debug.log` / `*.orig`).
+//! The algorithm has four passes:
 //!
-//! Glob support is limited to `*`, `**`, and `?`. Full
-//! `.npmignore` / `.gitignore` layering, `bundleDependencies` walking,
-//! and exotic glob features (negation, character classes) are deferred
-//! to a follow-up; the gap is logged at `tracing::warn!` when a
-//! manifest carries `bundleDependencies` so the omission is visible
-//! during install. Tracks pnpm's behavior at
-//! [`fs/packlist/src/index.ts:24-29`](https://github.com/pnpm/pnpm/blob/94240bc046/fs/packlist/src/index.ts#L24-L29).
+//! 1. **Honor `.npmignore` and `.gitignore`** while walking. The
+//!    `ignore::WalkBuilder` does per-directory inheritance: a
+//!    `.npmignore` in `lib/` applies to `lib/**` only, while the
+//!    package's root `.gitignore` applies to the whole tree.
+//! 2. **Apply the `files` field allowlist** on top of the walk's
+//!    output: when the manifest sets `files: ["dist/**"]`, drop
+//!    anything outside that set (except the always-included files
+//!    handled in pass 3).
+//! 3. **Always-include** the standard files: `package.json`,
+//!    `README*` / `LICEN[SC]E*` / `CHANGES*` / `CHANGELOG*` /
+//!    `HISTORY*` / `NOTICE*` at the root, plus the paths declared in
+//!    `main` / `bin`. These survive `.npmignore` rejection and the
+//!    `files`-field filter.
+//! 4. **`bundleDependencies` recursion**: for each name in
+//!    `manifest.bundleDependencies` (or the legacy
+//!    `bundledDependencies`), recurse into `node_modules/<name>/` and
+//!    splice its packlist under that prefix.
+//!
+//! Two intentional divergences from upstream:
+//!
+//! - The `ignore` crate combines `.npmignore` and `.gitignore` rules
+//!   when both files exist in the same directory; npm-packlist would
+//!   use only `.npmignore`. The combined-rules outcome is the same
+//!   for the common case (a `.npmignore` that's a strict superset of
+//!   `.gitignore`); the divergence shows up only when `.npmignore`
+//!   explicitly *includes* a path `.gitignore` excludes, which is a
+//!   rare configuration in the wild. Documented gap; revisit if a
+//!   real package surfaces it.
+//! - `.git/info/exclude` and global `~/.gitignore` are NOT honored —
+//!   only the in-tree `.gitignore` / `.npmignore` files. The fetcher
+//!   imports a clean tarball / git checkout, not a user's working
+//!   tree, so the global-state ignores are wrong by construction.
 
 use crate::error::PacklistError;
+use ignore::{WalkBuilder, gitignore::Gitignore};
+use pacquet_package_manifest::safe_read_package_json_from_dir;
 use serde_json::Value;
 use std::{
     collections::BTreeSet,
+    fs,
     path::{Path, PathBuf},
 };
-use walkdir::WalkDir;
 
-/// Filenames always included regardless of `manifest.files`, matching
-/// `npm-packlist`'s `alwaysIncluded` plus pnpm's
-/// [`packlist`](https://github.com/pnpm/pnpm/blob/94240bc046/fs/packlist/src/index.ts#L13)
-/// pattern set. Case-insensitive prefix matches.
+/// Case-insensitive prefix matches for files always-included at the
+/// package root regardless of `.npmignore` / `files`. Mirrors
+/// `npm-packlist`'s `alwaysIncluded` plus pnpm's pattern set at
+/// [`fs/packlist/src/index.ts:13`](https://github.com/pnpm/pnpm/blob/94240bc046/fs/packlist/src/index.ts#L13).
 const ALWAYS_INCLUDED_PREFIXES: &[&str] =
     &["readme", "license", "licence", "changes", "changelog", "history", "notice"];
 
-/// Files / directories always excluded from the published view. The
-/// repo's own lockfiles must not bleed into the consumer's install —
-/// only the dep's source/build artifacts should ship.
+/// Always-excluded basenames. Same set as upstream: pacquet's CAS must
+/// never carry a dep's own lockfile or VCS state.
 const ALWAYS_EXCLUDED_NAMES: &[&str] = &[
     ".git",
-    "node_modules",
     ".npmrc",
     "npm-debug.log",
     ".DS_Store",
@@ -53,32 +70,19 @@ const ALWAYS_EXCLUDED_NAMES: &[&str] = &[
     ".hg",
 ];
 
-/// File-name suffixes always excluded (matched case-sensitively on the
-/// basename, like `npm-packlist` does for the `*.orig` family).
+/// Suffix-based always-excluded set, matching `npm-packlist`'s
+/// `*.orig` exclusion family.
 const ALWAYS_EXCLUDED_SUFFIXES: &[&str] = &[".orig"];
 
 /// Walk `pkg_dir` and return forward-slash relative paths for every
-/// file the published tarball should contain. Mirrors the return shape
-/// of `packlist()` at
+/// file the published tarball should contain. Mirrors the return
+/// shape of `packlist()` at
 /// [`fs/packlist/src/index.ts:24-29`](https://github.com/pnpm/pnpm/blob/94240bc046/fs/packlist/src/index.ts#L24-L29)
-/// (paths relative to `pkgDir`, no leading `./`).
+/// (paths relative to `pkg_dir`, no leading `./`).
 pub fn packlist(pkg_dir: &Path, manifest: &Value) -> Result<Vec<String>, PacklistError> {
-    if let Some(bundle) =
-        manifest.get("bundleDependencies").or_else(|| manifest.get("bundledDependencies"))
-        && bundle.as_array().is_some_and(|a| !a.is_empty())
-    {
-        tracing::warn!(
-            target: "pacquet::git_fetcher::packlist",
-            pkg_dir = %pkg_dir.display(),
-            "manifest declares bundleDependencies, but the MVP packlist port does not yet recurse into bundled deps — they will be missing from the cached snapshot",
-        );
-    }
-
     let files_field = manifest.get("files").and_then(Value::as_array);
-    let files_globs: Option<Vec<&str>> = files_field
-        .map(|arr| arr.iter().filter_map(Value::as_str).collect::<Vec<_>>())
-        .filter(|v| !v.is_empty());
-
+    let files_matcher: Option<Gitignore> =
+        files_field.and_then(|arr| build_files_matcher(pkg_dir, arr));
     let main_path = manifest.get("main").and_then(Value::as_str);
     let bin_paths: Vec<&str> = manifest
         .get("bin")
@@ -90,72 +94,234 @@ pub fn packlist(pkg_dir: &Path, manifest: &Value) -> Result<Vec<String>, Packlis
         .unwrap_or_default();
 
     let mut out: BTreeSet<String> = BTreeSet::new();
-    for entry in WalkDir::new(pkg_dir).into_iter().filter_entry(|e| {
-        // Hard-exclude `.git` / `node_modules` etc. before descent so
-        // we never spend time walking them. Note: this also filters
-        // the root once `e.depth() == 0`, hence the `is_root` guard.
-        let is_root = e.depth() == 0;
-        is_root || !is_always_excluded_dir(e.file_name())
-    }) {
-        let entry = entry
-            .map_err(|err| io_error(pkg_dir, err.into_io_error().unwrap_or_else(other_io_error)))?;
-        if !entry.file_type().is_file() {
+
+    // Pass 1: walk with `.gitignore` / `.npmignore` filtering.
+    // `standard_filters(false)` turns off `ignore`'s opinionated
+    // defaults (hidden-file skip, `.git`-dir skip, etc.) so we control
+    // every filter explicitly. `git_ignore(true)` /
+    // `add_custom_ignore_filename(".npmignore")` enable the two ignore
+    // file sources; `require_git(false)` makes `ignore` honor
+    // `.gitignore` even though a git-hosted snapshot's `.git/` has
+    // already been deleted by [`crate::GitFetcher`] before this point.
+    let mut builder = WalkBuilder::new(pkg_dir);
+    builder
+        .standard_filters(false)
+        .hidden(false)
+        .git_ignore(true)
+        .git_exclude(false)
+        .git_global(false)
+        .require_git(false)
+        .add_custom_ignore_filename(".npmignore");
+
+    for entry in builder.build() {
+        let entry = entry.map_err(|err| io_error(pkg_dir, into_io(err)))?;
+        if !entry.file_type().is_some_and(|t| t.is_file()) {
             continue;
         }
         let rel = relative_forward_slash(pkg_dir, entry.path());
-        if should_always_exclude_file(&rel) {
+        if should_always_exclude(&rel) {
             continue;
         }
-        if should_include(&rel, &files_globs, main_path, &bin_paths) {
-            out.insert(rel);
+        // `node_modules/` is handled by the `bundleDependencies`
+        // pass below — never include its contents via the general
+        // walk. Without this gate a manifest that publishes a stray
+        // `node_modules/something` would slip through.
+        if rel.starts_with("node_modules/") || rel == "node_modules" {
+            continue;
+        }
+        if let Some(matcher) = &files_matcher
+            && !files_field_includes(matcher, &rel)
+            && !is_always_included_at_root(&rel)
+            && !is_main_or_bin(&rel, main_path, &bin_paths)
+        {
+            continue;
+        }
+        out.insert(rel);
+    }
+
+    // Pass 2: scan the root for always-included names (README, LICENSE,
+    // etc.) that `.npmignore` might have removed from pass 1. npm-
+    // packlist guarantees these survive `.npmignore`.
+    let root_entries = fs::read_dir(pkg_dir)
+        .map_err(|source| PacklistError::Io { pkg_dir: pkg_dir.display().to_string(), source })?;
+    for entry in root_entries {
+        let entry = entry.map_err(|source| PacklistError::Io {
+            pkg_dir: pkg_dir.display().to_string(),
+            source,
+        })?;
+        if !entry.file_type().is_ok_and(|t| t.is_file()) {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if should_always_exclude(&name) {
+            continue;
+        }
+        if is_always_included_at_root(&name) {
+            out.insert(name);
         }
     }
+
+    // Pass 3: force-include `main` / `bin` paths, which always ship
+    // regardless of `.npmignore`. (`files`-field rejection is already
+    // overridden in pass 1.)
+    if let Some(main) = main_path {
+        let m = normalize_field_path(main);
+        if !m.is_empty() && pkg_dir.join(&m).is_file() {
+            out.insert(m);
+        }
+    }
+    for bin in &bin_paths {
+        let b = normalize_field_path(bin);
+        if !b.is_empty() && pkg_dir.join(&b).is_file() {
+            out.insert(b);
+        }
+    }
+
+    // Pass 4: recurse into `bundleDependencies` /
+    // `bundledDependencies`. Each bundled dep gets its own packlist
+    // pass; the result splices in under `node_modules/<name>/`. Both
+    // field names are accepted because some published packages use
+    // one and some the other (npm-packlist tolerates both).
+    for bundle_name in bundle_dep_names(manifest) {
+        let bundle_pkg_dir = pkg_dir.join("node_modules").join(&bundle_name);
+        if !bundle_pkg_dir.is_dir() {
+            tracing::debug!(
+                target: "pacquet::git_fetcher::packlist",
+                bundle_name = %bundle_name,
+                pkg_dir = %pkg_dir.display(),
+                "bundleDependencies entry not present under node_modules/; skipping",
+            );
+            continue;
+        }
+        let bundle_manifest = safe_read_package_json_from_dir(&bundle_pkg_dir)
+            .ok()
+            .flatten()
+            .unwrap_or_else(|| Value::Object(serde_json::Map::new()));
+        let nested = packlist(&bundle_pkg_dir, &bundle_manifest)?;
+        for rel in nested {
+            out.insert(format!("node_modules/{bundle_name}/{rel}"));
+        }
+    }
+
     Ok(out.into_iter().collect())
 }
 
-fn should_include(
-    rel: &str,
-    files_globs: &Option<Vec<&str>>,
-    main: Option<&str>,
-    bins: &[&str],
-) -> bool {
-    if is_always_included_basename(rel) {
+/// Compile the `manifest.files` allowlist into a single `Gitignore`
+/// matcher rooted at `pkg_dir`. Returns `None` when no entries
+/// compile (e.g., the field was present but every entry was empty or
+/// malformed) so the caller treats the absence as "include
+/// everything", matching upstream's behavior for an unset / empty
+/// `files`. Lines that fail to parse are dropped with a
+/// `tracing::debug!` — npm-packlist tolerates bad globs the same way
+/// (a bad pattern just doesn't match anything).
+fn build_files_matcher(pkg_dir: &Path, entries: &[Value]) -> Option<Gitignore> {
+    let mut builder = ignore::gitignore::GitignoreBuilder::new(pkg_dir);
+    let mut added = 0;
+    for entry in entries {
+        let Some(raw) = entry.as_str() else { continue };
+        let pattern = normalize_field_path(raw);
+        if pattern.is_empty() {
+            continue;
+        }
+        if let Err(error) = builder.add_line(None, &pattern) {
+            tracing::debug!(
+                target: "pacquet::git_fetcher::packlist",
+                ?pattern,
+                ?error,
+                "skipping invalid `files` entry",
+            );
+            continue;
+        }
+        added += 1;
+    }
+    if added == 0 {
+        return None;
+    }
+    match builder.build() {
+        Ok(gi) => Some(gi),
+        Err(error) => {
+            tracing::debug!(
+                target: "pacquet::git_fetcher::packlist",
+                ?error,
+                "failed to build `files`-field matcher; treating field as absent",
+            );
+            None
+        }
+    }
+}
+
+/// `true` when `rel` matches the `files`-field allowlist. The matcher
+/// was built with the `files` entries as gitignore-style include
+/// patterns; `Gitignore::matched(rel, false).is_ignore()` is `true`
+/// when one of those patterns matches, which is what we want for an
+/// include list.
+///
+/// gitignore-style patterns also match directories implicitly: a
+/// pattern like `dist` matches both `dist` and everything under it.
+/// Bare basenames like `cli` should also match at any depth; the
+/// fallback below splits the candidate to try the leaf name.
+fn files_field_includes(matcher: &Gitignore, rel: &str) -> bool {
+    if matcher.matched(rel, false).is_ignore() {
         return true;
     }
-    if let Some(globs) = files_globs {
-        if let Some(main) = main
-            && normalize_field_path(main) == rel
-        {
-            return true;
-        }
-        if bins.iter().any(|bin| normalize_field_path(bin) == rel) {
-            return true;
-        }
-        return globs.iter().any(|glob| glob_match(normalize_field_path(glob).as_str(), rel));
-    }
-    // No `files` field — everything that wasn't excluded above ships.
-    true
+    rel.rsplit('/').next().is_some_and(|leaf| matcher.matched(leaf, false).is_ignore())
 }
 
-fn is_always_included_basename(rel: &str) -> bool {
-    let basename = rel.rsplit('/').next().unwrap_or(rel).to_ascii_lowercase();
-    if basename == "package.json" {
+fn is_always_included_at_root(rel: &str) -> bool {
+    // Only files at the root carry the always-include semantics; a
+    // `LICENSE` deep in a subtree follows the same `.npmignore` /
+    // `files` rules as any other file. Matches npm-packlist's
+    // root-only treatment of the README/LICENSE/etc. set.
+    if rel.contains('/') {
+        return false;
+    }
+    let lower = rel.to_ascii_lowercase();
+    if lower == "package.json" {
         return true;
     }
-    ALWAYS_INCLUDED_PREFIXES.iter().any(|prefix| basename.starts_with(prefix))
+    ALWAYS_INCLUDED_PREFIXES.iter().any(|prefix| lower.starts_with(prefix))
 }
 
-fn is_always_excluded_dir(name: &std::ffi::OsStr) -> bool {
-    let Some(name) = name.to_str() else { return false };
-    ALWAYS_EXCLUDED_NAMES.contains(&name)
+fn is_main_or_bin(rel: &str, main: Option<&str>, bins: &[&str]) -> bool {
+    if let Some(main) = main
+        && normalize_field_path(main) == rel
+    {
+        return true;
+    }
+    bins.iter().any(|bin| normalize_field_path(bin) == rel)
 }
 
-fn should_always_exclude_file(rel: &str) -> bool {
+fn should_always_exclude(rel: &str) -> bool {
     let basename = rel.rsplit('/').next().unwrap_or(rel);
     if ALWAYS_EXCLUDED_NAMES.contains(&basename) {
         return true;
     }
+    if rel.split('/').any(|seg| ALWAYS_EXCLUDED_NAMES.contains(&seg)) {
+        return true;
+    }
     ALWAYS_EXCLUDED_SUFFIXES.iter().any(|s| basename.ends_with(s))
+}
+
+/// Collect names from `bundleDependencies` (or the legacy
+/// `bundledDependencies`). Both spellings appear in real published
+/// packages; npm-packlist accepts either.
+fn bundle_dep_names(manifest: &Value) -> Vec<String> {
+    let raw = manifest.get("bundleDependencies").or_else(|| manifest.get("bundledDependencies"));
+    let Some(raw) = raw else { return Vec::new() };
+    match raw {
+        Value::Array(arr) => arr.iter().filter_map(Value::as_str).map(String::from).collect(),
+        Value::Bool(true) => {
+            // `bundleDependencies: true` means "bundle every entry in
+            // `dependencies`". Rare but supported by npm. Materialize
+            // the keys from the dependencies map.
+            manifest
+                .get("dependencies")
+                .and_then(Value::as_object)
+                .map(|m| m.keys().cloned().collect::<Vec<_>>())
+                .unwrap_or_default()
+        }
+        _ => Vec::new(),
+    }
 }
 
 fn relative_forward_slash(root: &Path, full: &Path) -> String {
@@ -168,97 +334,20 @@ fn relative_forward_slash(root: &Path, full: &Path) -> String {
 }
 
 /// Strip a leading `./` and any leading slashes from `path` so manifest
-/// `files` entries match the forward-slash relative form `packlist`
-/// produces. Mirrors `npm-packlist`'s normalisation step.
+/// field entries match the forward-slash relative form `packlist`
+/// produces. Mirrors `npm-packlist`'s normalization step.
 fn normalize_field_path(path: &str) -> String {
     let trimmed = path.trim_start_matches("./");
     trimmed.trim_start_matches('/').to_string()
-}
-
-/// Minimal glob matcher supporting `*` (any non-slash run), `**` (any
-/// sequence including slashes), and `?` (single non-slash char). Good
-/// enough for the common `files` patterns: `dist/**`, `lib/*.js`,
-/// `bin/cli`, etc.
-fn glob_match(pattern: &str, candidate: &str) -> bool {
-    glob_match_inner(pattern.as_bytes(), candidate.as_bytes())
-}
-
-fn glob_match_inner(pattern: &[u8], candidate: &[u8]) -> bool {
-    // Two-pointer walk with one backtrack point. The asymptotic worst
-    // case is O(n*m), but real `files` patterns have only one or two
-    // wildcards so the inner loop terminates fast.
-    let mut p = 0;
-    let mut c = 0;
-    let mut star_p: Option<usize> = None;
-    let mut star_c = 0;
-    while c < candidate.len() {
-        if p < pattern.len()
-            && pattern[p] == b'*'
-            && p + 1 < pattern.len()
-            && pattern[p + 1] == b'*'
-        {
-            // `**` — match any sequence (including slashes).
-            star_p = Some(p);
-            p += 2;
-            // Skip a single following `/` so `dist/**` matches `dist/x`.
-            if p < pattern.len() && pattern[p] == b'/' {
-                p += 1;
-            }
-            star_c = c;
-            continue;
-        }
-        if p < pattern.len() && pattern[p] == b'*' {
-            // single `*` — match any non-slash run.
-            star_p = Some(p);
-            p += 1;
-            star_c = c;
-            continue;
-        }
-        // `?` matches any single non-slash byte; otherwise the byte
-        // must match exactly. (Without the explicit `candidate[c] !=
-        // b'/'` gate, `a?b` would incorrectly match `a/b`.)
-        if p < pattern.len() {
-            let pc = pattern[p];
-            let matches = (pc == b'?' && candidate[c] != b'/') || pc == candidate[c];
-            if matches {
-                p += 1;
-                c += 1;
-                continue;
-            }
-        }
-        if let Some(sp) = star_p {
-            // Backtrack: the `*` swallows one more candidate byte.
-            // For single `*`, refuse to swallow a `/`.
-            if pattern[sp] == b'*'
-                && (sp + 1 >= pattern.len() || pattern[sp + 1] != b'*')
-                && candidate[star_c] == b'/'
-            {
-                return false;
-            }
-            star_c += 1;
-            c = star_c;
-            p = sp
-                + if pattern[sp] == b'*' && sp + 1 < pattern.len() && pattern[sp + 1] == b'*' {
-                    2
-                } else {
-                    1
-                };
-            continue;
-        }
-        return false;
-    }
-    while p < pattern.len() && pattern[p] == b'*' {
-        p += 1;
-    }
-    p == pattern.len()
 }
 
 fn io_error(pkg_dir: &Path, source: std::io::Error) -> PacklistError {
     PacklistError::Io { pkg_dir: pkg_dir.display().to_string(), source }
 }
 
-fn other_io_error() -> std::io::Error {
-    std::io::Error::other("walkdir produced an entry with no underlying io::Error")
+fn into_io(err: ignore::Error) -> std::io::Error {
+    err.into_io_error()
+        .unwrap_or_else(|| std::io::Error::other("ignore walker produced a non-io error"))
 }
 
 #[cfg(test)]

--- a/crates/git-fetcher/src/packlist.rs
+++ b/crates/git-fetcher/src/packlist.rs
@@ -43,10 +43,18 @@ use ignore::{WalkBuilder, gitignore::Gitignore};
 use pacquet_package_manifest::safe_read_package_json_from_dir;
 use serde_json::Value;
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeSet, HashSet},
     fs,
     path::{Path, PathBuf},
 };
+
+/// Cap on `bundleDependencies` recursion depth. Real packages bundle
+/// at most a handful of levels (most published packages bundle zero;
+/// the rare ones bundle one or two). The cap prevents a runaway
+/// recursion if a bundled dep declares its own bundle pointing at
+/// itself (or a symlink loop in the source tree slips past
+/// `canonicalize`).
+const MAX_BUNDLE_DEPTH: u32 = 32;
 
 /// Case-insensitive prefix matches for files always-included at the
 /// package root regardless of `.npmignore` / `files`. Mirrors
@@ -80,6 +88,47 @@ const ALWAYS_EXCLUDED_SUFFIXES: &[&str] = &[".orig"];
 /// [`fs/packlist/src/index.ts:24-29`](https://github.com/pnpm/pnpm/blob/94240bc046/fs/packlist/src/index.ts#L24-L29)
 /// (paths relative to `pkg_dir`, no leading `./`).
 pub fn packlist(pkg_dir: &Path, manifest: &Value) -> Result<Vec<String>, PacklistError> {
+    let mut visited = HashSet::new();
+    packlist_inner(pkg_dir, manifest, &mut visited, 0)
+}
+
+/// Inner recursive entry point that threads cycle detection and a
+/// depth cap through `bundleDependencies` traversals. Each
+/// recursion's canonicalised `pkg_dir` is inserted into `visited`
+/// so a bundled dep that points back at an ancestor (cycle) gets
+/// skipped instead of stack-overflowing. The `depth` counter is a
+/// belt-and-braces guard against any cycle the canonical-path check
+/// can't see (e.g. filesystem mount tricks).
+fn packlist_inner(
+    pkg_dir: &Path,
+    manifest: &Value,
+    visited: &mut HashSet<PathBuf>,
+    depth: u32,
+) -> Result<Vec<String>, PacklistError> {
+    // `fs::canonicalize` resolves symlinks, which is precisely what
+    // we want for cycle detection — a symlink loop in the source
+    // tree shows up as the same canonical path. Fall back to the
+    // input path on canonicalisation failure (e.g. permission
+    // denied); the cycle check then degrades to identity on the
+    // raw path, which is still enough to catch trivial self-bundles.
+    let canonical = fs::canonicalize(pkg_dir).unwrap_or_else(|_| pkg_dir.to_path_buf());
+    if !visited.insert(canonical) {
+        tracing::warn!(
+            target: "pacquet::git_fetcher::packlist",
+            pkg_dir = %pkg_dir.display(),
+            "bundleDependencies cycle: directory already visited at this canonical path; skipping",
+        );
+        return Ok(Vec::new());
+    }
+    if depth > MAX_BUNDLE_DEPTH {
+        tracing::warn!(
+            target: "pacquet::git_fetcher::packlist",
+            pkg_dir = %pkg_dir.display(),
+            depth,
+            "bundleDependencies recursion exceeded MAX_BUNDLE_DEPTH; refusing to descend further",
+        );
+        return Ok(Vec::new());
+    }
     let files_field = manifest.get("files").and_then(Value::as_array);
     let files_matcher: Option<Gitignore> =
         files_field.and_then(|arr| build_files_matcher(pkg_dir, arr));
@@ -169,16 +218,21 @@ pub fn packlist(pkg_dir: &Path, manifest: &Value) -> Result<Vec<String>, Packlis
 
     // Pass 3: force-include `main` / `bin` paths, which always ship
     // regardless of `.npmignore`. (`files`-field rejection is already
-    // overridden in pass 1.)
+    // overridden in pass 1.) Still consult `should_always_exclude`
+    // first — a manifest declaring e.g. `"main": "package-lock.json"`
+    // would otherwise re-add the lockfile we just refused above. The
+    // always-excluded set wins over manifest fields; npm-packlist
+    // does the same and emits no warning, so we stay silent too
+    // (a `tracing::debug!` would be lost in install logs).
     if let Some(main) = main_path {
         let m = normalize_field_path(main);
-        if !m.is_empty() && pkg_dir.join(&m).is_file() {
+        if !m.is_empty() && !should_always_exclude(&m) && pkg_dir.join(&m).is_file() {
             out.insert(m);
         }
     }
     for bin in &bin_paths {
         let b = normalize_field_path(bin);
-        if !b.is_empty() && pkg_dir.join(&b).is_file() {
+        if !b.is_empty() && !should_always_exclude(&b) && pkg_dir.join(&b).is_file() {
             out.insert(b);
         }
     }
@@ -217,7 +271,7 @@ pub fn packlist(pkg_dir: &Path, manifest: &Value) -> Result<Vec<String>, Packlis
             .ok()
             .flatten()
             .unwrap_or_else(|| Value::Object(serde_json::Map::new()));
-        let nested = packlist(&bundle_pkg_dir, &bundle_manifest)?;
+        let nested = packlist_inner(&bundle_pkg_dir, &bundle_manifest, visited, depth + 1)?;
         for rel in nested {
             out.insert(format!("node_modules/{bundle_name}/{rel}"));
         }

--- a/crates/git-fetcher/src/packlist.rs
+++ b/crates/git-fetcher/src/packlist.rs
@@ -55,20 +55,20 @@ use std::{
 const ALWAYS_INCLUDED_PREFIXES: &[&str] =
     &["readme", "license", "licence", "changes", "changelog", "history", "notice"];
 
-/// Always-excluded basenames. Same set as upstream: pacquet's CAS must
-/// never carry a dep's own lockfile or VCS state.
-const ALWAYS_EXCLUDED_NAMES: &[&str] = &[
-    ".git",
-    ".npmrc",
-    "npm-debug.log",
-    ".DS_Store",
-    "package-lock.json",
-    "yarn.lock",
-    "pnpm-lock.yaml",
-    ".svn",
-    "CVS",
-    ".hg",
-];
+/// Version-control directory names that exclude every file under
+/// them at any depth. Matches the upstream behavior of dropping VCS
+/// state from a published package regardless of where in the tree it
+/// happens to sit. Exact-segment match: a path with a literal segment
+/// named `.git` / `.svn` / `.hg` / `CVS` is filtered, but a regular
+/// file like `lib/foo.hg-stub` (basename `foo.hg-stub`, not `.hg`) is
+/// not.
+const ALWAYS_EXCLUDED_DIR_SEGMENTS: &[&str] = &[".git", ".svn", ".hg", "CVS"];
+
+/// Basenames always excluded regardless of where the file sits.
+/// Matches npm-packlist's per-file cruft set: lockfiles for sibling
+/// package managers, debug logs, OS junk, npm runtime config.
+const ALWAYS_EXCLUDED_BASENAMES: &[&str] =
+    &[".npmrc", "npm-debug.log", ".DS_Store", "package-lock.json", "yarn.lock", "pnpm-lock.yaml"];
 
 /// Suffix-based always-excluded set, matching `npm-packlist`'s
 /// `*.orig` exclusion family.
@@ -111,6 +111,12 @@ pub fn packlist(pkg_dir: &Path, manifest: &Value) -> Result<Vec<String>, Packlis
         .git_exclude(false)
         .git_global(false)
         .require_git(false)
+        // Don't search parent directories of `pkg_dir` for ignore
+        // files: the packlist must depend only on the contents of the
+        // package directory itself. Otherwise a `.gitignore` in the
+        // workspace root above a git-hosted snapshot's working copy
+        // would leak into the published file set.
+        .parents(false)
         .add_custom_ignore_filename(".npmignore");
 
     for entry in builder.build() {
@@ -183,6 +189,20 @@ pub fn packlist(pkg_dir: &Path, manifest: &Value) -> Result<Vec<String>, Packlis
     // field names are accepted because some published packages use
     // one and some the other (npm-packlist tolerates both).
     for bundle_name in bundle_dep_names(manifest) {
+        // Defense-in-depth: a malicious manifest could carry
+        // `bundleDependencies: ["../../etc"]` (or an absolute path).
+        // Reject anything that's not a single safe segment before
+        // building the join path; let `is_safe_bundle_name` log the
+        // refusal so the gap is observable in install logs.
+        if !is_safe_bundle_name(&bundle_name) {
+            tracing::warn!(
+                target: "pacquet::git_fetcher::packlist",
+                bundle_name = %bundle_name,
+                pkg_dir = %pkg_dir.display(),
+                "rejecting bundleDependencies entry that is not a single path segment",
+            );
+            continue;
+        }
         let bundle_pkg_dir = pkg_dir.join("node_modules").join(&bundle_name);
         if !bundle_pkg_dir.is_dir() {
             tracing::debug!(
@@ -252,19 +272,19 @@ fn build_files_matcher(pkg_dir: &Path, entries: &[Value]) -> Option<Gitignore> {
 
 /// `true` when `rel` matches the `files`-field allowlist. The matcher
 /// was built with the `files` entries as gitignore-style include
-/// patterns; `Gitignore::matched(rel, false).is_ignore()` is `true`
-/// when one of those patterns matches, which is what we want for an
-/// include list.
+/// patterns. Two cases must succeed:
 ///
-/// gitignore-style patterns also match directories implicitly: a
-/// pattern like `dist` matches both `dist` and everything under it.
-/// Bare basenames like `cli` should also match at any depth; the
-/// fallback below splits the candidate to try the leaf name.
+/// - The path itself matches a pattern (`files: ["cli"]` includes a
+///   file named `cli` at any depth).
+/// - An ancestor directory matches (`files: ["cli"]` includes
+///   `lib/cli/index.js` because `cli` matches `lib/cli`).
+///
+/// `Gitignore::matched_path_or_any_parents` walks the path's ancestor
+/// chain and returns `Ignore` when any segment matches — exactly the
+/// behavior npm-packlist's `files`-field needs (a directory pattern
+/// includes its contents recursively).
 fn files_field_includes(matcher: &Gitignore, rel: &str) -> bool {
-    if matcher.matched(rel, false).is_ignore() {
-        return true;
-    }
-    rel.rsplit('/').next().is_some_and(|leaf| matcher.matched(leaf, false).is_ignore())
+    matcher.matched_path_or_any_parents(rel, false).is_ignore()
 }
 
 fn is_always_included_at_root(rel: &str) -> bool {
@@ -293,13 +313,51 @@ fn is_main_or_bin(rel: &str, main: Option<&str>, bins: &[&str]) -> bool {
 
 fn should_always_exclude(rel: &str) -> bool {
     let basename = rel.rsplit('/').next().unwrap_or(rel);
-    if ALWAYS_EXCLUDED_NAMES.contains(&basename) {
+    // Basename-cruft check: per-file entries (`.npmrc`, lockfiles,
+    // debug logs, OS junk) are excluded at any depth.
+    if ALWAYS_EXCLUDED_BASENAMES.contains(&basename) {
         return true;
     }
-    if rel.split('/').any(|seg| ALWAYS_EXCLUDED_NAMES.contains(&seg)) {
+    // VCS dir check: a path is excluded if any segment is literally
+    // `.git` / `.svn` / `.hg` / `CVS`. Exact-segment match (not
+    // prefix) so a regular file `lib/foo.hg-stub` isn't accidentally
+    // dropped just because its basename mentions `.hg`.
+    if rel.split('/').any(|seg| ALWAYS_EXCLUDED_DIR_SEGMENTS.contains(&seg)) {
         return true;
     }
     ALWAYS_EXCLUDED_SUFFIXES.iter().any(|s| basename.ends_with(s))
+}
+
+/// True when `name` is a safe `bundleDependencies` entry — the join
+/// `pkg_dir/node_modules/<name>` stays inside `pkg_dir/node_modules`.
+///
+/// Rejects parent-dir components, root, and drive prefixes. Accepts
+/// scoped names like `@scope/foo`: those legitimately carry a slash
+/// and resolve to `pkg_dir/node_modules/@scope/foo`, which is still
+/// inside the package tree. Same component-based discipline
+/// `cas_io::join_checked` uses for tarball entries.
+fn is_safe_bundle_name(name: &str) -> bool {
+    if name.is_empty() {
+        return false;
+    }
+    let path = std::path::Path::new(name);
+    if path.is_absolute() {
+        return false;
+    }
+    for component in path.components() {
+        match component {
+            std::path::Component::Normal(_) => {}
+            std::path::Component::ParentDir
+            | std::path::Component::RootDir
+            | std::path::Component::Prefix(_) => {
+                return false;
+            }
+            // `.` components are stripped silently — `./foo` resolves
+            // the same as `foo` on every platform.
+            std::path::Component::CurDir => {}
+        }
+    }
+    true
 }
 
 /// Collect names from `bundleDependencies` (or the legacy

--- a/crates/git-fetcher/src/packlist/tests.rs
+++ b/crates/git-fetcher/src/packlist/tests.rs
@@ -421,3 +421,108 @@ fn files_field_bare_basename_matches_at_depth() {
         "files entry matching a directory also includes its contents: {out:?}",
     );
 }
+
+#[test]
+fn bundle_dependencies_self_cycle_is_caught() {
+    // Defense-in-depth: a bundled dep whose own manifest declares a
+    // bundle pointing back at itself (or any cycle reachable through
+    // the canonical-path chain) must not stack-overflow the fetcher.
+    // The visited-set + depth cap inside `packlist_inner` stops the
+    // recursion; the test just confirms the fetcher returns without
+    // panicking and includes the one-level bundle's files exactly
+    // once.
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    touch(root, "package.json");
+    touch(root, "node_modules/self/package.json");
+    touch(root, "node_modules/self/lib.js");
+    // The bundled dep declares itself as a bundleDependency. Without
+    // cycle detection this becomes infinite recursion.
+    fs::write(
+        root.join("node_modules/self/package.json"),
+        r#"{"name":"self","version":"1.0.0","bundleDependencies":["self"]}"#,
+    )
+    .unwrap();
+    // Symlink `node_modules/self/node_modules/self` back to the
+    // outer `node_modules/self` so the canonical-path check has
+    // something to catch. (On platforms that can't symlink, the
+    // depth cap kicks in instead.)
+    fs::create_dir_all(root.join("node_modules/self/node_modules")).unwrap();
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(
+            root.join("node_modules/self"),
+            root.join("node_modules/self/node_modules/self"),
+        )
+        .unwrap();
+    }
+
+    let manifest = json!({
+        "name": "x",
+        "version": "0.0.0",
+        "bundleDependencies": ["self"],
+    });
+    let out = packlist(root, &manifest).unwrap();
+
+    assert!(out.contains(&"package.json".to_string()));
+    assert!(out.contains(&"node_modules/self/package.json".to_string()));
+    assert!(out.contains(&"node_modules/self/lib.js".to_string()));
+    // No deeper paths via the cycle — the visited-set / depth cap
+    // refused the re-entry.
+    assert!(
+        !out.iter().any(|p| p.starts_with("node_modules/self/node_modules/")),
+        "cycle through node_modules/self/node_modules/self/... must be cut: {out:?}",
+    );
+}
+
+#[test]
+fn main_field_pointing_at_always_excluded_basename_is_refused() {
+    // Regression: pass 3 force-includes `main` / `bin` only after
+    // running them through `should_always_exclude`. A manifest with
+    // `"main": "package-lock.json"` previously would have re-added
+    // the lockfile despite the basename-cruft filter.
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    touch(root, "package.json");
+    touch(root, "package-lock.json");
+    touch(root, "real-entry.js");
+
+    let manifest = json!({
+        "name": "x",
+        "version": "0.0.0",
+        "main": "package-lock.json",
+    });
+    let out = packlist(root, &manifest).unwrap();
+
+    assert!(out.contains(&"package.json".to_string()));
+    assert!(out.contains(&"real-entry.js".to_string()));
+    assert!(
+        !out.contains(&"package-lock.json".to_string()),
+        "always-excluded basename must win over `main` field: {out:?}",
+    );
+}
+
+#[test]
+fn bin_field_pointing_at_vcs_segment_is_refused() {
+    // Same idea for `bin`: a manifest pointing `bin/cli` at
+    // `.git/something` (silly but possible) must not re-add a VCS
+    // file. Uses a basename inside a `.git` segment to hit the dir-
+    // segment exclusion path rather than the basename one.
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    touch(root, "package.json");
+    touch(root, ".git/hook");
+
+    let manifest = json!({
+        "name": "x",
+        "version": "0.0.0",
+        "bin": { "weird": ".git/hook" },
+    });
+    let out = packlist(root, &manifest).unwrap();
+
+    assert!(out.contains(&"package.json".to_string()));
+    assert!(
+        !out.iter().any(|p| p.contains(".git/")),
+        "VCS-segment exclusion must win over `bin` field: {out:?}",
+    );
+}

--- a/crates/git-fetcher/src/packlist/tests.rs
+++ b/crates/git-fetcher/src/packlist/tests.rs
@@ -156,3 +156,150 @@ fn single_star_does_not_cross_directory() {
     assert!(out.contains(&"lib/index.js".to_string()));
     assert!(!out.contains(&"lib/sub/inner.js".to_string()));
 }
+
+#[test]
+fn npmignore_excludes_listed_paths() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    touch(root, "package.json");
+    touch(root, "index.js");
+    touch(root, "test/foo.test.js");
+    fs::write(root.join(".npmignore"), "test/\n").unwrap();
+
+    let manifest = json!({ "name": "x", "version": "0.0.0" });
+    let mut out = packlist(root, &manifest).unwrap();
+    out.sort();
+
+    assert!(out.contains(&"index.js".to_string()));
+    assert!(out.contains(&"package.json".to_string()));
+    assert!(
+        !out.iter().any(|p| p.starts_with("test/")),
+        "`.npmignore` must exclude `test/`; received {out:?}",
+    );
+}
+
+#[test]
+fn gitignore_excludes_when_no_npmignore() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    touch(root, "package.json");
+    touch(root, "index.js");
+    touch(root, "build/output.js");
+    fs::write(root.join(".gitignore"), "build/\n").unwrap();
+
+    let manifest = json!({ "name": "x", "version": "0.0.0" });
+    let mut out = packlist(root, &manifest).unwrap();
+    out.sort();
+
+    assert!(out.contains(&"index.js".to_string()));
+    assert!(
+        !out.iter().any(|p| p.starts_with("build/")),
+        "`.gitignore` must exclude `build/` when no `.npmignore` exists; received {out:?}",
+    );
+}
+
+#[test]
+fn npmignore_does_not_drop_always_included_files() {
+    // Even when `.npmignore` says to drop README/LICENSE/etc., they
+    // must still ship — npm-packlist's always-included override.
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    touch(root, "package.json");
+    touch(root, "README.md");
+    touch(root, "LICENSE");
+    touch(root, "index.js");
+    fs::write(root.join(".npmignore"), "README.md\nLICENSE\n").unwrap();
+
+    let manifest = json!({ "name": "x", "version": "0.0.0" });
+    let out = packlist(root, &manifest).unwrap();
+
+    assert!(out.contains(&"README.md".to_string()), "README.md is always-included: {out:?}");
+    assert!(out.contains(&"LICENSE".to_string()), "LICENSE is always-included: {out:?}");
+    assert!(out.contains(&"package.json".to_string()));
+    assert!(out.contains(&"index.js".to_string()));
+}
+
+#[test]
+fn npmignore_in_subdir_applies_to_subtree_only() {
+    // A nested `.npmignore` should narrow only its own subtree, not
+    // override the root's view.
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    touch(root, "package.json");
+    touch(root, "lib/index.js");
+    touch(root, "lib/internal/private.js");
+    fs::write(root.join("lib/internal/.npmignore"), "private.js\n").unwrap();
+
+    let manifest = json!({ "name": "x", "version": "0.0.0" });
+    let out = packlist(root, &manifest).unwrap();
+
+    assert!(out.contains(&"lib/index.js".to_string()));
+    assert!(
+        !out.contains(&"lib/internal/private.js".to_string()),
+        "nested .npmignore must exclude `private.js`: {out:?}",
+    );
+}
+
+#[test]
+fn bundle_dependencies_subtree_is_included() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    touch(root, "package.json");
+    touch(root, "index.js");
+    touch(root, "node_modules/dep/package.json");
+    touch(root, "node_modules/dep/lib.js");
+    // Sibling node_modules entry that is NOT bundled — must not ship.
+    touch(root, "node_modules/other/package.json");
+    touch(root, "node_modules/other/lib.js");
+
+    let manifest = json!({
+        "name": "x",
+        "version": "0.0.0",
+        "bundleDependencies": ["dep"],
+    });
+    let out = packlist(root, &manifest).unwrap();
+
+    assert!(out.contains(&"node_modules/dep/package.json".to_string()));
+    assert!(out.contains(&"node_modules/dep/lib.js".to_string()));
+    assert!(
+        !out.iter().any(|p| p.starts_with("node_modules/other")),
+        "non-bundled `other` must not ship: {out:?}",
+    );
+}
+
+#[test]
+fn bundled_dependencies_legacy_spelling_works() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    touch(root, "package.json");
+    touch(root, "node_modules/legacy-bundle/package.json");
+
+    let manifest = json!({
+        "name": "x",
+        "version": "0.0.0",
+        "bundledDependencies": ["legacy-bundle"],
+    });
+    let out = packlist(root, &manifest).unwrap();
+
+    assert!(
+        out.contains(&"node_modules/legacy-bundle/package.json".to_string()),
+        "`bundledDependencies` is the legacy spelling and must be accepted: {out:?}",
+    );
+}
+
+#[test]
+fn bundle_dependency_missing_dir_is_silently_skipped() {
+    // A bundleDependencies entry that's not actually on disk should
+    // not crash the fetcher — npm-packlist treats it as a no-op.
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    touch(root, "package.json");
+
+    let manifest = json!({
+        "name": "x",
+        "version": "0.0.0",
+        "bundleDependencies": ["ghost"],
+    });
+    let out = packlist(root, &manifest).unwrap();
+    assert_eq!(out, vec!["package.json".to_string()]);
+}

--- a/crates/git-fetcher/src/packlist/tests.rs
+++ b/crates/git-fetcher/src/packlist/tests.rs
@@ -303,3 +303,121 @@ fn bundle_dependency_missing_dir_is_silently_skipped() {
     let out = packlist(root, &manifest).unwrap();
     assert_eq!(out, vec!["package.json".to_string()]);
 }
+
+#[test]
+fn npmignore_in_parent_dir_does_not_leak_in() {
+    // Regression: `ignore::WalkBuilder::parents` defaults to `true`,
+    // which would let a `.gitignore` above `pkg_dir` exclude files
+    // inside it. The packlist must depend only on the package
+    // directory's own contents — we set `parents(false)` precisely
+    // to prevent this. Test: drop a `.gitignore` *above* the pkg dir
+    // saying to exclude `index.js`, then confirm the file still ships.
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join(".gitignore"), "index.js\n").unwrap();
+    let root = dir.path().join("pkg");
+    fs::create_dir_all(&root).unwrap();
+    touch(&root, "package.json");
+    touch(&root, "index.js");
+
+    let manifest = json!({ "name": "x", "version": "0.0.0" });
+    let out = packlist(&root, &manifest).unwrap();
+
+    assert!(
+        out.contains(&"index.js".to_string()),
+        "parent-directory .gitignore must NOT leak into the packlist: {out:?}",
+    );
+}
+
+#[test]
+fn bundle_dependencies_rejects_path_traversal() {
+    // Defense-in-depth regression: a malicious manifest with a `..`
+    // in bundleDependencies must not let the fetcher read files
+    // outside the package directory. Build a "valid" sibling dir
+    // outside the package's node_modules and prove its files don't
+    // end up in the result.
+    let dir = tempdir().unwrap();
+    let root = dir.path().join("pkg");
+    fs::create_dir_all(&root).unwrap();
+    touch(&root, "package.json");
+    // A sibling next to the package's would-be node_modules. If
+    // path traversal worked, this directory would be reachable via
+    // `node_modules/../escape`.
+    let escape = dir.path().join("escape");
+    fs::create_dir_all(&escape).unwrap();
+    fs::write(escape.join("secret.txt"), "DO NOT EXFIL\n").unwrap();
+
+    let manifest = json!({
+        "name": "x",
+        "version": "0.0.0",
+        "bundleDependencies": ["../escape"],
+    });
+    let out = packlist(&root, &manifest).unwrap();
+
+    assert!(
+        !out.iter().any(|p| p.contains("escape") || p.contains("secret")),
+        "bundle name traversal must not leak files outside pkg_dir: {out:?}",
+    );
+}
+
+#[test]
+fn always_excluded_dir_segments_only_match_vcs() {
+    // Regression for the over-eager segment walk that used to match
+    // anything in `ALWAYS_EXCLUDED_NAMES` at any depth — including
+    // file-typed entries (`.npmrc`, `package-lock.json`). A literal
+    // VCS dir segment still excludes everything under it.
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    touch(root, "package.json");
+    // A dir literally named `CVS` — VCS state, must be excluded at
+    // any depth.
+    touch(root, "lib/CVS/Root");
+    // A file whose *basename contains* `CVS` but isn't itself a VCS
+    // segment — must NOT be excluded.
+    touch(root, "lib/cvs-tools.txt");
+    // A `.git`-nested file — must be excluded by the VCS segment.
+    touch(root, "scripts/.git/HEAD");
+
+    let manifest = json!({ "name": "x", "version": "0.0.0" });
+    let mut out = packlist(root, &manifest).unwrap();
+    out.sort();
+
+    assert!(out.contains(&"lib/cvs-tools.txt".to_string()));
+    assert!(
+        !out.iter().any(|p| p.starts_with("lib/CVS/")),
+        "CVS/ subdirectory must be excluded at any depth: {out:?}",
+    );
+    assert!(
+        !out.iter().any(|p| p.contains("/.git/")),
+        ".git/ subdirectory must be excluded at any depth: {out:?}",
+    );
+}
+
+#[test]
+fn files_field_bare_basename_matches_at_depth() {
+    // npm-packlist treats `files: ["cli"]` as an unanchored gitignore
+    // pattern, so it matches both root-level `cli` and a nested
+    // `bin/cli`. The `Gitignore::matched` call already handles this
+    // because gitignore patterns without a leading slash are
+    // unanchored — drop the previously-present leaf fallback once
+    // this test pins the behavior.
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    touch(root, "package.json");
+    touch(root, "cli");
+    touch(root, "bin/cli");
+    touch(root, "lib/cli/index.js");
+
+    let manifest = json!({
+        "name": "x",
+        "version": "0.0.0",
+        "files": ["cli"],
+    });
+    let out = packlist(root, &manifest).unwrap();
+
+    assert!(out.contains(&"cli".to_string()), "root-level cli: {out:?}");
+    assert!(out.contains(&"bin/cli".to_string()), "nested cli matches at depth: {out:?}");
+    assert!(
+        out.contains(&"lib/cli/index.js".to_string()),
+        "files entry matching a directory also includes its contents: {out:?}",
+    );
+}


### PR DESCRIPTION
## Summary

Replaces the MVP `files`-field-only packlist with a faithful port of [`npm-packlist`](https://github.com/npm/npm-packlist) / [`pnpm/fs/packlist`](https://github.com/pnpm/pnpm/blob/94240bc046/fs/packlist/src/index.ts). Four passes:

1. **`.npmignore` + `.gitignore` walk** via `ignore::WalkBuilder` with per-directory inheritance. A `.npmignore` in `lib/` applies to `lib/**` only; the root `.gitignore` applies to the whole tree. `parents(false)` keeps ignore-file lookup confined to `pkg_dir` so a `.gitignore` *above* the package can't leak into the published file set.
2. **`files`-field allowlist** compiled into a single `Gitignore` matcher. Uses `matched_path_or_any_parents` so a pattern like `cli` matches both `bin/cli` (file match) and `lib/cli/index.js` (directory match, where `lib/cli` is a dir).
3. **Always-included files**: `package.json`, `README*`, `LICEN[SC]E*`, `CHANGES*`, `CHANGELOG*`, `HISTORY*`, `NOTICE*` at the root, plus `main` / `bin` paths. Override `.npmignore` and the `files`-field filter, matching npm-packlist's `alwaysIncluded`. `main` and `bin` are vetted through the always-excluded check before insertion — a manifest with `"main": "package-lock.json"` or `"bin": ".git/hook"` does not get to re-add cruft.
4. **`bundleDependencies` / `bundledDependencies` recursion** with cycle detection: each bundled dep gets its own packlist pass under `node_modules/<name>/`. Both spellings accepted plus the `bundleDependencies: true` shorthand. Cycle protection uses a `HashSet<PathBuf>` of canonical visited paths + a `MAX_BUNDLE_DEPTH = 32` belt-and-braces cap so a symlink loop or self-referencing bundle can't stack-overflow the fetcher. `bundleDependencies` names are validated against the same path-traversal discipline `cas_io::join_checked` uses (`Component::Normal` / `CurDir` only; rejects `..`, root, drive prefix).

### Always-excluded set, split by type

- `ALWAYS_EXCLUDED_DIR_SEGMENTS` — `.git`, `.svn`, `.hg`, `CVS`. Matched at any path segment, so VCS state is dropped at any depth.
- `ALWAYS_EXCLUDED_BASENAMES` — `.npmrc`, `npm-debug.log`, `.DS_Store`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`. Basename-only match, so a regular file like `lib/cvs-tools.txt` ships even though it mentions `CVS`.
- `ALWAYS_EXCLUDED_SUFFIXES` — `.orig` family.

### New runtime dep

`ignore = "0.4.25"` (BurntSushi, used by ripgrep; `Unlicense OR MIT`, `cargo deny` clean). Replaces the hand-rolled `*` / `**` / `?` matcher in the old `packlist.rs` — the new matcher uses `ignore::gitignore::GitignoreBuilder::add_line`, which gives full gitignore semantics (negation, anchored vs unanchored, directory-suffix rules) for free.

### Intentional upstream divergences (documented in the module header)

- When both `.npmignore` and `.gitignore` exist in the same directory, `ignore` combines their rules; npm-packlist would use only `.npmignore`. Same outcome for the common case (a `.npmignore` that's a strict superset); divergence only when `.npmignore` explicitly includes a path `.gitignore` excludes — rare in published packages.
- `.git/info/exclude` and global `~/.gitignore` are NOT honored. The fetcher operates on a clean tarball / checkout, not the user's working tree.

## Out of scope (still on #436)

- Two-slot CAS layout (`${filesIndexFile}\traw` + final) for skipping the re-import when packlist == raw. Pure perf optimization.
- §E real-npm test deferrals (need a `skip-if-no-npm` helper) + PATH-shim shallow-fetch test + Stage 2 resolver-side install tests.

## Test plan

- [x] `cargo nextest run -p pacquet-git-fetcher` — 21 packlist tests pass:
      - 7 carried over from the MVP packlist (files-field, *.orig, glob edge cases, etc.).
      - 7 new for `.npmignore` / `.gitignore` / `bundleDependencies` core behaviour: `npmignore_excludes_listed_paths`, `gitignore_excludes_when_no_npmignore`, `npmignore_does_not_drop_always_included_files`, `npmignore_in_subdir_applies_to_subtree_only`, `bundle_dependencies_subtree_is_included`, `bundled_dependencies_legacy_spelling_works`, `bundle_dependency_missing_dir_is_silently_skipped`.
      - 4 new safety regressions from review round 1: `npmignore_in_parent_dir_does_not_leak_in`, `bundle_dependencies_rejects_path_traversal`, `always_excluded_dir_segments_only_match_vcs`, `files_field_bare_basename_matches_at_depth`.
      - 3 new safety regressions from review round 2: `bundle_dependencies_self_cycle_is_caught` (symlink loop), `main_field_pointing_at_always_excluded_basename_is_refused`, `bin_field_pointing_at_vcs_segment_is_refused`.
- [x] `just ready` — 928 tests, 928 pass.
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace --document-private-items` — clean.
- [x] `taplo format --check`
- [x] `just dylint`
- [x] `cargo deny check` — license + bans + advisories clean for the new `ignore` dep.

---
Written by an agent (Claude Code, claude-opus-4-7).
