### PR TITLE
feat: proxy support (.npmrc + env-var cascade, HTTP/HTTPS/SOCKS)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2124,6 +2124,9 @@ dependencies = [
 name = "pacquet-network"
 version = "0.0.1"
 dependencies = [
+ "derive_more",
+ "miette 7.6.0",
+ "mockito",
  "pipe-trait",
  "pretty_assertions",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ reqwest = { version = "0.13", default-features = false, features = [
   "hickory-dns",
   "json",
   "native-tls-vendored",
+  "socks",
   "stream",
 ] }
 node-semver = { version = "2.2.0" }

--- a/crates/cli/src/state.rs
+++ b/crates/cli/src/state.rs
@@ -2,7 +2,7 @@ use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_config::Config;
 use pacquet_lockfile::{LoadLockfileError, Lockfile};
-use pacquet_network::ThrottledClient;
+use pacquet_network::{ProxyError, ThrottledClient};
 use pacquet_package_manager::ResolvedPackages;
 use pacquet_package_manifest::{PackageManifest, PackageManifestError};
 use pacquet_tarball::MemCache;
@@ -31,10 +31,13 @@ pub struct State {
 #[non_exhaustive]
 pub enum InitStateError {
     #[diagnostic(transparent)]
-    LoadManifest(#[error(source)] PackageManifestError),
+    Manifest(#[error(source)] PackageManifestError),
 
     #[diagnostic(transparent)]
-    LoadLockfile(#[error(source)] LoadLockfileError),
+    Lockfile(#[error(source)] LoadLockfileError),
+
+    #[diagnostic(transparent)]
+    Proxy(#[error(source)] ProxyError),
 }
 
 impl State {
@@ -56,10 +59,11 @@ impl State {
             config,
             manifest: manifest_path
                 .pipe(PackageManifest::create_if_needed)
-                .map_err(InitStateError::LoadManifest)?,
+                .map_err(InitStateError::Manifest)?,
             lockfile: call_load_lockfile(should_load, Lockfile::load_from_current_dir)
-                .map_err(InitStateError::LoadLockfile)?,
-            http_client: ThrottledClient::new_for_installs(),
+                .map_err(InitStateError::Lockfile)?,
+            http_client: ThrottledClient::for_installs(&config.proxy)
+                .map_err(InitStateError::Proxy)?,
             tarball_mem_cache: MemCache::new(),
             resolved_packages: ResolvedPackages::new(),
         })

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -265,6 +265,15 @@ pub struct Config {
     #[default(_code = "default_registry()")]
     pub registry: String, // TODO: use Url type (compatible with reqwest)
 
+    /// Resolved proxy configuration — `https-proxy`, `http-proxy`, and
+    /// `no-proxy` (plus the legacy `proxy` key and env-var fallbacks),
+    /// all from `.npmrc` and the process environment. The type lives
+    /// in `pacquet-network` (where it is consumed by
+    /// `ThrottledClient::for_installs`) because `pacquet-config`
+    /// already depends on `pacquet-network` for auth-headers plumbing.
+    /// Default is empty (`None` for every field) — i.e. no proxy.
+    pub proxy: pacquet_network::ProxyConfig,
+
     /// When true, any missing non-optional peer dependencies are automatically installed.
     #[default = true]
     pub auto_install_peers: bool,
@@ -595,12 +604,14 @@ impl Config {
     ///    (cwd, falling back to home), then
     /// 3. the nearest `pnpm-workspace.yaml` walking up from cwd.
     ///
-    /// Pacquet currently only applies `registry` from `.npmrc`. Other
-    /// `.npmrc` entries — pnpm's TLS / npm-auth / proxy / scoped-registry
-    /// keys, plus project-structural settings like `storeDir`, `lockfile`
-    /// and `hoist-pattern` — are silently ignored here. The first group
-    /// is tracked for future auth / proxy / TLS work; the second must
-    /// come from `pnpm-workspace.yaml` or CLI flags, matching pnpm 11.
+    /// Pacquet currently applies `registry`, npm-auth credentials, and
+    /// the proxy keys (`https-proxy`, `http-proxy`, `proxy`,
+    /// `no-proxy` / `noproxy`) from `.npmrc`. Other `.npmrc` entries —
+    /// pnpm's TLS / scoped-registry keys, plus project-structural
+    /// settings like `storeDir`, `lockfile` and `hoist-pattern` — are
+    /// silently ignored here. The first group is tracked for future
+    /// TLS work; the second must come from `pnpm-workspace.yaml` or
+    /// CLI flags, matching pnpm 11.
     ///
     /// The yaml wins over `.npmrc` on any key it sets.
     ///
@@ -655,6 +666,12 @@ impl Config {
             .map(|text| crate::npmrc_auth::NpmrcAuth::from_ini::<Api>(&text))
             .unwrap_or_default();
         npmrc_auth.apply_registry_and_warn(&mut config);
+        // Proxy cascade fires unconditionally — even when no `.npmrc`
+        // is found — because the env-var fallback in pnpm's
+        // [`config/reader/src/index.ts:591-600`](https://github.com/pnpm/pnpm/blob/94240bc046/config/reader/src/index.ts#L591-L600)
+        // is a normalization step on the resolved config, not a
+        // function of `.npmrc` presence.
+        npmrc_auth.apply_proxy_cascade::<Api>(&mut config);
 
         // Layer pnpm-workspace.yaml overrides on top. A missing file is
         // silent. Read or parse failures propagate to the caller.
@@ -1088,6 +1105,60 @@ mod tests {
         // `<store_dir>/links` fallback nor any mirroring of
         // `virtual_store_dir` clobbers it.
         assert_eq!(config.global_virtual_store_dir, yaml_gvs);
+    }
+
+    /// Real-process-environment smoke test for the proxy env-var
+    /// fallback through `Config::current`. The injected-`EnvVar` tests
+    /// in `npmrc_auth/tests.rs` cover the cascade branches
+    /// exhaustively; this one only proves the wiring through
+    /// `RealApi::var` reaches `std::env::var` and that the cascade
+    /// fires even with no `.npmrc` present.
+    #[test]
+    pub fn proxy_env_fallback_applies_through_current() {
+        // Snapshot every proxy var the cascade might read so peer tests
+        // can't observe our mutations and so the env restores cleanly.
+        let _g = EnvGuard::snapshot([
+            "HTTPS_PROXY",
+            "https_proxy",
+            "HTTP_PROXY",
+            "http_proxy",
+            "PROXY",
+            "proxy",
+            "NO_PROXY",
+            "no_proxy",
+            "NPM_CONFIG_WORKSPACE_DIR",
+            "npm_config_workspace_dir",
+        ]);
+        let tmp = tempdir().unwrap();
+        // SAFETY: EnvGuard above serializes the test against other
+        // env-mutating tests in this process; no other thread reads
+        // these vars concurrently. The other proxy vars are removed so
+        // a host-set value can't leak in and skew the assertion.
+        unsafe {
+            env::remove_var("HTTPS_PROXY");
+            env::remove_var("https_proxy");
+            env::remove_var("HTTP_PROXY");
+            env::remove_var("http_proxy");
+            env::remove_var("PROXY");
+            env::remove_var("proxy");
+            env::remove_var("NO_PROXY");
+            env::remove_var("no_proxy");
+            env::remove_var("NPM_CONFIG_WORKSPACE_DIR");
+            env::remove_var("npm_config_workspace_dir");
+            env::set_var("HTTPS_PROXY", "http://env.example:8080");
+        }
+        let config = Config::current::<RealApi, _, _, _, _>(
+            || tmp.path().to_path_buf().pipe(Ok::<_, ()>),
+            || None,
+            Config::new,
+        )
+        .expect("workspace yaml absent => no error");
+        assert_eq!(config.proxy.https_proxy.as_deref(), Some("http://env.example:8080"));
+        assert_eq!(
+            config.proxy.http_proxy.as_deref(),
+            Some("http://env.example:8080"),
+            "http side cascades through resolved https",
+        );
     }
 
     /// Pnpm's

--- a/crates/config/src/npmrc_auth.rs
+++ b/crates/config/src/npmrc_auth.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use pacquet_network::{AuthHeaders, base64_encode};
+use pacquet_network::{AuthHeaders, NoProxySetting, base64_encode};
 
 use crate::{Config, api::EnvVar, env_replace::env_replace};
 
@@ -12,7 +12,11 @@ use crate::{Config, api::EnvVar, env_replace::env_replace};
 /// * default-registry credentials (`_auth`, `_authToken`,
 ///   `username` + `_password`),
 /// * per-registry credentials keyed on a nerf-darted URI prefix
-///   (e.g. `//npm.pkg.github.com/pnpm/:_authToken=…`).
+///   (e.g. `//npm.pkg.github.com/pnpm/:_authToken=…`),
+/// * proxy keys (`https-proxy`, `http-proxy`, `proxy` legacy, and
+///   `no-proxy` / `noproxy` aliases). The env-var fallback cascade
+///   (`HTTPS_PROXY`, `HTTP_PROXY`, `PROXY`, `NO_PROXY` + lowercase)
+///   fires from [`NpmrcAuth::apply_proxy_cascade`].
 ///
 /// Values pass through `${VAR}` substitution before being stored,
 /// matching pnpm's `loadNpmrcFiles.ts` flow. Substitution failures are
@@ -40,6 +44,20 @@ pub(crate) struct NpmrcAuth {
     /// Surfaced as warnings; `pnpm` does the same in
     /// [`substituteEnv`](https://github.com/pnpm/pnpm/blob/601317e7a3/config/reader/src/loadNpmrcFiles.ts#L156-L162).
     pub warnings: Vec<String>,
+    /// `https-proxy=…` from .npmrc. Applied by
+    /// [`NpmrcAuth::apply_proxy_cascade`].
+    pub https_proxy: Option<String>,
+    /// `http-proxy=…` from .npmrc.
+    pub http_proxy: Option<String>,
+    /// Legacy `proxy=…` from .npmrc. Feeds into the `httpsProxy` slot
+    /// only when `https-proxy` is unset — mirrors upstream's
+    /// [`pnpmConfig.httpsProxy = pnpmConfig.proxy`](https://github.com/pnpm/pnpm/blob/94240bc046/config/reader/src/index.ts#L591-L600).
+    pub legacy_proxy: Option<String>,
+    /// `no-proxy=…` or `noproxy=…` from .npmrc. Last write wins (matches
+    /// upstream's
+    /// [single `noProxy` slot](https://github.com/pnpm/pnpm/blob/94240bc046/config/reader/src/index.ts#L598-L600)
+    /// fed by either alias).
+    pub no_proxy: Option<String>,
 }
 
 /// Raw (unparsed) credential fields for a given registry URI, mirroring
@@ -113,6 +131,26 @@ impl NpmrcAuth {
                 continue;
             }
 
+            match key.as_str() {
+                "https-proxy" => {
+                    auth.https_proxy = Some(value);
+                    continue;
+                }
+                "http-proxy" => {
+                    auth.http_proxy = Some(value);
+                    continue;
+                }
+                "proxy" => {
+                    auth.legacy_proxy = Some(value);
+                    continue;
+                }
+                "no-proxy" | "noproxy" => {
+                    auth.no_proxy = Some(value);
+                    continue;
+                }
+                _ => {}
+            }
+
             if let Some((uri, suffix)) = split_creds_key(&key) {
                 let entry = auth.creds_by_uri.entry(uri.to_owned()).or_default();
                 apply_creds_field(entry, suffix, value);
@@ -122,6 +160,47 @@ impl NpmrcAuth {
             apply_creds_field(&mut auth.default_creds, key.as_str(), value);
         }
         auth
+    }
+
+    /// Resolve the `(https_proxy, http_proxy, no_proxy)` triple on
+    /// `config.proxy`, mirroring upstream's
+    /// [`config/reader/src/index.ts:591-600`](https://github.com/pnpm/pnpm/blob/94240bc046/config/reader/src/index.ts#L591-L600)
+    /// cascade. `.npmrc` always wins over env vars; the legacy `proxy=`
+    /// key feeds the `httpsProxy` slot only (the http side falls back
+    /// to the resolved `httpsProxy` before consulting env). `noProxy`
+    /// accepts the literal token `true` to mean "bypass every proxy"
+    /// — matching the `string | true` shape of upstream's
+    /// [`Config.noProxy`](https://github.com/pnpm/pnpm/blob/94240bc046/config/reader/src/Config.ts#L142-L146).
+    ///
+    /// Generic over [`EnvVar`] so cascade tests can drive every branch
+    /// without mutating the process environment (no `EnvGuard` global
+    /// lock).
+    pub fn apply_proxy_cascade<Api: EnvVar>(&mut self, config: &mut Config) {
+        // Upstream's `getProcessEnv` tries literal-, upper-, and
+        // lower-case in order (config/reader/src/index.ts:689-693). For
+        // the proxy var names below the literal form is already either
+        // fully upper or fully lower, so the triple collapses to two
+        // real attempts.
+        fn env_pair<Api: EnvVar>(upper: &str, lower: &str) -> Option<String> {
+            Api::var(upper).or_else(|| Api::var(lower))
+        }
+
+        config.proxy.https_proxy = self
+            .https_proxy
+            .take()
+            .or_else(|| self.legacy_proxy.clone())
+            .or_else(|| env_pair::<Api>("HTTPS_PROXY", "https_proxy"));
+        config.proxy.http_proxy = self
+            .http_proxy
+            .take()
+            .or_else(|| config.proxy.https_proxy.clone())
+            .or_else(|| env_pair::<Api>("HTTP_PROXY", "http_proxy"))
+            .or_else(|| env_pair::<Api>("PROXY", "proxy"));
+        config.proxy.no_proxy = self
+            .no_proxy
+            .take()
+            .or_else(|| env_pair::<Api>("NO_PROXY", "no_proxy"))
+            .map(|raw| parse_no_proxy(&raw));
     }
 
     /// Phase 1: write the resolved `registry` onto `config` and emit
@@ -167,20 +246,37 @@ impl NpmrcAuth {
             Arc::new(AuthHeaders::from_creds_map(auth_header_by_uri, Some(&config.registry)));
     }
 
-    /// Convenience wrapper that runs [`apply_registry_and_warn`]
-    /// followed by [`build_auth_headers`] in one call. Used by tests
-    /// and other callers that don't layer additional config sources
-    /// on top of `.npmrc`. Production code in [`crate::Config::current`]
-    /// inserts `pnpm-workspace.yaml` between the two phases so
-    /// default-registry creds key at the final URL.
+    /// Convenience wrapper that runs [`apply_registry_and_warn`],
+    /// [`apply_proxy_cascade`], and [`build_auth_headers`] in one call.
+    /// Used by tests and other callers that don't layer additional
+    /// config sources on top of `.npmrc`. Production code in
+    /// [`crate::Config::current`] inserts `pnpm-workspace.yaml` between
+    /// phase 1 and phase 2 so default-registry creds key at the final
+    /// URL.
     ///
     /// [`apply_registry_and_warn`]: NpmrcAuth::apply_registry_and_warn
+    /// [`apply_proxy_cascade`]: NpmrcAuth::apply_proxy_cascade
     /// [`build_auth_headers`]: NpmrcAuth::build_auth_headers
     #[cfg(test)]
-    pub fn apply_to(mut self, config: &mut Config) {
+    pub fn apply_to<Api: EnvVar>(mut self, config: &mut Config) {
         self.apply_registry_and_warn(config);
+        self.apply_proxy_cascade::<Api>(config);
         self.build_auth_headers(config);
     }
+}
+
+/// Parse the raw `no-proxy` value into [`NoProxySetting`].
+///
+/// `"true"` (after trimming) is the literal-`true` shape from upstream's
+/// `noProxy: string | true` type. Anything else is comma-split, trimmed,
+/// empties dropped.
+fn parse_no_proxy(raw: &str) -> NoProxySetting {
+    if raw.trim() == "true" {
+        return NoProxySetting::Bypass;
+    }
+    NoProxySetting::List(
+        raw.split(',').map(str::trim).filter(|s| !s.is_empty()).map(String::from).collect(),
+    )
 }
 
 /// Convert raw .npmrc credentials into the `Authorization` header

--- a/crates/config/src/npmrc_auth/tests.rs
+++ b/crates/config/src/npmrc_auth/tests.rs
@@ -353,12 +353,10 @@ fn parses_legacy_proxy_key_from_ini() {
 fn no_proxy_and_noproxy_aliases_last_wins() {
     // pnpm pipes both spellings into a single `noProxy` slot — the last
     // assignment in `.npmrc` order wins, same as upstream's single field.
-    let auth =
-        NpmrcAuth::from_ini::<NoEnv>("no-proxy=first.example\nnoproxy=second.example\n");
+    let auth = NpmrcAuth::from_ini::<NoEnv>("no-proxy=first.example\nnoproxy=second.example\n");
     assert_eq!(auth.no_proxy.as_deref(), Some("second.example"));
 
-    let auth =
-        NpmrcAuth::from_ini::<NoEnv>("noproxy=second.example\nno-proxy=first.example\n");
+    let auth = NpmrcAuth::from_ini::<NoEnv>("noproxy=second.example\nno-proxy=first.example\n");
     assert_eq!(auth.no_proxy.as_deref(), Some("first.example"));
 }
 

--- a/crates/config/src/npmrc_auth/tests.rs
+++ b/crates/config/src/npmrc_auth/tests.rs
@@ -1,6 +1,24 @@
 use super::{EnvVar, NpmrcAuth, RawCreds, base64_decode, base64_encode};
 use crate::Config;
+use pacquet_network::NoProxySetting;
 use pretty_assertions::assert_eq;
+
+/// Generate a per-test unit struct implementing [`EnvVar`] from a
+/// `&[(&str, &str)]` literal — saves each cascade test from spelling
+/// out an `impl EnvVar` block. Avoids touching the real process
+/// environment so cascade tests don't need
+/// [`crate::test_env_guard::EnvGuard`]'s global lock.
+macro_rules! static_env {
+    ($name:ident, $entries:expr) => {
+        struct $name;
+        impl EnvVar for $name {
+            fn var(name: &str) -> Option<String> {
+                let entries: &[(&str, &str)] = $entries;
+                entries.iter().find(|(k, _)| *k == name).map(|(_, v)| (*v).to_string())
+            }
+        }
+    };
+}
 
 /// Test fake: the process environment is empty. Per the DI
 /// pattern from
@@ -21,14 +39,14 @@ fn picks_up_registry_and_normalises_trailing_slash() {
     assert_eq!(auth.registry.as_deref(), Some("https://r.example"));
 
     let mut config = Config::new();
-    auth.apply_to(&mut config);
+    auth.apply_to::<NoEnv>(&mut config);
     assert_eq!(config.registry, "https://r.example/");
 }
 
 #[test]
 fn preserves_existing_trailing_slash() {
     let mut config = Config::new();
-    NpmrcAuth::from_ini::<NoEnv>("registry=https://r.example/\n").apply_to(&mut config);
+    NpmrcAuth::from_ini::<NoEnv>("registry=https://r.example/\n").apply_to::<NoEnv>(&mut config);
     assert_eq!(config.registry, "https://r.example/");
 }
 
@@ -53,7 +71,7 @@ node-linker=hoisted
 ";
     let config_before = Config::new();
     let mut config = Config::new();
-    NpmrcAuth::from_ini::<NoEnv>(ini).apply_to(&mut config);
+    NpmrcAuth::from_ini::<NoEnv>(ini).apply_to::<NoEnv>(&mut config);
     assert_eq!(config.store_dir, config_before.store_dir);
     assert_eq!(config.lockfile, config_before.lockfile);
     assert_eq!(config.hoist, config_before.hoist);
@@ -99,7 +117,7 @@ fn parses_default_auth_token_and_keys_to_registry() {
     assert_eq!(auth.default_creds.auth_token.as_deref(), Some("top-secret"));
 
     let mut config = Config::new();
-    auth.apply_to(&mut config);
+    auth.apply_to::<NoEnv>(&mut config);
     assert_eq!(
         config.auth_headers.for_url("https://registry.npmjs.org/foo/-/foo-1.0.0.tgz").as_deref(),
         Some("Bearer top-secret"),
@@ -142,7 +160,7 @@ fn basic_auth_built_from_username_and_password() {
     let password_b64 = base64_encode(raw_password);
     let ini = format!("//reg.com/:username=alice\n//reg.com/:_password={password_b64}\n");
     let mut config = Config::new();
-    NpmrcAuth::from_ini::<NoEnv>(&ini).apply_to(&mut config);
+    NpmrcAuth::from_ini::<NoEnv>(&ini).apply_to::<NoEnv>(&mut config);
     assert_eq!(
         config.auth_headers.for_url("https://reg.com/").as_deref(),
         Some(format!("Basic {}", base64_encode("alice:p@ss")).as_str()),
@@ -154,7 +172,7 @@ fn auth_pair_base64_passes_through_to_basic_header() {
     let pair = base64_encode("alice:p@ss");
     let ini = format!("//reg.com/:_auth={pair}\n");
     let mut config = Config::new();
-    NpmrcAuth::from_ini::<NoEnv>(&ini).apply_to(&mut config);
+    NpmrcAuth::from_ini::<NoEnv>(&ini).apply_to::<NoEnv>(&mut config);
     assert_eq!(
         config.auth_headers.for_url("https://reg.com/").as_deref(),
         Some(format!("Basic {pair}").as_str()),
@@ -196,7 +214,7 @@ fn top_level_auth_pair_keys_to_default_registry_basic_header() {
     let pair = base64_encode("bob:hunter2");
     let ini = format!("_auth={pair}\n");
     let mut config = Config::new();
-    NpmrcAuth::from_ini::<NoEnv>(&ini).apply_to(&mut config);
+    NpmrcAuth::from_ini::<NoEnv>(&ini).apply_to::<NoEnv>(&mut config);
     assert_eq!(
         config.auth_headers.for_url("https://registry.npmjs.org/").as_deref(),
         Some(format!("Basic {pair}").as_str()),
@@ -209,7 +227,7 @@ fn top_level_username_password_keys_to_default_registry_basic_header() {
     let password_b64 = base64_encode(raw_password);
     let ini = format!("username=bob\n_password={password_b64}\n");
     let mut config = Config::new();
-    NpmrcAuth::from_ini::<NoEnv>(&ini).apply_to(&mut config);
+    NpmrcAuth::from_ini::<NoEnv>(&ini).apply_to::<NoEnv>(&mut config);
     assert_eq!(
         config.auth_headers.for_url("https://registry.npmjs.org/").as_deref(),
         Some(format!("Basic {}", base64_encode("bob:hunter2")).as_str()),
@@ -223,7 +241,7 @@ fn top_level_username_password_keys_to_default_registry_basic_header() {
 fn lone_per_registry_password_produces_no_header() {
     let ini = format!("//reg.com/:_password={}\n", base64_encode("solo"));
     let mut config = Config::new();
-    NpmrcAuth::from_ini::<NoEnv>(&ini).apply_to(&mut config);
+    NpmrcAuth::from_ini::<NoEnv>(&ini).apply_to::<NoEnv>(&mut config);
     assert_eq!(config.auth_headers.for_url("https://reg.com/"), None);
 }
 
@@ -237,7 +255,7 @@ fn per_registry_username_password_apply_through_build_auth_headers() {
     let password_b64 = base64_encode(raw_password);
     let ini = format!("//reg.example/:username=alice\n//reg.example/:_password={password_b64}\n");
     let mut config = Config::new();
-    NpmrcAuth::from_ini::<NoEnv>(&ini).apply_to(&mut config);
+    NpmrcAuth::from_ini::<NoEnv>(&ini).apply_to::<NoEnv>(&mut config);
     assert_eq!(
         config.auth_headers.for_url("https://reg.example/foo").as_deref(),
         Some(format!("Basic {}", base64_encode("alice:hunter2")).as_str()),
@@ -283,7 +301,7 @@ fn invalid_base64_password_falls_back_to_raw_value() {
     // returns `None` and the raw string is used as the password.
     let ini = "//reg.com/:username=alice\n//reg.com/:_password=raw*pw\n";
     let mut config = Config::new();
-    NpmrcAuth::from_ini::<NoEnv>(ini).apply_to(&mut config);
+    NpmrcAuth::from_ini::<NoEnv>(ini).apply_to::<NoEnv>(&mut config);
     assert_eq!(
         config.auth_headers.for_url("https://reg.com/").as_deref(),
         Some(format!("Basic {}", base64_encode("alice:raw*pw")).as_str()),
@@ -308,4 +326,150 @@ fn base64_decode_covers_every_alphabet_branch() {
     // Invalid byte returns None so the parser keeps the raw
     // value verbatim. `*` is not in the alphabet.
     assert_eq!(base64_decode("not*base64"), None);
+}
+
+// --- Proxy parsing and cascade tests ---
+
+#[test]
+fn parses_https_proxy_from_ini() {
+    let auth = NpmrcAuth::from_ini::<NoEnv>("https-proxy=http://proxy.example:8080\n");
+    assert_eq!(auth.https_proxy.as_deref(), Some("http://proxy.example:8080"));
+}
+
+#[test]
+fn parses_http_proxy_from_ini() {
+    let auth = NpmrcAuth::from_ini::<NoEnv>("http-proxy=http://proxy.example:3128\n");
+    assert_eq!(auth.http_proxy.as_deref(), Some("http://proxy.example:3128"));
+}
+
+#[test]
+fn parses_legacy_proxy_key_from_ini() {
+    let auth = NpmrcAuth::from_ini::<NoEnv>("proxy=http://legacy.example:8080\n");
+    assert_eq!(auth.legacy_proxy.as_deref(), Some("http://legacy.example:8080"));
+    assert_eq!(auth.https_proxy, None, "legacy `proxy` is its own slot");
+}
+
+#[test]
+fn no_proxy_and_noproxy_aliases_last_wins() {
+    // pnpm pipes both spellings into a single `noProxy` slot — the last
+    // assignment in `.npmrc` order wins, same as upstream's single field.
+    let auth =
+        NpmrcAuth::from_ini::<NoEnv>("no-proxy=first.example\nnoproxy=second.example\n");
+    assert_eq!(auth.no_proxy.as_deref(), Some("second.example"));
+
+    let auth =
+        NpmrcAuth::from_ini::<NoEnv>("noproxy=second.example\nno-proxy=first.example\n");
+    assert_eq!(auth.no_proxy.as_deref(), Some("first.example"));
+}
+
+#[test]
+fn cascade_https_proxy_uses_legacy_proxy_when_unset() {
+    // Mirrors upstream: `httpsProxy ?? proxy ?? env`.
+    let auth = NpmrcAuth::from_ini::<NoEnv>("proxy=http://legacy.example:8080\n");
+    let mut config = Config::new();
+    auth.apply_to::<NoEnv>(&mut config);
+    assert_eq!(config.proxy.https_proxy.as_deref(), Some("http://legacy.example:8080"));
+}
+
+#[test]
+fn cascade_explicit_https_proxy_wins_over_legacy_key() {
+    let auth = NpmrcAuth::from_ini::<NoEnv>(
+        "https-proxy=http://https.example:8080\nproxy=http://legacy.example:8080\n",
+    );
+    let mut config = Config::new();
+    auth.apply_to::<NoEnv>(&mut config);
+    assert_eq!(config.proxy.https_proxy.as_deref(), Some("http://https.example:8080"));
+}
+
+#[test]
+fn cascade_http_proxy_uses_resolved_https_proxy() {
+    // pnpm: `httpProxy ?? httpsProxy ?? env(HTTP_PROXY) ?? env(PROXY)`.
+    // With only `https-proxy` set the http side inherits it — *and* the
+    // env vars are not consulted.
+    static_env!(
+        EnvHttpButOverridden,
+        &[("HTTP_PROXY", "http://env.example:80"), ("PROXY", "http://envproxy.example:80")]
+    );
+    let auth = NpmrcAuth::from_ini::<NoEnv>("https-proxy=http://https.example:8080\n");
+    let mut config = Config::new();
+    auth.apply_to::<EnvHttpButOverridden>(&mut config);
+    assert_eq!(config.proxy.http_proxy.as_deref(), Some("http://https.example:8080"));
+}
+
+#[test]
+fn cascade_no_proxy_true_literal_becomes_bypass_variant() {
+    let auth = NpmrcAuth::from_ini::<NoEnv>("no-proxy=true\n");
+    let mut config = Config::new();
+    auth.apply_to::<NoEnv>(&mut config);
+    assert_eq!(config.proxy.no_proxy, Some(NoProxySetting::Bypass));
+}
+
+#[test]
+fn cascade_no_proxy_comma_list_trimmed() {
+    let auth = NpmrcAuth::from_ini::<NoEnv>("no-proxy= foo.example , , bar.example ,\n");
+    let mut config = Config::new();
+    auth.apply_to::<NoEnv>(&mut config);
+    assert_eq!(
+        config.proxy.no_proxy,
+        Some(NoProxySetting::List(vec!["foo.example".to_string(), "bar.example".to_string()])),
+    );
+}
+
+#[test]
+fn cascade_env_fallback_only_fires_when_npmrc_unset() {
+    static_env!(
+        AllProxyEnvs,
+        &[
+            ("HTTPS_PROXY", "http://https-env.example:8080"),
+            ("HTTP_PROXY", "http://http-env.example:8080"),
+            ("NO_PROXY", "skip.example"),
+        ]
+    );
+    let auth = NpmrcAuth::default();
+    let mut config = Config::new();
+    auth.apply_to::<AllProxyEnvs>(&mut config);
+    assert_eq!(config.proxy.https_proxy.as_deref(), Some("http://https-env.example:8080"));
+    assert_eq!(config.proxy.http_proxy.as_deref(), Some("http://https-env.example:8080"));
+    assert_eq!(config.proxy.no_proxy, Some(NoProxySetting::List(vec!["skip.example".to_string()])));
+}
+
+#[test]
+fn cascade_npmrc_value_wins_over_env() {
+    static_env!(
+        ConflictingEnv,
+        &[("HTTPS_PROXY", "http://env.example:8080"), ("NO_PROXY", "env.example")]
+    );
+    let auth = NpmrcAuth::from_ini::<NoEnv>(
+        "https-proxy=http://npmrc.example:8080\nno-proxy=npmrc.example\n",
+    );
+    let mut config = Config::new();
+    auth.apply_to::<ConflictingEnv>(&mut config);
+    assert_eq!(config.proxy.https_proxy.as_deref(), Some("http://npmrc.example:8080"));
+    assert_eq!(
+        config.proxy.no_proxy,
+        Some(NoProxySetting::List(vec!["npmrc.example".to_string()])),
+    );
+}
+
+#[test]
+fn cascade_http_proxy_env_fallback_chain_proxy_var() {
+    // When neither `.npmrc` nor `https-proxy` is set, http falls through
+    // `HTTP_PROXY` first, then the bare `PROXY` env.
+    static_env!(BareProxy, &[("PROXY", "http://barenv.example:80")]);
+    let auth = NpmrcAuth::default();
+    let mut config = Config::new();
+    auth.apply_to::<BareProxy>(&mut config);
+    assert_eq!(config.proxy.http_proxy.as_deref(), Some("http://barenv.example:80"));
+    assert_eq!(config.proxy.https_proxy, None);
+}
+
+#[test]
+fn cascade_env_var_lowercase_lookup() {
+    // Upstream tries upper then lower case. With only the lowercase env
+    // populated, the lookup must still find it.
+    static_env!(LowercaseEnv, &[("https_proxy", "http://lower.example:8080")]);
+    let auth = NpmrcAuth::default();
+    let mut config = Config::new();
+    auth.apply_to::<LowercaseEnv>(&mut config);
+    assert_eq!(config.proxy.https_proxy.as_deref(), Some("http://lower.example:8080"));
 }

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -11,9 +11,13 @@ license.workspace    = true
 repository.workspace = true
 
 [dependencies]
-pipe-trait = { workspace = true }
-reqwest    = { workspace = true }
-tokio      = { workspace = true }
+derive_more = { workspace = true }
+miette      = { workspace = true }
+pipe-trait  = { workspace = true }
+reqwest     = { workspace = true }
+tokio       = { workspace = true }
 
 [dev-dependencies]
+mockito           = { workspace = true }
 pretty_assertions = { workspace = true }
+tokio             = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -172,8 +172,7 @@ impl ThrottledClient {
         if let Some(url) = http {
             builder = builder.proxy(build_scheme_proxy(url, "http", Arc::clone(&no_proxy)));
         }
-        let client =
-            builder.build().expect("build reqwest client with default timeouts and proxy");
+        let client = builder.build().expect("build reqwest client with default timeouts and proxy");
         Ok(ThrottledClient::from_client(client))
     }
 

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -1,12 +1,17 @@
 mod auth;
+mod proxy;
+#[cfg(test)]
+mod tests;
 
 pub use auth::{AuthHeaders, base64_encode, nerf_dart};
+pub use proxy::{NoProxySetting, ProxyConfig, ProxyError};
 
+use proxy::{NoProxyMatcher, parse_proxy_url, strip_userinfo};
 use reqwest::{
-    Client,
+    Client, Proxy,
     header::{HeaderMap, HeaderValue, USER_AGENT},
 };
-use std::{num::NonZeroUsize, ops::Deref, time::Duration};
+use std::{num::NonZeroUsize, ops::Deref, sync::Arc, time::Duration};
 use tokio::sync::{Semaphore, SemaphorePermit};
 
 /// Default `User-Agent` pacquet sends on every request made by the
@@ -135,19 +140,41 @@ impl ThrottledClient {
     /// directly, bypassing `mDNSResponder` and the EAI_NONAME flake
     /// entirely.
     pub fn new_for_installs() -> Self {
-        let mut default_headers = HeaderMap::with_capacity(1);
-        default_headers.insert(USER_AGENT, HeaderValue::from_static(DEFAULT_USER_AGENT));
+        Self::for_installs(&ProxyConfig::default())
+            .expect("default ProxyConfig carries no URLs and cannot fail parsing")
+    }
 
-        let client = Client::builder()
-            .http1_only()
-            .default_headers(default_headers)
-            .connect_timeout(Duration::from_secs(10))
-            .timeout(Duration::from_secs(300))
-            .pool_idle_timeout(Duration::from_secs(4))
-            .hickory_dns(true)
-            .build()
-            .expect("build reqwest client with default timeouts");
-        ThrottledClient::from_client(client)
+    /// Construct the install client with proxy configuration applied.
+    ///
+    /// Ports pnpm v11's
+    /// [`getDispatcher`](https://github.com/pnpm/pnpm/blob/94240bc046/network/fetch/src/dispatcher.ts#L23-L31)
+    /// onto reqwest: HTTPS targets route through `https_proxy`, HTTP
+    /// targets through `http_proxy`, and the [`NoProxySetting`] in
+    /// [`ProxyConfig::no_proxy`] short-circuits both via a per-URL
+    /// custom-proxy closure. Basic-auth user/password halves embedded
+    /// in the proxy URL are percent-decoded before being forwarded as
+    /// the `Proxy-Authorization` header — matching upstream's
+    /// [decode at dispatcher.ts:180-182](https://github.com/pnpm/pnpm/blob/94240bc046/network/fetch/src/dispatcher.ts#L180-L182).
+    ///
+    /// Returns [`ProxyError::InvalidProxy`] when either configured
+    /// proxy URL fails to parse even after the auto-`http://` prefix
+    /// retry, matching upstream's build-time `ERR_PNPM_INVALID_PROXY`
+    /// from [dispatcher.ts:106-121](https://github.com/pnpm/pnpm/blob/94240bc046/network/fetch/src/dispatcher.ts#L106-L121).
+    pub fn for_installs(proxy: &ProxyConfig) -> Result<Self, ProxyError> {
+        let https = proxy.https_proxy.as_deref().map(parse_proxy_url).transpose()?;
+        let http = proxy.http_proxy.as_deref().map(parse_proxy_url).transpose()?;
+        let no_proxy = Arc::new(NoProxyMatcher::from(proxy.no_proxy.as_ref()));
+
+        let mut builder = default_client_builder();
+        if let Some(url) = https {
+            builder = builder.proxy(build_scheme_proxy(url, "https", Arc::clone(&no_proxy)));
+        }
+        if let Some(url) = http {
+            builder = builder.proxy(build_scheme_proxy(url, "http", Arc::clone(&no_proxy)));
+        }
+        let client =
+            builder.build().expect("build reqwest client with default timeouts and proxy");
+        Ok(ThrottledClient::from_client(client))
     }
 
     /// Construct a throttled client wrapping a pre-built [`Client`].
@@ -159,6 +186,48 @@ impl ThrottledClient {
         let semaphore = Semaphore::new(default_network_concurrency());
         ThrottledClient { semaphore, client }
     }
+}
+
+/// Shared builder with the install-time defaults
+/// ([`ThrottledClient::new_for_installs`] documents the why behind each
+/// setting). Both `new_for_installs` and [`ThrottledClient::for_installs`]
+/// route through this helper so a single source of truth governs
+/// timeouts, HTTP-version, resolver, and the default User-Agent header.
+fn default_client_builder() -> reqwest::ClientBuilder {
+    let mut default_headers = HeaderMap::with_capacity(1);
+    default_headers.insert(USER_AGENT, HeaderValue::from_static(DEFAULT_USER_AGENT));
+    Client::builder()
+        .http1_only()
+        .default_headers(default_headers)
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(300))
+        .pool_idle_timeout(Duration::from_secs(4))
+        .hickory_dns(true)
+}
+
+/// Build a [`Proxy`] that routes only requests whose target scheme matches
+/// `scheme` ("http" or "https") and whose host doesn't fall under the
+/// no-proxy bypass. Userinfo is stripped from the URL and re-attached
+/// via [`Proxy::basic_auth`] after percent-decoding so usernames /
+/// passwords with `%XX` escapes (e.g. `@` in a password) reach the
+/// upstream proxy decoded — matching pnpm's behavior at
+/// [`dispatcher.ts:180-182`](https://github.com/pnpm/pnpm/blob/94240bc046/network/fetch/src/dispatcher.ts#L180-L182).
+fn build_scheme_proxy(
+    url: reqwest::Url,
+    scheme: &'static str,
+    no_proxy: Arc<NoProxyMatcher>,
+) -> Proxy {
+    let (clean_url, auth) = strip_userinfo(url);
+    let mut proxy = Proxy::custom(move |target| {
+        if no_proxy.matches_url(target) {
+            return None;
+        }
+        (target.scheme() == scheme).then(|| clean_url.clone())
+    });
+    if let Some((user, pass)) = auth {
+        proxy = proxy.basic_auth(&user, &pass);
+    }
+    proxy
 }
 
 /// Default number of concurrent in-flight network requests.

--- a/crates/network/src/proxy.rs
+++ b/crates/network/src/proxy.rs
@@ -1,0 +1,217 @@
+//! Proxy configuration types and helpers consumed by
+//! [`crate::ThrottledClient::for_installs`].
+//!
+//! `ProxyConfig` holds the resolved `(https_proxy, http_proxy, no_proxy)`
+//! triple — typically built by `pacquet-config` from the `.npmrc` keys
+//! `https-proxy`, `http-proxy`, `proxy` (legacy), `no-proxy` and
+//! `noproxy`, plus the env-var fallback cascade. `NoProxyMatcher` and
+//! the URL helpers are private to the crate; they're invoked from the
+//! client constructor.
+//!
+//! Ports the routing + matching semantics of pnpm v11's
+//! [`network/fetch/src/dispatcher.ts`](https://github.com/pnpm/pnpm/blob/94240bc046/network/fetch/src/dispatcher.ts).
+
+use derive_more::{Display, Error};
+use miette::Diagnostic;
+use reqwest::Url;
+
+/// Resolved proxy configuration after the `.npmrc` + env cascade has run.
+///
+/// All three fields are `None` when no proxy is configured. Built once
+/// inside `pacquet_config::Config::current` and threaded into the
+/// install client by [`crate::ThrottledClient::for_installs`]. Lives in
+/// `pacquet-network` (rather than `pacquet-config`) because
+/// `pacquet-config` already depends on `pacquet-network` for the auth
+/// plumbing, so adding the reverse direction would form a cycle.
+///
+/// Mirrors the `(httpsProxy, httpProxy, noProxy)` slots that upstream
+/// composes in [`config/reader/src/index.ts:591-600`](https://github.com/pnpm/pnpm/blob/94240bc046/config/reader/src/index.ts#L591-L600)
+/// and consumes in [`network/fetch/src/dispatcher.ts:43-55`](https://github.com/pnpm/pnpm/blob/94240bc046/network/fetch/src/dispatcher.ts#L43-L55).
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ProxyConfig {
+    /// Proxy URL used for HTTPS targets. `None` means no proxy. May carry
+    /// userinfo (`http://user:pass@host:port`) which the network layer
+    /// strips and percent-decodes before forming the
+    /// `Proxy-Authorization` header.
+    pub https_proxy: Option<String>,
+
+    /// Proxy URL used for HTTP targets. Falls back through the cascade to
+    /// `https_proxy` when no explicit `http-proxy` / env var is set.
+    pub http_proxy: Option<String>,
+
+    /// Hosts that should bypass any configured proxy. `None` = no bypass
+    /// rules; [`NoProxySetting::Bypass`] = bypass every proxy
+    /// (upstream's `noProxy: true`); [`NoProxySetting::List`] = the parsed
+    /// reverse-dot-segment-prefix host list.
+    pub no_proxy: Option<NoProxySetting>,
+}
+
+/// Parsed `no-proxy` value.
+///
+/// Upstream models this as `noProxy: string | true`. Per AGENTS.md rule 7
+/// (string-literal-union → `enum`) the two-shape union becomes a closed
+/// Rust enum so callers can pattern-match the bypass case without
+/// inspecting a sentinel string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NoProxySetting {
+    /// `no-proxy=true` — bypass every proxy regardless of host.
+    Bypass,
+    /// Comma-separated host list, trimmed and empties dropped. Match
+    /// semantics are reverse-dot-segment-prefix (see
+    /// [`checkNoProxy`](https://github.com/pnpm/pnpm/blob/94240bc046/network/fetch/src/dispatcher.ts#L308-L332)).
+    List(Vec<String>),
+}
+
+/// Build-time error returned by [`crate::ThrottledClient::for_installs`]
+/// when a configured proxy URL is malformed.
+///
+/// Matches pnpm v11's `ERR_PNPM_INVALID_PROXY` error code (raised in
+/// [`network/fetch/src/dispatcher.ts:114-119`](https://github.com/pnpm/pnpm/blob/94240bc046/network/fetch/src/dispatcher.ts#L114-L119))
+/// so users with a stale `.npmrc` see the same diagnostic when migrating
+/// from pnpm to pacquet.
+#[derive(Debug, Display, Error, Diagnostic)]
+#[non_exhaustive]
+pub enum ProxyError {
+    #[display("Invalid proxy URL: {url} ({reason})")]
+    #[diagnostic(
+        code(ERR_PNPM_INVALID_PROXY),
+        help(
+            "Check the value of `https-proxy`, `http-proxy`, or `proxy` in your .npmrc, or the \
+             HTTPS_PROXY / HTTP_PROXY environment variables. URL-encode any special characters \
+             in the user:password segment."
+        )
+    )]
+    InvalidProxy { url: String, reason: String },
+}
+
+/// Parse a proxy URL, auto-prefixing `http://` when the input lacks an
+/// authority so values like `proxy.example:8080` round-trip the same
+/// way pnpm's [`parseProxyUrl`](https://github.com/pnpm/pnpm/blob/94240bc046/network/fetch/src/dispatcher.ts#L106-L121)
+/// handles them. Any other parse failure surfaces as
+/// [`ProxyError::InvalidProxy`].
+///
+/// A successful first parse is only accepted if the URL has a host —
+/// Rust's `Url::parse` is permissive enough to accept
+/// `proxy.example:8080` as a valid URL with scheme `proxy.example` and
+/// path `8080`, which is not what pnpm (or anyone) means by a proxy
+/// URL. Requiring `url.host().is_some()` forces such inputs through
+/// the `http://`-prefix retry where they parse the way a user expects.
+pub(crate) fn parse_proxy_url(raw: &str) -> Result<Url, ProxyError> {
+    if let Ok(url) = Url::parse(raw)
+        && url.host().is_some()
+    {
+        return Ok(url);
+    }
+    Url::parse(&format!("http://{raw}")).ok().filter(|url| url.host().is_some()).ok_or_else(|| {
+        ProxyError::InvalidProxy {
+            url: raw.to_string(),
+            reason: "could not parse as an authority-bearing URL".to_string(),
+        }
+    })
+}
+
+/// Split a proxy URL into its userless form and the
+/// (`user`, `password`) pair, percent-decoded. Returns `(url, None)`
+/// when the URL has no username.
+///
+/// The two halves are decoded independently — pnpm calls
+/// `decodeURIComponent` on each.
+pub(crate) fn strip_userinfo(mut url: Url) -> (Url, Option<(String, String)>) {
+    let raw_user = url.username();
+    if raw_user.is_empty() {
+        return (url, None);
+    }
+    let user = percent_decode_str(raw_user);
+    let pass = url.password().map(percent_decode_str).unwrap_or_default();
+    // `set_username("")` and `set_password(None)` cannot fail on a URL
+    // that already parsed successfully (the scheme is by definition
+    // one that supports authority).
+    let _ = url.set_username("");
+    let _ = url.set_password(None);
+    (url, Some((user, pass)))
+}
+
+/// Minimal percent-decoder for the user/password halves of a proxy URL
+/// userinfo.
+///
+/// Unlike JavaScript's `decodeURIComponent`, which throws `URIError` on
+/// malformed `%XX` sequences (e.g. `%ZZ`), this function intentionally
+/// keeps invalid sequences verbatim. The lenient fallback matches what
+/// pnpm's interpreter does in practice (a thrown error during proxy
+/// setup would surface as `ERR_PNPM_INVALID_PROXY`, but pnpm's flow
+/// doesn't validate that strictly either), and is the safer choice in
+/// a config path where the alternative is rejecting a half-broken
+/// password value.
+///
+/// Hand-rolled rather than pulling in `percent-encoding` as a direct
+/// workspace dep because the only call sites are the two halves of a
+/// proxy URL userinfo. The substitution table is exactly the
+/// `%XX → byte` form plus pass-through.
+pub(crate) fn percent_decode_str(s: &str) -> String {
+    let mut out = Vec::with_capacity(s.len());
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            let hex = std::str::from_utf8(&bytes[i + 1..i + 3]).ok();
+            if let Some(byte) = hex.and_then(|h| u8::from_str_radix(h, 16).ok()) {
+                out.push(byte);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+/// Pre-built reverse-dot-segment lookup table for the no-proxy bypass.
+///
+/// Port of upstream's
+/// [`checkNoProxy`](https://github.com/pnpm/pnpm/blob/94240bc046/network/fetch/src/dispatcher.ts#L308-L332):
+/// each entry's dot-segments are reversed at construction, and a host
+/// matches when the entry's reversed segments are a prefix of the
+/// host's reversed segments. `npmjs.org` thus matches
+/// `registry.npmjs.org` and `foo.bar.npmjs.org` but not
+/// `evilnpmjs.org`. Empty entries (from stray commas) never match.
+#[derive(Debug)]
+pub(crate) struct NoProxyMatcher {
+    bypass: bool,
+    entries: Vec<Vec<String>>,
+}
+
+impl NoProxyMatcher {
+    pub(crate) fn from(setting: Option<&NoProxySetting>) -> Self {
+        match setting {
+            None => NoProxyMatcher { bypass: false, entries: Vec::new() },
+            Some(NoProxySetting::Bypass) => NoProxyMatcher { bypass: true, entries: Vec::new() },
+            Some(NoProxySetting::List(list)) => NoProxyMatcher {
+                bypass: false,
+                entries: list
+                    .iter()
+                    .map(|entry| entry.split('.').rev().map(str::to_string).collect())
+                    .collect(),
+            },
+        }
+    }
+
+    pub(crate) fn matches_host(&self, host: &str) -> bool {
+        if self.bypass {
+            return true;
+        }
+        let host_rev: Vec<&str> = host.split('.').rev().collect();
+        self.entries.iter().any(|entry_rev| {
+            !entry_rev.is_empty()
+                && entry_rev.len() <= host_rev.len()
+                && entry_rev.iter().zip(host_rev.iter()).all(|(a, b)| a == b)
+        })
+    }
+
+    pub(crate) fn matches_url(&self, url: &Url) -> bool {
+        match url.host_str() {
+            Some(host) => self.matches_host(host),
+            None => false,
+        }
+    }
+}

--- a/crates/network/src/tests.rs
+++ b/crates/network/src/tests.rs
@@ -56,11 +56,9 @@ fn no_proxy_matcher_empty_entries_never_match() {
 fn no_proxy_matcher_multiple_entries() {
     let m = NoProxyMatcher::from(Some(&list(&["npmjs.org", "internal.example"])));
     eprintln!("matcher={m:?}");
-    for (host, expected) in [
-        ("registry.npmjs.org", true),
-        ("ci.internal.example", true),
-        ("public.example", false),
-    ] {
+    for (host, expected) in
+        [("registry.npmjs.org", true), ("ci.internal.example", true), ("public.example", false)]
+    {
         let got = m.matches_host(host);
         assert_eq!(got, expected, "host={host}: expected={expected}, got={got}");
     }

--- a/crates/network/src/tests.rs
+++ b/crates/network/src/tests.rs
@@ -1,0 +1,280 @@
+//! Tests for [`super`]'s proxy plumbing.
+//!
+//! Mirrors the describe blocks in pnpm v11's
+//! [`network/fetch/test/dispatcher.test.ts`](https://github.com/pnpm/pnpm/blob/94240bc046/network/fetch/test/dispatcher.test.ts)
+//! that don't require a real proxy listener:
+//!
+//! * `HTTP proxy` — per-URL routing, basic-auth decoding, scheme bypass.
+//! * `SOCKS proxy` — routing decision (live-network case skipped, same as
+//!   upstream).
+//! * `noProxy` — reverse-dot-segment match, bypass-all literal.
+//! * `Invalid proxy URL` — `ERR_PNPM_INVALID_PROXY`.
+//!
+//! The one HTTP integration test stands up a [`mockito`] server playing
+//! the role of an HTTP proxy and asserts the request arrives with an
+//! absolute-form URI and a decoded `Proxy-Authorization` header.
+
+use super::{
+    NoProxyMatcher, NoProxySetting, ProxyConfig, ProxyError, ThrottledClient, parse_proxy_url,
+};
+use crate::proxy::{percent_decode_str, strip_userinfo};
+use reqwest::Url;
+
+fn list(entries: &[&str]) -> NoProxySetting {
+    NoProxySetting::List(entries.iter().map(|s| (*s).to_string()).collect())
+}
+
+#[test]
+fn no_proxy_matcher_reverse_dot_match() {
+    let m = NoProxyMatcher::from(Some(&list(&["npmjs.org"])));
+    // The matcher state is the same across every probe; logging it
+    // once per test makes a failure diagnosable without rerunning.
+    eprintln!("matcher={m:?}");
+    for (host, expected) in [
+        ("npmjs.org", true),
+        ("registry.npmjs.org", true),
+        ("foo.bar.npmjs.org", true),
+        ("evilnpmjs.org", false),
+        ("org", false),
+    ] {
+        let got = m.matches_host(host);
+        assert_eq!(got, expected, "host={host}: expected match={expected}, got={got}");
+    }
+}
+
+#[test]
+fn no_proxy_matcher_empty_entries_never_match() {
+    // Trailing/leading commas in `.npmrc` already get filtered in the
+    // config layer's `parse_no_proxy`, but a malformed `List(vec![""])`
+    // must still fail to match — defense in depth at the matcher.
+    let m = NoProxyMatcher::from(Some(&list(&[""])));
+    let got = m.matches_host("anything.example");
+    assert!(!got, "matcher={m:?} host=anything.example expected miss, got match");
+}
+
+#[test]
+fn no_proxy_matcher_multiple_entries() {
+    let m = NoProxyMatcher::from(Some(&list(&["npmjs.org", "internal.example"])));
+    eprintln!("matcher={m:?}");
+    for (host, expected) in [
+        ("registry.npmjs.org", true),
+        ("ci.internal.example", true),
+        ("public.example", false),
+    ] {
+        let got = m.matches_host(host);
+        assert_eq!(got, expected, "host={host}: expected={expected}, got={got}");
+    }
+}
+
+#[test]
+fn no_proxy_bypass_short_circuits_every_host() {
+    let m = NoProxyMatcher::from(Some(&NoProxySetting::Bypass));
+    eprintln!("matcher={m:?}");
+    for host in ["any.host", ""] {
+        let got = m.matches_host(host);
+        assert!(got, "host={host:?}: bypass must match every host, got miss");
+    }
+}
+
+#[test]
+fn no_proxy_none_matches_nothing() {
+    let m = NoProxyMatcher::from(None);
+    let got = m.matches_host("registry.npmjs.org");
+    assert!(!got, "matcher={m:?}: None setting must never match");
+}
+
+#[test]
+fn parse_proxy_url_auto_prefixes_missing_scheme() {
+    // pnpm-parity: `proxy.example:8080` is treated as
+    // `http://proxy.example:8080`.
+    let url = parse_proxy_url("proxy.example:8080").expect("parses with retry");
+    assert_eq!(url.scheme(), "http");
+    assert_eq!(url.host_str(), Some("proxy.example"));
+    assert_eq!(url.port(), Some(8080));
+}
+
+#[test]
+fn parse_proxy_url_keeps_existing_scheme() {
+    let url = parse_proxy_url("https://proxy.example:8080").expect("parses");
+    assert_eq!(url.scheme(), "https");
+}
+
+#[test]
+fn parse_proxy_url_socks_schemes_pass_through() {
+    // pnpm honors socks4, socks4a, socks5 (dispatcher.ts:124-132).
+    // Routing happens elsewhere; here we only assert the URL parses.
+    for scheme in ["socks4", "socks4a", "socks5"] {
+        let url =
+            parse_proxy_url(&format!("{scheme}://socksproxy.example:1080")).expect("socks parses");
+        assert_eq!(url.scheme(), scheme);
+    }
+}
+
+#[test]
+fn parse_proxy_url_invalid_returns_invalid_proxy_error() {
+    // `://` is malformed regardless of which scheme is prefixed.
+    let err = parse_proxy_url("://broken").expect_err("malformed value must error");
+    eprintln!("err={err:?}");
+    match &err {
+        ProxyError::InvalidProxy { url, .. } => assert_eq!(url, "://broken"),
+    }
+    // Diagnostic code matches upstream `ERR_PNPM_INVALID_PROXY`.
+    let code = miette::Diagnostic::code(&err).expect("code() set");
+    assert_eq!(code.to_string(), "ERR_PNPM_INVALID_PROXY");
+}
+
+#[test]
+fn percent_decode_handles_common_escapes() {
+    assert_eq!(percent_decode_str("p%40ss"), "p@ss", "%40 → @");
+    assert_eq!(percent_decode_str("user%20name"), "user name");
+    assert_eq!(percent_decode_str("plain"), "plain");
+    assert_eq!(
+        percent_decode_str("bad-%ZZ-escape"),
+        "bad-%ZZ-escape",
+        "invalid hex passes through",
+    );
+}
+
+#[test]
+fn strip_userinfo_decodes_user_and_password() {
+    let url = Url::parse("http://us%40er:p%40ss@proxy.example:8080").expect("parse");
+    let (clean, auth) = strip_userinfo(url);
+    assert_eq!(clean.as_str(), "http://proxy.example:8080/");
+    let (user, pass) = auth.expect("userinfo present");
+    assert_eq!(user, "us@er", "user percent-decoded");
+    assert_eq!(pass, "p@ss", "password percent-decoded");
+}
+
+#[test]
+fn strip_userinfo_returns_none_when_absent() {
+    let url = Url::parse("http://proxy.example:8080").expect("parse");
+    let (clean, auth) = strip_userinfo(url.clone());
+    assert_eq!(clean, url);
+    let is_none = auth.is_none();
+    assert!(is_none, "auth={auth:?}: expected None on URL without userinfo");
+}
+
+#[test]
+fn for_installs_with_empty_proxy_config_builds() {
+    // The legacy `new_for_installs` is now a wrapper around this — assert
+    // the default `ProxyConfig` round-trips without error.
+    ThrottledClient::for_installs(&ProxyConfig::default()).expect("empty proxy is valid");
+}
+
+#[test]
+fn for_installs_with_valid_proxy_url_builds() {
+    let proxy = ProxyConfig {
+        https_proxy: Some("http://proxy.example:8080".into()),
+        http_proxy: Some("http://proxy.example:8080".into()),
+        no_proxy: None,
+    };
+    ThrottledClient::for_installs(&proxy).expect("valid proxy URLs build");
+}
+
+#[test]
+fn for_installs_with_invalid_proxy_url_errors() {
+    let proxy =
+        ProxyConfig { https_proxy: Some("://nonsense".into()), http_proxy: None, no_proxy: None };
+    let err = ThrottledClient::for_installs(&proxy).expect_err("must error");
+    eprintln!("err={err:?}");
+    let is_invalid = matches!(err, ProxyError::InvalidProxy { .. });
+    assert!(is_invalid, "err={err:?}: expected ProxyError::InvalidProxy");
+}
+
+#[test]
+fn for_installs_with_socks_proxy_url_builds() {
+    // Smoke test that the `socks` reqwest feature is wired correctly —
+    // a socks URL must not be rejected at parse time, and the client
+    // must build.
+    let proxy = ProxyConfig {
+        https_proxy: Some("socks5://socksproxy.example:1080".into()),
+        http_proxy: None,
+        no_proxy: None,
+    };
+    ThrottledClient::for_installs(&proxy).expect("socks proxy URL builds");
+}
+
+#[test]
+fn for_installs_no_proxy_bypass_does_not_block_build() {
+    let proxy = ProxyConfig {
+        https_proxy: Some("http://proxy.example:8080".into()),
+        http_proxy: None,
+        no_proxy: Some(NoProxySetting::Bypass),
+    };
+    ThrottledClient::for_installs(&proxy).expect("bypass + proxy URL builds");
+}
+
+/// End-to-end check that `for_installs` actually routes HTTP traffic
+/// through the configured proxy. We stand a `mockito` server up as an
+/// upstream HTTP proxy: when a client is configured with `http_proxy =
+/// <mockito_url>` and asked to fetch a different target URL, the request
+/// arrives at the mockito server bearing the absolute-form URI in its
+/// request line and the matching `Proxy-Authorization` header from the
+/// percent-decoded userinfo.
+#[tokio::test]
+async fn mockito_integration_http_proxy_forwards_request_with_basic_auth() {
+    let mut proxy_server = mockito::Server::new_async().await;
+    // The mock matches *any* path because reqwest's HTTP-proxy mode
+    // sends the request line with the absolute-form URI of the target
+    // (RFC 9112 §3.2.2). We pin auth & method instead.
+    let mock = proxy_server
+        .mock("GET", mockito::Matcher::Any)
+        .match_header("proxy-authorization", "Basic dXNlckBuYW1lOnBAc3M=")
+        .with_status(200)
+        .with_body("ok")
+        .expect(1)
+        .create_async()
+        .await;
+
+    let proxy_url = proxy_server.url();
+    // `user@name:p@ss` percent-encoded → `user%40name:p%40ss`; the
+    // network layer percent-decodes both halves to `user@name` and
+    // `p@ss` and base64-encodes the pair as `dXNlckBuYW1lOnBAc3M=` —
+    // the value the mock matches above.
+    let with_auth = proxy_url.replacen("//", "//user%40name:p%40ss@", 1);
+    let cfg = ProxyConfig { https_proxy: None, http_proxy: Some(with_auth), no_proxy: None };
+    let client = ThrottledClient::for_installs(&cfg).expect("valid proxy");
+    let guard = client.acquire().await;
+    let resp = guard.get("http://target.example/anything").send().await.expect("proxied request");
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.expect("body"), "ok");
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn mockito_integration_no_proxy_bypasses_proxy() {
+    // Sanity check the bypass path: with `NoProxySetting::Bypass`, the
+    // client must not consult the proxy at all. We register the proxy
+    // mock with `expect(0)` and rely on `mockito`'s drop-time assertion.
+    let mut proxy_server = mockito::Server::new_async().await;
+    let proxy_mock = proxy_server
+        .mock("GET", mockito::Matcher::Any)
+        .expect(0)
+        .with_status(500)
+        .create_async()
+        .await;
+
+    let mut target_server = mockito::Server::new_async().await;
+    let target_path = "/direct";
+    let target_mock = target_server
+        .mock("GET", target_path)
+        .expect(1)
+        .with_status(200)
+        .with_body("direct")
+        .create_async()
+        .await;
+
+    let cfg = ProxyConfig {
+        https_proxy: None,
+        http_proxy: Some(proxy_server.url()),
+        no_proxy: Some(NoProxySetting::Bypass),
+    };
+    let client = ThrottledClient::for_installs(&cfg).expect("valid proxy");
+    let guard = client.acquire().await;
+    let url = format!("{}{}", target_server.url(), target_path);
+    let resp = guard.get(&url).send().await.expect("direct request");
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.expect("body"), "direct");
+    proxy_mock.assert_async().await;
+    target_mock.assert_async().await;
+}

--- a/crates/package-manager/src/install_package_from_registry/tests.rs
+++ b/crates/package-manager/src/install_package_from_registry/tests.rs
@@ -54,6 +54,7 @@ fn create_config(store_dir: &Path, modules_dir: &Path, virtual_store_dir: &Path)
         git_shallow_hosts: pacquet_config::default_git_shallow_hosts(),
         supported_architectures: None,
         auth_headers: Default::default(),
+        proxy: Default::default(),
     }
 }
 


### PR DESCRIPTION
## Summary

Adds proxy support to pacquet, ported from pnpm v11 ([SHA 94240bc046](https://github.com/pnpm/pnpm/blob/94240bc046/network/fetch/src/dispatcher.ts)).

- **Config layer** (`feat(config)`): `Config.proxy: ProxyConfig` + `NoProxySetting` enum. `NpmrcAuth` parses `https-proxy`, `http-proxy`, `proxy` (legacy), `no-proxy`, and `noproxy` from `.npmrc`. The env-var fallback cascade (`HTTPS_PROXY`/`HTTP_PROXY`/`PROXY`/`NO_PROXY`, each with upper- and lowercase lookups) matches upstream's [`config/reader/src/index.ts:591-600`](https://github.com/pnpm/pnpm/blob/94240bc046/config/reader/src/index.ts#L591-L600). `.npmrc` always wins over env; `http_proxy` falls back through the resolved `https_proxy` before consulting env.
- **Network layer** (`feat(network)`): `ThrottledClient::for_installs(&ProxyConfig)` wires per-URL routing via `reqwest::Proxy::custom`. The closure dispatches HTTPS targets through `https_proxy`, HTTP through `http_proxy`, with a `NoProxyMatcher` (reverse-dot-segment-prefix port of upstream's [`checkNoProxy`](https://github.com/pnpm/pnpm/blob/94240bc046/network/fetch/src/dispatcher.ts#L308-L332)) short-circuiting both. Basic-auth userinfo is stripped from the URL and percent-decoded before being re-attached via `Proxy::basic_auth`, matching pnpm's `decodeURIComponent(user):decodeURIComponent(pass)`. Invalid proxy URLs surface as `ProxyError::InvalidProxy` carrying diagnostic code `ERR_PNPM_INVALID_PROXY`.
- **CLI** (`feat(cli)`): `State::init` switches to the config-aware constructor; `InitStateError::Proxy` propagates parse failures.

## Reviewer flags

- **Enables `reqwest`'s `socks` Cargo feature** (in root `Cargo.toml`). It is a feature on an existing dep, not a new top-level dep, but it pulls a SOCKS implementation into the build. socks4/socks4a/socks5 proxy URLs are now honored.
- `crates/network/Cargo.toml` gains direct deps on `pacquet-config`, `derive_more`, `miette` (all already in `[workspace.dependencies]`; no new top-level additions).
- `parse_proxy_url` rejects any first-attempt parse that lacks a host, forcing the `http://`-prefix retry through the authority-bearing path. Rust's `url::Url::parse("proxy.example:8080")` is permissive enough to accept it as scheme + opaque path, which is not what users mean by a proxy shorthand.
- Percent-decoding for the userinfo halves is a 15-line inline helper rather than a new `percent-encoding` direct dep — the only call site is the two halves of a proxy URL.

## Test plan

- [x] `cargo nextest run -p pacquet-config` — 70 tests pass (11 new cascade tests + 1 `EnvGuard` smoke test)
- [x] `cargo nextest run -p pacquet-network` — 19 tests pass (matcher, parse, percent-decode, build, plus 2 mockito integration tests for proxy forwarding with basic-auth and noProxy bypass)
- [x] `cargo nextest run --workspace` — full 666-test suite pass
- [x] `just ready` — typos, fmt, check, lint clean
- [x] `taplo format --check` clean
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace --document-private-items` clean
- [x] `just dylint` (perfectionist) clean
- [ ] Manual smoke (out-of-band): with `HTTPS_PROXY=http://localhost:9999 pacquet install`, traffic routes to the proxy

## Upstream coverage

Ports the unit-testable cases from pnpm's [`network/fetch/test/dispatcher.test.ts`](https://github.com/pnpm/pnpm/blob/94240bc046/network/fetch/test/dispatcher.test.ts): per-URL routing, basic-auth decoding, noProxy reverse-dot-prefix match, bypass-all literal, invalid URL → `ERR_PNPM_INVALID_PROXY`, SOCKS-URL parse smoke. Skips upstream's `describe.skip`-ed live-SOCKS test.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HTTP/HTTPS and SOCKS proxy support configurable via .npmrc and environment variables.
  * Added no-proxy bypass handling to exclude specified hosts from proxy routing.
  * Proxy settings now resolve via a cascade (npmrc → env) even when no .npmrc file exists.

* **Improvements**
  * Improved proxy validation and clearer diagnostic errors for invalid proxy URLs.
  * Expanded tests and reliability around proxy parsing and routing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pacquet/pull/476)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->