### PR TITLE
feat(store-dir): pacquet store prune for the global virtual store (#458)

### DIFF
--- a/crates/fs/src/symlink_dir.rs
+++ b/crates/fs/src/symlink_dir.rs
@@ -39,10 +39,12 @@ pub fn remove_symlink_dir(link: &Path) -> io::Result<()> {
 /// see [`rust-lang/rust#28528`](https://github.com/rust-lang/rust/issues/28528),
 /// which has been open since 2015. Since [`symlink_dir`] creates
 /// junctions on Windows, every entry pacquet writes would
-/// otherwise be unreadable. Fall back to
-/// [`junction::get_target`] on `InvalidInput` to handle the
-/// junction case while keeping `fs::read_link` as the fast path
-/// for true symlinks.
+/// otherwise be unreadable. Fall back to `junction::get_target`
+/// on `InvalidInput` to handle the junction case while keeping
+/// `fs::read_link` as the fast path for true symlinks. (Plain
+/// backticks rather than an intra-doc link because the `junction`
+/// crate is only in scope on Windows targets — a link would
+/// break the Linux doc build.)
 pub fn read_symlink_dir(link: &Path) -> io::Result<PathBuf> {
     #[cfg(unix)]
     return std::fs::read_link(link);

--- a/crates/fs/src/symlink_dir.rs
+++ b/crates/fs/src/symlink_dir.rs
@@ -1,4 +1,7 @@
-use std::{io, path::Path};
+use std::{
+    io,
+    path::{Path, PathBuf},
+};
 
 /// Create a symlink to a directory.
 ///
@@ -24,4 +27,35 @@ pub fn remove_symlink_dir(link: &Path) -> io::Result<()> {
     return std::fs::remove_file(link);
     #[cfg(windows)]
     return std::fs::remove_dir(link);
+}
+
+/// Read the target of a directory symlink (or junction on Windows).
+///
+/// On Unix this is just [`std::fs::read_link`]. On Windows the
+/// stdlib's `read_link` only handles
+/// [`IO_REPARSE_TAG_SYMLINK`](https://learn.microsoft.com/en-us/windows/win32/fileio/reparse-point-tags)
+/// reparse points and returns `ERROR_NOT_A_REPARSE_POINT`
+/// (`InvalidInput`) for `IO_REPARSE_TAG_MOUNT_POINT` junctions —
+/// see [`rust-lang/rust#28528`](https://github.com/rust-lang/rust/issues/28528),
+/// which has been open since 2015. Since [`symlink_dir`] creates
+/// junctions on Windows, every entry pacquet writes would
+/// otherwise be unreadable. Fall back to
+/// [`junction::get_target`] on `InvalidInput` to handle the
+/// junction case while keeping `fs::read_link` as the fast path
+/// for true symlinks.
+pub fn read_symlink_dir(link: &Path) -> io::Result<PathBuf> {
+    #[cfg(unix)]
+    return std::fs::read_link(link);
+    #[cfg(windows)]
+    {
+        match std::fs::read_link(link) {
+            Ok(target) => Ok(target),
+            // EINVAL on Windows from `read_link` means the reparse
+            // point isn't a symbolic link tag — almost certainly a
+            // junction, the only other kind of reparse point
+            // pacquet's writer produces.
+            Err(error) if error.kind() == io::ErrorKind::InvalidInput => junction::get_target(link),
+            Err(error) => Err(error),
+        }
+    }
 }

--- a/crates/fs/src/symlink_dir.rs
+++ b/crates/fs/src/symlink_dir.rs
@@ -9,3 +9,19 @@ pub fn symlink_dir(original: &Path, link: &Path) -> io::Result<()> {
     #[cfg(windows)]
     return junction::create(original, link); // junctions instead of symlinks because symlinks may require elevated privileges.
 }
+
+/// Remove a symlink (or junction on Windows) previously created with
+/// [`symlink_dir`].
+///
+/// On Unix a directory symlink is a file-shaped entry and removed
+/// with `fs::remove_file`. On Windows [`symlink_dir`] creates a
+/// junction (a directory-shaped reparse point) so it needs
+/// `fs::remove_dir` to be unlinked — `remove_file` returns
+/// `ERROR_ACCESS_DENIED`. Wrapping both in one helper keeps the
+/// platform split contained.
+pub fn remove_symlink_dir(link: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    return std::fs::remove_file(link);
+    #[cfg(windows)]
+    return std::fs::remove_dir(link);
+}

--- a/crates/store-dir/src/project_registry.rs
+++ b/crates/store-dir/src/project_registry.rs
@@ -185,7 +185,7 @@ pub enum GetRegisteredProjectsError {
     #[display("Cannot read project registry entry {link_path:?}: {error}")]
     #[diagnostic(
         code(pacquet_store_dir::get_registered_projects::entry_inaccessible),
-        help("To remove this project from the registry, delete the file at: {link_path:?}")
+        help("To remove this project from the registry, delete the entry at: {link_path:?}")
     )]
     EntryInaccessible {
         link_path: PathBuf,
@@ -202,7 +202,7 @@ pub enum GetRegisteredProjectsError {
     #[display("Cannot access registered project {project_dir:?} (via {link_path:?}): {error}")]
     #[diagnostic(
         code(pacquet_store_dir::get_registered_projects::project_inaccessible),
-        help("To remove this project from the registry, delete the symlink at: {link_path:?}")
+        help("To remove this project from the registry, delete the entry at: {link_path:?}")
     )]
     ProjectInaccessible {
         project_dir: PathBuf,

--- a/crates/store-dir/src/project_registry.rs
+++ b/crates/store-dir/src/project_registry.rs
@@ -8,8 +8,9 @@
 //! slots — without it, a `pacquet store prune` (tracked separately) could
 //! not distinguish abandoned packages from packages a project still uses.
 //!
-//! Stage 1 of pnpm/pacquet#432 only writes registry entries; the prune
-//! sweep and `getRegisteredProjects` stale-entry cleanup are deferred.
+//! [`register_project`] (the write half) lives here alongside
+//! [`get_registered_projects`] (the read half ported in pnpm/pacquet#458),
+//! mirroring upstream's `projectRegistry.ts` module layout.
 
 use crate::StoreDir;
 use derive_more::{Display, Error};
@@ -159,6 +160,186 @@ pub fn register_project(
     }
 }
 
+/// Error type for [`get_registered_projects`].
+#[derive(Debug, Display, Error, Diagnostic)]
+pub enum GetRegisteredProjectsError {
+    #[display("Failed to read the projects registry directory at {dir:?}: {error}")]
+    #[diagnostic(code(pacquet_store_dir::get_registered_projects::read_registry_dir))]
+    ReadRegistryDir {
+        dir: PathBuf,
+        #[error(source)]
+        error: io::Error,
+    },
+
+    /// Mirrors upstream's `PROJECT_REGISTRY_ENTRY_INACCESSIBLE`. Fires
+    /// only when `read_link` failed with something *other* than
+    /// `ENOENT` / `EINVAL` (those two are silently skipped to match
+    /// upstream).
+    #[display("Cannot read project registry entry {link_path:?}: {error}")]
+    #[diagnostic(
+        code(pacquet_store_dir::get_registered_projects::entry_inaccessible),
+        help("To remove this project from the registry, delete the file at: {link_path:?}")
+    )]
+    EntryInaccessible {
+        link_path: PathBuf,
+        #[error(source)]
+        error: io::Error,
+    },
+
+    /// Mirrors upstream's `PROJECT_INACCESSIBLE`. The registry entry
+    /// exists and points at a path that exists according to the
+    /// filesystem, but the stat returned a permission / I/O error.
+    /// Surfaces instead of silently dropping the entry — pruning on an
+    /// inaccessible project could remove slots the project still
+    /// references.
+    #[display("Cannot access registered project {project_dir:?} (via {link_path:?}): {error}")]
+    #[diagnostic(
+        code(pacquet_store_dir::get_registered_projects::project_inaccessible),
+        help("To remove this project from the registry, delete the symlink at: {link_path:?}")
+    )]
+    ProjectInaccessible {
+        project_dir: PathBuf,
+        link_path: PathBuf,
+        #[error(source)]
+        error: io::Error,
+    },
+
+    #[display("Failed to remove stale project registry entry at {link_path:?}: {error}")]
+    #[diagnostic(code(pacquet_store_dir::get_registered_projects::unlink_stale))]
+    UnlinkStale {
+        link_path: PathBuf,
+        #[error(source)]
+        error: io::Error,
+    },
+}
+
+/// List every project that's still registered against `store_dir` and
+/// drop registry entries whose target directory no longer exists.
+/// Mirrors upstream's
+/// [`getRegisteredProjects`](https://github.com/pnpm/pnpm/blob/94240bc046/store/controller/src/storeController/projectRegistry.ts#L37-L100).
+///
+/// Returns the surviving project root paths (absolute, after the
+/// `path.isAbsolute(target) ? target : path.resolve(path.dirname(linkPath), target)`
+/// normalisation upstream performs — pacquet's [`register_project`]
+/// always writes absolute targets via [`pacquet_fs::symlink_dir`], but
+/// the relative-target branch is preserved so a registry seeded by
+/// pnpm (which uses `symlink-dir`'s "make relative when possible"
+/// behaviour on some platforms) still resolves correctly).
+///
+/// Side effects: any registry entry whose target stat returns
+/// `NotFound` is unlinked here, so the projects directory self-heals
+/// on every prune. Other I/O errors surface as
+/// [`GetRegisteredProjectsError`] variants — a `PROJECT_INACCESSIBLE`
+/// would otherwise leave the prune unable to tell whether the
+/// project's slots are still referenced, so we refuse rather than
+/// silently dropping the entry.
+///
+/// `ENOENT` on the registry directory itself returns an empty `Vec`
+/// (matches upstream's `if (err.code === 'ENOENT') return []` branch)
+/// — a store that hasn't seen any GVS install yet has no projects
+/// dir, and that's not an error.
+pub fn get_registered_projects(
+    store_dir: &StoreDir,
+) -> Result<Vec<PathBuf>, GetRegisteredProjectsError> {
+    let registry_dir = store_dir.projects();
+    let entries = match fs::read_dir(&registry_dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => {
+            return Err(GetRegisteredProjectsError::ReadRegistryDir { dir: registry_dir, error });
+        }
+    };
+
+    let mut projects = Vec::new();
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) => {
+                return Err(GetRegisteredProjectsError::ReadRegistryDir {
+                    dir: registry_dir,
+                    error,
+                });
+            }
+        };
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        // Skip dotfiles — matches upstream's `if (entry.name.startsWith('.')) return`.
+        if name_str.starts_with('.') {
+            continue;
+        }
+        // Only symlinks (junctions on Windows count via `is_symlink`).
+        let file_type = match entry.file_type() {
+            Ok(ft) => ft,
+            Err(_) => continue,
+        };
+        if !file_type.is_symlink() {
+            continue;
+        }
+        let link_path = entry.path();
+
+        let target = match fs::read_link(&link_path) {
+            Ok(target) => target,
+            // Upstream silently skips both ENOENT and EINVAL (the
+            // "file is not a symlink" errno on Linux). EINVAL doesn't
+            // have a portable `ErrorKind` variant in stable Rust, so
+            // we match raw `errno` via `raw_os_error` when present
+            // and fall through to the generic "inaccessible" error
+            // otherwise.
+            Err(error) if is_enoent_or_einval(&error) => continue,
+            Err(error) => {
+                return Err(GetRegisteredProjectsError::EntryInaccessible { link_path, error });
+            }
+        };
+
+        let absolute_target = if target.is_absolute() {
+            target.clone()
+        } else {
+            link_path.parent().map(|p| p.join(&target)).unwrap_or_else(|| target.clone())
+        };
+
+        match fs::metadata(&absolute_target) {
+            Ok(_) => projects.push(absolute_target),
+            Err(error) if error.kind() == ErrorKind::NotFound => {
+                fs::remove_file(&link_path).map_err(|error| {
+                    GetRegisteredProjectsError::UnlinkStale { link_path: link_path.clone(), error }
+                })?;
+            }
+            Err(error) => {
+                return Err(GetRegisteredProjectsError::ProjectInaccessible {
+                    project_dir: absolute_target,
+                    link_path,
+                    error,
+                });
+            }
+        }
+    }
+
+    Ok(projects)
+}
+
+/// Match upstream's "silently skip on ENOENT or EINVAL" branch in
+/// `getRegisteredProjects`. `EINVAL` from `readlink` means "not a
+/// symbolic link" on Linux — the entry is benign garbage (e.g. a
+/// stray regular file) and gets ignored. `ErrorKind::InvalidInput`
+/// is the stable mapping for EINVAL on Unix; the raw errno fallback
+/// covers platforms where the std mapping hasn't been tightened.
+fn is_enoent_or_einval(error: &io::Error) -> bool {
+    if matches!(error.kind(), ErrorKind::NotFound | ErrorKind::InvalidInput) {
+        return true;
+    }
+    #[cfg(unix)]
+    {
+        // EINVAL = 22 on every Unix pacquet supports (Linux, macOS, *BSD).
+        // Hardcoded because there's no `libc::EINVAL` access without a
+        // libc dep in this crate; the value is part of the POSIX
+        // standard and won't change.
+        if error.raw_os_error() == Some(22) {
+            return true;
+        }
+    }
+    false
+}
+
 /// Port of npm `is-subdir`: returns `true` when `inner` is `outer`
 /// itself or any descendant of it. Renamed from upstream's
 /// `isSubdir(parent, child)` because the bare name reads ambiguously
@@ -193,7 +374,7 @@ fn canonicalize_or_join(link_path: &Path, target: &Path) -> PathBuf {
 
 #[cfg(test)]
 mod tests {
-    use super::{create_short_hash, register_project};
+    use super::{create_short_hash, get_registered_projects, register_project};
     use crate::StoreDir;
     use std::fs;
     use tempfile::tempdir;
@@ -271,5 +452,101 @@ mod tests {
             !store_dir.projects().exists(),
             "subdir guard must skip the registry-dir creation entirely",
         );
+    }
+
+    /// `get_registered_projects` on a store with no `projects/` dir
+    /// returns an empty vec — the registry doesn't exist until the
+    /// first `register_project` write. Mirrors upstream's
+    /// `if (err.code === 'ENOENT') return []` branch.
+    #[test]
+    fn get_returns_empty_when_registry_dir_absent() {
+        let store = tempdir().unwrap();
+        let store_dir = StoreDir::new(store.path().to_path_buf());
+        let projects = get_registered_projects(&store_dir).expect("missing registry is fine");
+        assert!(projects.is_empty(), "no entries, no projects");
+    }
+
+    /// Surviving project: register, then list. The returned path
+    /// resolves back to the original project dir.
+    #[test]
+    fn get_lists_a_registered_project() {
+        let project = tempdir().unwrap();
+        let store = tempdir().unwrap();
+        let store_dir = StoreDir::new(store.path().to_path_buf());
+        register_project(&store_dir, project.path()).expect("register");
+        let projects = get_registered_projects(&store_dir).expect("list");
+        assert_eq!(projects.len(), 1, "exactly one surviving project");
+        assert_eq!(
+            dunce::canonicalize(&projects[0]).unwrap(),
+            dunce::canonicalize(project.path()).unwrap(),
+            "listed path canonicalises back to the registered project",
+        );
+    }
+
+    /// Stale entry self-heal: register, then remove the project
+    /// directory on disk, then list — the entry must disappear from
+    /// both the result and from `<store>/projects/`. Mirrors upstream's
+    /// `if (err.code === 'ENOENT') { await fs.unlink(linkPath); ... }`.
+    #[test]
+    fn get_unlinks_stale_entry_and_skips_it() {
+        let project = tempdir().unwrap();
+        let project_path = project.path().to_path_buf();
+        let store = tempdir().unwrap();
+        let store_dir = StoreDir::new(store.path().to_path_buf());
+        register_project(&store_dir, project.path()).expect("register");
+        // Take ownership of the tempdir to force its drop / removal
+        // before we run the cleanup pass.
+        drop(project);
+        assert!(!project_path.exists(), "test setup: project dir must be gone");
+
+        let projects = get_registered_projects(&store_dir).expect("list");
+        assert!(projects.is_empty(), "stale entry must not show up in the result");
+        let remaining: Vec<_> =
+            fs::read_dir(store_dir.projects()).unwrap().collect::<Result<_, _>>().unwrap();
+        assert!(remaining.is_empty(), "stale entry must be unlinked from disk");
+    }
+
+    /// Mixed: one live project + one stale entry. Live survives,
+    /// stale is unlinked. Order-independent.
+    #[test]
+    fn get_keeps_live_and_drops_stale_when_mixed() {
+        let live = tempdir().unwrap();
+        let dead = tempdir().unwrap();
+        let dead_path = dead.path().to_path_buf();
+        let store = tempdir().unwrap();
+        let store_dir = StoreDir::new(store.path().to_path_buf());
+
+        register_project(&store_dir, live.path()).expect("register live");
+        register_project(&store_dir, dead.path()).expect("register dead");
+        drop(dead);
+        assert!(!dead_path.exists(), "test setup: dead project dir must be gone");
+
+        let projects = get_registered_projects(&store_dir).expect("list");
+        assert_eq!(projects.len(), 1, "only the live project survives");
+        assert_eq!(
+            dunce::canonicalize(&projects[0]).unwrap(),
+            dunce::canonicalize(live.path()).unwrap(),
+        );
+        let remaining: Vec<_> =
+            fs::read_dir(store_dir.projects()).unwrap().collect::<Result<_, _>>().unwrap();
+        assert_eq!(remaining.len(), 1, "exactly one registry entry left");
+    }
+
+    /// Dotfile entries (e.g. `.DS_Store`) are skipped — they're never
+    /// real registry entries. Matches upstream's
+    /// `if (entry.name.startsWith('.')) return`.
+    #[test]
+    fn get_skips_dotfile_entries() {
+        let project = tempdir().unwrap();
+        let store = tempdir().unwrap();
+        let store_dir = StoreDir::new(store.path().to_path_buf());
+        register_project(&store_dir, project.path()).expect("register");
+        // Drop a `.DS_Store` style sentinel into the registry dir.
+        fs::write(store_dir.projects().join(".DS_Store"), b"sentinel").unwrap();
+
+        let projects = get_registered_projects(&store_dir).expect("list");
+        assert_eq!(projects.len(), 1, "dotfile must not register as a project");
+        // Sentinel must still be there (we don't touch it).
+        assert!(store_dir.projects().join(".DS_Store").exists());
     }
 }

--- a/crates/store-dir/src/project_registry.rs
+++ b/crates/store-dir/src/project_registry.rs
@@ -15,7 +15,7 @@
 use crate::StoreDir;
 use derive_more::{Display, Error};
 use miette::Diagnostic;
-use pacquet_fs::{remove_symlink_dir, symlink_dir};
+use pacquet_fs::{read_symlink_dir, remove_symlink_dir, symlink_dir};
 use sha2::{Digest, Sha256};
 use std::{
     fs,
@@ -123,8 +123,12 @@ pub fn register_project(
         Err(error) if error.kind() == ErrorKind::AlreadyExists => {
             // Either the same project re-registering (no-op) or an
             // unrelated path that hashed to the same slug (heal).
-            // Resolve and compare the existing link's target.
-            let existing_target = fs::read_link(&link_path).map_err(|error| {
+            // Resolve and compare the existing link's target. The
+            // cross-platform helper handles Windows junctions —
+            // `fs::read_link` alone would fail with `EINVAL` for
+            // every entry pacquet writes there (see
+            // [`rust-lang/rust#28528`](https://github.com/rust-lang/rust/issues/28528)).
+            let existing_target = read_symlink_dir(&link_path).map_err(|error| {
                 RegisterProjectError::InspectExisting {
                     project_dir: project_dir.to_path_buf(),
                     link_path: link_path.clone(),
@@ -281,23 +285,29 @@ pub fn get_registered_projects(
         // there's no upstream analogue to mirror — we err on the
         // side of strictness.
         let file_type = entry.file_type().map_err(|error| {
-            GetRegisteredProjectsError::EntryInaccessible {
-                link_path: link_path.clone(),
-                error,
-            }
+            GetRegisteredProjectsError::EntryInaccessible { link_path: link_path.clone(), error }
         })?;
         if !file_type.is_symlink() {
             continue;
         }
 
-        let target = match fs::read_link(&link_path) {
+        // Use the cross-platform symlink reader. On Windows
+        // pacquet's writer creates junctions; `fs::read_link` alone
+        // would EINVAL on every live entry (see
+        // [`rust-lang/rust#28528`](https://github.com/rust-lang/rust/issues/28528)),
+        // and the EINVAL silent-skip below would then drop every
+        // registered project on that platform.
+        let target = match read_symlink_dir(&link_path) {
             Ok(target) => target,
             // Upstream silently skips both ENOENT and EINVAL (the
-            // "file is not a symlink" errno on Linux). EINVAL doesn't
-            // have a portable `ErrorKind` variant in stable Rust, so
-            // we match raw `errno` via `raw_os_error` when present
-            // and fall through to the generic "inaccessible" error
-            // otherwise.
+            // "file is not a symlink" errno on Linux). Now that the
+            // helper handles junctions, an EINVAL here means the
+            // entry is neither a symlink nor a junction (some other
+            // reparse-point shape, or a race) — still benign to
+            // skip. EINVAL doesn't have a portable `ErrorKind`
+            // variant in stable Rust, so we match raw `errno` via
+            // `raw_os_error` when present and fall through to the
+            // generic "inaccessible" error otherwise.
             Err(error) if is_enoent_or_einval(&error) => continue,
             Err(error) => {
                 return Err(GetRegisteredProjectsError::EntryInaccessible { link_path, error });

--- a/crates/store-dir/src/project_registry.rs
+++ b/crates/store-dir/src/project_registry.rs
@@ -15,7 +15,7 @@
 use crate::StoreDir;
 use derive_more::{Display, Error};
 use miette::Diagnostic;
-use pacquet_fs::symlink_dir;
+use pacquet_fs::{remove_symlink_dir, symlink_dir};
 use sha2::{Digest, Sha256};
 use std::{
     fs,
@@ -137,8 +137,11 @@ pub fn register_project(
             if canonical_existing == canonical_project {
                 return Ok(());
             }
-            // Mismatch — remove the stale entry and recreate.
-            fs::remove_file(&link_path).map_err(|error| RegisterProjectError::RemoveStale {
+            // Mismatch — remove the stale entry and recreate. The
+            // entry is a directory symlink on Unix (file-shaped) and
+            // a junction on Windows (directory-shaped); the helper
+            // covers both.
+            remove_symlink_dir(&link_path).map_err(|error| RegisterProjectError::RemoveStale {
                 project_dir: project_dir.to_path_buf(),
                 link_path: link_path.clone(),
                 old_target: existing_target.clone(),
@@ -267,15 +270,25 @@ pub fn get_registered_projects(
         if name_str.starts_with('.') {
             continue;
         }
+        let link_path = entry.path();
         // Only symlinks (junctions on Windows count via `is_symlink`).
-        let file_type = match entry.file_type() {
-            Ok(ft) => ft,
-            Err(_) => continue,
-        };
+        // Surfacing `file_type()` errors instead of swallowing them:
+        // a permission failure here would otherwise silently drop a
+        // live registry entry, and a downstream prune could then
+        // remove slots that project still references. Upstream's
+        // `entry.isSymbolicLink()` cannot fail (Node returns the
+        // bit it already loaded with `withFileTypes: true`), so
+        // there's no upstream analogue to mirror — we err on the
+        // side of strictness.
+        let file_type = entry.file_type().map_err(|error| {
+            GetRegisteredProjectsError::EntryInaccessible {
+                link_path: link_path.clone(),
+                error,
+            }
+        })?;
         if !file_type.is_symlink() {
             continue;
         }
-        let link_path = entry.path();
 
         let target = match fs::read_link(&link_path) {
             Ok(target) => target,
@@ -300,7 +313,10 @@ pub fn get_registered_projects(
         match fs::metadata(&absolute_target) {
             Ok(_) => projects.push(absolute_target),
             Err(error) if error.kind() == ErrorKind::NotFound => {
-                fs::remove_file(&link_path).map_err(|error| {
+                // Use the cross-platform helper: the registry entry
+                // is a directory symlink on Unix and a junction on
+                // Windows, which need different syscalls to unlink.
+                remove_symlink_dir(&link_path).map_err(|error| {
                     GetRegisteredProjectsError::UnlinkStale { link_path: link_path.clone(), error }
                 })?;
             }

--- a/crates/store-dir/src/prune.rs
+++ b/crates/store-dir/src/prune.rs
@@ -25,6 +25,7 @@
 use crate::{GetRegisteredProjectsError, StoreDir, get_registered_projects};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
+use pacquet_fs::read_symlink_dir;
 use std::{
     collections::HashSet,
     fs,
@@ -102,11 +103,22 @@ impl StoreDir {
             projects.len(),
         );
 
+        // Canonicalize the links root once and pass it down. The
+        // mark walk compares every target's canonical form against
+        // this root, and canonicalising inside the per-entry loop
+        // would burn one extra syscall per visited symlink — wasteful
+        // on large trees where the answer is invariant.
+        let canonical_links = dunce::canonicalize(&links_dir).unwrap_or_else(|_| links_dir.clone());
         let mut reachable: HashSet<PathBuf> = HashSet::new();
         let mut visited: HashSet<PathBuf> = HashSet::new();
         for project_dir in &projects {
             for modules_dir in find_all_node_modules_dirs(project_dir) {
-                walk_symlinks_to_store(&modules_dir, &links_dir, &mut reachable, &mut visited);
+                walk_symlinks_to_store(
+                    &modules_dir,
+                    &canonical_links,
+                    &mut reachable,
+                    &mut visited,
+                );
             }
         }
 
@@ -173,11 +185,16 @@ fn find_all_node_modules_dirs(project_dir: &Path) -> Vec<PathBuf> {
 }
 
 /// Recursively follow every symlink under `dir`. When a symlink
-/// resolves to a slot under `links_dir`, record the slot's
+/// resolves to a slot under `canonical_links`, record the slot's
 /// `<scope>/<name>/<version>/<hash>` segment in `reachable` and
 /// recurse into the slot's `node_modules/` for transitive deps.
 /// Mirrors upstream's
 /// [`walkSymlinksToStore`](https://github.com/pnpm/pnpm/blob/94240bc046/store/controller/src/storeController/pruneGlobalVirtualStore.ts#L103-L163).
+///
+/// `canonical_links` must already be the canonicalised links root
+/// — [`StoreDir::prune`] does this once and threads it through, so
+/// the per-entry loop doesn't pay a `canonicalize` syscall for an
+/// invariant value.
 ///
 /// `visited` is the cycle guard, keyed by the canonical (real) path
 /// of `dir`. Upstream uses a sha256-base64url hash of the realpath;
@@ -186,7 +203,7 @@ fn find_all_node_modules_dirs(project_dir: &Path) -> Vec<PathBuf> {
 /// don't.
 fn walk_symlinks_to_store(
     dir: &Path,
-    links_dir: &Path,
+    canonical_links: &Path,
     reachable: &mut HashSet<PathBuf>,
     visited: &mut HashSet<PathBuf>,
 ) {
@@ -211,7 +228,13 @@ fn walk_symlinks_to_store(
         };
 
         if file_type.is_symlink() {
-            let Ok(target) = fs::read_link(&entry_path) else {
+            // `read_symlink_dir` handles Windows junctions (which
+            // `pacquet_fs::symlink_dir` creates for every
+            // `node_modules/<pkg>` entry); plain `fs::read_link`
+            // would EINVAL on them and the mark walk would miss
+            // every direct dep on Windows. See
+            // [`rust-lang/rust#28528`](https://github.com/rust-lang/rust/issues/28528).
+            let Ok(target) = read_symlink_dir(&entry_path) else {
                 continue;
             };
             let absolute_target = if target.is_absolute() {
@@ -219,20 +242,20 @@ fn walk_symlinks_to_store(
             } else {
                 entry_path.parent().map(|p| p.join(&target)).unwrap_or(target)
             };
-            // Canonicalise both sides so a symlink-bearing path
-            // prefix doesn't fool the `starts_with` check.
+            // Canonicalise the target so a symlink-bearing path
+            // prefix doesn't fool the `starts_with` check against
+            // the (already-canonical) links root.
             let canonical_target =
                 dunce::canonicalize(&absolute_target).unwrap_or_else(|_| absolute_target.clone());
-            let canonical_links =
-                dunce::canonicalize(links_dir).unwrap_or_else(|_| links_dir.to_path_buf());
-            if !canonical_target.starts_with(&canonical_links) {
+            if !canonical_target.starts_with(canonical_links) {
                 continue;
             }
-            // Slot path is the segment after `links_dir` up to (but
-            // excluding) the first `node_modules` component. Layout:
+            // Slot path is the segment after `canonical_links` up to
+            // (but excluding) the first `node_modules` component.
+            // Layout:
             //   <links>/<scope>/<name>/<version>/<hash>/node_modules/<pkg>
             // We want `<scope>/<name>/<version>/<hash>`.
-            let Ok(rel) = canonical_target.strip_prefix(&canonical_links) else {
+            let Ok(rel) = canonical_target.strip_prefix(canonical_links) else {
                 continue;
             };
             let parts: Vec<_> = rel.components().collect();
@@ -244,7 +267,7 @@ fn walk_symlinks_to_store(
                 // Recurse into the slot's own node_modules for
                 // transitive deps.
                 let inner_modules = canonical_links.join(&slot).join("node_modules");
-                walk_symlinks_to_store(&inner_modules, links_dir, reachable, visited);
+                walk_symlinks_to_store(&inner_modules, canonical_links, reachable, visited);
             }
         } else if file_type.is_dir() {
             // Skip `.pnpm` — that's the project-local virtual store.
@@ -256,7 +279,7 @@ fn walk_symlinks_to_store(
             if name.to_string_lossy() == ".pnpm" {
                 continue;
             }
-            walk_symlinks_to_store(&entry_path, links_dir, reachable, visited);
+            walk_symlinks_to_store(&entry_path, canonical_links, reachable, visited);
         }
     }
 }

--- a/crates/store-dir/src/prune.rs
+++ b/crates/store-dir/src/prune.rs
@@ -1,15 +1,503 @@
-use crate::StoreDir;
+//! Pacquet port of upstream pnpm's
+//! [`pruneGlobalVirtualStore`](https://github.com/pnpm/pnpm/blob/94240bc046/store/controller/src/storeController/pruneGlobalVirtualStore.ts).
+//!
+//! Mark-and-sweep over `<store_dir>/links/<scope>/<name>/<version>/<hash>`:
+//!
+//! 1. **Mark** — walk every registered project (see
+//!    [`crate::get_registered_projects`]). For each project, find every
+//!    `node_modules/` directory (root + workspace packages), follow every
+//!    symlink it contains, and if the symlink target lands under
+//!    `<store_dir>/links/...` record the slot path
+//!    (`<scope>/<name>/<version>/<hash>`) as reachable. Then recurse
+//!    into the slot's own `node_modules/` for transitive deps.
+//! 2. **Sweep** — walk the four-level
+//!    `<scope>/<name>/<version>/<hash>` tree and remove every `<hash>`
+//!    that isn't in the reachable set. Empty `<version>/` and `<name>/`
+//!    parents are removed in a second pass.
+//!
+//! Pacquet doesn't yet have rayon plumbing in the store-dir crate, so
+//! the port walks sequentially. Prune is a one-shot CLI command (not
+//! on the hot install path); parallelism can be added later if
+//! profiling shows it's worth the complexity. The shape mirrors
+//! upstream's `Promise.all`-driven layout so the parallelism graft
+//! is mechanical when it lands.
+
+use crate::{GetRegisteredProjectsError, StoreDir, get_registered_projects};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
+use std::{
+    collections::HashSet,
+    fs,
+    io::{self, ErrorKind},
+    path::{Path, PathBuf},
+};
 
 /// Error type of [`StoreDir::prune`].
 #[derive(Debug, Display, Error, Diagnostic)]
-pub enum PruneError {}
+pub enum PruneError {
+    /// Surface from the read-side of the project registry — stale
+    /// entries that can't be unlinked, inaccessible registry dirs,
+    /// or projects whose `stat` returned a permission error.
+    #[diagnostic(transparent)]
+    ListProjects(#[error(source)] GetRegisteredProjectsError),
+
+    #[display("Failed to remove unreferenced slot at {path:?}: {error}")]
+    #[diagnostic(code(pacquet_store_dir::prune::remove_slot))]
+    RemoveSlot {
+        path: PathBuf,
+        #[error(source)]
+        error: io::Error,
+    },
+}
 
 impl StoreDir {
-    /// Remove all files in the store that don't have reference elsewhere.
+    /// Remove unreferenced packages from the global virtual store at
+    /// `<store_dir>/links`. Mirrors upstream's
+    /// [`pruneGlobalVirtualStore`](https://github.com/pnpm/pnpm/blob/94240bc046/store/controller/src/storeController/pruneGlobalVirtualStore.ts#L21-L58).
+    ///
+    /// Behaviour:
+    /// - No `links/` directory yet: silent no-op (matches upstream's
+    ///   `if (!await pathExists(linksDir)) return`).
+    /// - No registered projects: prints `pnpm`'s informational message
+    ///   and returns. Pacquet doesn't yet thread the install-time
+    ///   reporter into store-dir, so the message goes to stderr via
+    ///   `eprintln!` until [#344] lands the proper reporter wiring.
+    /// - Otherwise: mark-and-sweep as documented in the module-level
+    ///   comment. Returns the count of removed slot directories (zero
+    ///   when nothing was unreachable).
+    ///
+    /// Returns `Ok(())` on success; surfaces I/O errors from the mark
+    /// or sweep walks as [`PruneError`]. Stale registry entries are
+    /// healed transparently by [`crate::get_registered_projects`].
+    ///
+    /// [#344]: https://github.com/pnpm/pacquet/issues/344
     pub fn prune(&self) -> Result<(), PruneError> {
-        // Ref: https://pnpm.io/cli/store#prune
-        todo!("remove orphaned files")
+        let links_dir = self.links();
+        if !path_exists(&links_dir) {
+            return Ok(());
+        }
+
+        let projects = get_registered_projects(self).map_err(PruneError::ListProjects)?;
+        if projects.is_empty() {
+            eprintln!("No registered projects for global virtual store");
+            return Ok(());
+        }
+        eprintln!(
+            "Checking {} registered project(s) for global virtual store usage",
+            projects.len(),
+        );
+
+        let mut reachable: HashSet<PathBuf> = HashSet::new();
+        let mut visited: HashSet<PathBuf> = HashSet::new();
+        for project_dir in &projects {
+            for modules_dir in find_all_node_modules_dirs(project_dir) {
+                walk_symlinks_to_store(&modules_dir, &links_dir, &mut reachable, &mut visited);
+            }
+        }
+
+        let removed = remove_unreachable_packages(&links_dir, &reachable)?;
+        if removed > 0 {
+            eprintln!(
+                "Removed {} package{} from global virtual store",
+                removed,
+                if removed == 1 { "" } else { "s" },
+            );
+        } else {
+            eprintln!("No unused packages found in global virtual store");
+        }
+        Ok(())
+    }
+}
+
+/// Find every `node_modules/` directory under `project_dir`,
+/// including those inside workspace packages. Mirrors upstream's
+/// [`findAllNodeModulesDirs`](https://github.com/pnpm/pnpm/blob/94240bc046/store/controller/src/storeController/pruneGlobalVirtualStore.ts#L64-L97):
+/// descends into every non-hidden subdir until it sees `node_modules`,
+/// at which point it records the path and stops descending — the
+/// hoisted deps inside `node_modules/.pnpm` and friends are picked up
+/// by `walk_symlinks_to_store`'s transitive recursion instead.
+fn find_all_node_modules_dirs(project_dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    scan(project_dir, &mut out);
+    return out;
+
+    fn scan(dir: &Path, out: &mut Vec<PathBuf>) {
+        let Ok(entries) = fs::read_dir(dir) else {
+            return;
+        };
+        let mut subdirs = Vec::new();
+        for entry in entries.flatten() {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if !file_type.is_dir() {
+                continue;
+            }
+            let entry_path = entry.path();
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+            if name_str == "node_modules" {
+                out.push(entry_path);
+                // Don't descend into node_modules
+            } else if !name_str.starts_with('.') {
+                subdirs.push(entry_path);
+            }
+        }
+        for sub in subdirs {
+            scan(&sub, out);
+        }
+    }
+}
+
+/// Recursively follow every symlink under `dir`. When a symlink
+/// resolves to a slot under `links_dir`, record the slot's
+/// `<scope>/<name>/<version>/<hash>` segment in `reachable` and
+/// recurse into the slot's `node_modules/` for transitive deps.
+/// Mirrors upstream's
+/// [`walkSymlinksToStore`](https://github.com/pnpm/pnpm/blob/94240bc046/store/controller/src/storeController/pruneGlobalVirtualStore.ts#L103-L163).
+///
+/// `visited` is the cycle guard, keyed by the canonical (real) path
+/// of `dir`. Upstream uses a sha256-base64url hash of the realpath;
+/// in pacquet we can store the canonical `PathBuf` directly — the
+/// extra hashing only helps when serialising the set, which we
+/// don't.
+fn walk_symlinks_to_store(
+    dir: &Path,
+    links_dir: &Path,
+    reachable: &mut HashSet<PathBuf>,
+    visited: &mut HashSet<PathBuf>,
+) {
+    let canonical_dir = dunce::canonicalize(dir).unwrap_or_else(|_| dir.to_path_buf());
+    if !visited.insert(canonical_dir) {
+        return;
+    }
+
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let entry_path = entry.path();
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+
+        if file_type.is_symlink() {
+            let Ok(target) = fs::read_link(&entry_path) else {
+                continue;
+            };
+            let absolute_target = if target.is_absolute() {
+                target
+            } else {
+                entry_path.parent().map(|p| p.join(&target)).unwrap_or(target)
+            };
+            // Canonicalise both sides so a symlink-bearing path
+            // prefix doesn't fool the `starts_with` check.
+            let canonical_target =
+                dunce::canonicalize(&absolute_target).unwrap_or_else(|_| absolute_target.clone());
+            let canonical_links =
+                dunce::canonicalize(links_dir).unwrap_or_else(|_| links_dir.to_path_buf());
+            if !canonical_target.starts_with(&canonical_links) {
+                continue;
+            }
+            // Slot path is the segment after `links_dir` up to (but
+            // excluding) the first `node_modules` component. Layout:
+            //   <links>/<scope>/<name>/<version>/<hash>/node_modules/<pkg>
+            // We want `<scope>/<name>/<version>/<hash>`.
+            let Ok(rel) = canonical_target.strip_prefix(&canonical_links) else {
+                continue;
+            };
+            let parts: Vec<_> = rel.components().collect();
+            let nm_idx =
+                parts.iter().position(|c| c.as_os_str() == std::ffi::OsStr::new("node_modules"));
+            if let Some(idx) = nm_idx {
+                let slot: PathBuf = parts[..idx].iter().collect();
+                reachable.insert(slot.clone());
+                // Recurse into the slot's own node_modules for
+                // transitive deps.
+                let inner_modules = canonical_links.join(&slot).join("node_modules");
+                walk_symlinks_to_store(&inner_modules, links_dir, reachable, visited);
+            }
+        } else if file_type.is_dir() {
+            // Skip `.pnpm` — that's the project-local virtual store.
+            // The slots we want are reached *through* `.pnpm`'s
+            // symlinks, not by descending into it directly. (When
+            // GVS is on, `.pnpm` may also be absent, in which case
+            // the skip is a no-op.)
+            let name = entry.file_name();
+            if name.to_string_lossy() == ".pnpm" {
+                continue;
+            }
+            walk_symlinks_to_store(&entry_path, links_dir, reachable, visited);
+        }
+    }
+}
+
+/// Sweep phase: walk `<links_dir>/<scope>/<name>/<version>/<hash>`
+/// and remove every `<hash>` directory whose
+/// `<scope>/<name>/<version>/<hash>` path isn't in `reachable`.
+/// Cleans up emptied `<version>/`, `<name>/`, and `<scope>/`
+/// parents. Mirrors upstream's
+/// [`removeUnreachablePackages`](https://github.com/pnpm/pnpm/blob/94240bc046/store/controller/src/storeController/pruneGlobalVirtualStore.ts#L187-L226)
+/// + [`removeUnreachableVersions`](https://github.com/pnpm/pnpm/blob/94240bc046/store/controller/src/storeController/pruneGlobalVirtualStore.ts#L232-L271).
+fn remove_unreachable_packages(
+    links_dir: &Path,
+    reachable: &HashSet<PathBuf>,
+) -> Result<usize, PruneError> {
+    let mut count = 0usize;
+    let scopes = list_subdirs(links_dir);
+    for scope in &scopes {
+        let scope_path = links_dir.join(scope);
+        let pkg_names = list_subdirs(&scope_path);
+        let mut removed_pkgs = 0;
+        for pkg_name in &pkg_names {
+            let pkg_dir = scope_path.join(pkg_name);
+            let pkg_rel = Path::new(scope).join(pkg_name);
+            let (removed_here, all_versions_removed) =
+                remove_unreachable_versions(&pkg_dir, &pkg_rel, reachable)?;
+            count += removed_here;
+            if all_versions_removed {
+                // Every version under this pkg was removed — drop the
+                // empty `<name>/` parent.
+                remove_dir_if_present(&pkg_dir)?;
+                removed_pkgs += 1;
+            }
+        }
+        if removed_pkgs == pkg_names.len() && !pkg_names.is_empty() {
+            remove_dir_if_present(&scope_path)?;
+        }
+    }
+    Ok(count)
+}
+
+fn remove_unreachable_versions(
+    pkg_dir: &Path,
+    pkg_rel: &Path,
+    reachable: &HashSet<PathBuf>,
+) -> Result<(usize, bool), PruneError> {
+    let versions = list_subdirs(pkg_dir);
+    let mut count = 0usize;
+    let mut removed_versions = 0;
+    for version in &versions {
+        let version_dir = pkg_dir.join(version);
+        let hashes = list_subdirs(&version_dir);
+        let mut removed_hashes = 0;
+        for hash in &hashes {
+            let slot_rel = pkg_rel.join(version).join(hash);
+            if !reachable.contains(&slot_rel) {
+                let slot_dir = version_dir.join(hash);
+                remove_dir_if_present(&slot_dir)?;
+                removed_hashes += 1;
+                count += 1;
+            }
+        }
+        if removed_hashes == hashes.len() && !hashes.is_empty() {
+            remove_dir_if_present(&version_dir)?;
+            removed_versions += 1;
+        }
+    }
+    Ok((count, removed_versions == versions.len() && !versions.is_empty()))
+}
+
+fn list_subdirs(dir: &Path) -> Vec<std::ffi::OsString> {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for entry in entries.flatten() {
+        if entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+            out.push(entry.file_name());
+        }
+    }
+    out
+}
+
+fn remove_dir_if_present(path: &Path) -> Result<(), PruneError> {
+    match fs::remove_dir_all(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(PruneError::RemoveSlot { path: path.to_path_buf(), error }),
+    }
+}
+
+fn path_exists(path: &Path) -> bool {
+    fs::metadata(path).is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{StoreDir, register_project};
+    use pacquet_fs::symlink_dir;
+    use std::{fs, path::PathBuf};
+    use tempfile::tempdir;
+
+    /// Helper: lay out a slot under
+    /// `<store>/links/<scope>/<name>/<version>/<hash>/node_modules/<name>/`
+    /// with a `package.json` marker so `find_all_node_modules_dirs`
+    /// and `walk_symlinks_to_store` have a real tree to traverse.
+    fn make_slot(
+        links_dir: &std::path::Path,
+        scope: &str,
+        name: &str,
+        version: &str,
+        hash: &str,
+    ) -> PathBuf {
+        let slot = links_dir.join(scope).join(name).join(version).join(hash);
+        let pkg_dir = slot.join("node_modules").join(name);
+        fs::create_dir_all(&pkg_dir).unwrap();
+        fs::write(pkg_dir.join("package.json"), b"{}").unwrap();
+        slot
+    }
+
+    /// `prune()` is a no-op when the store has no `links/` directory.
+    /// Mirrors upstream's
+    /// `if (!await pathExists(linksDir)) return` short-circuit.
+    #[test]
+    fn prune_is_noop_without_links_dir() {
+        let store = tempdir().unwrap();
+        let store_dir = StoreDir::new(store.path().to_path_buf());
+        store_dir.prune().expect("missing links/ must be a silent no-op");
+    }
+
+    /// `prune()` does nothing destructive when no projects are
+    /// registered — pacquet doesn't know which slots are still
+    /// referenced, so the safe stance is "keep everything". Mirrors
+    /// upstream's `if (projects.length === 0) { return }` branch.
+    #[test]
+    fn prune_keeps_everything_when_no_projects() {
+        let store = tempdir().unwrap();
+        let store_dir = StoreDir::new(store.path().to_path_buf());
+        let slot = make_slot(&store_dir.links(), "@", "left-pad", "1.0.0", "deadbeef");
+        store_dir.prune().expect("prune");
+        assert!(slot.exists(), "no-project prune must leave slots intact");
+    }
+
+    /// End-to-end: register two projects, delete one's directory,
+    /// run prune. The dead project's symlink should be unlinked from
+    /// `<store>/projects/` and any slot ONLY the dead project
+    /// referenced gets removed; slots the live project still
+    /// references survive.
+    #[test]
+    fn prune_removes_dead_project_slots_and_keeps_live_slots() {
+        let store = tempdir().unwrap();
+        let store_dir = StoreDir::new(store.path().to_path_buf());
+        let links = store_dir.links();
+        let live_slot = make_slot(&links, "@", "live-pkg", "1.0.0", "live01");
+        let dead_slot = make_slot(&links, "@", "dead-pkg", "1.0.0", "dead01");
+
+        let live_project = tempdir().unwrap();
+        fs::create_dir_all(live_project.path().join("node_modules")).unwrap();
+        symlink_dir(
+            &live_slot.join("node_modules").join("live-pkg"),
+            &live_project.path().join("node_modules").join("live-pkg"),
+        )
+        .unwrap();
+
+        let dead_project = tempdir().unwrap();
+        fs::create_dir_all(dead_project.path().join("node_modules")).unwrap();
+        symlink_dir(
+            &dead_slot.join("node_modules").join("dead-pkg"),
+            &dead_project.path().join("node_modules").join("dead-pkg"),
+        )
+        .unwrap();
+
+        register_project(&store_dir, live_project.path()).expect("register live");
+        register_project(&store_dir, dead_project.path()).expect("register dead");
+        let dead_path = dead_project.path().to_path_buf();
+        drop(dead_project);
+        assert!(!dead_path.exists());
+
+        store_dir.prune().expect("prune");
+
+        assert!(live_slot.exists(), "slot referenced by live project must survive");
+        assert!(!dead_slot.exists(), "slot only referenced by dead project must be swept");
+        // Empty `<version>/` and `<name>/` parents must be cleaned up.
+        assert!(!links.join("@").join("dead-pkg").exists(), "empty name dir gone");
+    }
+
+    /// Shared-slot case: two projects reference the same slot.
+    /// Removing one project must not delete the shared slot.
+    #[test]
+    fn prune_keeps_slot_referenced_by_any_surviving_project() {
+        let store = tempdir().unwrap();
+        let store_dir = StoreDir::new(store.path().to_path_buf());
+        let links = store_dir.links();
+        let shared_slot = make_slot(&links, "@", "shared", "2.0.0", "shared1");
+
+        let a_project = tempdir().unwrap();
+        fs::create_dir_all(a_project.path().join("node_modules")).unwrap();
+        symlink_dir(
+            &shared_slot.join("node_modules").join("shared"),
+            &a_project.path().join("node_modules").join("shared"),
+        )
+        .unwrap();
+
+        let b_project = tempdir().unwrap();
+        fs::create_dir_all(b_project.path().join("node_modules")).unwrap();
+        symlink_dir(
+            &shared_slot.join("node_modules").join("shared"),
+            &b_project.path().join("node_modules").join("shared"),
+        )
+        .unwrap();
+
+        register_project(&store_dir, a_project.path()).expect("register a");
+        register_project(&store_dir, b_project.path()).expect("register b");
+        let b_path = b_project.path().to_path_buf();
+        drop(b_project);
+        assert!(!b_path.exists());
+
+        store_dir.prune().expect("prune");
+        assert!(shared_slot.exists(), "shared slot survives when one referencer remains");
+    }
+
+    /// Orphan-slot case: a slot exists under `<store>/links/...` but
+    /// no project references it. Prune should remove it.
+    #[test]
+    fn prune_removes_orphan_slot_unreferenced_by_any_project() {
+        let store = tempdir().unwrap();
+        let store_dir = StoreDir::new(store.path().to_path_buf());
+        let links = store_dir.links();
+        let referenced = make_slot(&links, "@", "referenced", "1.0.0", "ref01");
+        let orphan = make_slot(&links, "@", "orphan", "1.0.0", "orph01");
+
+        let project = tempdir().unwrap();
+        fs::create_dir_all(project.path().join("node_modules")).unwrap();
+        symlink_dir(
+            &referenced.join("node_modules").join("referenced"),
+            &project.path().join("node_modules").join("referenced"),
+        )
+        .unwrap();
+        register_project(&store_dir, project.path()).expect("register");
+
+        store_dir.prune().expect("prune");
+        assert!(referenced.exists(), "referenced slot survives");
+        assert!(!orphan.exists(), "orphan slot must be swept");
+    }
+
+    /// Transitive case: project's `node_modules/foo` → slot. The
+    /// slot's own `node_modules/bar` → another slot. Both slots must
+    /// be marked reachable.
+    #[test]
+    fn prune_marks_transitive_slot_reachable() {
+        let store = tempdir().unwrap();
+        let store_dir = StoreDir::new(store.path().to_path_buf());
+        let links = store_dir.links();
+        let foo = make_slot(&links, "@", "foo", "1.0.0", "fooh01");
+        let bar = make_slot(&links, "@", "bar", "1.0.0", "barh01");
+        // Wire foo's internal node_modules/bar → bar's slot.
+        symlink_dir(&bar.join("node_modules").join("bar"), &foo.join("node_modules").join("bar"))
+            .unwrap();
+
+        let project = tempdir().unwrap();
+        fs::create_dir_all(project.path().join("node_modules")).unwrap();
+        symlink_dir(
+            &foo.join("node_modules").join("foo"),
+            &project.path().join("node_modules").join("foo"),
+        )
+        .unwrap();
+        register_project(&store_dir, project.path()).expect("register");
+
+        store_dir.prune().expect("prune");
+        assert!(foo.exists(), "direct dep slot survives");
+        assert!(bar.exists(), "transitive dep slot also survives");
     }
 }

--- a/crates/store-dir/src/prune.rs
+++ b/crates/store-dir/src/prune.rs
@@ -300,22 +300,25 @@ fn remove_unreachable_packages(
     for scope in &scopes {
         let scope_path = links_dir.join(scope);
         let pkg_names = list_subdirs(&scope_path)?;
-        let mut removed_pkgs = 0;
+        let mut emptied_pkgs = 0;
         for pkg_name in &pkg_names {
             let pkg_dir = scope_path.join(pkg_name);
             let pkg_rel = Path::new(scope).join(pkg_name);
-            let (removed_here, all_versions_removed) =
+            let (removed_here, all_versions_emptied) =
                 remove_unreachable_versions(&pkg_dir, &pkg_rel, reachable)?;
             count += removed_here;
-            if all_versions_removed {
-                // Every version under this pkg was removed — drop the
-                // empty `<name>/` parent.
-                remove_dir_if_present(&pkg_dir)?;
-                removed_pkgs += 1;
+            if all_versions_emptied {
+                // Every version under this pkg was emptied — try to
+                // drop the now-empty `<name>/` parent. Race-safe
+                // remove: a concurrent install that just materialised
+                // a fresh version dir here keeps its work.
+                if remove_empty_dir(&pkg_dir)? {
+                    emptied_pkgs += 1;
+                }
             }
         }
-        if removed_pkgs == pkg_names.len() && !pkg_names.is_empty() {
-            remove_dir_if_present(&scope_path)?;
+        if emptied_pkgs == pkg_names.len() && !pkg_names.is_empty() {
+            remove_empty_dir(&scope_path)?;
         }
     }
     Ok(count)
@@ -328,7 +331,7 @@ fn remove_unreachable_versions(
 ) -> Result<(usize, bool), PruneError> {
     let versions = list_subdirs(pkg_dir)?;
     let mut count = 0usize;
-    let mut removed_versions = 0;
+    let mut emptied_versions = 0;
     for version in &versions {
         let version_dir = pkg_dir.join(version);
         let hashes = list_subdirs(&version_dir)?;
@@ -337,17 +340,23 @@ fn remove_unreachable_versions(
             let slot_rel = pkg_rel.join(version).join(hash);
             if !reachable.contains(&slot_rel) {
                 let slot_dir = version_dir.join(hash);
-                remove_dir_if_present(&slot_dir)?;
+                // The slot subtree is unreferenced — recursive
+                // remove of its files is correct.
+                remove_slot_dir(&slot_dir)?;
                 removed_hashes += 1;
                 count += 1;
             }
         }
         if removed_hashes == hashes.len() && !hashes.is_empty() {
-            remove_dir_if_present(&version_dir)?;
-            removed_versions += 1;
+            // Try to drop the `<version>/` parent only if it's
+            // genuinely empty after the slot removals. A concurrent
+            // install that just landed a new hash dir here survives.
+            if remove_empty_dir(&version_dir)? {
+                emptied_versions += 1;
+            }
         }
     }
-    Ok((count, removed_versions == versions.len() && !versions.is_empty()))
+    Ok((count, emptied_versions == versions.len() && !versions.is_empty()))
 }
 
 /// Mirrors upstream's
@@ -375,10 +384,45 @@ fn list_subdirs(dir: &Path) -> Result<Vec<std::ffi::OsString>, PruneError> {
     Ok(out)
 }
 
-fn remove_dir_if_present(path: &Path) -> Result<(), PruneError> {
+/// Recursively remove an unreferenced slot directory and everything
+/// under it (`<store>/links/<scope>/<name>/<version>/<hash>/`). Used
+/// for the actual sweep target — that subtree is known unreachable
+/// at this point, so a recursive remove is safe.
+fn remove_slot_dir(path: &Path) -> Result<(), PruneError> {
     match fs::remove_dir_all(path) {
         Ok(()) => Ok(()),
         Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(PruneError::RemoveSlot { path: path.to_path_buf(), error }),
+    }
+}
+
+/// Race-safe parent-cleanup: try to remove `path` as an empty
+/// directory and report whether it actually disappeared. Returns
+/// `Ok(true)` when the directory was empty and is now gone,
+/// `Ok(false)` when it survived because something raced into it
+/// (`DirectoryNotEmpty`) or was already missing (`NotFound`), and
+/// propagates any other I/O error.
+///
+/// Pacquet deliberately diverges from upstream here. Upstream uses
+/// [`rimraf`](https://github.com/pnpm/pnpm/blob/94240bc046/store/controller/src/storeController/pruneGlobalVirtualStore.ts#L210-L223)
+/// on the empty `<version>/`, `<name>/`, and `<scope>/` parents — a
+/// concurrent install that materialises a fresh slot in the window
+/// between `list_subdirs` and the parent cleanup would have its
+/// just-written tree wiped by upstream's recursive remove. Switching
+/// to `fs::remove_dir` keeps pacquet race-safe (the new slot stays;
+/// only the parent that's truly empty is removed) while producing
+/// the same on-disk result in the non-race case. Slot directories
+/// themselves still go through [`remove_slot_dir`] — those are
+/// known-unreferenced by the time prune reaches them, so recursive
+/// removal is correct.
+fn remove_empty_dir(path: &Path) -> Result<bool, PruneError> {
+    match fs::remove_dir(path) {
+        Ok(()) => Ok(true),
+        Err(error)
+            if matches!(error.kind(), ErrorKind::NotFound | ErrorKind::DirectoryNotEmpty) =>
+        {
+            Ok(false)
+        }
         Err(error) => Err(PruneError::RemoveSlot { path: path.to_path_buf(), error }),
     }
 }

--- a/crates/store-dir/src/prune.rs
+++ b/crates/store-dir/src/prune.rs
@@ -48,6 +48,19 @@ pub enum PruneError {
         #[error(source)]
         error: io::Error,
     },
+
+    /// `read_dir` on a sweep-phase directory
+    /// (`<store>/links/<scope>/...`) failed with something other
+    /// than `NotFound`. Surfaces because silently treating it as
+    /// "empty" would leave unreachable slot directories in place
+    /// the next time the prune walker can't see them either.
+    #[display("Failed to read sweep directory {path:?}: {error}")]
+    #[diagnostic(code(pacquet_store_dir::prune::read_sweep_dir))]
+    ReadSweepDir {
+        path: PathBuf,
+        #[error(source)]
+        error: io::Error,
+    },
 }
 
 impl StoreDir {
@@ -63,8 +76,10 @@ impl StoreDir {
     ///   reporter into store-dir, so the message goes to stderr via
     ///   `eprintln!` until [#344] lands the proper reporter wiring.
     /// - Otherwise: mark-and-sweep as documented in the module-level
-    ///   comment. Returns the count of removed slot directories (zero
-    ///   when nothing was unreachable).
+    ///   comment. The removed-slot count is reported to stderr to
+    ///   match upstream's `globalInfo("Removed N package(s) ...")`
+    ///   message — the function itself returns `()` like upstream's
+    ///   `Promise<void>` shape.
     ///
     /// Returns `Ok(())` on success; surfaces I/O errors from the mark
     /// or sweep walks as [`PruneError`]. Stale registry entries are
@@ -122,6 +137,14 @@ fn find_all_node_modules_dirs(project_dir: &Path) -> Vec<PathBuf> {
     return out;
 
     fn scan(dir: &Path, out: &mut Vec<PathBuf>) {
+        // Swallow every `read_dir` error — matches upstream's
+        // [`scan`'s bare `catch { return }`](https://github.com/pnpm/pnpm/blob/94240bc046/store/controller/src/storeController/pruneGlobalVirtualStore.ts#L67-L73).
+        // A permission failure inside a workspace package would make
+        // `prune` over-aggressive (its node_modules wouldn't be
+        // marked), but tightening this without an upstream change
+        // would diverge from pnpm's behaviour — and `pacquet store
+        // prune` shares a store directory with `pnpm store prune`,
+        // so the two must agree on what counts as reachable.
         let Ok(entries) = fs::read_dir(dir) else {
             return;
         };
@@ -172,6 +195,12 @@ fn walk_symlinks_to_store(
         return;
     }
 
+    // Swallow every `read_dir` error — matches upstream's
+    // [`walkSymlinksToStore`'s bare `catch { return }`](https://github.com/pnpm/pnpm/blob/94240bc046/store/controller/src/storeController/pruneGlobalVirtualStore.ts#L116-L121).
+    // Same caveat as in [`find_all_node_modules_dirs`]: tightening
+    // this would diverge from pnpm and risk a `pacquet store
+    // prune` deciding more slots are unreachable than a parallel
+    // `pnpm store prune` would.
     let Ok(entries) = fs::read_dir(dir) else {
         return;
     };
@@ -244,10 +273,10 @@ fn remove_unreachable_packages(
     reachable: &HashSet<PathBuf>,
 ) -> Result<usize, PruneError> {
     let mut count = 0usize;
-    let scopes = list_subdirs(links_dir);
+    let scopes = list_subdirs(links_dir)?;
     for scope in &scopes {
         let scope_path = links_dir.join(scope);
-        let pkg_names = list_subdirs(&scope_path);
+        let pkg_names = list_subdirs(&scope_path)?;
         let mut removed_pkgs = 0;
         for pkg_name in &pkg_names {
             let pkg_dir = scope_path.join(pkg_name);
@@ -274,12 +303,12 @@ fn remove_unreachable_versions(
     pkg_rel: &Path,
     reachable: &HashSet<PathBuf>,
 ) -> Result<(usize, bool), PruneError> {
-    let versions = list_subdirs(pkg_dir);
+    let versions = list_subdirs(pkg_dir)?;
     let mut count = 0usize;
     let mut removed_versions = 0;
     for version in &versions {
         let version_dir = pkg_dir.join(version);
-        let hashes = list_subdirs(&version_dir);
+        let hashes = list_subdirs(&version_dir)?;
         let mut removed_hashes = 0;
         for hash in &hashes {
             let slot_rel = pkg_rel.join(version).join(hash);
@@ -298,9 +327,21 @@ fn remove_unreachable_versions(
     Ok((count, removed_versions == versions.len() && !versions.is_empty()))
 }
 
-fn list_subdirs(dir: &Path) -> Vec<std::ffi::OsString> {
-    let Ok(entries) = fs::read_dir(dir) else {
-        return Vec::new();
+/// Mirrors upstream's
+/// [`getSubdirsSafely`](https://github.com/pnpm/pnpm/blob/94240bc046/store/controller/src/storeController/pruneGlobalVirtualStore.ts#L282-L299):
+/// returns the names of every directory entry under `dir`, swallowing
+/// only `NotFound` (the path raced with a parallel install or the
+/// shape just isn't materialised yet) and surfacing other I/O errors
+/// as [`PruneError::ReadSweepDir`]. A permission failure here would
+/// otherwise mark the entire scope as "no children" and the
+/// downstream sweep could leave orphan files in place.
+fn list_subdirs(dir: &Path) -> Result<Vec<std::ffi::OsString>, PruneError> {
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => {
+            return Err(PruneError::ReadSweepDir { path: dir.to_path_buf(), error });
+        }
     };
     let mut out = Vec::new();
     for entry in entries.flatten() {
@@ -308,7 +349,7 @@ fn list_subdirs(dir: &Path) -> Vec<std::ffi::OsString> {
             out.push(entry.file_name());
         }
     }
-    out
+    Ok(out)
 }
 
 fn remove_dir_if_present(path: &Path) -> Result<(), PruneError> {


### PR DESCRIPTION
## Summary

Closes #458. Ports upstream's [`pruneGlobalVirtualStore`](https://github.com/pnpm/pnpm/blob/94240bc046/store/controller/src/storeController/pruneGlobalVirtualStore.ts) and the read half of [`projectRegistry`](https://github.com/pnpm/pnpm/blob/94240bc046/store/controller/src/storeController/projectRegistry.ts#L37-L100) (pacquet shipped only the write half in #432 / #444).

The CLI wiring already existed — `StoreCommand::Prune` → `StoreDir::prune()` — but `StoreDir::prune` was a `todo!()`. With this PR `pacquet store prune` actually runs.

## What it does

**Mark phase**: walk every registered project (`<store>/projects/<short-hash>` → project root). For each project, find every `node_modules/`, follow symlinks that land under `<store>/links/...`, record reachable `<scope>/<name>/<version>/<hash>` slots, and recurse into the slot's own `node_modules/` for transitive deps.

**Sweep phase**: walk `<store>/links/<scope>/<name>/<version>/<hash>` and remove every `<hash>` not in the reachable set. Empty `<version>/`, `<name>/`, and `<scope>/` parents get cleaned up.

**Self-healing registry**: `get_registered_projects` unlinks entries whose project directory has been deleted (`ENOENT` on stat). Permission / unrelated errors surface as `PROJECT_INACCESSIBLE` / `PROJECT_REGISTRY_ENTRY_INACCESSIBLE` — matches upstream's strict stance, since silently dropping an inaccessible registry entry could remove slots the project still references.

## Notes

- Pacquet's store-dir crate doesn't have rayon plumbing yet, so the walk is sequential. Prune is one-shot (CLI), not on the hot install path; the function shape mirrors upstream's `Promise.all`-driven layout so a parallelism graft is mechanical when it lands.
- Informational messages (\"Checking N registered project(s)…\", \"Removed N package(s)…\") go to stderr via `eprintln!`. Pacquet doesn't yet thread the install-time reporter through store-dir; the proper wiring is tracked under [#344](https://github.com/pnpm/pacquet/issues/344).

## Test plan

- [x] 5 `get_registered_projects` tests: missing-registry-dir, live project, stale self-heal, mixed live/stale, dotfile-entry skip
- [x] 6 `prune` tests: no-links no-op, no-projects no-op, dead-project slot removal + empty-name-dir cleanup, shared slot survives partial unregister, orphan slot removal, transitive reachability via slot-internal `node_modules`
- [x] `just ready` (955 tests pass, 2 skipped)
- [x] `taplo format --check`
- [x] `just dylint`

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full mark-and-sweep store prune for removing orphaned package slots while preserving reachable ones.
  * Registry listing API to enumerate registered projects for store operations.
  * Cross-platform helpers to read and remove directory-shaped symlinks/junctions.

* **Bug Fixes**
  * Self-healing removal of stale registry entries and clearer error classification for inaccessible entries/targets.
  * Safer, platform-consistent handling when registering or removing symlinked registry entries.

* **Tests**
  * Expanded coverage for pruning, registry listing, mixed live/stale scenarios, and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pacquet/pull/475)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->