### PR TITLE
test(modules-yaml): pin hoistedLocations round-trip (#438 slice 2)

### DIFF
--- a/crates/modules-yaml/src/lib.rs
+++ b/crates/modules-yaml/src/lib.rs
@@ -208,6 +208,18 @@ pub struct Modules {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub injected_deps: Option<BTreeMap<String, Vec<String>>>,
 
+    /// Per-depPath list of lockfile-relative directory paths where
+    /// the package was placed under `nodeLinker: hoisted`. Required
+    /// by rebuild (which throws `MISSING_HOISTED_LOCATIONS` when
+    /// absent) and consulted by `lockfileToHoistedDepGraph`'s
+    /// skip-fetch optimization to decide whether the package is
+    /// already on disk. Mirrors upstream's optional
+    /// `Record<string, string[]>` at
+    /// <https://github.com/pnpm/pnpm/blob/94240bc046/installing/modules-yaml/src/index.ts#L43>.
+    /// Pacquet's install pipeline does not populate this yet; the
+    /// field is wired into the schema so a future hoisted-linker
+    /// implementation can write it without changing the on-disk
+    /// shape.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hoisted_locations: Option<BTreeMap<String, Vec<String>>>,
 

--- a/crates/modules-yaml/tests/real_fs.rs
+++ b/crates/modules-yaml/tests/real_fs.rs
@@ -154,3 +154,69 @@ fn dep_path_serializes_transparently() {
         "DepPath element did not serialize as a plain string",
     );
 }
+
+/// `hoistedLocations` is the per-depPath list of lockfile-relative
+/// directory paths that `linkHoistedModules` and rebuild consult to
+/// find where a package lives on disk. Pacquet has no consumer yet
+/// (the install pipeline still writes the field as `None`), so this
+/// test pins the schema-level round-trip until a real producer
+/// appears. Mirrors the optional `Record<string, string[]>` shape at
+/// <https://github.com/pnpm/pnpm/blob/94240bc046/installing/modules-yaml/src/index.ts#L43>.
+#[test]
+fn hoisted_locations_round_trips() {
+    let temp_dir = tempfile::tempdir().expect("create temporary directory");
+    let modules_dir = temp_dir.path();
+    let manifest = manifest_from_json(json!({
+        "layoutVersion": 5,
+        "hoistedLocations": {
+            "/accepts/1.3.7": ["node_modules/accepts"],
+            "/body-parser/1.19.0": [
+                "node_modules/body-parser",
+                "node_modules/express/node_modules/body-parser",
+            ],
+        },
+    }));
+    assert_eq!(
+        manifest.hoisted_locations.as_ref().expect("present").get("/accepts/1.3.7"),
+        Some(&vec!["node_modules/accepts".to_string()]),
+    );
+
+    write_modules_manifest::<RealApi>(modules_dir, manifest.clone()).expect("write manifest");
+    let actual = read_modules_manifest::<RealApi>(modules_dir)
+        .expect("read manifest")
+        .expect("manifest exists");
+    assert_eq!(actual.hoisted_locations, manifest.hoisted_locations);
+
+    let raw: Value = modules_dir
+        .join(".modules.yaml")
+        .pipe(fs::read_to_string)
+        .expect("read raw .modules.yaml")
+        .pipe_as_ref(serde_json::from_str)
+        .expect("parse raw .modules.yaml");
+    assert_eq!(
+        raw["hoistedLocations"]["/body-parser/1.19.0"],
+        json!(["node_modules/body-parser", "node_modules/express/node_modules/body-parser"]),
+    );
+}
+
+/// A manifest with no `hoistedLocations` (the only state pacquet
+/// writes today) must omit the field on disk rather than emit
+/// `hoistedLocations: null`. Upstream's `Record<string, string[]> |
+/// undefined` shape relies on `JSON.stringify` dropping `undefined`
+/// values; pacquet relies on `skip_serializing_if = "Option::is_none"`.
+#[test]
+fn absent_hoisted_locations_is_omitted_on_write() {
+    let temp_dir = tempfile::tempdir().expect("create temporary directory");
+    let modules_dir = temp_dir.path();
+    let manifest = manifest_from_json(json!({ "layoutVersion": 5 }));
+    assert!(manifest.hoisted_locations.is_none(), "fixture seed");
+
+    write_modules_manifest::<RealApi>(modules_dir, manifest).expect("write manifest");
+    let raw: Value = modules_dir
+        .join(".modules.yaml")
+        .pipe(fs::read_to_string)
+        .expect("read raw .modules.yaml")
+        .pipe_as_ref(serde_json::from_str)
+        .expect("parse raw .modules.yaml");
+    assert!(raw.get("hoistedLocations").is_none(), "hoistedLocations was emitted when None: {raw}");
+}


### PR DESCRIPTION
## Summary

Slice 2 of #438 (the `nodeLinker: 'hoisted'` umbrella). Smaller than expected — when I looked, the schema field was already in place from #332's original `.modules.yaml` port, so the work reduced to pinning behavior rather than building plumbing.

Two round-trip tests + a doc-comment on the field.

## What was actually missing

The umbrella's §"Pacquet's current state" table claimed `hoistedLocations` was "Missing entirely" — that was wrong. The field is at `crates/modules-yaml/src/lib.rs:212` and serde-handles read/write correctly. What was missing:

- **A test pinning the wire shape.** Nothing was stopping a future edit from breaking the camelCase mapping, the optional-with-skip-on-None behavior, or the `Record<string, string[]>` shape upstream relies on.
- **A doc-comment** explaining what the field is for. Other Slice-related fields (`hoisted_dependencies`, `hoisted_aliases`) have full docstrings; this one was silent.

## Tests added

Both live in `crates/modules-yaml/tests/real_fs.rs` (pacquet-side, no upstream counterpart — upstream's `installing/modules-yaml/test/index.ts` doesn't exercise `hoistedLocations` directly):

- `hoisted_locations_round_trips` — a manifest with `hoistedLocations` populated survives write+read; the raw on-disk JSON keeps the per-depPath array shape (multi-entry arrays included, to pin the nested-conflict layout).
- `absent_hoisted_locations_is_omitted_on_write` — `None` (the state every pacquet install writes today) serializes as the field *absent* from the file, matching upstream's `JSON.stringify(undefined)` behavior. Guards against accidental `Option::is_some` regressions on the `skip_serializing_if`.

## Regression catch verified

Per `plans/TEST_PORTING.md`'s "break the subject to verify the test catches it" convention, I temporarily added `#[serde(rename = "wrongName")]` to the field. `hoisted_locations_round_trips` failed at the `expect("present")` on the deserialized value (the camelCase key no longer mapped). Reverted before commit.

## Type-shape decision

Upstream's actual `ModulesRaw.hoistedLocations` is `Record<string, string[]> | undefined` — *not* `Record<DepPath, string[]>` despite the values being populated from depPaths internally. The umbrella's scope item ("`Option<BTreeMap<DepPath, Vec<String>>>`") was inconsistent with the upstream schema; I kept the existing `BTreeMap<String, Vec<String>>` because:

1. It already matches the upstream wire shape exactly.
2. Same pattern as the `hoisted_dependencies` field below, which deliberately keeps `String` keys (per its doc-comment at lines 148-153) because pnpm's `DepPath | ProjectId` union can't be statically disambiguated.

## Test plan

- [x] `hoisted_locations_round_trips` — populated case
- [x] `absent_hoisted_locations_is_omitted_on_write` — `None` case
- [x] Sabotage check: renaming the serde key to `wrongName` causes `hoisted_locations_round_trips` to fail at the deserialize assertion
- [x] `just ready` (857 → 859 tests, all green)
- [x] `cargo doc --document-private-items`, `taplo format --check`, `just dylint` all clean

---
Written by an agent (Claude Code, claude-opus-4-7).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation for the hoisted locations field in module manifests, clarifying expected behavior and usage patterns.

* **Tests**
  * Added test coverage for module manifest serialization and deserialization of hoisted locations, including proper null-field handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pacquet/pull/473)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->