### PR TITLE
feat(tarball): binary fetcher for zip archives (#437 slice C)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,6 +472,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,6 +591,17 @@ name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "derive_more"
@@ -747,6 +776,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "miniz_oxide",
+ "zlib-rs",
+]
 
 [[package]]
 name = "fnv"
@@ -1615,6 +1654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -2326,6 +2366,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "zip",
  "zune-inflate",
 ]
 
@@ -4248,10 +4289,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "5.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f852905151ac8d4d06fdca66520a661c09730a74c6d4e2b0f27b436b382e532"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zune-inflate"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ tokio              = { version = "1", features = ["rt", "rt-multi-thread", "macr
 walkdir            = { version = "2.5.0" }
 wax                = { version = "0.7.0" }
 which              = { version = "8.0.2" }
+zip                = { version = "5", default-features = false, features = ["deflate"] }
 zune-inflate       = { version = "0.2.54" }
 
 # Dev dependencies

--- a/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/crates/package-manager/src/install_package_by_snapshot.rs
@@ -157,6 +157,7 @@ impl<'a> InstallPackageBySnapshot<'a> {
                     prefetched_cas_paths,
                     retry_opts: retry_opts_from_config(config),
                     auth_headers: &config.auth_headers,
+                    ignore_file_pattern: None,
                 }
                 .run_without_mem_cache::<R>()
                 .await

--- a/crates/package-manager/src/install_package_from_registry.rs
+++ b/crates/package-manager/src/install_package_from_registry.rs
@@ -162,6 +162,7 @@ impl<'a> InstallPackageFromRegistry<'a> {
             prefetched_cas_paths: None,
             retry_opts: retry_opts_from_config(config),
             auth_headers: &config.auth_headers,
+            ignore_file_pattern: None,
         }
         .run_with_mem_cache::<R>(tarball_mem_cache)
         .await

--- a/crates/tarball/Cargo.toml
+++ b/crates/tarball/Cargo.toml
@@ -32,6 +32,7 @@ ssri          = { workspace = true }
 tar           = { workspace = true }
 tokio         = { workspace = true }
 tracing       = { workspace = true }
+zip           = { workspace = true }
 zune-inflate  = { workspace = true }
 
 [dev-dependencies]

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -528,7 +528,19 @@ fn extract_tarball_entries(
         // — would land files outside the store (directory traversal).
         // Reject loudly rather than silently normalize so tampering
         // is visible.
-        let mut cleaned = PathBuf::new();
+        //
+        // Collect components into a `Vec<String>` and join with `/`
+        // rather than going through [`PathBuf::push`] + `to_string_lossy`.
+        // `PathBuf` uses the platform's native separator, so on
+        // Windows the joined form would be `bin\tool` — which
+        // diverges from pnpm's string-based path layer (always `/`)
+        // and breaks any [`ignore_file_pattern`] regex / hand-coded
+        // matcher that expects forward slashes. The shared `index.db`
+        // also has to stay byte-identical to what pnpm writes, so a
+        // pacquet install on Windows must emit the same keys.
+        // `to_string_lossy()` coerces non-UTF-8 bytes to U+FFFD
+        // per-component.
+        let mut parts: Vec<String> = Vec::new();
         for component in entry_path.components().skip(1) {
             let Component::Normal(part) = component else {
                 return Err(TarballError::ReadTarballEntries(std::io::Error::new(
@@ -538,9 +550,9 @@ fn extract_tarball_entries(
                     ),
                 )));
             };
-            cleaned.push(part);
+            parts.push(part.to_string_lossy().into_owned());
         }
-        if cleaned.as_os_str().is_empty() {
+        if parts.is_empty() {
             return Err(TarballError::ReadTarballEntries(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
                 format!(
@@ -548,10 +560,7 @@ fn extract_tarball_entries(
                 ),
             )));
         }
-        // `to_string_lossy()` coerces non-UTF-8 bytes to U+FFFD —
-        // matching pnpm's string-based path layer so a shared
-        // `index.db` stays consistent across the two tools.
-        let cleaned_entry_path = cleaned.to_string_lossy().into_owned();
+        let cleaned_entry_path = parts.join("/");
         // Drop ignored entries before the CAS write. Mirrors
         // upstream's `ignoreFilePattern` semantics: paths are matched
         // *after* the top-level prefix strip, so the callback sees

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -701,10 +701,14 @@ fn extract_zip_entries(
             url: package_url.to_string(),
             source,
         })?;
-        if entry.is_dir() {
-            continue;
-        }
-
+        // Validate the path *before* the `is_dir()` early-skip so an
+        // archive carrying a directory entry like `../evil/` still
+        // surfaces [`TarballError::PathTraversal`] rather than being
+        // silently dropped. Pacquet wouldn't write that directory
+        // either way (only file entries take the CAS write path
+        // below), but rejecting outright keeps the "no unsafe entry
+        // accepted" contract intact for tooling that inspects the
+        // error code.
         let raw_name = entry.name().to_string();
         // [`zip::read::ZipFile::enclosed_name`] returns `None` for
         // absolute paths and any path with a `..` component — a
@@ -716,6 +720,9 @@ fn extract_zip_entries(
                 entry_path: raw_name,
                 reason: "zip entry path is absolute or escapes the archive root",
             });
+        }
+        if entry.is_dir() {
+            continue;
         }
 
         // Strip the archive's top-level basename (`prefix` on

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -247,14 +247,23 @@ pub enum TarballError {
 
     /// Per-entry I/O failure during zip extraction — `try_reserve`
     /// for the entry's payload, the body read, or any other
-    /// [`std::io::Error`] surfaced from the zip iterator. Kept
-    /// separate from [`TarballError::ReadTarballEntries`] so the
-    /// retry-classification path emits `ERR_PACQUET_ZIP` rather
-    /// than the tar-specific `ERR_PACQUET_TARBALL_TAR`.
+    /// [`std::io::Error`] surfaced from the zip iterator. Carries
+    /// the archive URL and the entry path that triggered the
+    /// failure so a corrupt archive is diagnosable from the user-
+    /// facing message; the underlying [`std::io::Error`] is
+    /// exposed as `source` for miette / `Error::source` walkers.
+    /// Kept separate from [`TarballError::ReadTarballEntries`] so
+    /// the retry-classification path emits `ERR_PACQUET_ZIP`
+    /// rather than the tar-specific `ERR_PACQUET_TARBALL_TAR`.
     #[from(ignore)]
-    #[display("Failed to read zip entry: {_0}")]
+    #[display("Failed to read zip entry {entry_path:?} from {url}: {source}")]
     #[diagnostic(code(pacquet_tarball::read_zip_entry))]
-    ReadZipEntries(std::io::Error),
+    ReadZipEntries {
+        url: String,
+        entry_path: String,
+        #[error(source)]
+        source: std::io::Error,
+    },
 }
 
 /// Per-package callback that decides whether a given archive entry
@@ -794,13 +803,19 @@ fn extract_zip_entries(
         const MAX_ENTRY_PREALLOC_BYTES: u64 = 64 * 1024 * 1024;
         let prealloc_hint = entry.size().min(MAX_ENTRY_PREALLOC_BYTES) as usize;
         let mut buffer = Vec::new();
-        buffer.try_reserve(prealloc_hint).map_err(|err| {
-            TarballError::ReadZipEntries(std::io::Error::new(
+        buffer.try_reserve(prealloc_hint).map_err(|err| TarballError::ReadZipEntries {
+            url: package_url.to_string(),
+            entry_path: cleaned.clone(),
+            source: std::io::Error::new(
                 std::io::ErrorKind::OutOfMemory,
                 format!("failed to reserve {prealloc_hint} bytes for zip entry: {err}"),
-            ))
+            ),
         })?;
-        entry.read_to_end(&mut buffer).map_err(TarballError::ReadZipEntries)?;
+        entry.read_to_end(&mut buffer).map_err(|source| TarballError::ReadZipEntries {
+            url: package_url.to_string(),
+            entry_path: cleaned.clone(),
+            source,
+        })?;
 
         // Central-directory record carries a Unix mode only when
         // the archive was built by a Unix tool; Windows-built
@@ -1292,7 +1307,7 @@ fn tarball_error_to_request_retry(err: &TarballError) -> RequestRetryError {
         TarballError::PathTraversal { .. } => {
             out.code = Some("ERR_PACQUET_PATH_TRAVERSAL".to_string());
         }
-        TarballError::ReadZipArchive { .. } | TarballError::ReadZipEntries(_) => {
+        TarballError::ReadZipArchive { .. } | TarballError::ReadZipEntries { .. } => {
             out.code = Some("ERR_PACQUET_ZIP".to_string());
         }
     }
@@ -1955,6 +1970,10 @@ impl<'a> DownloadTarballToStore<'a> {
 // 8 arguments — over the default clippy threshold, but each is
 // distinct (see the matching note on `fetch_and_extract_zip_with_retry`).
 #[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "arg count is set by upstream pnpm's fetcher signature"
+)]
 async fn fetch_and_extract_zip_once<R: Reporter>(
     http_client: &ThrottledClient,
     package_url: &str,
@@ -1962,6 +1981,7 @@ async fn fetch_and_extract_zip_once<R: Reporter>(
     package_id: &str,
     attempt: u32,
     store_dir: &'static StoreDir,
+    auth_headers: &AuthHeaders,
     archive_prefix: Option<&str>,
     ignore_file_pattern: Option<Arc<IgnoreEntryFilter>>,
 ) -> Result<(HashMap<String, PathBuf>, PackageFilesIndex), TarballError> {
@@ -1970,7 +1990,19 @@ async fn fetch_and_extract_zip_once<R: Reporter>(
 
     let client = http_client.acquire().await;
 
-    let send_result = client.get(package_url).send().await;
+    let mut request = client.get(package_url);
+    // Match the tarball download path: resolve the per-URL auth
+    // header and attach it. Runtime artifacts (Node.js, Bun, Deno)
+    // are typically downloaded from public hosts that don't require
+    // auth, but a self-hosted mirror behind a token-protected proxy
+    // would 401 without this. Keeps parity with pnpm's binary
+    // fetcher which goes through the same `fetchFromRegistry` /
+    // auth-header plumbing.
+    if let Some(value) = auth_headers.for_url(package_url) {
+        request = request.header("authorization", value);
+    }
+
+    let send_result = request.send().await;
     let size = send_result.as_ref().ok().and_then(|r| r.content_length());
     R::emit(&LogEvent::FetchingProgress(FetchingProgressLog {
         level: LogLevel::Debug,
@@ -2090,11 +2122,14 @@ async fn fetch_and_extract_zip_once<R: Reporter>(
 /// backoff until [`RetryOpts::retries`] is exhausted. On success
 /// emits `pnpm:progress fetched` once per (resolved) package, same
 /// as the tarball path.
-// 9 arguments — over the default clippy threshold for the same
+// 10 arguments — over the default clippy threshold for the same
 // reason `fetch_and_extract_with_retry` is: each is distinct, and
 // bundling into a struct would just push the same fields into a
 // wrapper.
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "arg count is set by upstream pnpm's fetcher signature"
+)]
 async fn fetch_and_extract_zip_with_retry<R: Reporter>(
     http_client: &ThrottledClient,
     package_url: &str,
@@ -2103,6 +2138,7 @@ async fn fetch_and_extract_zip_with_retry<R: Reporter>(
     requester: &str,
     store_dir: &'static StoreDir,
     retry_opts: RetryOpts,
+    auth_headers: &AuthHeaders,
     archive_prefix: Option<&str>,
     ignore_file_pattern: Option<Arc<IgnoreEntryFilter>>,
 ) -> Result<(HashMap<String, PathBuf>, PackageFilesIndex), TarballError> {
@@ -2115,6 +2151,7 @@ async fn fetch_and_extract_zip_with_retry<R: Reporter>(
             package_id,
             attempt,
             store_dir,
+            auth_headers,
             archive_prefix,
             ignore_file_pattern.clone(),
         )
@@ -2196,6 +2233,11 @@ pub struct DownloadZipArchiveToStore<'a> {
     pub requester: &'a str,
     pub prefetched_cas_paths: Option<&'a PrefetchedCasPaths>,
     pub retry_opts: RetryOpts,
+    /// Auth headers resolved at install start. The zip pipeline
+    /// applies the per-URL match the same way the tarball pipeline
+    /// does (`AuthHeaders::for_url`), so a runtime archive hosted
+    /// behind a token-protected proxy still authenticates correctly.
+    pub auth_headers: &'a AuthHeaders,
     /// Basename of the archive's top-level directory, mirroring the
     /// `prefix` field on `pacquet_lockfile::BinaryResolution`. The
     /// zip extractor strips `{prefix}/` from each entry path before
@@ -2227,6 +2269,7 @@ impl<'a> DownloadZipArchiveToStore<'a> {
             verify_store_integrity,
             prefetched_cas_paths,
             retry_opts,
+            auth_headers,
             archive_prefix,
             ..
         } = self;
@@ -2276,6 +2319,7 @@ impl<'a> DownloadZipArchiveToStore<'a> {
             requester,
             store_dir,
             retry_opts,
+            auth_headers,
             archive_prefix,
             ignore_file_pattern,
         )

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -244,6 +244,17 @@ pub enum TarballError {
         #[error(source)]
         source: zip::result::ZipError,
     },
+
+    /// Per-entry I/O failure during zip extraction — `try_reserve`
+    /// for the entry's payload, the body read, or any other
+    /// [`std::io::Error`] surfaced from the zip iterator. Kept
+    /// separate from [`TarballError::ReadTarballEntries`] so the
+    /// retry-classification path emits `ERR_PACQUET_ZIP` rather
+    /// than the tar-specific `ERR_PACQUET_TARBALL_TAR`.
+    #[from(ignore)]
+    #[display("Failed to read zip entry: {_0}")]
+    #[diagnostic(code(pacquet_tarball::read_zip_entry))]
+    ReadZipEntries(std::io::Error),
 }
 
 /// Per-package callback that decides whether a given archive entry
@@ -738,19 +749,23 @@ fn extract_zip_entries(
         let prealloc_hint = entry.size().min(MAX_ENTRY_PREALLOC_BYTES) as usize;
         let mut buffer = Vec::new();
         buffer.try_reserve(prealloc_hint).map_err(|err| {
-            TarballError::ReadTarballEntries(std::io::Error::new(
+            TarballError::ReadZipEntries(std::io::Error::new(
                 std::io::ErrorKind::OutOfMemory,
                 format!("failed to reserve {prealloc_hint} bytes for zip entry: {err}"),
             ))
         })?;
-        entry.read_to_end(&mut buffer).map_err(TarballError::ReadTarballEntries)?;
+        entry.read_to_end(&mut buffer).map_err(TarballError::ReadZipEntries)?;
 
         // Central-directory record carries a Unix mode only when
         // the archive was built by a Unix tool; Windows-built
         // archives omit it. Fall back to `0o644` so the executable
         // bit defaults to off — `addFilesFromDir` on pnpm's side
-        // lands at the same mode after `fs.writeFile`.
-        let file_mode = entry.unix_mode().unwrap_or(0o644);
+        // lands at the same mode after `fs.writeFile`. Mask off
+        // the high `st_mode` bits (e.g. `0o100000` for a regular
+        // file) so `CafsFileInfo.mode` stays permission-only,
+        // matching the convention `add_files_from_dir.rs` enforces
+        // for tar / on-disk imports.
+        let file_mode = entry.unix_mode().unwrap_or(0o644) & 0o777;
         let file_is_executable = file_mode::is_executable(file_mode);
 
         let (file_path, file_hash) = store_dir
@@ -1168,7 +1183,14 @@ pub struct DownloadTarballToStore<'a> {
     /// `None` (the default for ordinary npm tarballs) writes every
     /// regular-file entry; `Some(filter)` is what the binary fetcher
     /// uses to strip Node's bundled `npm` / `corepack` from the CAS.
-    pub ignore_file_pattern: Option<&'static IgnoreEntryFilter>,
+    ///
+    /// Stored as `Arc` so the install dispatcher (Slice D) can
+    /// construct one filter per fetch from runtime config — e.g.
+    /// `archiveFilters` keyed by `pkg.name` — without leaking
+    /// memory or pinning the filter to `'static`. Cloning the
+    /// Arc per retry attempt is cheap; the inner trait object
+    /// is shared.
+    pub ignore_file_pattern: Option<Arc<IgnoreEntryFilter>>,
 }
 
 /// Project [`TarballError`] onto pnpm's `requestRetryLogger`'s
@@ -1224,7 +1246,7 @@ fn tarball_error_to_request_retry(err: &TarballError) -> RequestRetryError {
         TarballError::PathTraversal { .. } => {
             out.code = Some("ERR_PACQUET_PATH_TRAVERSAL".to_string());
         }
-        TarballError::ReadZipArchive { .. } => {
+        TarballError::ReadZipArchive { .. } | TarballError::ReadZipEntries(_) => {
             out.code = Some("ERR_PACQUET_ZIP".to_string());
         }
     }
@@ -1284,7 +1306,7 @@ async fn fetch_and_extract_once<R: Reporter>(
     attempt: u32,
     store_dir: &'static StoreDir,
     auth_headers: &AuthHeaders,
-    ignore_file_pattern: Option<&'static IgnoreEntryFilter>,
+    ignore_file_pattern: Option<Arc<IgnoreEntryFilter>>,
 ) -> Result<(HashMap<String, PathBuf>, PackageFilesIndex), TarballError> {
     let network_error =
         |error| TarballError::FetchTarball(NetworkError { url: package_url.to_string(), error });
@@ -1481,7 +1503,7 @@ async fn fetch_and_extract_once<R: Reporter>(
                 let mut archive = decompress_gzip(&buffer, package_unpacked_size)?
                     .pipe(Cursor::new)
                     .pipe(Archive::new);
-                extract_tarball_entries(&mut archive, store_dir, ignore_file_pattern)?
+                extract_tarball_entries(&mut archive, store_dir, ignore_file_pattern.as_deref())?
             };
             Ok((cas_paths, pkg_files_idx))
         },
@@ -1534,7 +1556,7 @@ async fn fetch_and_extract_with_retry<R: Reporter>(
     store_dir: &'static StoreDir,
     retry_opts: RetryOpts,
     auth_headers: &AuthHeaders,
-    ignore_file_pattern: Option<&'static IgnoreEntryFilter>,
+    ignore_file_pattern: Option<Arc<IgnoreEntryFilter>>,
 ) -> Result<(HashMap<String, PathBuf>, PackageFilesIndex), TarballError> {
     let mut attempt: u32 = 0;
     loop {
@@ -1547,7 +1569,7 @@ async fn fetch_and_extract_with_retry<R: Reporter>(
             attempt,
             store_dir,
             auth_headers,
-            ignore_file_pattern,
+            ignore_file_pattern.clone(),
         )
         .await;
         match result {
@@ -1732,12 +1754,17 @@ impl<'a> DownloadTarballToStore<'a> {
             prefetched_cas_paths,
             retry_opts,
             auth_headers,
-            ignore_file_pattern,
             ..
         } = self;
         let store_index = self.store_index.clone();
         let store_index_writer = self.store_index_writer.clone();
         let verified_files_cache = Arc::clone(&self.verified_files_cache);
+        // `Option<Arc<IgnoreEntryFilter>>` isn't `Copy`, so it can't
+        // ride along in the deref-destructure above. `.clone()`
+        // here bumps the Arc refcount — cheap, and the trait
+        // object is shared with the install dispatcher that
+        // owns the original.
+        let ignore_file_pattern = self.ignore_file_pattern.clone();
 
         // Before hitting the network, check the SQLite store index: if the
         // tarball is already in the CAFS we can reuse its per-file paths
@@ -1858,6 +1885,9 @@ impl<'a> DownloadTarballToStore<'a> {
 /// temp dir + `addFilesFromDir` round-trip (pacquet's
 /// [`StoreDir::write_cas_file`] is the same content-addressed write
 /// `addFilesFromDir` does on each tempdir file).
+// 8 arguments — over the default clippy threshold, but each is
+// distinct (see the matching note on `fetch_and_extract_zip_with_retry`).
+#[allow(clippy::too_many_arguments)]
 async fn fetch_and_extract_zip_once<R: Reporter>(
     http_client: &ThrottledClient,
     package_url: &str,
@@ -1866,7 +1896,7 @@ async fn fetch_and_extract_zip_once<R: Reporter>(
     attempt: u32,
     store_dir: &'static StoreDir,
     archive_prefix: Option<&str>,
-    ignore_file_pattern: Option<&'static IgnoreEntryFilter>,
+    ignore_file_pattern: Option<Arc<IgnoreEntryFilter>>,
 ) -> Result<(HashMap<String, PathBuf>, PackageFilesIndex), TarballError> {
     let network_error =
         |error| TarballError::FetchTarball(NetworkError { url: package_url.to_string(), error });
@@ -1973,7 +2003,7 @@ async fn fetch_and_extract_zip_once<R: Reporter>(
                     &package_url_owned,
                     store_dir,
                     archive_prefix_owned.as_deref(),
-                    ignore_file_pattern,
+                    ignore_file_pattern.as_deref(),
                 )?
             };
             Ok((cas_paths, pkg_files_idx))
@@ -2007,7 +2037,7 @@ async fn fetch_and_extract_zip_with_retry<R: Reporter>(
     store_dir: &'static StoreDir,
     retry_opts: RetryOpts,
     archive_prefix: Option<&str>,
-    ignore_file_pattern: Option<&'static IgnoreEntryFilter>,
+    ignore_file_pattern: Option<Arc<IgnoreEntryFilter>>,
 ) -> Result<(HashMap<String, PathBuf>, PackageFilesIndex), TarballError> {
     let mut attempt: u32 = 0;
     loop {
@@ -2019,7 +2049,7 @@ async fn fetch_and_extract_zip_with_retry<R: Reporter>(
             attempt,
             store_dir,
             archive_prefix,
-            ignore_file_pattern,
+            ignore_file_pattern.clone(),
         )
         .await;
         match result {
@@ -2106,7 +2136,9 @@ pub struct DownloadZipArchiveToStore<'a> {
     /// consumers see paths relative to the package root rather than
     /// the runtime-version-stamped wrapper directory.
     pub archive_prefix: Option<&'a str>,
-    pub ignore_file_pattern: Option<&'static IgnoreEntryFilter>,
+    /// See [`DownloadTarballToStore::ignore_file_pattern`] — the
+    /// per-fetch archive filter is shared by both archive types.
+    pub ignore_file_pattern: Option<Arc<IgnoreEntryFilter>>,
 }
 
 impl<'a> DownloadZipArchiveToStore<'a> {
@@ -2129,12 +2161,16 @@ impl<'a> DownloadZipArchiveToStore<'a> {
             prefetched_cas_paths,
             retry_opts,
             archive_prefix,
-            ignore_file_pattern,
             ..
         } = self;
         let store_index = self.store_index.clone();
         let store_index_writer = self.store_index_writer.clone();
         let verified_files_cache = Arc::clone(&self.verified_files_cache);
+        // See the matching note in
+        // [`DownloadTarballToStore::run_without_mem_cache`]: the
+        // Arc-wrapped filter can't ride along in the deref pattern,
+        // so clone it out by hand.
+        let ignore_file_pattern = self.ignore_file_pattern.clone();
 
         let cache_key = store_index_key(&package_integrity.to_string(), package_id);
         if let Some(prefetched) = prefetched_cas_paths

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -204,7 +204,7 @@ pub enum TarballError {
 
     #[from(ignore)]
     #[display(
-        "Tarball at {url} advertised a Content-Length of {advertised_size} bytes, which exceeds what pacquet can allocate (either larger than `usize::MAX` on this target or memory pressure prevented a one-shot reservation)"
+        "Archive at {url} advertised a Content-Length of {advertised_size} bytes, which exceeds what pacquet can allocate (either larger than `usize::MAX` on this target or memory pressure prevented a one-shot reservation)"
     )]
     #[diagnostic(code(pacquet_tarball::tarball_too_large))]
     TarballTooLarge { url: String, advertised_size: u64 },
@@ -713,27 +713,57 @@ fn extract_zip_entries(
         // [`zip::read::ZipFile::enclosed_name`] returns `None` for
         // absolute paths and any path with a `..` component — a
         // single check covers both forms of traversal upstream's
-        // `validatePathSecurity` rejects.
-        if entry.enclosed_name().is_none() {
+        // `validatePathSecurity` rejects. The returned `PathBuf` has
+        // every `.` segment collapsed and is what we use below to
+        // build the canonical `cas_paths` / `pkg_files_idx` keys.
+        let Some(enclosed) = entry.enclosed_name() else {
             return Err(TarballError::PathTraversal {
                 url: package_url.to_string(),
                 entry_path: raw_name,
                 reason: "zip entry path is absolute or escapes the archive root",
             });
-        }
+        };
         if entry.is_dir() {
             continue;
         }
 
+        // Rebuild the path into a forward-slash string from the
+        // sanitized `enclosed_name()` components. Three reasons over
+        // using the raw `entry.name()`:
+        //
+        // 1. `.` segments are already collapsed by `enclosed_name`,
+        //    so `pkg/./foo.txt` and `pkg/foo.txt` produce the same
+        //    `cas_paths` key — no accidental duplicates from
+        //    publisher tooling quirks.
+        // 2. The ignore filter sees the same canonical strings the
+        //    map is keyed by, so the regex / hand-coded matchers
+        //    can't be tripped up by `.` segments either.
+        // 3. Zip entries are spec'd to use `/` separators; this also
+        //    rejects any `\` an in-the-wild Windows-built archive
+        //    might have smuggled in (those would be `Normal`
+        //    components on Unix but interpreted as separators on
+        //    Windows).
+        //
+        // `enclosed_name` only yields `Normal` components, so the
+        // path-component walk below covers every case.
+        let normalized: String = enclosed
+            .components()
+            .map(|c| match c {
+                Component::Normal(s) => s.to_string_lossy().into_owned(),
+                _ => unreachable!("enclosed_name returns only Normal components: {:?}", enclosed),
+            })
+            .collect::<Vec<_>>()
+            .join("/");
+
         // Strip the archive's top-level basename (`prefix` on
         // `pacquet_lockfile::BinaryResolution`) so the ignore filter
         // sees the same relative paths upstream's regex does. If the
-        // entry path doesn't start with `{prefix}/` we use the raw
-        // name — pnpm's slice does the same (no-op when the entry
-        // already lives at the archive root).
+        // entry path doesn't start with `{prefix}/` we use the
+        // normalized form — pnpm's slice does the same (no-op when
+        // the entry already lives at the archive root).
         let cleaned = match basename_prefix.as_deref() {
-            Some(prefix) => raw_name.strip_prefix(prefix).unwrap_or(&raw_name).to_string(),
-            None => raw_name.clone(),
+            Some(prefix) => normalized.strip_prefix(prefix).unwrap_or(&normalized).to_string(),
+            None => normalized,
         };
         if cleaned.is_empty() {
             // Skip an entry whose name was exactly the prefix
@@ -1643,6 +1673,27 @@ async fn fetch_and_extract_with_retry<R: Reporter>(
 
 impl<'a> DownloadTarballToStore<'a> {
     /// Execute the subroutine with an in-memory cache.
+    ///
+    /// # Caller invariant: stable filter per URL
+    ///
+    /// The mem cache is keyed solely by `package_url` (the same
+    /// shape as pnpm's `tarballCache` / `archiveCache`), so two
+    /// callers fetching the same URL with *different*
+    /// [`ignore_file_pattern`] values would receive the same
+    /// `cas_paths` map — the one the first caller's filter
+    /// produced. Callers must ensure that every fetch of a given
+    /// URL uses the same filter.
+    ///
+    /// In practice this holds because tarball URLs encode
+    /// `(name, version, integrity)` and the filter is keyed by
+    /// `pkg.name` upstream (`archiveFilters` in
+    /// [`binary-fetcher/src/index.ts`](https://github.com/pnpm/pnpm/blob/94240bc046/fetching/binary-fetcher/src/index.ts)),
+    /// so the (URL, filter) relation is functional. The dispatcher
+    /// in Slice D constructs filters from the same per-package
+    /// table; nothing else calls this method with a non-`None`
+    /// filter.
+    ///
+    /// [`ignore_file_pattern`]: DownloadTarballToStore::ignore_file_pattern
     pub async fn run_with_mem_cache<R: Reporter>(
         self,
         mem_cache: &'a MemCache,

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -221,7 +221,48 @@ pub enum TarballError {
     )]
     #[diagnostic(code(pacquet_tarball::sibling_fetch_failed))]
     SiblingFetchFailed { url: String },
+
+    /// Path-traversal rejection on a zip entry. Mirrors upstream's
+    /// `PATH_TRAVERSAL` error in
+    /// [`fetching/binary-fetcher/src/index.ts`](https://github.com/pnpm/pnpm/blob/94240bc046/fetching/binary-fetcher/src/index.ts):
+    /// any entry whose path is absolute or whose normalized form
+    /// would land outside the target directory is rejected before any
+    /// bytes are written to the CAS.
+    #[from(ignore)]
+    #[display("Refusing to extract zip entry {entry_path:?} from {url} — {reason}")]
+    #[diagnostic(code(pacquet_tarball::path_traversal))]
+    PathTraversal { url: String, entry_path: String, reason: &'static str },
+
+    /// Zip-archive parse / read error. Wraps the underlying `zip`
+    /// crate error verbatim; pacquet does not interpret the failure
+    /// mode beyond surfacing the entry path that triggered it.
+    #[from(ignore)]
+    #[display("Failed to read zip archive {url}: {source}")]
+    #[diagnostic(code(pacquet_tarball::read_zip))]
+    ReadZipArchive {
+        url: String,
+        #[error(source)]
+        source: zip::result::ZipError,
+    },
 }
+
+/// Per-package callback that decides whether a given archive entry
+/// (path relative to the archive's top-level directory, after the
+/// `prefix` strip on zip archives, after the `package/` strip on
+/// npm tarballs) should be excluded from the CAS write.
+///
+/// Mirrors upstream's `ignoreFilePattern` / `archiveFilters` regex
+/// at <https://github.com/pnpm/pnpm/blob/94240bc046/fetching/binary-fetcher/src/index.ts>.
+/// Pacquet uses a callback rather than a regex so the caller can
+/// hand-code the filter without pulling a regex engine into
+/// `pacquet-tarball`; the canonical Node-runtime filter lives at
+/// the install-dispatch site (Slice D) where it's constructed once
+/// per fetch.
+///
+/// The callback receives the *cleaned* path (post-prefix strip,
+/// `to_string_lossy()` already applied), so its inputs are stable
+/// strings matching what pnpm's regex sees upstream.
+pub type IgnoreEntryFilter = dyn Fn(&str) -> bool + Send + Sync;
 
 /// Value of the cache.
 #[derive(Debug, Clone)]
@@ -413,6 +454,7 @@ fn normalize_bundled_manifest(value: &serde_json::Value) -> Option<serde_json::V
 fn extract_tarball_entries(
     archive: &mut Archive<Cursor<Vec<u8>>>,
     store_dir: &StoreDir,
+    ignore_file_pattern: Option<&IgnoreEntryFilter>,
 ) -> Result<(HashMap<String, PathBuf>, PackageFilesIndex), TarballError> {
     let entries = archive
         .entries()
@@ -499,6 +541,18 @@ fn extract_tarball_entries(
         // matching pnpm's string-based path layer so a shared
         // `index.db` stays consistent across the two tools.
         let cleaned_entry_path = cleaned.to_string_lossy().into_owned();
+        // Drop ignored entries before the CAS write. Mirrors
+        // upstream's `ignoreFilePattern` semantics: paths are matched
+        // *after* the top-level prefix strip, so the callback sees
+        // the same strings pnpm's regex does. Bypassing the CAS
+        // write here also keeps the package's
+        // [`PackageFilesIndex`] tight — an ignored entry never
+        // surfaces in `files` or `manifest`.
+        if let Some(filter) = ignore_file_pattern
+            && filter(&cleaned_entry_path)
+        {
+            continue;
+        }
         let (file_path, file_hash) = store_dir
             .write_cas_file(&buffer, file_is_executable)
             .map_err(TarballError::WriteCasFile)?;
@@ -563,6 +617,159 @@ fn extract_tarball_entries(
         };
 
         if let Some(previous) = pkg_files_idx.files.insert(cleaned_entry_path, file_attrs) {
+            tracing::warn!(?previous, "Duplication detected. Old entry has been ejected");
+        }
+    }
+
+    Ok((cas_paths, pkg_files_idx))
+}
+
+/// Walk a zip archive, writing each regular-file entry into the CAFS
+/// and returning the `{relative-path → CAFS path}` map plus the
+/// per-package [`PackageFilesIndex`] row to hand off to the shared
+/// store-index writer. Mirrors the contract of [`extract_tarball_entries`]
+/// — same outputs, same per-file CAS write — but for binary
+/// `BinaryResolution { archive: zip, prefix: ... }` artifacts (the
+/// shape Node.js / Bun / Deno ships their Windows builds in).
+///
+/// Ports the inner loop of upstream's `extractZipToTarget` at
+/// <https://github.com/pnpm/pnpm/blob/94240bc046/fetching/binary-fetcher/src/index.ts>:
+///
+/// 1. Directory entries are skipped — AdmZip's
+///    `extractEntryTo(dir, ...)` expands a directory entry to every
+///    descendant via `getEntryChildren`, which would bypass the
+///    `ignoreEntry` filter on per-file paths. Iterating only over
+///    file entries achieves the same filter coverage.
+/// 2. Each entry's path is validated against absolute / `..`
+///    components via [`zip::read::ZipFile::enclosed_name`]. Any
+///    rejection is surfaced as [`TarballError::PathTraversal`] —
+///    same `PATH_TRAVERSAL` error code pnpm raises.
+/// 3. If `archive_prefix` is set and the entry path starts with
+///    `{prefix}/`, the prefix is stripped before the ignore-filter
+///    check and before the entry is recorded in `cas_paths`.
+///    Mirrors upstream's `basenamePrefix` slice — the regex sees
+///    paths relative to the archive's top-level directory.
+/// 4. The cleaned path then runs through `ignore_file_pattern`;
+///    matching entries are dropped before any CAS write.
+/// 5. The remaining entry's bytes are read and committed via
+///    [`StoreDir::write_cas_file`], mirroring upstream's
+///    `addFilesFromDir` import step (pnpm extracts to a temp dir then
+///    imports; pacquet writes directly to the CAS).
+///
+/// Unix mode is read off the central-directory record via
+/// [`zip::read::ZipFile::unix_mode`]; archives written by Windows
+/// tooling don't populate it and we fall back to `0o644`, matching
+/// the implicit mode `addFilesFromDir` ends up with after
+/// `fs.writeFile` on the temp dir.
+fn extract_zip_entries(
+    archive: &mut zip::ZipArchive<Cursor<Vec<u8>>>,
+    package_url: &str,
+    store_dir: &StoreDir,
+    archive_prefix: Option<&str>,
+    ignore_file_pattern: Option<&IgnoreEntryFilter>,
+) -> Result<(HashMap<String, PathBuf>, PackageFilesIndex), TarballError> {
+    let entry_count = archive.len();
+    let mut cas_paths = HashMap::<String, PathBuf>::with_capacity(entry_count);
+    let mut pkg_files_idx = PackageFilesIndex {
+        manifest: None,
+        requires_build: None,
+        algo: "sha512".to_string(),
+        files: HashMap::with_capacity(entry_count),
+        side_effects: None,
+    };
+
+    // Build the `{prefix}/` slice once. Treat `Some("")` as `None`
+    // — upstream's `basename === ''` branch keeps entry paths
+    // verbatim. The trailing slash anchors the strip so a prefix of
+    // `foo` doesn't accidentally consume `foobar/...`.
+    let basename_prefix: Option<String> =
+        archive_prefix.filter(|p| !p.is_empty()).map(|p| format!("{p}/"));
+
+    for i in 0..entry_count {
+        let mut entry = archive.by_index(i).map_err(|source| TarballError::ReadZipArchive {
+            url: package_url.to_string(),
+            source,
+        })?;
+        if entry.is_dir() {
+            continue;
+        }
+
+        let raw_name = entry.name().to_string();
+        // [`zip::read::ZipFile::enclosed_name`] returns `None` for
+        // absolute paths and any path with a `..` component — a
+        // single check covers both forms of traversal upstream's
+        // `validatePathSecurity` rejects.
+        if entry.enclosed_name().is_none() {
+            return Err(TarballError::PathTraversal {
+                url: package_url.to_string(),
+                entry_path: raw_name,
+                reason: "zip entry path is absolute or escapes the archive root",
+            });
+        }
+
+        // Strip the archive's top-level basename (`prefix` on
+        // [`crate::BinaryResolution`]) so the ignore filter sees the
+        // same relative paths upstream's regex does. If the entry
+        // path doesn't start with `{prefix}/` we use the raw name —
+        // pnpm's slice does the same (no-op when the entry already
+        // lives at the archive root).
+        let cleaned = match basename_prefix.as_deref() {
+            Some(prefix) => raw_name.strip_prefix(prefix).unwrap_or(&raw_name).to_string(),
+            None => raw_name.clone(),
+        };
+        if cleaned.is_empty() {
+            // Skip an entry whose name was exactly the prefix
+            // directory: no relative payload survives the strip.
+            continue;
+        }
+
+        if let Some(filter) = ignore_file_pattern
+            && filter(&cleaned)
+        {
+            continue;
+        }
+
+        // Same allocation-safety shape as
+        // [`extract_tarball_entries`]: clamp the pre-allocation
+        // hint at 64 MiB so a maliciously huge `uncompressed_size`
+        // in the central directory can't crash the process before
+        // `read_to_end` has a chance to surface the real error.
+        const MAX_ENTRY_PREALLOC_BYTES: u64 = 64 * 1024 * 1024;
+        let prealloc_hint = entry.size().min(MAX_ENTRY_PREALLOC_BYTES) as usize;
+        let mut buffer = Vec::new();
+        buffer.try_reserve(prealloc_hint).map_err(|err| {
+            TarballError::ReadTarballEntries(std::io::Error::new(
+                std::io::ErrorKind::OutOfMemory,
+                format!("failed to reserve {prealloc_hint} bytes for zip entry: {err}"),
+            ))
+        })?;
+        entry.read_to_end(&mut buffer).map_err(TarballError::ReadTarballEntries)?;
+
+        // Central-directory record carries a Unix mode only when
+        // the archive was built by a Unix tool; Windows-built
+        // archives omit it. Fall back to `0o644` so the executable
+        // bit defaults to off — `addFilesFromDir` on pnpm's side
+        // lands at the same mode after `fs.writeFile`.
+        let file_mode = entry.unix_mode().unwrap_or(0o644);
+        let file_is_executable = file_mode::is_executable(file_mode);
+
+        let (file_path, file_hash) = store_dir
+            .write_cas_file(&buffer, file_is_executable)
+            .map_err(TarballError::WriteCasFile)?;
+
+        let file_size = u64::try_from(buffer.len()).unwrap_or(u64::MAX);
+        let checked_at = UNIX_EPOCH.elapsed().ok().and_then(|x| u64::try_from(x.as_millis()).ok());
+        let file_attrs = CafsFileInfo {
+            digest: format!("{file_hash:x}"),
+            mode: file_mode,
+            size: file_size,
+            checked_at,
+        };
+
+        if let Some(previous) = cas_paths.insert(cleaned.clone(), file_path) {
+            tracing::warn!(?previous, "Duplication detected. Old entry has been ejected");
+        }
+        if let Some(previous) = pkg_files_idx.files.insert(cleaned, file_attrs) {
             tracing::warn!(?previous, "Duplication detected. Old entry has been ejected");
         }
     }
@@ -952,6 +1159,16 @@ pub struct DownloadTarballToStore<'a> {
     /// 4xx / 5xx, network resets, timeouts, mid-stream body errors,
     /// integrity mismatches, and gzip / tar parse failures (#259).
     pub retry_opts: RetryOpts,
+    /// Per-package archive-entry filter applied during CAS extraction.
+    /// Receives the entry's path *after* the top-level
+    /// `package/` strip; returning `true` drops the entry before the
+    /// CAS write. Mirrors upstream's `ignoreFilePattern` /
+    /// `archiveFilters` regex at
+    /// <https://github.com/pnpm/pnpm/blob/94240bc046/fetching/binary-fetcher/src/index.ts>.
+    /// `None` (the default for ordinary npm tarballs) writes every
+    /// regular-file entry; `Some(filter)` is what the binary fetcher
+    /// uses to strip Node's bundled `npm` / `corepack` from the CAS.
+    pub ignore_file_pattern: Option<&'static IgnoreEntryFilter>,
 }
 
 /// Project [`TarballError`] onto pnpm's `requestRetryLogger`'s
@@ -1003,6 +1220,12 @@ fn tarball_error_to_request_retry(err: &TarballError) -> RequestRetryError {
         }
         TarballError::SiblingFetchFailed { .. } => {
             out.code = Some("ERR_PACQUET_SIBLING_FETCH".to_string());
+        }
+        TarballError::PathTraversal { .. } => {
+            out.code = Some("ERR_PACQUET_PATH_TRAVERSAL".to_string());
+        }
+        TarballError::ReadZipArchive { .. } => {
+            out.code = Some("ERR_PACQUET_ZIP".to_string());
         }
     }
     out
@@ -1061,6 +1284,7 @@ async fn fetch_and_extract_once<R: Reporter>(
     attempt: u32,
     store_dir: &'static StoreDir,
     auth_headers: &AuthHeaders,
+    ignore_file_pattern: Option<&'static IgnoreEntryFilter>,
 ) -> Result<(HashMap<String, PathBuf>, PackageFilesIndex), TarballError> {
     let network_error =
         |error| TarballError::FetchTarball(NetworkError { url: package_url.to_string(), error });
@@ -1257,7 +1481,7 @@ async fn fetch_and_extract_once<R: Reporter>(
                 let mut archive = decompress_gzip(&buffer, package_unpacked_size)?
                     .pipe(Cursor::new)
                     .pipe(Archive::new);
-                extract_tarball_entries(&mut archive, store_dir)?
+                extract_tarball_entries(&mut archive, store_dir, ignore_file_pattern)?
             };
             Ok((cas_paths, pkg_files_idx))
         },
@@ -1293,11 +1517,12 @@ fn emit_progress_found_in_store<R: Reporter>(package_id: &str, requester: &str) 
     }));
 }
 
-// 8 arguments — over the default clippy threshold but each is
+// 9 arguments — over the default clippy threshold but each is
 // distinct: client + URL + integrity describe the request, ID +
 // requester are the reporter dimensions, unpacked-size is allocation
-// hinting, store_dir + retry_opts are install-scoped. Bundling into
-// a struct would just push the same fields into a wrapper.
+// hinting, store_dir + retry_opts are install-scoped, and
+// ignore_file_pattern is the per-fetch archive filter. Bundling
+// into a struct would just push the same fields into a wrapper.
 #[allow(clippy::too_many_arguments)]
 async fn fetch_and_extract_with_retry<R: Reporter>(
     http_client: &ThrottledClient,
@@ -1309,6 +1534,7 @@ async fn fetch_and_extract_with_retry<R: Reporter>(
     store_dir: &'static StoreDir,
     retry_opts: RetryOpts,
     auth_headers: &AuthHeaders,
+    ignore_file_pattern: Option<&'static IgnoreEntryFilter>,
 ) -> Result<(HashMap<String, PathBuf>, PackageFilesIndex), TarballError> {
     let mut attempt: u32 = 0;
     loop {
@@ -1321,6 +1547,7 @@ async fn fetch_and_extract_with_retry<R: Reporter>(
             attempt,
             store_dir,
             auth_headers,
+            ignore_file_pattern,
         )
         .await;
         match result {
@@ -1505,6 +1732,7 @@ impl<'a> DownloadTarballToStore<'a> {
             prefetched_cas_paths,
             retry_opts,
             auth_headers,
+            ignore_file_pattern,
             ..
         } = self;
         let store_index = self.store_index.clone();
@@ -1588,6 +1816,7 @@ impl<'a> DownloadTarballToStore<'a> {
             store_dir,
             retry_opts,
             auth_headers,
+            ignore_file_pattern,
         )
         .await?;
 
@@ -1608,6 +1837,355 @@ impl<'a> DownloadTarballToStore<'a> {
                 target: "pacquet::download",
                 ?index_key,
                 "no shared store-index writer; skipping index row for this tarball",
+            );
+        }
+
+        Ok(cas_paths)
+    }
+}
+
+/// Run one full zip-archive fetch attempt: hit the network, drain the
+/// body into RAM, verify the integrity hash, then walk the zip and
+/// extract every file entry into the CAFS. Mirrors
+/// [`fetch_and_extract_once`] one-for-one (same network permit
+/// shape, same post-download semaphore gate, same retry-friendly
+/// errors) — only the spawn_blocking body differs: integrity check
+/// then [`extract_zip_entries`] instead of the gzip + tar path.
+///
+/// Mirrors upstream's `downloadAndUnpackZip` at
+/// <https://github.com/pnpm/pnpm/blob/94240bc046/fetching/binary-fetcher/src/index.ts>,
+/// but writes directly into the CAS rather than going through a
+/// temp dir + `addFilesFromDir` round-trip (pacquet's
+/// [`StoreDir::write_cas_file`] is the same content-addressed write
+/// `addFilesFromDir` does on each tempdir file).
+async fn fetch_and_extract_zip_once<R: Reporter>(
+    http_client: &ThrottledClient,
+    package_url: &str,
+    package_integrity: &Integrity,
+    package_id: &str,
+    attempt: u32,
+    store_dir: &'static StoreDir,
+    archive_prefix: Option<&str>,
+    ignore_file_pattern: Option<&'static IgnoreEntryFilter>,
+) -> Result<(HashMap<String, PathBuf>, PackageFilesIndex), TarballError> {
+    let network_error =
+        |error| TarballError::FetchTarball(NetworkError { url: package_url.to_string(), error });
+
+    let client = http_client.acquire().await;
+
+    let send_result = client.get(package_url).send().await;
+    let size = send_result.as_ref().ok().and_then(|r| r.content_length());
+    R::emit(&LogEvent::FetchingProgress(FetchingProgressLog {
+        level: LogLevel::Debug,
+        message: FetchingProgressMessage::Started {
+            attempt: attempt + 1,
+            package_id: package_id.to_owned(),
+            size,
+        },
+    }));
+    let response_head = send_result.map_err(network_error)?;
+
+    let status = response_head.status();
+    if !status.is_success() {
+        const DRAIN_CAP: u64 = 64 * 1024;
+        if response_head.content_length().is_some_and(|len| len <= DRAIN_CAP) {
+            let _ = response_head.bytes().await;
+        }
+        return Err(TarballError::HttpStatus(HttpStatusError {
+            url: package_url.to_string(),
+            status: status.as_u16(),
+        }));
+    }
+
+    let expected_size = response_head.content_length();
+
+    let buffer = {
+        use futures_util::StreamExt;
+        let mut buf = allocate_tarball_buffer(expected_size, package_url)?;
+        let mut stream = response_head.bytes_stream();
+
+        const BIG_TARBALL_SIZE: u64 = 5 * 1024 * 1024;
+        const IN_PROGRESS_THROTTLE: Duration = Duration::from_millis(500);
+        let emit_progress = expected_size.is_some_and(|n| n >= BIG_TARBALL_SIZE);
+        let mut last_emit: Option<Instant> = None;
+        let mut last_emitted_downloaded: u64 = 0;
+        let mut downloaded: u64 = 0;
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(network_error)?;
+            buf.extend_from_slice(&chunk);
+            downloaded = downloaded.saturating_add(chunk.len() as u64);
+            let throttle_ready = last_emit.is_none_or(|t| t.elapsed() >= IN_PROGRESS_THROTTLE);
+            if emit_progress && throttle_ready {
+                R::emit(&LogEvent::FetchingProgress(FetchingProgressLog {
+                    level: LogLevel::Debug,
+                    message: FetchingProgressMessage::InProgress {
+                        downloaded,
+                        package_id: package_id.to_owned(),
+                    },
+                }));
+                last_emit = Some(Instant::now());
+                last_emitted_downloaded = downloaded;
+            }
+        }
+        if emit_progress && downloaded != last_emitted_downloaded {
+            R::emit(&LogEvent::FetchingProgress(FetchingProgressLog {
+                level: LogLevel::Debug,
+                message: FetchingProgressMessage::InProgress {
+                    downloaded,
+                    package_id: package_id.to_owned(),
+                },
+            }));
+        }
+        buf
+    };
+    drop(client);
+
+    let _post_download_permit = post_download_semaphore()
+        .acquire()
+        .await
+        .expect("post-download semaphore shouldn't be closed this soon");
+
+    tracing::info!(target: "pacquet::download", ?package_url, "Download completed");
+
+    let package_integrity = package_integrity.clone();
+    let package_url_owned = package_url.to_string();
+    let archive_prefix_owned: Option<String> = archive_prefix.map(str::to_string);
+    let result = tokio::task::spawn_blocking(
+        move || -> Result<(HashMap<String, PathBuf>, PackageFilesIndex), TarballError> {
+            package_integrity.check(&buffer).map_err(|error| {
+                TarballError::Checksum(VerifyChecksumError {
+                    url: package_url_owned.clone(),
+                    error,
+                })
+            })?;
+
+            // Open the archive in a scope so the buffer + ZipArchive
+            // are released before we return — large runtime archives
+            // (Node.js for Windows is ~30 MB) keep the buffer alive
+            // through the whole read otherwise.
+            let (cas_paths, pkg_files_idx) = {
+                let cursor = Cursor::new(buffer);
+                let mut archive = zip::ZipArchive::new(cursor).map_err(|source| {
+                    TarballError::ReadZipArchive { url: package_url_owned.clone(), source }
+                })?;
+                extract_zip_entries(
+                    &mut archive,
+                    &package_url_owned,
+                    store_dir,
+                    archive_prefix_owned.as_deref(),
+                    ignore_file_pattern,
+                )?
+            };
+            Ok((cas_paths, pkg_files_idx))
+        },
+    )
+    .await
+    .map_err(TarballError::TaskJoin)??;
+
+    tracing::info!(target: "pacquet::download", ?package_url, "Checksum verified");
+
+    Ok(result)
+}
+
+/// Run [`fetch_and_extract_zip_once`] under pnpm's retry policy.
+/// Same shape as [`fetch_and_extract_with_retry`]: HTTP 401 / 403 /
+/// 404 fail fast, every other error retries with exponential
+/// backoff until [`RetryOpts::retries`] is exhausted. On success
+/// emits `pnpm:progress fetched` once per (resolved) package, same
+/// as the tarball path.
+// 9 arguments — over the default clippy threshold for the same
+// reason `fetch_and_extract_with_retry` is: each is distinct, and
+// bundling into a struct would just push the same fields into a
+// wrapper.
+#[allow(clippy::too_many_arguments)]
+async fn fetch_and_extract_zip_with_retry<R: Reporter>(
+    http_client: &ThrottledClient,
+    package_url: &str,
+    package_integrity: &Integrity,
+    package_id: &str,
+    requester: &str,
+    store_dir: &'static StoreDir,
+    retry_opts: RetryOpts,
+    archive_prefix: Option<&str>,
+    ignore_file_pattern: Option<&'static IgnoreEntryFilter>,
+) -> Result<(HashMap<String, PathBuf>, PackageFilesIndex), TarballError> {
+    let mut attempt: u32 = 0;
+    loop {
+        let result = fetch_and_extract_zip_once::<R>(
+            http_client,
+            package_url,
+            package_integrity,
+            package_id,
+            attempt,
+            store_dir,
+            archive_prefix,
+            ignore_file_pattern,
+        )
+        .await;
+        match result {
+            Ok(value) => {
+                R::emit(&LogEvent::Progress(ProgressLog {
+                    level: LogLevel::Debug,
+                    message: ProgressMessage::Fetched {
+                        package_id: package_id.to_owned(),
+                        requester: requester.to_owned(),
+                    },
+                }));
+                return Ok(value);
+            }
+            Err(err) if !is_transient_error(&err) => return Err(err),
+            Err(err) if attempt >= retry_opts.retries => {
+                tracing::warn!(
+                    target: "pacquet::download",
+                    ?package_url,
+                    attempts = attempt + 1,
+                    ?err,
+                    "Zip archive fetch retry budget exhausted",
+                );
+                return Err(err);
+            }
+            Err(err) => {
+                let delay = retry_opts.delay_for(attempt);
+                tracing::warn!(
+                    target: "pacquet::download",
+                    ?package_url,
+                    attempt = attempt + 1,
+                    max_attempts = retry_opts.retries + 1,
+                    ?delay,
+                    ?err,
+                    "Zip archive fetch failed; retrying after backoff",
+                );
+                R::emit(&LogEvent::RequestRetry(RequestRetryLog {
+                    level: LogLevel::Debug,
+                    attempt: attempt + 1,
+                    error: tarball_error_to_request_retry(&err),
+                    max_retries: retry_opts.retries,
+                    method: "GET".to_string(),
+                    timeout: u64::try_from(delay.as_millis()).unwrap_or(u64::MAX),
+                    url: package_url.to_string(),
+                }));
+                tokio::time::sleep(delay).await;
+                attempt += 1;
+            }
+        }
+    }
+}
+
+/// Counterpart to [`DownloadTarballToStore`] for zip-archive binary
+/// resolutions. Mirrors pnpm's `downloadAndUnpackZip` at
+/// <https://github.com/pnpm/pnpm/blob/94240bc046/fetching/binary-fetcher/src/index.ts>:
+/// the zip flow downloads the body, verifies the integrity hash,
+/// then walks zip entries and writes each to the CAFS — with the
+/// `prefix` field stripped from each entry path before the ignore
+/// filter and CAS write so the runtime's top-level
+/// `node-vX.Y.Z-<platform>-<arch>/` directory doesn't leak into
+/// downstream consumers' paths.
+///
+/// The store-index lookup, prefetch cache reuse, and store-index
+/// writer queueing match [`DownloadTarballToStore`] — runtime
+/// artifacts share the same `index.db` schema as ordinary npm
+/// packages.
+#[must_use]
+pub struct DownloadZipArchiveToStore<'a> {
+    pub http_client: &'a ThrottledClient,
+    pub store_dir: &'static StoreDir,
+    pub store_index: Option<SharedReadonlyStoreIndex>,
+    pub store_index_writer: Option<Arc<StoreIndexWriter>>,
+    pub verify_store_integrity: bool,
+    pub verified_files_cache: SharedVerifiedFilesCache,
+    pub package_integrity: &'a Integrity,
+    pub package_url: &'a str,
+    pub package_id: &'a str,
+    pub requester: &'a str,
+    pub prefetched_cas_paths: Option<&'a PrefetchedCasPaths>,
+    pub retry_opts: RetryOpts,
+    /// Basename of the archive's top-level directory, mirroring
+    /// [`crate::BinaryResolution::prefix`]. The zip extractor
+    /// strips `{prefix}/` from each entry path before the
+    /// ignore-filter check and the CAS write, so downstream
+    /// consumers see paths relative to the package root rather than
+    /// the runtime-version-stamped wrapper directory.
+    pub archive_prefix: Option<&'a str>,
+    pub ignore_file_pattern: Option<&'static IgnoreEntryFilter>,
+}
+
+impl<'a> DownloadZipArchiveToStore<'a> {
+    /// Execute the subroutine without an in-memory cache. Mirrors
+    /// [`DownloadTarballToStore::run_without_mem_cache`] — same
+    /// prefetch-cas-paths reuse, same SQLite-index lookup, same
+    /// store-index writer queue — only the network and extract
+    /// path differs (zip instead of gzip + tar).
+    pub async fn run_without_mem_cache<R: Reporter>(
+        &self,
+    ) -> Result<HashMap<String, PathBuf>, TarballError> {
+        let &DownloadZipArchiveToStore {
+            http_client,
+            store_dir,
+            package_integrity,
+            package_url,
+            package_id,
+            requester,
+            verify_store_integrity,
+            prefetched_cas_paths,
+            retry_opts,
+            archive_prefix,
+            ignore_file_pattern,
+            ..
+        } = self;
+        let store_index = self.store_index.clone();
+        let store_index_writer = self.store_index_writer.clone();
+        let verified_files_cache = Arc::clone(&self.verified_files_cache);
+
+        let cache_key = store_index_key(&package_integrity.to_string(), package_id);
+        if let Some(prefetched) = prefetched_cas_paths
+            && let Some(cas_paths) = prefetched.get(&cache_key)
+        {
+            tracing::info!(
+                target: "pacquet::download",
+                ?package_url,
+                ?package_id,
+                "Reusing prefetched CAFS entry — skipping zip download",
+            );
+            emit_progress_found_in_store::<R>(package_id, requester);
+            return Ok((**cas_paths).clone());
+        }
+        if let Some(cas_paths) = load_cached_cas_paths(
+            store_index,
+            store_dir,
+            cache_key,
+            verify_store_integrity,
+            verified_files_cache,
+        )
+        .await
+        {
+            tracing::info!(target: "pacquet::download", ?package_url, ?package_id, "Reusing cached CAFS entry — skipping zip download");
+            emit_progress_found_in_store::<R>(package_id, requester);
+            return Ok(cas_paths);
+        }
+
+        tracing::info!(target: "pacquet::download", ?package_url, "New cache (zip)");
+
+        let (cas_paths, pkg_files_idx) = fetch_and_extract_zip_with_retry::<R>(
+            http_client,
+            package_url,
+            package_integrity,
+            package_id,
+            requester,
+            store_dir,
+            retry_opts,
+            archive_prefix,
+            ignore_file_pattern,
+        )
+        .await?;
+
+        let index_key = store_index_key(&package_integrity.to_string(), package_id);
+        if let Some(writer) = store_index_writer {
+            writer.queue(index_key, pkg_files_idx);
+        } else {
+            tracing::warn!(
+                target: "pacquet::download",
+                ?index_key,
+                "no shared store-index writer; skipping index row for this zip archive",
             );
         }
 

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -726,11 +726,11 @@ fn extract_zip_entries(
         }
 
         // Strip the archive's top-level basename (`prefix` on
-        // [`crate::BinaryResolution`]) so the ignore filter sees the
-        // same relative paths upstream's regex does. If the entry
-        // path doesn't start with `{prefix}/` we use the raw name —
-        // pnpm's slice does the same (no-op when the entry already
-        // lives at the archive root).
+        // `pacquet_lockfile::BinaryResolution`) so the ignore filter
+        // sees the same relative paths upstream's regex does. If the
+        // entry path doesn't start with `{prefix}/` we use the raw
+        // name — pnpm's slice does the same (no-op when the entry
+        // already lives at the archive root).
         let cleaned = match basename_prefix.as_deref() {
             Some(prefix) => raw_name.strip_prefix(prefix).unwrap_or(&raw_name).to_string(),
             None => raw_name.clone(),
@@ -2136,10 +2136,10 @@ pub struct DownloadZipArchiveToStore<'a> {
     pub requester: &'a str,
     pub prefetched_cas_paths: Option<&'a PrefetchedCasPaths>,
     pub retry_opts: RetryOpts,
-    /// Basename of the archive's top-level directory, mirroring
-    /// [`crate::BinaryResolution::prefix`]. The zip extractor
-    /// strips `{prefix}/` from each entry path before the
-    /// ignore-filter check and the CAS write, so downstream
+    /// Basename of the archive's top-level directory, mirroring the
+    /// `prefix` field on `pacquet_lockfile::BinaryResolution`. The
+    /// zip extractor strips `{prefix}/` from each entry path before
+    /// the ignore-filter check and the CAS write, so downstream
     /// consumers see paths relative to the package root rather than
     /// the runtime-version-stamped wrapper directory.
     pub archive_prefix: Option<&'a str>,

--- a/crates/tarball/src/tests.rs
+++ b/crates/tarball/src/tests.rs
@@ -1398,6 +1398,7 @@ async fn fetch_attaches_authorization_header_when_creds_match_tarball_url() {
         store_path,
         fast_retry_opts(),
         &auth_headers,
+        None,
     )
     .await
     .expect("server should accept the request once the bearer header is attached");
@@ -1451,6 +1452,7 @@ async fn retry_re_attaches_authorization_header_on_each_attempt() {
         store_path,
         fast_retry_opts(),
         &auth_headers,
+        None,
     )
     .await
     .expect("retry attempt should also carry the bearer header");

--- a/crates/tarball/src/tests.rs
+++ b/crates/tarball/src/tests.rs
@@ -888,6 +888,64 @@ fn extract_rejects_parent_dir_component_in_entry_path() {
     drop(tempdir);
 }
 
+/// The tarball extractor's `ignore_file_pattern` plumbing must drop
+/// the matched entries from *both* `cas_paths` and
+/// `pkg_files_idx.files`. The Slice D dispatcher will rely on this
+/// for runtime archive filtering (Node's bundled `npm` / `corepack`,
+/// per upstream's `NODE_EXTRAS_IGNORE_PATTERN`); without coverage
+/// here, a regression that, e.g., applied the filter to `cas_paths`
+/// but forgot the `pkg_files_idx` row would slip past the existing
+/// `None`-path tests.
+#[test]
+fn extract_tarball_applies_ignore_filter_dropping_entries_from_both_maps() {
+    let (tempdir, store_path) = tempdir_with_leaked_path();
+
+    let mut tar_bytes = Vec::new();
+    {
+        let mut builder = tar::Builder::new(&mut tar_bytes);
+        for (path, body) in [
+            ("package/bin/tool", &b"binary"[..]),
+            ("package/lib/node_modules/npm/package.json", &b"{}"[..]),
+            ("package/README.md", &b"readme"[..]),
+        ] {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(body.len() as u64);
+            header.set_mode(0o644);
+            header.set_entry_type(tar::EntryType::Regular);
+            header.set_cksum();
+            builder.append_data(&mut header, path, body).expect("append entry");
+        }
+        builder.finish().expect("finalize tar");
+    }
+    let mut archive = Archive::new(Cursor::new(tar_bytes));
+
+    fn drop_npm(path: &str) -> bool {
+        path.starts_with("lib/node_modules/npm/")
+    }
+
+    let (cas_paths, pkg_files_idx) =
+        extract_tarball_entries(&mut archive, store_path, Some(&drop_npm))
+            .expect("tarball extraction with ignore filter");
+
+    dbg!(&cas_paths);
+    assert!(cas_paths.contains_key("bin/tool"));
+    assert!(cas_paths.contains_key("README.md"));
+    assert!(
+        !cas_paths.contains_key("lib/node_modules/npm/package.json"),
+        "ignore filter should drop bundled npm from cas_paths",
+    );
+
+    dbg!(&pkg_files_idx.files);
+    assert!(pkg_files_idx.files.contains_key("bin/tool"));
+    assert!(pkg_files_idx.files.contains_key("README.md"));
+    assert!(
+        !pkg_files_idx.files.contains_key("lib/node_modules/npm/package.json"),
+        "ignore filter should drop bundled npm from pkg_files_idx.files",
+    );
+
+    drop(tempdir);
+}
+
 /// `RetryOpts::default()` reproduces pnpm's
 /// `network/fetch/src/fetch.ts` defaults: 2 retries, factor 10,
 /// minTimeout 10 s, maxTimeout 60 s. The first post-failure delay
@@ -2280,6 +2338,39 @@ fn extract_zip_uses_entry_path_when_no_prefix() {
     assert!(cas_paths.contains_key("bin/tool"));
     assert!(cas_paths.contains_key("README.md"));
     assert_eq!(cas_paths.len(), 2);
+
+    drop(tempdir);
+}
+
+/// `enclosed_name()` collapses `.` segments before we build the
+/// canonical `cas_paths` key. A publisher tool that wrote
+/// `pkg/./foo.txt` and `pkg/foo.txt` into the same archive must
+/// land at one `foo.txt` entry after the prefix strip — same key
+/// the ignore filter sees, same key downstream consumers look up.
+/// Without the normalization the two would split into separate
+/// `./foo.txt` / `foo.txt` rows.
+#[test]
+fn extract_zip_normalizes_dot_segments_in_entry_paths() {
+    let (tempdir, store_path) = tempdir_with_leaked_path();
+    let bytes = build_zip(&[
+        ("node-v22.0.0-darwin-arm64/./bin/node", b"binary"),
+        ("node-v22.0.0-darwin-arm64/lib/./README", b"readme"),
+    ]);
+    let mut archive = zip::ZipArchive::new(Cursor::new(bytes)).expect("open zip");
+
+    let (cas_paths, _) = extract_zip_entries(
+        &mut archive,
+        "https://example.test/dotted.zip",
+        store_path,
+        Some("node-v22.0.0-darwin-arm64"),
+        None,
+    )
+    .expect("zip with `.` segments");
+
+    dbg!(&cas_paths);
+    assert!(cas_paths.contains_key("bin/node"), "`.` segment must be collapsed");
+    assert!(cas_paths.contains_key("lib/README"), "`.` segment must be collapsed");
+    assert!(!cas_paths.keys().any(|k| k.contains("/./")), "no entry should retain a `.` segment");
 
     drop(tempdir);
 }

--- a/crates/tarball/src/tests.rs
+++ b/crates/tarball/src/tests.rs
@@ -1,7 +1,7 @@
 use super::{
     DownloadTarballToStore, HttpStatusError, MemCache, NetworkError, PrefetchedCasPaths, RetryOpts,
     TarballError, VerifyChecksumError, allocate_tarball_buffer, extract_tarball_entries,
-    fetch_and_extract_with_retry, is_transient_error, prefetch_cas_paths,
+    extract_zip_entries, fetch_and_extract_with_retry, is_transient_error, prefetch_cas_paths,
 };
 use pacquet_network::{AuthHeaders, ThrottledClient};
 use pacquet_reporter::SilentReporter;
@@ -176,6 +176,7 @@ async fn packages_under_orgs_should_work() {
         verified_files_cache: SharedVerifiedFilesCache::default(),
         retry_opts: test_retry_opts(),
         auth_headers: &AuthHeaders::default(),
+        ignore_file_pattern: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -224,6 +225,7 @@ async fn should_throw_error_on_checksum_mismatch() {
         verified_files_cache: SharedVerifiedFilesCache::default(),
         retry_opts: test_retry_opts(),
         auth_headers: &AuthHeaders::default(),
+        ignore_file_pattern: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -299,6 +301,7 @@ async fn reuses_cached_cas_paths_when_index_entry_is_live() {
         verified_files_cache: SharedVerifiedFilesCache::default(),
         retry_opts: test_retry_opts(),
         auth_headers: &AuthHeaders::default(),
+        ignore_file_pattern: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -358,6 +361,7 @@ async fn reuses_prefetched_cas_paths_when_provided() {
         verified_files_cache: SharedVerifiedFilesCache::default(),
         retry_opts: test_retry_opts(),
         auth_headers: &AuthHeaders::default(),
+        ignore_file_pattern: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -585,6 +589,7 @@ async fn falls_through_when_cafs_file_missing() {
         verified_files_cache: SharedVerifiedFilesCache::default(),
         retry_opts: test_retry_opts(),
         auth_headers: &AuthHeaders::default(),
+        ignore_file_pattern: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -644,6 +649,7 @@ async fn falls_through_when_digest_is_malformed() {
         verified_files_cache: SharedVerifiedFilesCache::default(),
         retry_opts: test_retry_opts(),
         auth_headers: &AuthHeaders::default(),
+        ignore_file_pattern: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -706,6 +712,7 @@ async fn falls_through_when_cafs_path_is_a_directory() {
         verified_files_cache: SharedVerifiedFilesCache::default(),
         retry_opts: test_retry_opts(),
         auth_headers: &AuthHeaders::default(),
+        ignore_file_pattern: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -778,6 +785,7 @@ async fn falls_through_when_cafs_path_is_a_symlink() {
         verified_files_cache: SharedVerifiedFilesCache::default(),
         retry_opts: test_retry_opts(),
         auth_headers: &AuthHeaders::default(),
+        ignore_file_pattern: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -816,7 +824,7 @@ fn extract_propagates_malformed_tar_instead_of_panicking() {
     let bogus: Vec<u8> = vec![0xFF; 1024];
     let mut archive = Archive::new(Cursor::new(bogus));
 
-    let err = extract_tarball_entries(&mut archive, store_path)
+    let err = extract_tarball_entries(&mut archive, store_path, None)
         .expect_err("malformed tar must surface a TarballError, not panic");
 
     assert!(
@@ -867,7 +875,7 @@ fn extract_rejects_parent_dir_component_in_entry_path() {
     }
 
     let mut archive = Archive::new(Cursor::new(tar_bytes));
-    let err = extract_tarball_entries(&mut archive, store_path)
+    let err = extract_tarball_entries(&mut archive, store_path, None)
         .expect_err("parent-dir component must be rejected, not normalized");
 
     match err {
@@ -996,6 +1004,7 @@ async fn retries_then_succeeds_on_transient_5xx() {
         store_path,
         fast_retry_opts(),
         &AuthHeaders::default(),
+        None,
     )
     .await
     .expect("transient 503 should be followed by a successful retry");
@@ -1043,6 +1052,7 @@ async fn retries_integrity_mismatch_until_exhausted() {
         store_path,
         fast_retry_opts(),
         &AuthHeaders::default(),
+        None,
     )
     .await
     .expect_err("integrity mismatch should exhaust the retry budget");
@@ -1074,6 +1084,7 @@ async fn fails_fast_on_404() {
         store_path,
         fast_retry_opts(),
         &AuthHeaders::default(),
+        None,
     )
     .await
     .expect_err("404 must fail-fast without retry");
@@ -1114,6 +1125,7 @@ async fn retries_other_4xx_codes() {
         store_path,
         fast_retry_opts(),
         &AuthHeaders::default(),
+        None,
     )
     .await
     .expect_err("non-401/403/404 4xx should exhaust the retry budget");
@@ -1148,6 +1160,7 @@ async fn retry_exhaustion_returns_last_error() {
         store_path,
         fast_retry_opts(),
         &AuthHeaders::default(),
+        None,
     )
     .await
     .expect_err("permanent 500s should exhaust the retry budget");
@@ -1271,6 +1284,7 @@ fn run_with_mem_cache_does_not_deadlock_on_dashmap_shard_contention() {
                     verified_files_cache: SharedVerifiedFilesCache::default(),
                     retry_opts: RetryOpts { retries: 0, ..RetryOpts::default() },
                     auth_headers,
+                    ignore_file_pattern: None,
                 };
 
                 // Spawn each task and yield once before the next so the
@@ -1339,6 +1353,7 @@ async fn zero_retries_makes_a_single_attempt() {
         store_path,
         opts,
         &AuthHeaders::default(),
+        None,
     )
     .await
     .expect_err("retries=0 must surface the first failure");
@@ -1512,6 +1527,7 @@ async fn mem_cache_hit_emits_found_in_store_for_second_requester() {
         prefetched_cas_paths: None,
         retry_opts: test_retry_opts(),
         auth_headers: &AuthHeaders::default(),
+        ignore_file_pattern: None,
     }
     .run_with_mem_cache::<RecordingReporter>(&mem_cache)
     .await
@@ -1538,6 +1554,7 @@ async fn mem_cache_hit_emits_found_in_store_for_second_requester() {
         prefetched_cas_paths: None,
         retry_opts: test_retry_opts(),
         auth_headers: &AuthHeaders::default(),
+        ignore_file_pattern: None,
     }
     .run_with_mem_cache::<RecordingReporter>(&mem_cache)
     .await
@@ -1626,6 +1643,7 @@ async fn run_with_mem_cache_recovers_from_owning_fetch_error() {
         prefetched_cas_paths: None,
         retry_opts: test_retry_opts(),
         auth_headers,
+        ignore_file_pattern: None,
     };
 
     // Drive both calls concurrently. Pre-fix: the first to hit the
@@ -1726,6 +1744,7 @@ async fn fetching_progress_and_fetched_events_fire_during_download() {
         store_path,
         fast_retry_opts(),
         &AuthHeaders::default(),
+        None,
     )
     .await
     .expect("transient 503 should be followed by a successful retry");
@@ -1815,6 +1834,7 @@ async fn started_fires_for_connection_level_failures() {
         store_path,
         RetryOpts { retries: 0, ..fast_retry_opts() },
         &AuthHeaders::default(),
+        None,
     )
     .await
     .expect_err("connect-refused must surface as a TarballError");
@@ -1904,6 +1924,7 @@ async fn found_in_store_event_fires_on_cache_hit() {
         prefetched_cas_paths: None,
         retry_opts: test_retry_opts(),
         auth_headers: &AuthHeaders::default(),
+        ignore_file_pattern: None,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -1940,6 +1961,7 @@ async fn found_in_store_event_fires_on_cache_hit() {
         prefetched_cas_paths: None,
         retry_opts: test_retry_opts(),
         auth_headers: &AuthHeaders::default(),
+        ignore_file_pattern: None,
     }
     .run_without_mem_cache::<RecordingReporter>()
     .await
@@ -2017,6 +2039,7 @@ async fn request_retry_event_fires_per_retried_attempt() {
         store_path,
         fast_retry_opts(),
         &AuthHeaders::default(),
+        None,
     )
     .await
     .expect("transient 503 should be followed by a successful retry");
@@ -2058,4 +2081,155 @@ async fn request_retry_event_fires_per_retried_attempt() {
     );
 
     drop(store_dir_keep);
+}
+
+/// Build a zip archive in memory with the given `(name, body)`
+/// entries. Entries are stored uncompressed (`Stored`) so the test
+/// doesn't depend on the deflate backend the production reader
+/// uses; the zip reader handles both transparently. The high byte
+/// of `unix_mode` is the entry type per stat(2) — `0o100000` for a
+/// regular file — and the low bytes are the permission bits.
+fn build_zip(entries: &[(&str, &[u8])]) -> Vec<u8> {
+    use std::io::Write;
+    let mut buf = Vec::new();
+    {
+        let mut writer = zip::ZipWriter::new(Cursor::new(&mut buf));
+        let opts: zip::write::FileOptions<()> = zip::write::FileOptions::default()
+            .compression_method(zip::CompressionMethod::Stored)
+            .unix_permissions(0o100644);
+        for (name, body) in entries {
+            writer.start_file(*name, opts).expect("start zip entry");
+            writer.write_all(body).expect("write zip entry body");
+        }
+        writer.finish().expect("finalize zip archive");
+    }
+    buf
+}
+
+/// Happy path: a zip with two file entries under a top-level
+/// `node-vX.Y.Z-darwin-arm64/` directory is extracted with the
+/// prefix stripped from each `cas_paths` key. Mirrors upstream's
+/// `basenamePrefix` strip — the install dispatcher will later
+/// resolve `bin/node` against `cas_paths` and that lookup must
+/// hit the stripped form, not the prefixed form.
+#[test]
+fn extract_zip_strips_prefix_from_entry_paths() {
+    let (tempdir, store_path) = tempdir_with_leaked_path();
+    let bytes = build_zip(&[
+        ("node-v22.0.0-darwin-arm64/bin/node", b"binary contents"),
+        ("node-v22.0.0-darwin-arm64/LICENSE", b"license text"),
+    ]);
+    let mut archive = zip::ZipArchive::new(Cursor::new(bytes)).expect("open zip");
+
+    let (cas_paths, pkg_files_idx) = extract_zip_entries(
+        &mut archive,
+        "https://example.test/node.zip",
+        store_path,
+        Some("node-v22.0.0-darwin-arm64"),
+        None,
+    )
+    .expect("happy-path zip extraction");
+
+    dbg!(&cas_paths);
+    assert!(cas_paths.contains_key("bin/node"), "prefix should be stripped");
+    assert!(cas_paths.contains_key("LICENSE"), "prefix should be stripped");
+    assert!(
+        !cas_paths.keys().any(|k| k.starts_with("node-v22")),
+        "no entry should retain the prefix",
+    );
+    assert_eq!(pkg_files_idx.files.len(), 2);
+
+    drop(tempdir);
+}
+
+/// The ignore filter must see the *post-strip* path, the same one
+/// upstream's regex sees. A filter that drops `LICENSE` must hit
+/// after the `node-v22.0.0-darwin-arm64/` prefix has been removed —
+/// otherwise the Node-runtime filter (which targets
+/// `^lib/node_modules/(npm|corepack)`) would never match.
+#[test]
+fn extract_zip_applies_ignore_filter_on_stripped_path() {
+    let (tempdir, store_path) = tempdir_with_leaked_path();
+    let bytes = build_zip(&[
+        ("node-v22.0.0-darwin-arm64/bin/node", b"binary"),
+        ("node-v22.0.0-darwin-arm64/lib/node_modules/npm/package.json", b"{}"),
+        ("node-v22.0.0-darwin-arm64/LICENSE", b"license"),
+    ]);
+    let mut archive = zip::ZipArchive::new(Cursor::new(bytes)).expect("open zip");
+
+    // Filter mirroring the upstream `NODE_EXTRAS_IGNORE_PATTERN`
+    // shape — strips bundled npm / corepack — but compiled by hand
+    // so the test doesn't pull a regex engine into pacquet-tarball.
+    fn node_extras_filter(path: &str) -> bool {
+        path.starts_with("lib/node_modules/npm/") || path.starts_with("lib/node_modules/corepack/")
+    }
+
+    let (cas_paths, _) = extract_zip_entries(
+        &mut archive,
+        "https://example.test/node.zip",
+        store_path,
+        Some("node-v22.0.0-darwin-arm64"),
+        Some(&node_extras_filter),
+    )
+    .expect("zip extraction with ignore filter");
+
+    dbg!(&cas_paths);
+    assert!(cas_paths.contains_key("bin/node"));
+    assert!(cas_paths.contains_key("LICENSE"));
+    assert!(
+        !cas_paths.contains_key("lib/node_modules/npm/package.json"),
+        "ignore filter should drop bundled npm",
+    );
+
+    drop(tempdir);
+}
+
+/// A zip whose entry path contains `..` (or any other escaping
+/// component) must be rejected with [`TarballError::PathTraversal`].
+/// Mirrors upstream's `validatePathSecurity` rejection — even if a
+/// later layer would have re-anchored the write, refusing the
+/// archive outright is the cheapest defense against a malicious
+/// publisher.
+#[test]
+fn extract_zip_rejects_parent_dir_component() {
+    let (tempdir, store_path) = tempdir_with_leaked_path();
+    let bytes = build_zip(&[("../evil.txt", b"evil")]);
+    let mut archive = zip::ZipArchive::new(Cursor::new(bytes)).expect("open zip");
+
+    let err =
+        extract_zip_entries(&mut archive, "https://example.test/evil.zip", store_path, None, None)
+            .expect_err("escaping zip entry must be rejected, not normalized");
+
+    match err {
+        TarballError::PathTraversal { url, entry_path, reason } => {
+            assert_eq!(url, "https://example.test/evil.zip");
+            assert!(entry_path.contains(".."), "raw entry path should be surfaced: {entry_path}");
+            assert!(!reason.is_empty());
+        }
+        other => panic!("expected PathTraversal, got: {other:?}"),
+    }
+
+    drop(tempdir);
+}
+
+/// `archive_prefix: None` keeps entry paths verbatim — same as
+/// upstream's `basename === ''` branch in `extractZipToTarget`.
+/// A zip without a top-level wrapper directory must round-trip
+/// each entry's path into `cas_paths` as-is.
+#[test]
+fn extract_zip_uses_entry_path_when_no_prefix() {
+    let (tempdir, store_path) = tempdir_with_leaked_path();
+    let bytes = build_zip(&[("bin/tool", b"x"), ("README.md", b"docs")]);
+    let mut archive = zip::ZipArchive::new(Cursor::new(bytes)).expect("open zip");
+
+    let (cas_paths, _) =
+        extract_zip_entries(&mut archive, "https://example.test/flat.zip", store_path, None, None)
+            .expect("flat zip extraction");
+
+    dbg!(&cas_paths);
+    assert!(cas_paths.contains_key("bin/tool"));
+    assert!(cas_paths.contains_key("README.md"));
+    assert_eq!(cas_paths.len(), 2);
+
+    drop(tempdir);
 }

--- a/crates/tarball/src/tests.rs
+++ b/crates/tarball/src/tests.rs
@@ -2214,6 +2214,54 @@ fn extract_zip_rejects_parent_dir_component() {
     drop(tempdir);
 }
 
+/// Path-traversal validation must run *before* the `is_dir()`
+/// early-skip — otherwise an archive carrying a malicious directory
+/// entry like `../evil/` is silently dropped instead of surfacing
+/// [`TarballError::PathTraversal`]. Pacquet wouldn't write that
+/// directory either way (the CAS write path is gated on file
+/// entries), but rejecting outright keeps the "no unsafe entry
+/// accepted" contract intact for tooling that inspects the error
+/// code (Caught by CodeRabbit on #472).
+#[test]
+fn extract_zip_rejects_directory_entry_with_parent_component() {
+    let (tempdir, store_path) = tempdir_with_leaked_path();
+    // Build a zip with a single directory entry whose name contains
+    // `..`. `build_zip` only writes files, so go through `ZipWriter`
+    // directly here to call `add_directory`.
+    let bytes = {
+        let mut buf = Vec::new();
+        {
+            let mut writer = zip::ZipWriter::new(Cursor::new(&mut buf));
+            let opts: zip::write::FileOptions<()> = zip::write::FileOptions::default()
+                .compression_method(zip::CompressionMethod::Stored);
+            writer.add_directory("../evil", opts).expect("add dir entry");
+            writer.finish().expect("finalize zip");
+        }
+        buf
+    };
+    let mut archive = zip::ZipArchive::new(Cursor::new(bytes)).expect("open zip");
+
+    let err = extract_zip_entries(
+        &mut archive,
+        "https://example.test/evil-dir.zip",
+        store_path,
+        None,
+        None,
+    )
+    .expect_err("escaping directory entry must be rejected, not silently skipped");
+
+    match err {
+        TarballError::PathTraversal { url, entry_path, reason } => {
+            assert_eq!(url, "https://example.test/evil-dir.zip");
+            assert!(entry_path.contains(".."), "raw entry path should be surfaced: {entry_path}");
+            assert!(!reason.is_empty());
+        }
+        other => panic!("expected PathTraversal, got: {other:?}"),
+    }
+
+    drop(tempdir);
+}
+
 /// `archive_prefix: None` keeps entry paths verbatim — same as
 /// upstream's `basename === ''` branch in `extractZipToTarget`.
 /// A zip without a top-level wrapper directory must round-trip

--- a/tasks/micro-benchmark/src/main.rs
+++ b/tasks/micro-benchmark/src/main.rs
@@ -51,6 +51,7 @@ fn bench_tarball(c: &mut Criterion, server: &mut ServerGuard, fixtures_folder: &
                 prefetched_cas_paths: None,
                 retry_opts: RetryOpts::default(),
                 auth_headers: &AuthHeaders::default(),
+                ignore_file_pattern: None,
             }
             .run_without_mem_cache::<pacquet_reporter::SilentReporter>()
             .await


### PR DESCRIPTION
## Summary

Slice C of [#437](https://github.com/pnpm/pacquet/issues/437) — the zip half of pnpm's binary fetcher. Slices A (lockfile types) and B (variant picker) have landed; this slice adds the per-archive download and CAS-extraction pipeline. The install-dispatch site (slice D) and the `--no-runtime` flag (slice E) will follow.

Mirrors upstream's [`downloadAndUnpackZip` / `extractZipToTarget`](https://github.com/pnpm/pnpm/blob/94240bc046/fetching/binary-fetcher/src/index.ts):

- `extract_zip_entries` walks every entry. Path validation runs *before* the `is_dir()` early-skip so directory entries like `../evil/` still surface `PATH_TRAVERSAL`. The canonical `cas_paths` / `pkg_files_idx` key is built from `enclosed_name()` rebuilt as `Normal` components joined with `/` — `.` segments collapse, separators are cross-platform consistent, and the ignore filter sees the same string the map is keyed by.
- `DownloadZipArchiveToStore` is the public sibling of `DownloadTarballToStore` — same store-index lookup, prefetch cache reuse, store-index writer queue. The retry policy, network-permit shape, and post-download semaphore gating exactly match the tarball path.
- `ignore_file_pattern` is `Option<Arc<IgnoreEntryFilter>>` on both `DownloadTarballToStore` and `DownloadZipArchiveToStore`, so the Slice D dispatcher can construct a filter per fetch from runtime config without pinning to `'static`. Cloned per retry attempt; the inner trait object is shared.
- `run_with_mem_cache` doc-blocks the "stable filter per URL" invariant: the cache keys solely on `package_url` (matching pnpm's `tarballCache`), and callers keep the (URL, filter) relation functional. Upstream's `archiveFilters` is keyed by `pkg.name`, and tarball URLs encode `(name, version, integrity)`, so this naturally holds.
- New `TarballError::ReadZipEntries(std::io::Error)` for zip per-entry I/O failures (`try_reserve` / `read_to_end`); maps to `ERR_PACQUET_ZIP` in the retry classifier, distinct from the tar-specific `ERR_PACQUET_TARBALL_TAR`. Zip `unix_mode()` is masked to `0o777` before write so `CafsFileInfo.mode` stays permission-only (matches `store_dir::add_files_from_dir::file_mode_from`). `TarballError::TarballTooLarge` display generalized from "Tarball at …" to "Archive at …" so the zip pipeline's OOM path doesn't surface a misleading message.
- Adds `zip = "5", default-features = false, features = ["deflate"]` to the workspace; reused in `pacquet-tarball`.

## Test plan

7 new unit tests (6 zip-extractor + 1 tarball ignore-filter). Each rejection / normalization guard was verified by temporarily disabling it and re-running the test (per the practice in `plans/TEST_PORTING.md`):

- [x] `extract_zip_strips_prefix_from_entry_paths` — prefix strip
- [x] `extract_zip_applies_ignore_filter_on_stripped_path` — filter sees post-strip paths
- [x] `extract_zip_rejects_parent_dir_component` — `PATH_TRAVERSAL` on file entry with `..`
- [x] `extract_zip_rejects_directory_entry_with_parent_component` — `PATH_TRAVERSAL` on *directory* entry with `..` (validation must run before `is_dir()` skip)
- [x] `extract_zip_normalizes_dot_segments_in_entry_paths` — `.` segments collapse in the canonical key
- [x] `extract_zip_uses_entry_path_when_no_prefix` — `archive_prefix: None` keeps entry names verbatim
- [x] `extract_tarball_applies_ignore_filter_dropping_entries_from_both_maps` — tarball filter drops entries from both `cas_paths` and `pkg_files_idx.files`
- [x] All 42 `pacquet-tarball` tests pass
- [x] `just ready` green
- [x] `taplo format --check`, `just dylint`, `cargo doc -D warnings` green

---
Written by an agent (Claude Code, claude-opus-4-7).