### PR TITLE
feat: fetch-failure swallow for optional snapshots + ResolutionFailure payload (#434 slice 4)

### DIFF
--- a/crates/package-manager/src/build_modules.rs
+++ b/crates/package-manager/src/build_modules.rs
@@ -659,7 +659,7 @@ fn build_one_snapshot<R: Reporter>(
                     R::emit(&LogEvent::SkippedOptionalDependency(SkippedOptionalDependencyLog {
                         level: LogLevel::Debug,
                         details: Some(err.to_string()),
-                        package: SkippedOptionalPackage {
+                        package: SkippedOptionalPackage::Installed {
                             id: pkg_dir.to_string_lossy().into_owned(),
                             name: name.clone(),
                             version: version.clone(),

--- a/crates/package-manager/src/build_modules/tests.rs
+++ b/crates/package-manager/src/build_modules/tests.rs
@@ -7,7 +7,8 @@ use pacquet_lockfile::{
     ResolvedDependencySpec, SnapshotEntry,
 };
 use pacquet_reporter::{
-    IgnoredScriptsLog, LogEvent, Reporter, SilentReporter, SkippedOptionalReason,
+    IgnoredScriptsLog, LogEvent, Reporter, SilentReporter, SkippedOptionalPackage,
+    SkippedOptionalReason,
 };
 use pretty_assertions::assert_eq;
 use std::{
@@ -525,8 +526,11 @@ fn do_not_fail_on_optional_dep_with_failing_postinstall() {
         })
         .expect("must emit pnpm:skipped-optional-dependency");
     assert_eq!(skipped_event.reason, SkippedOptionalReason::BuildFailure);
-    assert_eq!(skipped_event.package.name, "@pnpm.e2e/failing-postinstall");
-    assert_eq!(skipped_event.package.version, "1.0.0");
+    let SkippedOptionalPackage::Installed { name, version, .. } = &skipped_event.package else {
+        panic!("expected Installed payload for build_failure, got {:?}", skipped_event.package);
+    };
+    assert_eq!(name, "@pnpm.e2e/failing-postinstall");
+    assert_eq!(version, "1.0.0");
     assert!(skipped_event.details.is_some(), "details must carry the error toString");
 }
 

--- a/crates/package-manager/src/create_virtual_store.rs
+++ b/crates/package-manager/src/create_virtual_store.rs
@@ -656,13 +656,26 @@ impl<'a> CreateVirtualStore<'a> {
                     .await;
                     match result {
                         Ok(()) => Ok(None),
-                        Err(err) if snapshot.optional => {
+                        Err(err) if snapshot.optional && is_fetch_side_failure(&err) => {
                             // Silent swallow, matching upstream. `tracing::warn!`
                             // gives operator visibility without polluting
                             // the reporter wire (upstream's frozen path
                             // emits nothing; only the resolver-side
                             // emit site fires `pnpm:skipped-optional-
                             // dependency reason=resolution_failure`).
+                            //
+                            // Scoped via [`is_fetch_side_failure`] to the
+                            // tarball-fetch / git-fetch / CAS-write
+                            // variants — i.e. the same surface upstream
+                            // wraps in
+                            // <https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-builder/src/lockfileToDepGraph.ts#L286-L298>.
+                            // Local materialization (`CreateVirtualDir`)
+                            // and config-shape errors
+                            // (`MissingTarballIntegrity`,
+                            // `UnsupportedResolution`) abort even for
+                            // optional snapshots, matching upstream's
+                            // post-fetch `linkPkg` path which sits
+                            // outside the catch.
                             tracing::warn!(
                                 target: "pacquet::install",
                                 snapshot = %snapshot_key,
@@ -840,6 +853,36 @@ fn integrity_equal(current: Option<&PackageMetadata>, wanted: Option<&PackageMet
 /// unit-testable; the call site stays in the warm-batch hot path
 /// where setting up a non-empty prefetched-cas test would require a
 /// full lockfile + populated CAFS.
+/// True for the [`InstallPackageBySnapshotError`] variants pacquet
+/// classifies as **fetch-side** — the surface inside upstream's
+/// catch at
+/// <https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-builder/src/lockfileToDepGraph.ts#L286-L298>.
+/// These are the ones an optional snapshot is allowed to swallow:
+///
+/// - `DownloadTarball` — HTTP fetch, integrity check, gzip decode,
+///   CAS write. Equivalent to `storeController.fetchPackage`
+///   blowing up.
+/// - `GitFetch` — `git` CLI clone / checkout / preparePackage /
+///   packlist / CAS import. Equivalent to upstream's git-fetcher
+///   inside the same `fetchPackage` dispatch.
+///
+/// Excluded (propagate even for optional snapshots, matching
+/// upstream's post-`fetching()` `linkPkg` path that sits outside
+/// the catch):
+///
+/// - `CreateVirtualDir` — local materialization (clone / hardlink /
+///   copy / symlink from CAS into the slot dir).
+/// - `MissingTarballIntegrity`, `UnsupportedResolution` —
+///   config/shape errors; upstream's equivalents `throw` rather
+///   than going through `fetchPackage`.
+fn is_fetch_side_failure(err: &InstallPackageBySnapshotError) -> bool {
+    matches!(
+        err,
+        InstallPackageBySnapshotError::DownloadTarball(_)
+            | InstallPackageBySnapshotError::GitFetch(_),
+    )
+}
+
 fn emit_warm_snapshot_progress<R: Reporter>(package_id: &str, requester: &str) {
     R::emit(&LogEvent::Progress(ProgressLog {
         level: LogLevel::Debug,

--- a/crates/package-manager/src/create_virtual_store.rs
+++ b/crates/package-manager/src/create_virtual_store.rs
@@ -20,7 +20,11 @@ use pacquet_store_dir::{
 };
 use pacquet_tarball::{PrefetchResult, prefetch_cas_paths};
 use pipe_trait::Pipe;
-use std::{collections::HashMap, path::PathBuf, sync::atomic::AtomicU8};
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+    sync::atomic::AtomicU8,
+};
 
 /// Bundled package manifests recovered from the SQLite store index
 /// during [`CreateVirtualStore::run`], keyed by the same
@@ -60,11 +64,21 @@ pub type SideEffectsMapsBySnapshot =
     HashMap<PackageKey, std::sync::Arc<HashMap<String, HashMap<String, PathBuf>>>>;
 
 /// Output of [`CreateVirtualStore::run`]. Bundles the bin-link
-/// manifest cache and the per-snapshot side-effects-cache overlays
-/// the build-phase needs.
+/// manifest cache, the per-snapshot side-effects-cache overlays the
+/// build-phase needs, and the per-install fetch-failure set.
+///
+/// `fetch_failed` is the set of `optional: true` snapshots whose
+/// tarball / metadata / extract step blew up during this install.
+/// The caller (`InstallFrozenLockfile::run`) folds these into its
+/// own [`crate::SkippedSnapshots`] so downstream consumers
+/// (`build_sequence`, `link_bins`, hoisting, etc.) treat them as
+/// absent, mirroring upstream's `graph[dir]` simply not having the
+/// entry at
+/// <https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-builder/src/lockfileToDepGraph.ts#L294-L298>.
 pub struct CreateVirtualStoreOutput {
     pub package_manifests: PackageManifests,
     pub side_effects_maps_by_snapshot: SideEffectsMapsBySnapshot,
+    pub fetch_failed: HashSet<PackageKey>,
 }
 
 /// This subroutine generates filesystem layout for the virtual store at `node_modules/.pacquet`.
@@ -162,6 +176,7 @@ impl<'a> CreateVirtualStore<'a> {
             return Ok(CreateVirtualStoreOutput {
                 package_manifests: PackageManifests::new(),
                 side_effects_maps_by_snapshot: SideEffectsMapsBySnapshot::new(),
+                fetch_failed: HashSet::new(),
             });
         };
         let packages = packages.ok_or(CreateVirtualStoreError::MissingPackagesSection)?;
@@ -598,10 +613,22 @@ impl<'a> CreateVirtualStore<'a> {
 
         // Cold batch: snapshots that didn't prefetch — fall through to the
         // existing tokio + download path.
+        //
+        // Per-snapshot result is `Option<PackageKey>`: `Some(key)` flags
+        // a fetch/extract failure that was silently swallowed because
+        // the snapshot is `optional: true`. Mirrors upstream's
+        // `if (pkgSnapshot.optional) return; throw err;` at
+        // <https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-builder/src/lockfileToDepGraph.ts#L294-L298>.
+        // Aggregated into `fetch_failed` for the caller to fold into
+        // its [`crate::SkippedSnapshots`] so downstream walkers
+        // (`build_sequence`, `link_bins`, hoist) treat the snapshot
+        // as absent.
+        let mut fetch_failed: HashSet<PackageKey> = HashSet::new();
         if !cold.is_empty() {
             let prefetched_ref = Some(&prefetched);
             let verified_files_cache_ref = &verified_files_cache;
-            cold.iter()
+            let outcomes: Vec<Option<PackageKey>> = cold
+                .iter()
                 .map(|(snapshot_key, snapshot)| async move {
                     let metadata_key = snapshot_key.without_peer();
                     let metadata = packages.get(&metadata_key).ok_or_else(|| {
@@ -610,7 +637,7 @@ impl<'a> CreateVirtualStore<'a> {
                             metadata_key: metadata_key.to_string(),
                         }
                     })?;
-                    InstallPackageBySnapshot {
+                    let result = InstallPackageBySnapshot {
                         http_client,
                         config,
                         layout,
@@ -626,11 +653,30 @@ impl<'a> CreateVirtualStore<'a> {
                         allow_build_policy,
                     }
                     .run::<R>()
-                    .await
-                    .map_err(CreateVirtualStoreError::InstallPackageBySnapshot)
+                    .await;
+                    match result {
+                        Ok(()) => Ok(None),
+                        Err(err) if snapshot.optional => {
+                            // Silent swallow, matching upstream. `tracing::warn!`
+                            // gives operator visibility without polluting
+                            // the reporter wire (upstream's frozen path
+                            // emits nothing; only the resolver-side
+                            // emit site fires `pnpm:skipped-optional-
+                            // dependency reason=resolution_failure`).
+                            tracing::warn!(
+                                target: "pacquet::install",
+                                snapshot = %snapshot_key,
+                                error = %err,
+                                "optional snapshot fetch/extract failed; dropping from install",
+                            );
+                            Ok(Some((*snapshot_key).clone()))
+                        }
+                        Err(err) => Err(CreateVirtualStoreError::InstallPackageBySnapshot(err)),
+                    }
                 })
                 .pipe(future::try_join_all)
                 .await?;
+            fetch_failed.extend(outcomes.into_iter().flatten());
         }
 
         // The writer is owned by the caller now. They drop their
@@ -639,7 +685,11 @@ impl<'a> CreateVirtualStore<'a> {
         // row from both the download path and the WRITE-path
         // upload.
 
-        Ok(CreateVirtualStoreOutput { package_manifests, side_effects_maps_by_snapshot })
+        Ok(CreateVirtualStoreOutput {
+            package_manifests,
+            side_effects_maps_by_snapshot,
+            fetch_failed,
+        })
     }
 }
 

--- a/crates/package-manager/src/install.rs
+++ b/crates/package-manager/src/install.rs
@@ -469,7 +469,11 @@ fn build_modules_manifest(
         // `new Date().toUTCString()` at line 1622.
         pruned_at: httpdate::fmt_http_date(SystemTime::now()),
         registries: Some(BTreeMap::from([("default".to_string(), config.registry.clone())])),
-        skipped: skipped.iter().map(ToString::to_string).collect(),
+        // `iter_installability` excludes fetch-failure entries so they
+        // don't get persisted across installs — matches upstream's
+        // silent swallow of optional fetch failures at
+        // <https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-builder/src/lockfileToDepGraph.ts#L294-L298>.
+        skipped: skipped.iter_installability().map(ToString::to_string).collect(),
         store_dir: config.store_dir.display().to_string(),
         virtual_store_dir: config.virtual_store_dir.to_string_lossy().into_owned(),
         virtual_store_dir_max_length: DEFAULT_VIRTUAL_STORE_DIR_MAX_LENGTH,

--- a/crates/package-manager/src/install/tests.rs
+++ b/crates/package-manager/src/install/tests.rs
@@ -1761,6 +1761,12 @@ async fn frozen_install_silently_swallows_unreachable_optional_tarball() {
 
     let mut config = Config::new();
     config.lockfile = false;
+    // Opt out of the GVS layout so the assertion below can stat the
+    // legacy `<virtual_store_dir>/<flat-name>` slot directly. With
+    // GVS on, the slot lives under `<store_dir>/links/...` and the
+    // assertion would always pass regardless of whether the swallow
+    // path actually fired.
+    config.enable_global_virtual_store = false;
     config.store_dir = store_dir.clone().into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = virtual_store_dir.clone();
@@ -1850,6 +1856,11 @@ async fn frozen_install_propagates_non_optional_fetch_failure() {
 
     let mut config = Config::new();
     config.lockfile = false;
+    // Match the sister test's GVS-off setup so both swallow tests
+    // route through the same layout — sidesteps any GVS-routing
+    // path divergence affecting where the cold-batch dispatch even
+    // runs.
+    config.enable_global_virtual_store = false;
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir;
     config.virtual_store_dir = virtual_store_dir;

--- a/crates/package-manager/src/install/tests.rs
+++ b/crates/package-manager/src/install/tests.rs
@@ -1705,3 +1705,175 @@ async fn frozen_install_preserves_seeded_skipped_across_reinstall() {
 
     drop(dir);
 }
+
+/// Port of upstream's
+/// [`deps-restorer/test/index.ts:340`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-restorer/test/index.ts#L340-L360)
+/// `skipping optional dependency if it cannot be fetched`. An
+/// `optional: true` snapshot whose tarball URL is unreachable must
+/// not abort the install — the failure is silently swallowed at
+/// the per-snapshot fetch dispatch in `CreateVirtualStore`, mirroring
+/// upstream's
+/// [`lockfileToDepGraph.ts:294-298`](https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-builder/src/lockfileToDepGraph.ts#L294-L298)
+/// catch site.
+///
+/// Asserts:
+/// 1. The install resolves `Ok` (no abort).
+/// 2. The broken snapshot's virtual-store slot was NOT created.
+/// 3. The on-disk `.modules.yaml.skipped` does NOT contain the
+///    broken snapshot — fetch failures are transient by upstream's
+///    convention (the catch site never updates `opts.skipped`), so
+///    a subsequent install retries the fetch.
+#[tokio::test]
+async fn frozen_install_silently_swallows_unreachable_optional_tarball() {
+    // Lockfile with one `optional: true` snapshot whose `tarball` URL
+    // dials `127.0.0.1:1` (a reserved port that always refuses) so
+    // the fetch reliably fails without a network round-trip. The
+    // integrity is arbitrary — we never get far enough to verify it.
+    const BROKEN_OPTIONAL_LOCKFILE: &str = text_block! {
+        "lockfileVersion: '9.0'"
+        "importers:"
+        "  .:"
+        "    optionalDependencies:"
+        "      broken-pkg:"
+        "        specifier: 1.0.0"
+        "        version: 1.0.0"
+        "packages:"
+        "  broken-pkg@1.0.0:"
+        "    resolution: {integrity: sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA, tarball: 'http://127.0.0.1:1/broken.tgz'}"
+        "snapshots:"
+        "  broken-pkg@1.0.0:"
+        "    optional: true"
+    };
+
+    let dir = tempdir().unwrap();
+    let store_dir = dir.path().join("pacquet-store");
+    let project_root = dir.path().join("project");
+    let modules_dir = project_root.join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pacquet");
+
+    let manifest_path = dir.path().join("package.json");
+    let mut manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
+    // Manifest must match the lockfile importer entry so the
+    // freshness check (#447) doesn't reject the install before we
+    // reach the fetch site.
+    manifest.add_dependency("broken-pkg", "1.0.0", DependencyGroup::Optional).unwrap();
+    manifest.save().unwrap();
+
+    let mut config = Config::new();
+    config.lockfile = false;
+    config.store_dir = store_dir.clone().into();
+    config.modules_dir = modules_dir.clone();
+    config.virtual_store_dir = virtual_store_dir.clone();
+    // Keep retries minimal — 127.0.0.1:1 fails immediately on every
+    // try, but a long retry schedule would dominate the test runtime.
+    config.fetch_retries = 0;
+    let config = config.leak();
+
+    let lockfile: Lockfile = serde_saphyr::from_str(BROKEN_OPTIONAL_LOCKFILE)
+        .expect("parse broken-optional fixture lockfile");
+
+    Install {
+        tarball_mem_cache: &Default::default(),
+        http_client: &Default::default(),
+        config,
+        manifest: &manifest,
+        lockfile: Some(&lockfile),
+        dependency_groups: [DependencyGroup::Prod, DependencyGroup::Optional],
+        frozen_lockfile: true,
+        supported_architectures: None,
+        resolved_packages: &Default::default(),
+    }
+    .run::<SilentReporter>()
+    .await
+    .expect("install must NOT abort when an optional snapshot fails to fetch");
+
+    // The broken snapshot's virtual-store slot must not have been
+    // created — the cold-batch dispatch failed before extraction.
+    let expected_slot = virtual_store_dir.join("broken-pkg@1.0.0").join("node_modules");
+    assert!(
+        !expected_slot.exists(),
+        "broken optional snapshot's slot must not exist, found {expected_slot:?}",
+    );
+
+    // The fetch-failure entry must NOT have been persisted to
+    // `.modules.yaml.skipped`. Mirrors upstream's silent catch site
+    // that never updates `opts.skipped`, so a future install retries
+    // the fetch (in case the URL becomes reachable again).
+    let written = modules_dir
+        .pipe_as_ref(read_modules_manifest::<RealApi>)
+        .expect("read .modules.yaml")
+        .expect("modules manifest exists");
+    assert!(
+        written.skipped.is_empty(),
+        "fetch-failure entries must not land in .modules.yaml.skipped, got {:?}",
+        written.skipped,
+    );
+
+    drop(dir);
+}
+
+/// The fetch-failure swallow is gated on `snapshot.optional`. A
+/// non-optional snapshot whose tarball is unreachable must still
+/// abort the install — mirrors upstream's `if (pkgSnapshot.optional)
+/// return; throw err;` at
+/// [`lockfileToDepGraph.ts:296-298`](https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-builder/src/lockfileToDepGraph.ts#L296-L298).
+/// Same fixture as the swallow test but with `optional: true`
+/// removed from the snapshot entry — confirms the polarity is
+/// correct.
+#[tokio::test]
+async fn frozen_install_propagates_non_optional_fetch_failure() {
+    const NON_OPTIONAL_BROKEN_LOCKFILE: &str = text_block! {
+        "lockfileVersion: '9.0'"
+        "importers:"
+        "  .:"
+        "    dependencies:"
+        "      broken-pkg:"
+        "        specifier: 1.0.0"
+        "        version: 1.0.0"
+        "packages:"
+        "  broken-pkg@1.0.0:"
+        "    resolution: {integrity: sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA, tarball: 'http://127.0.0.1:1/broken.tgz'}"
+        "snapshots:"
+        "  broken-pkg@1.0.0: {}"
+    };
+
+    let dir = tempdir().unwrap();
+    let store_dir = dir.path().join("pacquet-store");
+    let project_root = dir.path().join("project");
+    let modules_dir = project_root.join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pacquet");
+
+    let manifest_path = dir.path().join("package.json");
+    let mut manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
+    manifest.add_dependency("broken-pkg", "1.0.0", DependencyGroup::Prod).unwrap();
+    manifest.save().unwrap();
+
+    let mut config = Config::new();
+    config.lockfile = false;
+    config.store_dir = store_dir.into();
+    config.modules_dir = modules_dir;
+    config.virtual_store_dir = virtual_store_dir;
+    config.fetch_retries = 0;
+    let config = config.leak();
+
+    let lockfile: Lockfile = serde_saphyr::from_str(NON_OPTIONAL_BROKEN_LOCKFILE)
+        .expect("parse non-optional broken-fixture lockfile");
+
+    let result = Install {
+        tarball_mem_cache: &Default::default(),
+        http_client: &Default::default(),
+        config,
+        manifest: &manifest,
+        lockfile: Some(&lockfile),
+        dependency_groups: [DependencyGroup::Prod],
+        frozen_lockfile: true,
+        supported_architectures: None,
+        resolved_packages: &Default::default(),
+    }
+    .run::<SilentReporter>()
+    .await;
+
+    assert!(result.is_err(), "non-optional fetch failure must abort the install, got {result:?}");
+
+    drop(dir);
+}

--- a/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/crates/package-manager/src/install_frozen_lockfile.rs
@@ -278,7 +278,7 @@ where
         // `host` is built only when needed. The detection path runs
         // `node --version` on the blocking pool so it doesn't stall
         // the reactor thread.
-        let (skipped, host_node) = if needs_installability_check {
+        let (mut skipped, host_node) = if needs_installability_check {
             let mut host = tokio::task::spawn_blocking(InstallabilityHost::detect)
                 .await
                 .unwrap_or_else(|_| InstallabilityHost {
@@ -372,24 +372,40 @@ where
             Some(&allow_build_policy),
         );
 
-        let CreateVirtualStoreOutput { package_manifests, side_effects_maps_by_snapshot } =
-            CreateVirtualStore {
-                http_client,
-                config,
-                packages,
-                snapshots,
-                current_snapshots,
-                current_packages,
-                layout: &layout,
-                logged_methods,
-                requester,
-                store_index_writer: &store_index_writer,
-                allow_build_policy: &allow_build_policy,
-                skipped: &skipped,
-            }
-            .run::<R>()
-            .await
-            .map_err(InstallFrozenLockfileError::CreateVirtualStore)?;
+        let CreateVirtualStoreOutput {
+            package_manifests,
+            side_effects_maps_by_snapshot,
+            fetch_failed,
+        } = CreateVirtualStore {
+            http_client,
+            config,
+            packages,
+            snapshots,
+            current_snapshots,
+            current_packages,
+            layout: &layout,
+            logged_methods,
+            requester,
+            store_index_writer: &store_index_writer,
+            allow_build_policy: &allow_build_policy,
+            skipped: &skipped,
+        }
+        .run::<R>()
+        .await
+        .map_err(InstallFrozenLockfileError::CreateVirtualStore)?;
+
+        // Fold fetch-failure swallows into the live skip set so
+        // downstream consumers (`SymlinkDirectDependencies`,
+        // `LinkVirtualStoreBins`, `BuildModules`, the hoist pass)
+        // observe the optional fetch-failed snapshots as absent.
+        // Tracked in the `fetch_failed` subset of `SkippedSnapshots`
+        // which is excluded from `.modules.yaml.skipped` serialization
+        // so a subsequent install retries the fetch — matches
+        // upstream's behavior of not updating `opts.skipped` at the
+        // catch site.
+        for key in fetch_failed {
+            skipped.add_fetch_failed(key);
+        }
 
         SymlinkDirectDependencies {
             config,

--- a/crates/package-manager/src/installability.rs
+++ b/crates/package-manager/src/installability.rs
@@ -33,29 +33,56 @@ use pacquet_reporter::{
 };
 
 /// The set of snapshot keys skipped on this host.
+///
+/// Two disjoint origin classes are tracked separately because they
+/// behave differently across installs:
+///
+/// - **Installability skips** (`installability`) — engine, platform,
+///   or libc mismatch surfaced by [`compute_skipped_snapshots`].
+///   Persisted to `.modules.yaml.skipped` and re-seeded on every
+///   subsequent install, mirroring upstream's
+///   `opts.skipped.add(depPath)` at
+///   <https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-builder/src/lockfileToDepGraph.ts#L213>.
+///
+/// - **Fetch-failure skips** (`fetch_failed`) — an `optional: true`
+///   snapshot whose tarball / metadata / extract step blew up
+///   during the install. **Not** persisted, matching upstream's
+///   silent `if (pkgSnapshot.optional) return` at
+///   <https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-builder/src/lockfileToDepGraph.ts#L294-L298>:
+///   upstream's catch site never updates `opts.skipped`, so a
+///   subsequent install retries the fetch. Tracked in this struct
+///   so downstream consumers (`build_sequence`, `link_bins`, etc.)
+///   can skip the snapshot through the same gate they use for
+///   installability skips — pacquet's downstream architecture
+///   walks the lockfile rather than a pre-pruned graph, so a
+///   separate filter is needed where upstream gets it for free
+///   from `graph[dir]` being absent.
+///
+/// [`compute_skipped_snapshots`]: crate::compute_skipped_snapshots
 #[derive(Debug, Default, Clone)]
 pub struct SkippedSnapshots {
-    set: HashSet<PackageKey>,
+    installability: HashSet<PackageKey>,
+    fetch_failed: HashSet<PackageKey>,
 }
 
 impl SkippedSnapshots {
     pub fn new() -> Self {
-        Self { set: HashSet::new() }
+        Self::default()
     }
 
-    /// Construct a [`SkippedSnapshots`] from an existing set. Test
-    /// helper for callers that want to drive build-sequence /
-    /// virtual-store filtering against a known skip set without
-    /// running the full installability pass.
+    /// Construct a [`SkippedSnapshots`] from an existing
+    /// installability set. Test helper for callers that want to
+    /// drive build-sequence / virtual-store filtering against a
+    /// known skip set without running the full installability pass.
     #[cfg(test)]
     pub(crate) fn from_set(set: HashSet<PackageKey>) -> Self {
-        Self { set }
+        Self { installability: set, fetch_failed: HashSet::new() }
     }
 
-    /// Seed the set with snapshot keys recorded as skipped by a
-    /// previous install (read from `.modules.yaml.skipped`).
-    /// Unparsable strings are silently dropped — upstream tolerates
-    /// the same shape mismatch at
+    /// Seed the installability set with snapshot keys recorded as
+    /// skipped by a previous install (read from
+    /// `.modules.yaml.skipped`). Unparsable strings are silently
+    /// dropped — upstream tolerates the same shape mismatch at
     /// <https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-builder/src/lockfileToDepGraph.ts#L194>
     /// (the seed is only consulted by `Set.has(depPath)`; a
     /// nonsense string never matches any current snapshot, so the
@@ -65,24 +92,55 @@ impl SkippedSnapshots {
         I: IntoIterator,
         I::Item: AsRef<str>,
     {
-        let set = iter.into_iter().filter_map(|s| s.as_ref().parse::<PackageKey>().ok()).collect();
-        Self { set }
+        let installability =
+            iter.into_iter().filter_map(|s| s.as_ref().parse::<PackageKey>().ok()).collect();
+        Self { installability, fetch_failed: HashSet::new() }
     }
 
+    /// Record an `optional: true` snapshot whose fetch / extract
+    /// failed during this install. Slice 4 wire-up — call site is
+    /// inside [`crate::CreateVirtualStore`]'s cold-batch dispatch.
+    pub fn add_fetch_failed(&mut self, key: PackageKey) {
+        self.fetch_failed.insert(key);
+    }
+
+    /// `true` if the snapshot is skipped for **any** reason
+    /// (installability or fetch-failure). Downstream consumers want
+    /// the union: a fetch-failed snapshot is just as absent from the
+    /// install graph as an installability-skipped one.
     pub fn contains(&self, key: &PackageKey) -> bool {
-        self.set.contains(key)
+        self.installability.contains(key) || self.fetch_failed.contains(key)
     }
 
     pub fn len(&self) -> usize {
-        self.set.len()
+        self.installability.len() + self.fetch_failed.len()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.set.is_empty()
+        self.installability.is_empty() && self.fetch_failed.is_empty()
     }
 
+    /// Insert into the installability set. Used by
+    /// [`compute_skipped_snapshots`] when the per-snapshot
+    /// installability check fails.
+    pub(crate) fn insert_installability(&mut self, key: PackageKey) {
+        self.installability.insert(key);
+    }
+
+    /// Iterate over the **installability** subset only — the entries
+    /// written to `.modules.yaml.skipped`. Fetch-failure entries are
+    /// transient and intentionally excluded so they aren't persisted
+    /// across installs.
+    pub fn iter_installability(&self) -> impl Iterator<Item = &PackageKey> + '_ {
+        self.installability.iter()
+    }
+
+    /// Iterate over the union of both subsets — every snapshot that
+    /// downstream consumers should treat as absent from the install,
+    /// regardless of origin. Used by `hoist.rs` and similar
+    /// graph-walking passes that don't care why a snapshot is gone.
     pub fn iter(&self) -> impl Iterator<Item = &PackageKey> + '_ {
-        self.set.iter()
+        self.installability.iter().chain(self.fetch_failed.iter())
     }
 }
 
@@ -264,7 +322,7 @@ pub fn compute_skipped_snapshots<R: Reporter>(
         let Some(warn) = warn else { continue };
 
         if snapshot.optional {
-            skipped.set.insert(snapshot_key.clone());
+            skipped.insert_installability(snapshot_key.clone());
             // Dedup events per metadata key, matching upstream's
             // emit-per-pkgId at `index.ts:49-58`.
             if seen_emit.insert(metadata_key.clone()) {
@@ -364,7 +422,7 @@ fn emit_skipped<R: Reporter>(pkg_id: &str, reason: SkipReason, details: String, 
     R::emit(&LogEvent::SkippedOptionalDependency(SkippedOptionalDependencyLog {
         level: LogLevel::Debug,
         details: Some(details),
-        package: SkippedOptionalPackage { id: pkg_id.to_string(), name, version },
+        package: SkippedOptionalPackage::Installed { id: pkg_id.to_string(), name, version },
         prefix: prefix.to_string(),
         reason: wire_reason,
     }));

--- a/crates/package-manager/src/installability/tests.rs
+++ b/crates/package-manager/src/installability/tests.rs
@@ -7,7 +7,7 @@ use pacquet_lockfile::{
     LockfileResolution, PackageKey, PackageMetadata, PkgNameVerPeer, SnapshotEntry,
     TarballResolution,
 };
-use pacquet_reporter::{LogEvent, Reporter, SkippedOptionalReason};
+use pacquet_reporter::{LogEvent, Reporter, SkippedOptionalPackage, SkippedOptionalReason};
 use pretty_assertions::assert_eq;
 
 use crate::installability::{
@@ -120,8 +120,11 @@ fn skip_optional_with_wrong_os() {
     assert_eq!(skipped_events.len(), 1);
     if let LogEvent::SkippedOptionalDependency(log) = skipped_events[0] {
         assert_eq!(log.reason, SkippedOptionalReason::UnsupportedPlatform);
-        assert_eq!(log.package.name, "not-compatible-with-any-os");
-        assert_eq!(log.package.version, "1.0.0");
+        let SkippedOptionalPackage::Installed { name, version, .. } = &log.package else {
+            panic!("expected Installed payload for unsupported_platform, got {:?}", log.package);
+        };
+        assert_eq!(name, "not-compatible-with-any-os");
+        assert_eq!(version, "1.0.0");
         assert_eq!(log.prefix, "/proj");
     }
 }

--- a/crates/reporter/src/lib.rs
+++ b/crates/reporter/src/lib.rs
@@ -550,16 +550,17 @@ pub struct IgnoredScriptsLog {
 /// `build_failure` / `unsupported_engine` / `unsupported_platform`
 /// all carry `package: { id, name, version }`; `resolution_failure`
 /// carries `package: { name?, version?, bareSpecifier }` with no
-/// `id`. This struct models only the **first** shape — the three
-/// reasons that share `{ id, name, version }`. The
-/// `ResolutionFailure` variant in [`SkippedOptionalReason`] is
-/// declared for forward compatibility on the enum side, but its
-/// distinct `package` shape means a `ResolutionFailure` emit will
-/// require a sibling struct (or a `#[serde(untagged)]` enum
-/// substituting for `SkippedOptionalDependencyLog`) — not just
-/// flipping the `reason` value. Refactoring is deferred until
-/// pacquet actually has a resolver-time emit site to produce that
-/// payload.
+/// `id`. See the canonical definition at
+/// <https://github.com/pnpm/pnpm/blob/94240bc046/core/core-loggers/src/skippedOptionalDependencyLogger.ts#L10-L31>.
+///
+/// The `reason` and `package` shapes co-vary upstream. The
+/// `package` field below is therefore a `#[serde(untagged)]` enum
+/// that picks the right shape depending on which variant the emit
+/// site constructs. The pairing is not type-enforced against
+/// `reason` (a `BuildFailure` reason with a
+/// `ResolutionFailure` package is constructible in Rust), but every
+/// emit site is centralized inside this crate, so the constructor
+/// discipline lives there rather than in the type.
 ///
 /// `parents` is a TODO upstream too (see
 /// `during-install/src/index.ts:227`) and is omitted here.
@@ -574,14 +575,43 @@ pub struct SkippedOptionalDependencyLog {
 }
 
 /// Package identifier carried on a [`SkippedOptionalDependencyLog`].
-/// Matches the upstream "non-resolution-failure" branch of
-/// `SkippedOptionalDependencyMessage` at
-/// <https://github.com/pnpm/pnpm/blob/b4f8f47ac2/core/core-loggers/src/skippedOptionalDependencyLogger.ts#L15-L19>.
+/// Two upstream shapes, depending on `reason`:
+///
+/// - [`SkippedOptionalPackage::Installed`] — `{ id, name, version }`
+///   for `build_failure` / `unsupported_engine` /
+///   `unsupported_platform`. Used by the slice 1 emit site in
+///   `installability.rs` and the build-failure emit in
+///   `build_modules.rs`.
+/// - [`SkippedOptionalPackage::ResolutionFailure`] —
+///   `{ name?, version?, bareSpecifier }` for `resolution_failure`.
+///   Defined for the resolver-side emit upstream has at
+///   <https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-resolver/src/resolveDependencies.ts#L1376-L1383>.
+///   Pacquet has no resolver yet so this variant is wire-shape-only
+///   in slice 4 — wired so a future resolver port can land without
+///   re-touching this type.
+///
+/// `#[serde(untagged)]` so each variant serializes as its own object
+/// shape, matching upstream's union of two `package: { ... }` types
+/// at
+/// <https://github.com/pnpm/pnpm/blob/94240bc046/core/core-loggers/src/skippedOptionalDependencyLogger.ts#L15-L30>.
 #[derive(Debug, Clone, Serialize)]
-pub struct SkippedOptionalPackage {
-    pub id: String,
-    pub name: String,
-    pub version: String,
+#[serde(untagged)]
+pub enum SkippedOptionalPackage {
+    /// `{ id, name, version }` shape used by every non-resolver
+    /// emit (installability + build-failure).
+    Installed { id: String, name: String, version: String },
+    /// `{ name?, version?, bareSpecifier }` shape used by the
+    /// resolver-side `resolution_failure` emit. `name` and `version`
+    /// are upstream-optional and stay `None` when the resolver fails
+    /// before it could resolve those fields.
+    ResolutionFailure {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        version: Option<String>,
+        #[serde(rename = "bareSpecifier")]
+        bare_specifier: String,
+    },
 }
 
 /// Discriminator on a [`SkippedOptionalDependencyLog`]. Only

--- a/crates/reporter/src/lib.rs
+++ b/crates/reporter/src/lib.rs
@@ -565,7 +565,7 @@ pub struct IgnoredScriptsLog {
 /// pairing correct by hand. Tightening this into a closed-set
 /// builder API would constrain a future resolver port without
 /// adding much real safety, so it's left to convention until a
-/// site actually mis-pairs.
+/// site actually pairs the wrong shapes.
 ///
 /// `parents` is a TODO upstream too (see
 /// `during-install/src/index.ts:227`) and is omitted here.

--- a/crates/reporter/src/lib.rs
+++ b/crates/reporter/src/lib.rs
@@ -558,9 +558,14 @@ pub struct IgnoredScriptsLog {
 /// that picks the right shape depending on which variant the emit
 /// site constructs. The pairing is not type-enforced against
 /// `reason` (a `BuildFailure` reason with a
-/// `ResolutionFailure` package is constructible in Rust), but every
-/// emit site is centralized inside this crate, so the constructor
-/// discipline lives there rather than in the type.
+/// `ResolutionFailure` package is constructible in Rust); emit
+/// sites live in `pacquet-package-manager`
+/// (`installability.rs`, `build_modules.rs`,
+/// `create_virtual_store.rs` for slice 4) and must keep the
+/// pairing correct by hand. Tightening this into a closed-set
+/// builder API would constrain a future resolver port without
+/// adding much real safety, so it's left to convention until a
+/// site actually mis-pairs.
 ///
 /// `parents` is a TODO upstream too (see
 /// `during-install/src/index.ts:227`) and is omitted here.

--- a/crates/reporter/src/lib.rs
+++ b/crates/reporter/src/lib.rs
@@ -559,13 +559,16 @@ pub struct IgnoredScriptsLog {
 /// site constructs. The pairing is not type-enforced against
 /// `reason` (a `BuildFailure` reason with a
 /// `ResolutionFailure` package is constructible in Rust); emit
-/// sites live in `pacquet-package-manager`
-/// (`installability.rs`, `build_modules.rs`,
-/// `create_virtual_store.rs` for slice 4) and must keep the
-/// pairing correct by hand. Tightening this into a closed-set
-/// builder API would constrain a future resolver port without
-/// adding much real safety, so it's left to convention until a
-/// site actually pairs the wrong shapes.
+/// sites live in `pacquet-package-manager` (`installability.rs`
+/// for the installability skips, `build_modules.rs` for the
+/// build-failure path) and must keep the pairing correct by hand.
+/// `CreateVirtualStore`'s slice 4 fetch-failure path is silent on
+/// the reporter wire — it only swallows the error, no event is
+/// emitted from there — so it isn't a constructor site for this
+/// log. Tightening the pairing into a closed-set builder API
+/// would constrain a future resolver port without adding much
+/// real safety, so it's left to convention until a site actually
+/// pairs the wrong shapes.
 ///
 /// `parents` is a TODO upstream too (see
 /// `during-install/src/index.ts:227`) and is omitted here.

--- a/crates/reporter/src/tests.rs
+++ b/crates/reporter/src/tests.rs
@@ -587,7 +587,7 @@ fn skipped_optional_dependency_event_matches_pnpm_wire_shape() {
     let event = LogEvent::SkippedOptionalDependency(SkippedOptionalDependencyLog {
         level: LogLevel::Debug,
         details: Some("build failed: exit code 1".to_string()),
-        package: SkippedOptionalPackage {
+        package: SkippedOptionalPackage::Installed {
             id: "/foo/1.0.0".to_string(),
             name: "foo".to_string(),
             version: "1.0.0".to_string(),
@@ -619,7 +619,7 @@ fn skipped_optional_omits_absent_details() {
     let event = LogEvent::SkippedOptionalDependency(SkippedOptionalDependencyLog {
         level: LogLevel::Debug,
         details: None,
-        package: SkippedOptionalPackage {
+        package: SkippedOptionalPackage::Installed {
             id: "/bar/2.0.0".to_string(),
             name: "bar".to_string(),
             version: "2.0.0".to_string(),
@@ -655,6 +655,69 @@ fn broken_modules_event_matches_pnpm_wire_shape() {
     assert_eq!(json["name"], "pnpm:_broken_node_modules");
     assert_eq!(json["level"], "debug");
     assert_eq!(json["missing"], "/proj/node_modules/.pacquet/react@18.0.0/node_modules/react");
+}
+
+/// `resolution_failure` payload uses the second upstream variant:
+/// no `id`, optional `name` / `version`, and a `bareSpecifier`
+/// (camelCase on the wire). Mirrors the `package` shape at
+/// <https://github.com/pnpm/pnpm/blob/94240bc046/core/core-loggers/src/skippedOptionalDependencyLogger.ts#L21-L29>:
+/// pnpm renders the resolver-time emit with whatever fields the
+/// resolver had at fail time — bare specifier always present;
+/// `name` / `version` only when the resolver advanced far enough
+/// to extract them.
+#[test]
+fn skipped_optional_resolution_failure_event_matches_pnpm_wire_shape() {
+    let event = LogEvent::SkippedOptionalDependency(SkippedOptionalDependencyLog {
+        level: LogLevel::Debug,
+        details: Some("ERR_PNPM_FETCH_404: tarball not found".to_string()),
+        package: SkippedOptionalPackage::ResolutionFailure {
+            name: Some("foo".to_string()),
+            version: Some("1.2.3".to_string()),
+            bare_specifier: "^1.2.0".to_string(),
+        },
+        prefix: "/projects/x".to_string(),
+        reason: SkippedOptionalReason::ResolutionFailure,
+    });
+    let envelope = Envelope { time: 1_700_000_000_000, hostname: "host", pid: 4242, event: &event };
+    let json: Value = envelope
+        .pipe_ref(serde_json::to_string)
+        .expect("serialize envelope")
+        .pipe_as_ref(serde_json::from_str)
+        .expect("parse JSON");
+    dbg!(&json);
+    assert_eq!(json["name"], "pnpm:skipped-optional-dependency");
+    assert_eq!(json["reason"], "resolution_failure");
+    assert!(json["package"].get("id").is_none(), "id must NOT be present on resolution_failure");
+    assert_eq!(json["package"]["name"], "foo");
+    assert_eq!(json["package"]["version"], "1.2.3");
+    assert_eq!(json["package"]["bareSpecifier"], "^1.2.0");
+}
+
+/// `name` and `version` are upstream-optional on the
+/// resolution-failure variant and must be omitted from the wire
+/// when absent. `bareSpecifier` is required.
+#[test]
+fn skipped_optional_resolution_failure_omits_absent_name_and_version() {
+    let event = LogEvent::SkippedOptionalDependency(SkippedOptionalDependencyLog {
+        level: LogLevel::Debug,
+        details: None,
+        package: SkippedOptionalPackage::ResolutionFailure {
+            name: None,
+            version: None,
+            bare_specifier: "git+ssh://broken-url".to_string(),
+        },
+        prefix: "/projects/y".to_string(),
+        reason: SkippedOptionalReason::ResolutionFailure,
+    });
+    let envelope = Envelope { time: 1_700_000_000_000, hostname: "host", pid: 4242, event: &event };
+    let json: Value = envelope
+        .pipe_ref(serde_json::to_string)
+        .expect("serialize envelope")
+        .pipe_as_ref(serde_json::from_str)
+        .expect("parse JSON");
+    assert!(json["package"].get("name").is_none(), "name omitted when absent, got {json:?}");
+    assert!(json["package"].get("version").is_none(), "version omitted when absent");
+    assert_eq!(json["package"]["bareSpecifier"], "git+ssh://broken-url");
 }
 
 /// All four reason variants serialize as the snake_case strings

--- a/crates/reporter/src/tests.rs
+++ b/crates/reporter/src/tests.rs
@@ -717,10 +717,7 @@ fn skipped_optional_resolution_failure_omits_absent_name_and_version() {
         .expect("parse JSON");
     dbg!(&json);
     assert!(json["package"].get("name").is_none(), "name omitted when absent, got {json:?}");
-    assert!(
-        json["package"].get("version").is_none(),
-        "version omitted when absent, got {json:?}",
-    );
+    assert!(json["package"].get("version").is_none(), "version omitted when absent, got {json:?}");
     assert_eq!(json["package"]["bareSpecifier"], "git+ssh://broken-url");
 }
 

--- a/crates/reporter/src/tests.rs
+++ b/crates/reporter/src/tests.rs
@@ -715,8 +715,12 @@ fn skipped_optional_resolution_failure_omits_absent_name_and_version() {
         .expect("serialize envelope")
         .pipe_as_ref(serde_json::from_str)
         .expect("parse JSON");
+    dbg!(&json);
     assert!(json["package"].get("name").is_none(), "name omitted when absent, got {json:?}");
-    assert!(json["package"].get("version").is_none(), "version omitted when absent");
+    assert!(
+        json["package"].get("version").is_none(),
+        "version omitted when absent, got {json:?}",
+    );
     assert_eq!(json["package"]["bareSpecifier"], "git+ssh://broken-url");
 }
 


### PR DESCRIPTION
## Summary

Slice 4 of the [#434 umbrella](https://github.com/pnpm/pacquet/issues/434) (`Proper optionalDependencies support`). Slices 1–3 (#439, #456, #467) close the installability-driven skip path; this slice adds the second skip pathway upstream handles in the frozen install: an `optional: true` snapshot whose **fetch / extract** step fails at install time must not abort the install. Local-materialization errors (`CreateVirtualDir`) and config-shape errors still abort even for optional snapshots — matching upstream's `linkPkg` path which sits outside the catch.

Mirrors the silent catch sites at [`deps/graph-builder/src/lockfileToDepGraph.ts:294-298`](https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-builder/src/lockfileToDepGraph.ts#L294-L298) and [`installing/deps-restorer/src/index.ts:912-921`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-restorer/src/index.ts#L912-L921):

```ts
try { ... fetch ... }
catch (err) { if (pkgSnapshot.optional) return; throw err }
```

## Changes

- **Reporter**: `SkippedOptionalPackage` becomes a `#[serde(untagged)]` enum with `Installed { id, name, version }` and `ResolutionFailure { name?, version?, bareSpecifier }` variants. Models upstream's discriminated union at [`core-loggers/src/skippedOptionalDependencyLogger.ts:10-31`](https://github.com/pnpm/pnpm/blob/94240bc046/core/core-loggers/src/skippedOptionalDependencyLogger.ts#L10-L31). The new variant is wire-shape-only in slice 4 — pacquet has no resolver yet, but a future resolver port at the upstream emit site ([`resolveDependencies.ts:1376-1383`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-resolver/src/resolveDependencies.ts#L1376-L1383)) lands without re-touching this type.
- **`SkippedSnapshots`**: gains a `fetch_failed` subset disjoint from the existing `installability` subset. `contains` / `iter` return the union (downstream consumers treat both as absent); `iter_installability` returns only the persistent subset that `.modules.yaml.skipped` records, matching upstream's behavior of never updating `opts.skipped` at the fetch-failure catch sites.
- **`CreateVirtualStore`**: cold-batch dispatch swallows per-snapshot errors when `snapshot.optional` is true **and** the error is fetch-side. A new `is_fetch_side_failure` helper restricts the swallow to `InstallPackageBySnapshotError::DownloadTarball` and `::GitFetch` — the same surface upstream wraps in `storeController.fetchPackage`. Local-materialization (`CreateVirtualDir`) and config-shape errors (`MissingTarballIntegrity` / `UnsupportedResolution`) propagate even for optional snapshots, matching upstream's `linkPkg` path which sits outside the catch. Side benefit: the warm-batch path (which only surfaces `CreateVirtualDir` errors) stays consistently abort-on-error without a parallel swallow site. The per-install `fetch_failed: HashSet<PackageKey>` rides out on `CreateVirtualStoreOutput`.
- **`InstallFrozenLockfile::run`**: folds the returned `fetch_failed` into its mutable `SkippedSnapshots` so downstream phases (`SymlinkDirectDependencies`, `LinkVirtualStoreBins`, `BuildModules`, hoist) treat the dropped snapshots as absent through the same gate they already use for installability skips.

## Test plan

- [x] `reporter::tests::skipped_optional_resolution_failure_event_matches_pnpm_wire_shape` — full payload (`bareSpecifier` camelCase, no `id`).
- [x] `reporter::tests::skipped_optional_resolution_failure_omits_absent_name_and_version` — optional-field shape.
- [x] `install::tests::frozen_install_silently_swallows_unreachable_optional_tarball` — ports [`installing/deps-restorer/test/index.ts:340-360`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-restorer/test/index.ts#L340-L360): unreachable optional tarball (`http://127.0.0.1:1/...`), install succeeds, slot not created, `.modules.yaml.skipped` left empty. **Test-the-test verified** by inverting the `optional` guard in the cold-batch match arm. Runs with `enable_global_virtual_store = false` so the slot-path assertion targets the legacy layout.
- [x] `install::tests::frozen_install_propagates_non_optional_fetch_failure` — pins the polarity: same fixture, non-optional snapshot, install must error.
- [x] `just ready` (typos + fmt + check + nextest + clippy).
- [x] `taplo format --check`.
- [x] `just dylint` (perfectionist).
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace`.

## Out of scope

- Resolver-side `resolution_failure` emit site — needs a resolver, tracked separately.
- `--no-optional` / `--omit=optional` plumbing — umbrella slice 5.
- Surfacing fetch failures to the reporter on the frozen path — upstream itself is silent here; only the resolver-side emit fires `pnpm:skipped-optional-dependency`.

Closes #471.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Frozen installs now silently succeed when optional dependency tarballs are unreachable.

* **Bug Fixes**
  * Optional dependency fetch failures are recorded for the run but not persisted to .modules.yaml, avoiding repeated handling on subsequent installs.
  * Non-optional fetch failures continue to fail the install as expected.
  * Skipped-optional dependency events now include richer serialized details for resolution failures.

* **Tests**
  * Added integration and unit tests covering frozen-install behavior and skipped-optional reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pacquet/pull/474)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->