### PR TITLE
feat(graph-hasher): engine-agnostic GVS hash gating (#459)

### DIFF
--- a/crates/graph-hasher/src/dep_state.rs
+++ b/crates/graph-hasher/src/dep_state.rs
@@ -131,9 +131,78 @@ where
     cache.get(dep_path).expect("just inserted").clone()
 }
 
+/// Recursive helper used by [`crate::calc_graph_node_hash`] to decide
+/// whether a snapshot's engine string should contribute to its global-
+/// virtual-store hash. Mirrors upstream's
+/// [`transitivelyRequiresBuild`](https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-hasher/src/index.ts#L221-L249).
+///
+/// Returns `true` if `dep_path` is either in `built_dep_paths`
+/// directly, or transitively depends on a snapshot that is. The
+/// returned boolean drives `includeEngine` at upstream's
+/// [`calcGraphNodeHash`](https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-hasher/src/index.ts#L140-L142)
+/// — pure-JS leaves (and their pure-JS ancestors) get
+/// `engine = null`, so their GVS hashes survive Node.js upgrades and
+/// architecture moves. Snapshots that *might* run a postinstall
+/// script keep `engine = ENGINE_NAME` so the hash partitions them by
+/// host environment.
+///
+/// The cycle guard uses `dep_path` itself, not `node.full_pkg_id`
+/// (unlike [`calc_dep_graph_hash`]). Upstream picked `depPath`
+/// because the same pkg id reachable through two different peer
+/// contexts is two distinct nodes — once one is mid-walk we still
+/// want to recurse into the other.
+///
+/// On cycle hit (`parents.contains(dep_path)`) the function returns
+/// `false` *without* caching. The "false in this particular cycle
+/// rotation" answer isn't the canonical one — a sibling visit might
+/// still find a builder upstream, and caching `false` here would
+/// poison the next visit at the same key.
+///
+/// `cache` is install-scoped and threaded across every snapshot
+/// visited inside one [`crate::calc_graph_node_hash`] walk. `parents`
+/// is the per-walk cycle-tracking set — callers always pass a fresh
+/// empty `HashSet`, the function inserts/removes `dep_path` around
+/// the recursion.
+pub(crate) fn transitively_requires_build<K>(
+    graph: &HashMap<K, DepsGraphNode<K>>,
+    built_dep_paths: &HashSet<K>,
+    cache: &mut HashMap<K, bool>,
+    dep_path: &K,
+    parents: &mut HashSet<K>,
+) -> bool
+where
+    K: Clone + Eq + std::hash::Hash,
+{
+    if let Some(&cached) = cache.get(dep_path) {
+        return cached;
+    }
+    if built_dep_paths.contains(dep_path) {
+        cache.insert(dep_path.clone(), true);
+        return true;
+    }
+    let Some(node) = graph.get(dep_path) else {
+        cache.insert(dep_path.clone(), false);
+        return false;
+    };
+    if parents.contains(dep_path) {
+        return false;
+    }
+    parents.insert(dep_path.clone());
+    let mut result = false;
+    for child in node.children.values() {
+        if transitively_requires_build(graph, built_dep_paths, cache, child, parents) {
+            result = true;
+            break;
+        }
+    }
+    parents.remove(dep_path);
+    cache.insert(dep_path.clone(), result);
+    result
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{CalcDepStateOptions, DepsGraphNode, calc_dep_state};
+    use super::{CalcDepStateOptions, DepsGraphNode, calc_dep_state, transitively_requires_build};
     use pretty_assertions::assert_eq;
     use std::collections::HashMap;
 
@@ -337,5 +406,203 @@ mod tests {
         let deps_pos = result.find(";deps=").expect("deps section present");
         let patch_pos = result.find(";patch=").expect("patch section present");
         assert!(deps_pos < patch_pos, "deps must come before patch in {result:?}");
+    }
+
+    /// Self-hit: a snapshot listed in `built_dep_paths` returns
+    /// `true` and caches `true` without looking at its children.
+    #[test]
+    fn transitively_requires_build_self_in_built_set() {
+        let mut graph: HashMap<String, DepsGraphNode<String>> = HashMap::new();
+        graph.insert(
+            "builder@1.0.0".to_string(),
+            DepsGraphNode {
+                full_pkg_id: "builder@1.0.0:sha512-b".to_string(),
+                children: HashMap::new(),
+            },
+        );
+        let built: std::collections::HashSet<String> =
+            ["builder@1.0.0".to_string()].into_iter().collect();
+        let mut cache = HashMap::new();
+        let mut parents = std::collections::HashSet::new();
+        assert!(transitively_requires_build(
+            &graph,
+            &built,
+            &mut cache,
+            &"builder@1.0.0".to_string(),
+            &mut parents
+        ));
+        assert_eq!(cache.get("builder@1.0.0"), Some(&true));
+    }
+
+    /// Transitive: a snapshot whose child is a builder returns
+    /// `true` and caches `true` at every level walked.
+    #[test]
+    fn transitively_requires_build_walks_to_descendant_builder() {
+        let mut graph: HashMap<String, DepsGraphNode<String>> = HashMap::new();
+        let mut root_children = HashMap::new();
+        root_children.insert("dep".to_string(), "builder@1.0.0".to_string());
+        graph.insert(
+            "root@1.0.0".to_string(),
+            DepsGraphNode {
+                full_pkg_id: "root@1.0.0:sha512-r".to_string(),
+                children: root_children,
+            },
+        );
+        graph.insert(
+            "builder@1.0.0".to_string(),
+            DepsGraphNode {
+                full_pkg_id: "builder@1.0.0:sha512-b".to_string(),
+                children: HashMap::new(),
+            },
+        );
+        let built: std::collections::HashSet<String> =
+            ["builder@1.0.0".to_string()].into_iter().collect();
+        let mut cache = HashMap::new();
+        let mut parents = std::collections::HashSet::new();
+        assert!(transitively_requires_build(
+            &graph,
+            &built,
+            &mut cache,
+            &"root@1.0.0".to_string(),
+            &mut parents
+        ));
+        assert_eq!(cache.get("root@1.0.0"), Some(&true));
+        assert_eq!(cache.get("builder@1.0.0"), Some(&true));
+    }
+
+    /// Unrelated: a snapshot whose subtree contains no builder
+    /// returns `false` and caches `false` at every visited node.
+    #[test]
+    fn transitively_requires_build_returns_false_for_unrelated_tree() {
+        let mut graph: HashMap<String, DepsGraphNode<String>> = HashMap::new();
+        let mut root_children = HashMap::new();
+        root_children.insert("dep".to_string(), "leaf@1.0.0".to_string());
+        graph.insert(
+            "root@1.0.0".to_string(),
+            DepsGraphNode {
+                full_pkg_id: "root@1.0.0:sha512-r".to_string(),
+                children: root_children,
+            },
+        );
+        graph.insert(
+            "leaf@1.0.0".to_string(),
+            DepsGraphNode {
+                full_pkg_id: "leaf@1.0.0:sha512-l".to_string(),
+                children: HashMap::new(),
+            },
+        );
+        let built: std::collections::HashSet<String> =
+            ["builder@9.9.9".to_string()].into_iter().collect();
+        let mut cache = HashMap::new();
+        let mut parents = std::collections::HashSet::new();
+        assert!(!transitively_requires_build(
+            &graph,
+            &built,
+            &mut cache,
+            &"root@1.0.0".to_string(),
+            &mut parents
+        ));
+        assert_eq!(cache.get("root@1.0.0"), Some(&false));
+        assert_eq!(cache.get("leaf@1.0.0"), Some(&false));
+    }
+
+    /// Missing node: returns `false` and caches `false`. Mirrors
+    /// upstream's `if (!node) { cache[depPath] = false; return false }`
+    /// branch — the install-time graph build can drop entries for
+    /// resolutions the linker rejects later, so the walker must not
+    /// panic on missing keys.
+    #[test]
+    fn transitively_requires_build_caches_false_for_missing_node() {
+        let graph: HashMap<String, DepsGraphNode<String>> = HashMap::new();
+        let built: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut cache = HashMap::new();
+        let mut parents = std::collections::HashSet::new();
+        assert!(!transitively_requires_build(
+            &graph,
+            &built,
+            &mut cache,
+            &"ghost@1.0.0".to_string(),
+            &mut parents
+        ));
+        assert_eq!(cache.get("ghost@1.0.0"), Some(&false));
+    }
+
+    /// Cycle: a → b → a with no builder anywhere. The walk must
+    /// terminate and return `false`. Cache state on `a` is `false`
+    /// (the post-loop write), `b` is also `false`. The cycle short
+    /// circuit at upstream's `if (parents.has(depPath)) return false`
+    /// fires once but doesn't taint the eventual cache write at
+    /// the frame that owns `a`.
+    #[test]
+    fn transitively_requires_build_cycle_terminates() {
+        let mut graph: HashMap<String, DepsGraphNode<String>> = HashMap::new();
+        let mut a_children = HashMap::new();
+        a_children.insert("b".to_string(), "b@1.0.0".to_string());
+        graph.insert(
+            "a@1.0.0".to_string(),
+            DepsGraphNode { full_pkg_id: "a@1.0.0:sha512-a".to_string(), children: a_children },
+        );
+        let mut b_children = HashMap::new();
+        b_children.insert("a".to_string(), "a@1.0.0".to_string());
+        graph.insert(
+            "b@1.0.0".to_string(),
+            DepsGraphNode { full_pkg_id: "b@1.0.0:sha512-b".to_string(), children: b_children },
+        );
+        let built: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut cache = HashMap::new();
+        let mut parents = std::collections::HashSet::new();
+        assert!(!transitively_requires_build(
+            &graph,
+            &built,
+            &mut cache,
+            &"a@1.0.0".to_string(),
+            &mut parents
+        ));
+        assert_eq!(cache.get("a@1.0.0"), Some(&false));
+        assert_eq!(cache.get("b@1.0.0"), Some(&false));
+        assert!(parents.is_empty(), "parents set must be restored to empty");
+    }
+
+    /// Cycle with builder elsewhere in the tree: `a → b → a` plus
+    /// `a → builder`. The cycle must not short-circuit `a`'s overall
+    /// answer to `false` — the sibling builder visit still drives
+    /// `a` to `true`. Verifies that the no-cache-on-cycle behaviour
+    /// is what makes this work.
+    #[test]
+    fn transitively_requires_build_cycle_does_not_mask_sibling_builder() {
+        let mut graph: HashMap<String, DepsGraphNode<String>> = HashMap::new();
+        // Use a BTreeMap-style two-key insert so child iteration
+        // order can take either path; both must yield `true`.
+        let mut a_children = HashMap::new();
+        a_children.insert("b".to_string(), "b@1.0.0".to_string());
+        a_children.insert("c".to_string(), "builder@1.0.0".to_string());
+        graph.insert(
+            "a@1.0.0".to_string(),
+            DepsGraphNode { full_pkg_id: "a@1.0.0:sha512-a".to_string(), children: a_children },
+        );
+        let mut b_children = HashMap::new();
+        b_children.insert("a".to_string(), "a@1.0.0".to_string());
+        graph.insert(
+            "b@1.0.0".to_string(),
+            DepsGraphNode { full_pkg_id: "b@1.0.0:sha512-b".to_string(), children: b_children },
+        );
+        graph.insert(
+            "builder@1.0.0".to_string(),
+            DepsGraphNode {
+                full_pkg_id: "builder@1.0.0:sha512-x".to_string(),
+                children: HashMap::new(),
+            },
+        );
+        let built: std::collections::HashSet<String> =
+            ["builder@1.0.0".to_string()].into_iter().collect();
+        let mut cache = HashMap::new();
+        let mut parents = std::collections::HashSet::new();
+        assert!(transitively_requires_build(
+            &graph,
+            &built,
+            &mut cache,
+            &"a@1.0.0".to_string(),
+            &mut parents
+        ));
     }
 }

--- a/crates/graph-hasher/src/global_virtual_store_path.rs
+++ b/crates/graph-hasher/src/global_virtual_store_path.rs
@@ -4,19 +4,18 @@
 //! [`formatGlobalVirtualStorePath`](https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-hasher/src/index.ts#L155-L160).
 //!
 //! The engine string contribution is gated by
-//! [`transitively_requires_build`]: when the caller supplies a
-//! `built_dep_paths` set (derived from `allowBuilds` /
-//! `dangerouslyAllowAllBuilds`), only snapshots that themselves run
-//! a build script — or that transitively depend on one — keep the
-//! engine in the GVS hash payload. Pure-JS leaves and their pure-JS
-//! ancestors hash with `engine = null`, so their GVS directories
-//! survive Node.js upgrades and architecture moves. Passing `None`
-//! for `built_dep_paths` reproduces the always-include behaviour
+//! `transitively_requires_build` (private to this crate): when the
+//! caller supplies a `built_dep_paths` set (derived from
+//! `allowBuilds` / `dangerouslyAllowAllBuilds`), only snapshots
+//! that themselves run a build script — or that transitively
+//! depend on one — keep the engine in the GVS hash payload.
+//! Pure-JS leaves and their pure-JS ancestors hash with
+//! `engine = null`, so their GVS directories survive Node.js
+//! upgrades and architecture moves. Passing `None` for
+//! `built_dep_paths` reproduces the always-include behaviour
 //! (matches upstream's
 //! [`builtDepPaths === undefined`](https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-hasher/src/index.ts#L140-L142)
 //! branch).
-//!
-//! [`transitively_requires_build`]: crate::dep_state::transitively_requires_build
 
 use crate::{
     HashEncoding,
@@ -56,7 +55,8 @@ use crate::dep_state::{DepsGraphNode, DepsStateCache};
 ///   every snapshot in the install — see
 ///   [`iterateHashedGraphNodes`](https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-hasher/src/index.ts#L99-L120)
 ///   for the upstream lifecycle. Untouched when `built_dep_paths`
-///   is `None`; callers can pass `&mut HashMap::new()` in that case.
+///   is `None`; callers that don't care can hold a throwaway
+///   `let mut cache = HashMap::new();` and pass `&mut cache`.
 pub fn calc_graph_node_hash<K>(
     graph: &HashMap<K, DepsGraphNode<K>>,
     cache: &mut DepsStateCache<K>,

--- a/crates/graph-hasher/src/global_virtual_store_path.rs
+++ b/crates/graph-hasher/src/global_virtual_store_path.rs
@@ -3,14 +3,26 @@
 //! and
 //! [`formatGlobalVirtualStorePath`](https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-hasher/src/index.ts#L155-L160).
 //!
-//! Stage 1 of pnpm/pacquet#432 keeps the engine string unconditional —
-//! the engine-agnostic gating that flips `engine` to `null` when no
-//! package transitively requires a build is tracked separately. The
-//! `engine` parameter on [`calc_graph_node_hash`] still threads through
-//! so the follow-up that adds the gating doesn't have to change the
-//! signature.
+//! The engine string contribution is gated by
+//! [`transitively_requires_build`]: when the caller supplies a
+//! `built_dep_paths` set (derived from `allowBuilds` /
+//! `dangerouslyAllowAllBuilds`), only snapshots that themselves run
+//! a build script — or that transitively depend on one — keep the
+//! engine in the GVS hash payload. Pure-JS leaves and their pure-JS
+//! ancestors hash with `engine = null`, so their GVS directories
+//! survive Node.js upgrades and architecture moves. Passing `None`
+//! for `built_dep_paths` reproduces the always-include behaviour
+//! (matches upstream's
+//! [`builtDepPaths === undefined`](https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-hasher/src/index.ts#L140-L142)
+//! branch).
+//!
+//! [`transitively_requires_build`]: crate::dep_state::transitively_requires_build
 
-use crate::{HashEncoding, dep_state::calc_dep_graph_hash, hash_object_without_sorting};
+use crate::{
+    HashEncoding,
+    dep_state::{calc_dep_graph_hash, transitively_requires_build},
+    hash_object_without_sorting,
+};
 use serde_json::{Value, json};
 use std::collections::{HashMap, HashSet};
 
@@ -27,20 +39,54 @@ use crate::dep_state::{DepsGraphNode, DepsStateCache};
 /// value and therefore share one directory under
 /// `<store>/links/<name>/<version>/` — which is how pnpm and pacquet
 /// avoid re-extracting the same tarball once per peer-context.
+///
+/// `engine` is the candidate `ENGINE_NAME`-shaped string
+/// (`<platform>-<arch>-node<major>`). It is included in the hash
+/// payload only when the snapshot transitively requires a build —
+/// pure-JS subgraphs hash with `engine = null` so their GVS
+/// directories survive Node.js upgrades. The gating is driven by:
+///
+/// - `built_dep_paths`: when `Some`, the set of snapshot keys whose
+///   `allowBuilds` entry evaluates to `true` (or every snapshot when
+///   `dangerouslyAllowAllBuilds` is on). `None` disables the gating
+///   and forces `include_engine = true` — matches upstream's
+///   `builtDepPaths === undefined` branch.
+/// - `build_required_cache`: install-scoped memoization for the
+///   gating walk. Allocated once at the call site and reused across
+///   every snapshot in the install — see
+///   [`iterateHashedGraphNodes`](https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-hasher/src/index.ts#L99-L120)
+///   for the upstream lifecycle. Untouched when `built_dep_paths`
+///   is `None`; callers can pass `&mut HashMap::new()` in that case.
 pub fn calc_graph_node_hash<K>(
     graph: &HashMap<K, DepsGraphNode<K>>,
     cache: &mut DepsStateCache<K>,
     dep_path: &K,
     engine: Option<&str>,
+    built_dep_paths: Option<&HashSet<K>>,
+    build_required_cache: &mut HashMap<K, bool>,
 ) -> String
 where
     K: Clone + Eq + std::hash::Hash,
 {
-    let deps_hash = calc_dep_graph_hash(graph, cache, &mut HashSet::new(), dep_path);
-    let engine_value = match engine {
-        Some(s) => Value::String(s.to_owned()),
-        None => Value::Null,
+    let include_engine = match built_dep_paths {
+        None => true,
+        Some(set) => transitively_requires_build(
+            graph,
+            set,
+            build_required_cache,
+            dep_path,
+            &mut HashSet::new(),
+        ),
     };
+    let engine_value = if include_engine {
+        match engine {
+            Some(s) => Value::String(s.to_owned()),
+            None => Value::Null,
+        }
+    } else {
+        Value::Null
+    };
+    let deps_hash = calc_dep_graph_hash(graph, cache, &mut HashSet::new(), dep_path);
     let payload = json!({
         "engine": engine_value,
         "deps": deps_hash,
@@ -64,7 +110,7 @@ pub fn format_global_virtual_store_path(name: &str, version: &str, hex_digest: &
 mod tests {
     use super::{calc_graph_node_hash, format_global_virtual_store_path};
     use crate::dep_state::DepsGraphNode;
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
 
     /// Scoped packages don't get the `@/` prefix — they already start
     /// with `@<scope>/`. Unscoped packages do.
@@ -95,27 +141,32 @@ mod tests {
         );
         let mut cache_a = HashMap::new();
         let mut cache_b = HashMap::new();
+        let mut br_a = HashMap::new();
+        let mut br_b = HashMap::new();
         let a = calc_graph_node_hash(
             &graph,
             &mut cache_a,
             &"leaf@1.0.0".to_string(),
             Some("darwin-arm64-node20"),
+            None,
+            &mut br_a,
         );
         let b = calc_graph_node_hash(
             &graph,
             &mut cache_b,
             &"leaf@1.0.0".to_string(),
             Some("darwin-arm64-node20"),
+            None,
+            &mut br_b,
         );
         assert_eq!(a, b, "deterministic for same input");
         assert_eq!(a.len(), 64, "sha256 hex digest is 64 chars");
     }
 
-    /// Different engines produce different hashes (the field is part
-    /// of the hash payload). Mirrors the "engine flips between
-    /// `null` and `ENGINE_NAME`" branch in upstream — pacquet always
-    /// passes `Some(...)` today, but the param exists so a follow-up
-    /// implementing the engine-agnostic gating slots in cleanly.
+    /// Different engines produce different hashes when the engine
+    /// is included. Mirrors upstream's contribution of `ENGINE_NAME`
+    /// (vs `null`) to the hash payload at
+    /// `deps/graph-hasher/src/index.ts:140-146`.
     #[test]
     fn engine_string_changes_hash() {
         let mut graph: HashMap<String, DepsGraphNode<String>> = HashMap::new();
@@ -127,25 +178,206 @@ mod tests {
             },
         );
         let mut cache = HashMap::new();
+        let mut br = HashMap::new();
         let with_engine = calc_graph_node_hash(
             &graph,
             &mut cache,
             &"leaf@1.0.0".to_string(),
             Some("darwin-arm64-node20"),
+            None,
+            &mut br,
         );
         let mut cache_other = HashMap::new();
+        let mut br_other = HashMap::new();
         let with_other_engine = calc_graph_node_hash(
             &graph,
             &mut cache_other,
             &"leaf@1.0.0".to_string(),
             Some("linux-x64-node22"),
+            None,
+            &mut br_other,
         );
         let mut cache_null = HashMap::new();
-        let with_null =
-            calc_graph_node_hash(&graph, &mut cache_null, &"leaf@1.0.0".to_string(), None);
+        let mut br_null = HashMap::new();
+        let with_null = calc_graph_node_hash(
+            &graph,
+            &mut cache_null,
+            &"leaf@1.0.0".to_string(),
+            None,
+            None,
+            &mut br_null,
+        );
         assert_ne!(with_engine, with_other_engine);
         assert_ne!(with_engine, with_null);
         assert_ne!(with_other_engine, with_null);
+    }
+
+    /// Engine-agnostic gating: when `built_dep_paths` excludes the
+    /// snapshot and its subtree, two different `engine` strings
+    /// hash to the *same* digest. This is the whole point of the
+    /// `transitivelyRequiresBuild` gating — pure-JS leaves survive
+    /// Node.js upgrades because their GVS hash drops the engine
+    /// contribution.
+    #[test]
+    fn engine_agnostic_when_subtree_has_no_builders() {
+        let mut graph: HashMap<String, DepsGraphNode<String>> = HashMap::new();
+        graph.insert(
+            "pure-js@1.0.0".to_string(),
+            DepsGraphNode {
+                full_pkg_id: "pure-js@1.0.0:sha512-x".to_string(),
+                children: HashMap::new(),
+            },
+        );
+        // builtDepPaths exists but doesn't contain pure-js. Gating fires.
+        let built: HashSet<String> = ["someone-else@1.0.0".to_string()].into_iter().collect();
+        let mut cache_a = HashMap::new();
+        let mut br_a = HashMap::new();
+        let darwin = calc_graph_node_hash(
+            &graph,
+            &mut cache_a,
+            &"pure-js@1.0.0".to_string(),
+            Some("darwin-arm64-node20"),
+            Some(&built),
+            &mut br_a,
+        );
+        let mut cache_b = HashMap::new();
+        let mut br_b = HashMap::new();
+        let linux = calc_graph_node_hash(
+            &graph,
+            &mut cache_b,
+            &"pure-js@1.0.0".to_string(),
+            Some("linux-x64-node22"),
+            Some(&built),
+            &mut br_b,
+        );
+        assert_eq!(
+            darwin, linux,
+            "pure-js subtree must hash engine-agnostically when gated by builtDepPaths",
+        );
+    }
+
+    /// Gating's positive case: when the snapshot itself is in
+    /// `built_dep_paths`, the engine *is* included — two different
+    /// engines diverge. Symmetric with [`engine_agnostic_when_subtree_has_no_builders`].
+    #[test]
+    fn engine_included_when_self_in_built_set() {
+        let mut graph: HashMap<String, DepsGraphNode<String>> = HashMap::new();
+        graph.insert(
+            "native@1.0.0".to_string(),
+            DepsGraphNode {
+                full_pkg_id: "native@1.0.0:sha512-n".to_string(),
+                children: HashMap::new(),
+            },
+        );
+        let built: HashSet<String> = ["native@1.0.0".to_string()].into_iter().collect();
+        let mut cache_a = HashMap::new();
+        let mut br_a = HashMap::new();
+        let darwin = calc_graph_node_hash(
+            &graph,
+            &mut cache_a,
+            &"native@1.0.0".to_string(),
+            Some("darwin-arm64-node20"),
+            Some(&built),
+            &mut br_a,
+        );
+        let mut cache_b = HashMap::new();
+        let mut br_b = HashMap::new();
+        let linux = calc_graph_node_hash(
+            &graph,
+            &mut cache_b,
+            &"native@1.0.0".to_string(),
+            Some("linux-x64-node22"),
+            Some(&built),
+            &mut br_b,
+        );
+        assert_ne!(darwin, linux, "builder must partition by engine string");
+    }
+
+    /// Gating's transitive case: a non-builder snapshot whose
+    /// child *is* a builder also includes the engine. Mirrors
+    /// upstream's recursion at index.ts:241-245.
+    #[test]
+    fn engine_included_for_ancestor_of_builder() {
+        let mut graph: HashMap<String, DepsGraphNode<String>> = HashMap::new();
+        let mut root_children = HashMap::new();
+        root_children.insert("dep".to_string(), "native@1.0.0".to_string());
+        graph.insert(
+            "root@1.0.0".to_string(),
+            DepsGraphNode {
+                full_pkg_id: "root@1.0.0:sha512-r".to_string(),
+                children: root_children,
+            },
+        );
+        graph.insert(
+            "native@1.0.0".to_string(),
+            DepsGraphNode {
+                full_pkg_id: "native@1.0.0:sha512-n".to_string(),
+                children: HashMap::new(),
+            },
+        );
+        let built: HashSet<String> = ["native@1.0.0".to_string()].into_iter().collect();
+        let mut cache_a = HashMap::new();
+        let mut br_a = HashMap::new();
+        let darwin = calc_graph_node_hash(
+            &graph,
+            &mut cache_a,
+            &"root@1.0.0".to_string(),
+            Some("darwin-arm64-node20"),
+            Some(&built),
+            &mut br_a,
+        );
+        let mut cache_b = HashMap::new();
+        let mut br_b = HashMap::new();
+        let linux = calc_graph_node_hash(
+            &graph,
+            &mut cache_b,
+            &"root@1.0.0".to_string(),
+            Some("linux-x64-node22"),
+            Some(&built),
+            &mut br_b,
+        );
+        assert_ne!(darwin, linux, "ancestor of a builder must partition by engine string");
+    }
+
+    /// `built_dep_paths = None` reproduces the always-include-engine
+    /// behaviour: two different engines hash differently even for a
+    /// snapshot that no builder reaches. Mirrors upstream's
+    /// `builtDepPaths === undefined || ...` short-circuit at
+    /// index.ts:140.
+    #[test]
+    fn none_built_dep_paths_disables_gating() {
+        let mut graph: HashMap<String, DepsGraphNode<String>> = HashMap::new();
+        graph.insert(
+            "pure-js@1.0.0".to_string(),
+            DepsGraphNode {
+                full_pkg_id: "pure-js@1.0.0:sha512-x".to_string(),
+                children: HashMap::new(),
+            },
+        );
+        let mut cache_a = HashMap::new();
+        let mut br_a = HashMap::new();
+        let darwin = calc_graph_node_hash(
+            &graph,
+            &mut cache_a,
+            &"pure-js@1.0.0".to_string(),
+            Some("darwin-arm64-node20"),
+            None,
+            &mut br_a,
+        );
+        let mut cache_b = HashMap::new();
+        let mut br_b = HashMap::new();
+        let linux = calc_graph_node_hash(
+            &graph,
+            &mut cache_b,
+            &"pure-js@1.0.0".to_string(),
+            Some("linux-x64-node22"),
+            None,
+            &mut br_b,
+        );
+        assert_ne!(
+            darwin, linux,
+            "without builtDepPaths gating, engine is always part of the hash",
+        );
     }
 
     /// Two snapshots whose children differ (same `full_pkg_id`,
@@ -178,18 +410,24 @@ mod tests {
             },
         );
         let mut cache_a = HashMap::new();
+        let mut br_a = HashMap::new();
         let with_dep = calc_graph_node_hash(
             &graph,
             &mut cache_a,
             &"root@1.0.0(a)".to_string(),
             Some("darwin-arm64-node20"),
+            None,
+            &mut br_a,
         );
         let mut cache_b = HashMap::new();
+        let mut br_b = HashMap::new();
         let without_dep = calc_graph_node_hash(
             &graph,
             &mut cache_b,
             &"root@1.0.0(b)".to_string(),
             Some("darwin-arm64-node20"),
+            None,
+            &mut br_b,
         );
         assert_ne!(
             with_dep, without_dep,

--- a/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/crates/package-manager/src/install_frozen_lockfile.rs
@@ -326,7 +326,13 @@ where
         // `slot_dir` call. Either way every downstream consumer
         // (warm batch, cold batch, direct-dep symlinks, bin linker,
         // build module) routes through this one lookup.
-        let layout = VirtualStoreLayout::new(config, engine_name.as_deref(), snapshots, packages);
+        let layout = VirtualStoreLayout::new(
+            config,
+            engine_name.as_deref(),
+            snapshots,
+            packages,
+            Some(&allow_build_policy),
+        );
 
         let CreateVirtualStoreOutput { package_manifests, side_effects_maps_by_snapshot } =
             CreateVirtualStore {

--- a/crates/package-manager/src/virtual_store_layout.rs
+++ b/crates/package-manager/src/virtual_store_layout.rs
@@ -20,6 +20,7 @@
 //! [`PkgNameVerPeer::to_virtual_store_name`]: pacquet_lockfile::PkgNameVerPeer::to_virtual_store_name
 //! [`pacquet_graph_hasher::format_global_virtual_store_path`]: pacquet_graph_hasher::format_global_virtual_store_path
 
+use crate::AllowBuildPolicy;
 use pacquet_config::Config;
 use pacquet_graph_hasher::{
     DepsGraphNode, DepsStateCache, calc_graph_node_hash, format_global_virtual_store_path,
@@ -28,7 +29,7 @@ use pacquet_lockfile::{
     LockfileResolution, PackageKey, PackageMetadata, PkgName, SnapshotDepRef, SnapshotEntry,
 };
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
 };
 
@@ -109,11 +110,25 @@ impl VirtualStoreLayout {
     /// already has by the time the install dispatches to a frozen-
     /// lockfile flow — see
     /// [`crate::InstallFrozenLockfile::run`].
+    ///
+    /// `allow_build_policy` drives engine-agnostic gating. When
+    /// `Some`, the constructor walks `snapshots` once to collect
+    /// every key whose `(name, version)` passes
+    /// [`AllowBuildPolicy::check`] returning `Some(true)`, then
+    /// passes that set as `built_dep_paths` to
+    /// [`calc_graph_node_hash`]. Pure-JS subgraphs hash with
+    /// `engine = null` so their GVS directories survive Node.js
+    /// upgrades. When `None`, every snapshot keeps the engine in
+    /// its hash payload — matches upstream's
+    /// [`builtDepPaths === undefined`](https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-hasher/src/index.ts#L140-L142)
+    /// branch and the existing pacquet behaviour from
+    /// pnpm/pacquet#449.
     pub fn new(
         config: &Config,
         engine: Option<&str>,
         snapshots: Option<&HashMap<PackageKey, SnapshotEntry>>,
         packages: Option<&HashMap<PackageKey, PackageMetadata>>,
+        allow_build_policy: Option<&AllowBuildPolicy>,
     ) -> Self {
         // Pacquet keeps `virtual_store_dir` and `global_virtual_store_dir`
         // as two separate fields (see
@@ -134,10 +149,40 @@ impl VirtualStoreLayout {
             return VirtualStoreLayout { package_store_dir, gvs_suffixes: Some(HashMap::new()) };
         };
         let graph = lockfile_to_dep_graph(snapshots, packages);
+        // Build the engine-agnostic gating set once per install,
+        // mirroring upstream's
+        // [`computeBuiltDepPaths`](https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-hasher/src/index.ts#L208-L219).
+        // `None` here disables gating so every snapshot still hashes
+        // with its engine string — the pre-pnpm/pacquet#459 behaviour.
+        let built_dep_paths: Option<HashSet<PackageKey>> = allow_build_policy.map(|policy| {
+            snapshots
+                .keys()
+                .filter(|k| {
+                    let metadata_key = k.without_peer();
+                    let name = metadata_key.name.to_string();
+                    let version = metadata_key.suffix.version().to_string();
+                    policy.check(&name, &version) == Some(true)
+                })
+                .cloned()
+                .collect()
+        });
         let mut cache: DepsStateCache<PackageKey> = HashMap::new();
+        // Install-scoped memoization for the `transitivelyRequiresBuild`
+        // walk; shared across every snapshot's hash computation so
+        // diamond-shaped subgraphs only get visited once. Untouched
+        // when `built_dep_paths` is `None`. Mirrors upstream's
+        // [`buildRequiredCache`](https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-hasher/src/index.ts#L113-L114).
+        let mut build_required_cache: HashMap<PackageKey, bool> = HashMap::new();
         let mut gvs_suffixes: HashMap<PackageKey, String> = HashMap::with_capacity(snapshots.len());
         for snapshot_key in snapshots.keys() {
-            let hex_digest = calc_graph_node_hash(&graph, &mut cache, snapshot_key, engine);
+            let hex_digest = calc_graph_node_hash(
+                &graph,
+                &mut cache,
+                snapshot_key,
+                engine,
+                built_dep_paths.as_ref(),
+                &mut build_required_cache,
+            );
             let metadata_key = snapshot_key.without_peer();
             let name = metadata_key.name.to_string();
             let version = metadata_key.suffix.version().to_string();
@@ -294,7 +339,7 @@ mod tests {
             PathBuf::from("/tmp/proj/node_modules/.pnpm"),
             PathBuf::from("/tmp/store/links"),
         );
-        let layout = VirtualStoreLayout::new(&config, Some("ignored"), None, None);
+        let layout = VirtualStoreLayout::new(&config, Some("ignored"), None, None, None);
         let key: PackageKey = "@scope/foo@1.2.3".parse().unwrap();
         assert_eq!(
             layout.slot_dir(&key),
@@ -342,6 +387,7 @@ mod tests {
             Some("darwin-arm64-node20"),
             Some(&snapshots),
             Some(&packages),
+            None,
         );
         let slot = layout.slot_dir(&key);
         // Shape: `/tmp/store/links/@scope/foo/1.2.3/<64-hex>`.
@@ -394,10 +440,128 @@ mod tests {
             Some("linux-x64-node22"),
             Some(&snapshots),
             Some(&packages),
+            None,
         );
         let slot = layout.slot_dir(&key);
         let _ = slot
             .strip_prefix("/tmp/store/links/@/foo/1.0.0/")
             .expect("unscoped GVS slots live under <root>/@/<name>/<version>/<hash>");
+    }
+
+    /// End-to-end gating check: a pure-JS snapshot's GVS slot is
+    /// engine-agnostic when an empty `AllowBuildPolicy` is supplied
+    /// (matches upstream's
+    /// [`enableGlobalVirtualStore: true` → `allowBuilds ??= {}`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-restorer/src/index.ts#L342-L344)
+    /// shape). Two installs that differ only in the `engine` string
+    /// produce the *same* slot directory.
+    #[test]
+    fn slot_dir_engine_agnostic_with_empty_allow_build_policy() {
+        let config = make_config(
+            true,
+            PathBuf::from("/tmp/proj/node_modules/.pnpm"),
+            PathBuf::from("/tmp/store/links"),
+        );
+        let key: PackageKey = "left-pad@1.0.0".parse().unwrap();
+        let mut packages = HashMap::new();
+        packages.insert(
+            key.clone(),
+            PackageMetadata {
+                resolution: LockfileResolution::Registry(RegistryResolution {
+                    integrity: "sha512-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+                        .parse()
+                        .expect("parse integrity"),
+                }),
+                engines: None,
+                cpu: None,
+                os: None,
+                libc: None,
+                deprecated: None,
+                has_bin: None,
+                prepare: None,
+                bundled_dependencies: None,
+                peer_dependencies: None,
+                peer_dependencies_meta: None,
+            },
+        );
+        let mut snapshots = HashMap::new();
+        snapshots.insert(key.clone(), SnapshotEntry::default());
+        let policy = crate::AllowBuildPolicy::default();
+        let darwin = VirtualStoreLayout::new(
+            &config,
+            Some("darwin-arm64-node20"),
+            Some(&snapshots),
+            Some(&packages),
+            Some(&policy),
+        )
+        .slot_dir(&key);
+        let linux = VirtualStoreLayout::new(
+            &config,
+            Some("linux-x64-node22"),
+            Some(&snapshots),
+            Some(&packages),
+            Some(&policy),
+        )
+        .slot_dir(&key);
+        assert_eq!(
+            darwin, linux,
+            "pure-JS snapshot must share one GVS slot across engines when gating is active",
+        );
+    }
+
+    /// Symmetric to [`slot_dir_engine_agnostic_with_empty_allow_build_policy`]:
+    /// when the snapshot is in `allow_builds`, the engine *is* part
+    /// of the slot path. Two installs that differ in `engine` end up
+    /// in different directories.
+    #[test]
+    fn slot_dir_engine_specific_when_snapshot_is_built() {
+        let config = make_config(
+            true,
+            PathBuf::from("/tmp/proj/node_modules/.pnpm"),
+            PathBuf::from("/tmp/store/links"),
+        );
+        let key: PackageKey = "native-pkg@1.0.0".parse().unwrap();
+        let mut packages = HashMap::new();
+        packages.insert(
+            key.clone(),
+            PackageMetadata {
+                resolution: LockfileResolution::Registry(RegistryResolution {
+                    integrity: "sha512-CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"
+                        .parse()
+                        .expect("parse integrity"),
+                }),
+                engines: None,
+                cpu: None,
+                os: None,
+                libc: None,
+                deprecated: None,
+                has_bin: None,
+                prepare: None,
+                bundled_dependencies: None,
+                peer_dependencies: None,
+                peer_dependencies_meta: None,
+            },
+        );
+        let mut snapshots = HashMap::new();
+        snapshots.insert(key.clone(), SnapshotEntry::default());
+        let allowed: std::collections::HashSet<String> =
+            ["native-pkg".to_string()].into_iter().collect();
+        let policy = crate::AllowBuildPolicy::new(allowed, std::collections::HashSet::new(), false);
+        let darwin = VirtualStoreLayout::new(
+            &config,
+            Some("darwin-arm64-node20"),
+            Some(&snapshots),
+            Some(&packages),
+            Some(&policy),
+        )
+        .slot_dir(&key);
+        let linux = VirtualStoreLayout::new(
+            &config,
+            Some("linux-x64-node22"),
+            Some(&snapshots),
+            Some(&packages),
+            Some(&policy),
+        )
+        .slot_dir(&key);
+        assert_ne!(darwin, linux, "builder snapshot must partition GVS slot by engine string");
     }
 }


### PR DESCRIPTION
## Summary

Closes #459. Ports pnpm's `transitivelyRequiresBuild` + `computeBuiltDepPaths` into `pacquet-graph-hasher` and wires the `builtDepPaths`-driven engine gating from upstream's [`calcGraphNodeHash`](https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-hasher/src/index.ts#L140-L142) into pacquet's GVS slot-path computation.

When a snapshot — and its entire transitive subtree — has no entry in `allowBuilds` (and `dangerouslyAllowAllBuilds` is off), its GVS hash payload now sets `engine: null` instead of `engine: ENGINE_NAME`. Pure-JS packages share one slot directory across Node.js versions, OSes, and CPUs, which is what makes the shared global virtual store cross-host portable.

## What changed

- **`graph-hasher::dep_state`** — new `pub(crate) fn transitively_requires_build`, mirroring upstream's [`transitivelyRequiresBuild`](https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-hasher/src/index.ts#L221-L249) verbatim. Notable subtleties preserved: cycle guard uses `depPath` (not `fullPkgId`), and a cycle hit returns `false` *without* caching to avoid poisoning sibling walks.
- **`graph-hasher::calc_graph_node_hash`** — grows two parameters: `built_dep_paths: Option<&HashSet<K>>` and `build_required_cache: &mut HashMap<K, bool>`. `None` reproduces the always-include-engine shape (matches upstream's `builtDepPaths === undefined` short-circuit), so callers can opt into the gating only when they have an `AllowBuildPolicy` available.
- **`VirtualStoreLayout::new`** — grows an `Option<&AllowBuildPolicy>` parameter. Internally walks `snapshots` once to derive `built_dep_paths`, then threads that set through every `calc_graph_node_hash` call.
- **`InstallFrozenLockfile::run`** — passes the install's existing `AllowBuildPolicy` to `VirtualStoreLayout::new`. The policy was already built upstream of this call site so this is a one-line wiring change.

## Why pacquet still needed this after #449

#449 introduced the GVS path computation but left every snapshot hashing with `engine = ENGINE_NAME`. A `darwin-arm64-node20` install and a `linux-x64-node22` install of the same pure-JS package would land in *different* GVS slots, defeating the whole point of a shared global store. #459 closes that gap: pure-JS subtrees hash engine-agnostically, native subtrees keep partitioning by engine.

## Test plan

- [x] Six new `transitively_requires_build` unit tests (self-hit, transitive ancestor, unrelated tree, missing node, cycle termination, cycle-doesn't-mask-sibling-builder)
- [x] Four new `calc_graph_node_hash` tests (engine-agnostic when gated, engine-specific for self-builder, engine-specific for ancestor-of-builder, `None` disables gating)
- [x] Two new `VirtualStoreLayout::new` end-to-end tests (slot identical across engines for pure-JS with empty policy; slot differs across engines when the snapshot is in `allowBuilds`)
- [x] `just ready` (926 tests pass)
- [x] `taplo format --check`
- [x] `just dylint`

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More accurate detection of when dependency subgraphs require native builds.
  * Optimized global virtual store slot computation to better handle engine-agnostic (JS-only) packages.
* **Changes**
  * Layout initialization now accepts an allow-build policy to control engine inclusion in hashing.
* **Tests**
  * Updated and added tests covering build-gating, hashing, and virtual store behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pacquet/pull/469)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->