### PR TITLE
perf(git-fetcher): skip CAS re-import when packlist matches input (#436 follow-up)

### DIFF
--- a/crates/git-fetcher/src/cas_io.rs
+++ b/crates/git-fetcher/src/cas_io.rs
@@ -239,13 +239,19 @@ pub(crate) fn synthesize_files_index(
 /// the path doesn't match that shape, so callers can surface a clear
 /// error rather than silently producing a malformed digest.
 fn cas_path_digest(path: &Path) -> Option<String> {
+    // SHA-512 produces 64 bytes / 128 hex chars. The first 2 hex
+    // chars become the shard directory; the rest become the file
+    // stem. Anything outside that exact shape is not a v11 CAS path
+    // — fail closed instead of producing a short / over-long digest
+    // that would later poison `index.db`.
+    const STEM_LEN: usize = 128 - 2;
     let file_name = path.file_name()?.to_str()?;
     let stem = file_name.strip_suffix("-exec").unwrap_or(file_name);
     let shard = path.parent()?.file_name()?.to_str()?;
     if shard.len() != 2 || !shard.bytes().all(|b| b.is_ascii_hexdigit()) {
         return None;
     }
-    if !stem.bytes().all(|b| b.is_ascii_hexdigit()) || stem.is_empty() {
+    if stem.len() != STEM_LEN || !stem.bytes().all(|b| b.is_ascii_hexdigit()) {
         return None;
     }
     Some(format!("{shard}{stem}"))
@@ -344,12 +350,28 @@ mod tests {
 
     #[test]
     fn cas_path_digest_rejects_malformed_paths() {
-        // Wrong shape — too few components.
+        // Shard has wrong length (3 chars vs the required 2) — the
+        // most common "wrong shape" failure mode for a path that
+        // accidentally ends up here from outside the CAS layout.
         assert!(cas_path_digest(Path::new("/tmp/foo")).is_none());
         // Non-hex shard.
         assert!(cas_path_digest(&PathBuf::from("/tmp/zz/abc")).is_none());
-        // Empty stem.
-        assert!(cas_path_digest(&PathBuf::from("/tmp/ab/")).is_none());
+        // Right shard shape but the stem is far too short to be
+        // half of a sha512 digest — explicitly exercises the
+        // length check so a future refactor can't silently weaken
+        // it back to "any non-empty hex string".
+        assert!(cas_path_digest(&PathBuf::from("/tmp/ab/cd")).is_none());
+        // Stem one char short of the full 126.
+        let short = format!("/tmp/ab/{}", "c".repeat(125));
+        assert!(cas_path_digest(&PathBuf::from(short)).is_none());
+        // Stem one char too long.
+        let long = format!("/tmp/ab/{}", "c".repeat(127));
+        assert!(cas_path_digest(&PathBuf::from(long)).is_none());
+        // Right total length but with a non-hex byte in the stem.
+        let mut bogus_stem = "c".repeat(125);
+        bogus_stem.push('z');
+        let bad_hex = format!("/tmp/ab/{bogus_stem}");
+        assert!(cas_path_digest(&PathBuf::from(bad_hex)).is_none());
     }
 
     #[test]

--- a/crates/git-fetcher/src/cas_io.rs
+++ b/crates/git-fetcher/src/cas_io.rs
@@ -184,9 +184,71 @@ fn file_mode_from(_meta: &fs::Metadata) -> u32 {
 /// suffix pnpm's CAFS layout uses. Cheaper than reading filesystem
 /// metadata, and matches the write-side encoding in
 /// [`pacquet_store_dir::StoreDir::cas_file_path`].
-#[cfg(unix)]
 fn cas_path_is_executable(path: &Path) -> bool {
     path.file_name().and_then(|n| n.to_str()).is_some_and(|n| n.ends_with("-exec"))
+}
+
+/// Synthesize the [`PackageFilesIndex::files`](pacquet_store_dir::PackageFilesIndex::files)
+/// payload from an existing `cas_paths` map without re-reading file
+/// bytes. Used by [`crate::GitHostedTarballFetcher`]'s fast path
+/// (mirrors upstream's [`gitHostedTarballFetcher.ts:88-100`](https://github.com/pnpm/pnpm/blob/94240bc046/fetching/tarball-fetcher/src/gitHostedTarballFetcher.ts#L88-L100)),
+/// where the prepared file set is byte-identical to the raw tarball,
+/// so re-hashing every entry into the CAS would be wasted work.
+///
+/// The digest is extracted from the CAS path itself — pnpm v11 lays
+/// CAS files out as `files/XX/<rest>[-exec]`, so concatenating the
+/// shard byte (parent directory name) with the file stem (sans the
+/// optional `-exec` suffix) reconstructs the full hex digest. Mode
+/// reporting follows the read side's
+/// [`cas_file_path_by_mode`](pacquet_store_dir::StoreDir::cas_file_path_by_mode)
+/// rule: any-exec-bit-set ↔ `-exec` suffix, so a synthesized `0o755`
+/// for `-exec` entries and `0o644` otherwise round-trip cleanly.
+/// `size` still requires a `fs::metadata` stat, but that's two syscalls
+/// per file rather than a full read + sha512.
+pub(crate) fn synthesize_files_index(
+    cas_paths: &HashMap<String, PathBuf>,
+) -> Result<HashMap<String, CafsFileInfo>, GitFetcherError> {
+    let mut out = HashMap::with_capacity(cas_paths.len());
+    for (rel, cas_path) in cas_paths {
+        let digest = cas_path_digest(cas_path).ok_or_else(|| {
+            GitFetcherError::Io(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "CAS path {cas_path:?} for {rel:?} does not match `files/XX/<rest>[-exec]`",
+                ),
+            ))
+        })?;
+        let executable = cas_path_is_executable(cas_path);
+        // Match the read-side `cas_file_path_by_mode` round-trip rule:
+        // any-exec-bit-set ↔ `-exec` suffix. The exact mode value is
+        // only consulted by `is_executable`, so `0o755` / `0o644` are
+        // canonical representatives — they replay through the same
+        // `-exec` decision the write side made for these blobs.
+        let mode = if executable { 0o755 } else { 0o644 };
+        let metadata = fs::metadata(cas_path).map_err(GitFetcherError::Io)?;
+        let size = metadata.len();
+        out.insert(rel.clone(), CafsFileInfo { digest, mode, size, checked_at: None });
+    }
+    Ok(out)
+}
+
+/// Reconstruct the hex digest of a CAS file from its path. The pnpm
+/// v11 layout puts CAS files at `<store>/v11/files/<XX>/<rest>[-exec]`
+/// where `<XX>` is the first byte of the sha512 hex digest and
+/// `<rest>` is the remaining 126 hex characters. Returns `None` when
+/// the path doesn't match that shape, so callers can surface a clear
+/// error rather than silently producing a malformed digest.
+fn cas_path_digest(path: &Path) -> Option<String> {
+    let file_name = path.file_name()?.to_str()?;
+    let stem = file_name.strip_suffix("-exec").unwrap_or(file_name);
+    let shard = path.parent()?.file_name()?.to_str()?;
+    if shard.len() != 2 || !shard.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return None;
+    }
+    if !stem.bytes().all(|b| b.is_ascii_hexdigit()) || stem.is_empty() {
+        return None;
+    }
+    Some(format!("{shard}{stem}"))
 }
 
 /// Re-wrap a CAFS write failure as a `GitFetcherError::AddFilesFromDir`.
@@ -202,9 +264,15 @@ pub(crate) fn map_write_cas(err: pacquet_store_dir::WriteCasFileError) -> GitFet
 
 #[cfg(test)]
 mod tests {
-    use super::{GitFetcherError, join_checked, materialize_into};
+    use super::{
+        GitFetcherError, cas_path_digest, join_checked, materialize_into, synthesize_files_index,
+    };
     use pacquet_store_dir::StoreDir;
-    use std::{collections::HashMap, io, path::Path};
+    use std::{
+        collections::HashMap,
+        io,
+        path::{Path, PathBuf},
+    };
     use tempfile::tempdir;
 
     fn assert_invalid_input(err: GitFetcherError) {
@@ -248,6 +316,92 @@ mod tests {
         // Even a `..` deep in the path must be refused — otherwise
         // `a/../../escape` would slip through.
         assert_invalid_input(join_checked(Path::new("/root"), "a/../escape").unwrap_err());
+    }
+
+    #[test]
+    fn cas_path_digest_round_trips_through_write_cas_file() {
+        // Anchor the digest-reconstruction logic against the canonical
+        // write side: whatever `write_cas_file` produces, the read
+        // side has to invert. A mismatch would silently corrupt the
+        // `files_index` rows the fast path queues.
+        let cas_root = tempdir().unwrap();
+        let store_dir = StoreDir::from(cas_root.path().to_path_buf());
+
+        let (regular_path, regular_hash) = store_dir.write_cas_file(b"hello", false).unwrap();
+        assert_eq!(
+            cas_path_digest(&regular_path).expect("round-trip non-exec"),
+            format!("{regular_hash:x}"),
+        );
+
+        let (exec_path, exec_hash) = store_dir.write_cas_file(b"#!/bin/sh\n", true).unwrap();
+        let digest = cas_path_digest(&exec_path).expect("round-trip exec");
+        assert_eq!(
+            digest,
+            format!("{exec_hash:x}"),
+            "`-exec` suffix must be stripped before parse",
+        );
+    }
+
+    #[test]
+    fn cas_path_digest_rejects_malformed_paths() {
+        // Wrong shape — too few components.
+        assert!(cas_path_digest(Path::new("/tmp/foo")).is_none());
+        // Non-hex shard.
+        assert!(cas_path_digest(&PathBuf::from("/tmp/zz/abc")).is_none());
+        // Empty stem.
+        assert!(cas_path_digest(&PathBuf::from("/tmp/ab/")).is_none());
+    }
+
+    #[test]
+    fn synthesize_files_index_recovers_digest_size_and_exec_bit() {
+        // The slow path computes `CafsFileInfo` by reading every file,
+        // re-hashing, and stat'ing. The fast path must produce the
+        // same `(digest, mode-class, size)` triple from the CAS path
+        // alone — anything else and the warm prefetch would miss.
+        let store_root = tempdir().unwrap();
+        let store_dir = StoreDir::from(store_root.path().to_path_buf());
+
+        let (regular_path, regular_hash) = store_dir.write_cas_file(b"abc", false).unwrap();
+        let (exec_path, exec_hash) =
+            store_dir.write_cas_file(b"#!/usr/bin/env node\n", true).unwrap();
+
+        let mut cas_paths = HashMap::new();
+        cas_paths.insert("README.md".to_string(), regular_path);
+        cas_paths.insert("bin/run".to_string(), exec_path);
+
+        let index = synthesize_files_index(&cas_paths).unwrap();
+        assert_eq!(index.len(), 2);
+
+        let readme = index.get("README.md").expect("README entry");
+        assert_eq!(readme.digest, format!("{regular_hash:x}"));
+        assert_eq!(readme.size, 3);
+        assert_eq!(readme.mode & 0o111, 0, "regular files have no exec bit");
+        assert_eq!(readme.checked_at, None);
+
+        let bin = index.get("bin/run").expect("bin entry");
+        assert_eq!(bin.digest, format!("{exec_hash:x}"));
+        assert_eq!(bin.size, b"#!/usr/bin/env node\n".len() as u64);
+        assert_eq!(bin.mode & 0o111, 0o111, "exec files keep all exec bits");
+    }
+
+    #[test]
+    fn synthesize_files_index_errors_on_malformed_cas_path() {
+        // A caller handing us paths that don't match the v11 CAS
+        // layout is a programming error — better to surface it as
+        // `InvalidData` than to silently bake a bogus digest into
+        // `index.db`.
+        let mut bad = HashMap::new();
+        // A path that exists but isn't shaped like a CAS file.
+        let tmp = tempdir().unwrap();
+        let scratch = tmp.path().join("scratch.txt");
+        std::fs::write(&scratch, b"x").unwrap();
+        bad.insert("scratch.txt".to_string(), scratch);
+
+        let err = synthesize_files_index(&bad).unwrap_err();
+        match err {
+            GitFetcherError::Io(io_err) => assert_eq!(io_err.kind(), io::ErrorKind::InvalidData),
+            other => panic!("expected Io(InvalidData), got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/git-fetcher/src/tarball_fetcher.rs
+++ b/crates/git-fetcher/src/tarball_fetcher.rs
@@ -13,22 +13,23 @@
 //!
 //! Differences from upstream worth flagging:
 //!
-//! - **No "raw" vs "built" two-slot CAS today.** Upstream stores the
-//!   raw download at `${filesIndexFile}\traw` and the prepared output
-//!   at `filesIndexFile`, and on the fast path promotes the raw entry
-//!   to the final key in place. Pacquet currently doesn't expose the
-//!   "filesIndexFile" hook at this layer (the install dispatcher
-//!   feeds the result straight into `CreateVirtualDirBySnapshot`), so
-//!   we always re-import. Hash-deduplication means duplicate work but
-//!   not duplicate storage; the optimization is a follow-up
-//!   alongside warm-prefetch for git-hosted slots.
+//! - **No two-slot store-index row.** Upstream writes a `\traw` row
+//!   from the tarball download and copies it to the prepared key on
+//!   the fast path. Pacquet's tarball download path doesn't write a
+//!   raw row at this key, so on the fast path we synthesize the
+//!   prepared row directly from the input `cas_paths` (no fs::read,
+//!   no re-hash). When fast-path triggers and `should_be_built` is
+//!   false, the synthesized row lands at the final key — matches the
+//!   shape upstream's "copy raw→prepared" produces. The skipped
+//!   re-import is the perf win; the orphan raw row (if pacquet-tarball
+//!   ever starts writing one) is a separate cleanup follow-up.
 //! - **`globalWarn` becomes `tracing::warn!`.** When `ignore_scripts`
 //!   suppresses a needed build, both upstream and pacquet log a
 //!   warning — we route through `tracing` since pacquet's reporter
 //!   model doesn't have a `globalWarn` equivalent.
 
 use crate::{
-    cas_io::{ImportedFiles, import_into_cas, materialize_into},
+    cas_io::{ImportedFiles, import_into_cas, materialize_into, synthesize_files_index},
     error::GitFetcherError,
     fetcher::GitFetchOutput,
     packlist::packlist,
@@ -151,12 +152,56 @@ impl<'a> GitHostedTarballFetcher<'a> {
             .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new()));
         let files = packlist(&pkg_dir, &manifest).map_err(GitFetcherError::Packlist)?;
 
-        // Step 4: Re-import the filtered file set back into CAS and
-        // hand the resulting map to the install dispatcher.
+        // Step 4: Fast path — when nothing got filtered out AND
+        // prepare didn't mutate the tree (no build needed, or scripts
+        // ignored), the materialized files are byte-identical to the
+        // CAS source. Re-hashing every entry through `import_into_cas`
+        // would land them at the same CAS paths via hash-dedup, so the
+        // work is wasted. Mirrors upstream's [`gitHostedTarballFetcher.ts:88-100`](https://github.com/pnpm/pnpm/blob/94240bc046/fetching/tarball-fetcher/src/gitHostedTarballFetcher.ts#L88-L100).
+        //
+        // `path.is_none()` is required because a sub-path means
+        // `cas_paths` covers the whole monorepo while `files` covers
+        // only the sub-package — the count match is a coincidence
+        // there, not equivalence.
+        let fast_path_eligible = self.path.is_none() && files.len() == self.cas_paths.len();
+        if fast_path_eligible && !should_be_built {
+            // Upstream copies the raw row to the final key here. We
+            // synthesize it from `cas_paths` instead: pacquet's tarball
+            // download doesn't write a `\traw` row at the same key, so
+            // there's nothing to copy — but the CAS files themselves
+            // are already in place, which is what `cas_paths` points at.
+            if let Some(writer) = self.store_index_writer {
+                let files_index = synthesize_files_index(&self.cas_paths)?;
+                writer.queue(
+                    self.files_index_file.to_string(),
+                    PackageFilesIndex {
+                        manifest: None,
+                        requires_build: Some(false),
+                        algo: "sha512".to_string(),
+                        files: files_index,
+                        side_effects: None,
+                    },
+                );
+            }
+            return Ok(GitFetchOutput { cas_paths: self.cas_paths, built: false });
+        }
+        if fast_path_eligible && self.ignore_scripts {
+            // `should_be_built && ignore_scripts`: prepare skipped the
+            // scripts (warning already logged above), so the
+            // materialized tree is still byte-identical to the source.
+            // Upstream returns the raw filesMap *without* writing a
+            // final-key row, so subsequent installs re-check the build
+            // gate. Matching that behavior keeps `--ignore-scripts`
+            // installs idempotent.
+            return Ok(GitFetchOutput { cas_paths: self.cas_paths, built: should_be_built });
+        }
+
+        // Step 5: Slow path — re-import the filtered file set back
+        // into CAS and hand the resulting map to the install dispatcher.
         let ImportedFiles { cas_paths, files_index } =
             import_into_cas(self.store_dir, &pkg_dir, &files)?;
 
-        // Step 5: Queue a `PackageFilesIndex` row so a future install's
+        // Step 6: Queue a `PackageFilesIndex` row so a future install's
         // warm prefetch skips the materialize+prepare+packlist+re-import
         // pass entirely. Upstream writes the final row at
         // `gitHostedStoreIndexKey(pkgId, { built: shouldBeBuilt })` in

--- a/crates/git-fetcher/src/tarball_fetcher/tests.rs
+++ b/crates/git-fetcher/src/tarball_fetcher/tests.rs
@@ -471,28 +471,30 @@ async fn fast_path_queues_synthesized_index_row() {
     assert_eq!(resolved, bin_cas_path, "synthesized digest must round-trip to the input CAS path");
 }
 
-/// Sub-path resolutions never qualify for the fast path: `cas_paths`
-/// covers the whole monorepo while `packlist` only walks the
-/// sub-dir, so the count check could only coincidentally pass on
-/// degenerate single-package monorepos. Pin the slow-path behavior
-/// to guard against a future refactor that loosens the `path.is_none()`
-/// guard.
+/// Sub-path resolutions never qualify for the fast path: even when
+/// `cas_paths.len() == packlist.len()` (e.g. a tarball that only
+/// contains the sub-package's files), the keys themselves live
+/// under `packages/sub/...` while packlist runs *inside* `pkg_dir`
+/// and produces keys relative to that sub-dir. Returning the input
+/// `cas_paths` verbatim would surface monorepo-prefixed paths to
+/// the dispatcher and corrupt the virtual store. Pin the slow-path
+/// behavior to guard against a future refactor that loosens the
+/// `path.is_none()` guard.
 #[tokio::test(flavor = "multi_thread")]
 async fn sub_path_never_takes_fast_path() {
     let store_root = tempdir().unwrap();
     let store_dir = StoreDir::from(store_root.path().to_path_buf());
     let (writer, writer_task) = StoreIndexWriter::spawn(&store_dir);
 
-    // Single-package "monorepo": one package.json at the root, one
-    // at `packages/sub`. If the fast-path guard ever dropped
-    // `path.is_none()`, this configuration would slip through —
-    // root manifest + sub manifest = 2 files at the top, packlist
-    // of `packages/sub` returns 1 file, no coincidental match. The
-    // test verifies the slow path re-imports under the sub-path.
+    // Tarball contains *only* the sub-package's files, so the
+    // count check (`packlist.len() == cas_paths.len()`) would
+    // otherwise pass: both sides see exactly two files. The only
+    // thing keeping the fast path out is `path.is_none()`. If that
+    // guard ever weakens, the assertion below would flag the
+    // misshaped `packages/sub/...` keys in the row.
     let cas_paths = write_to_cas(
         &store_dir,
         &[
-            ("package.json", br#"{"name":"monorepo","version":"0.0.0","private":true}"#, false),
             (
                 "packages/sub/package.json",
                 br#"{"name":"sub","version":"1.0.0","main":"index.js"}"#,
@@ -503,7 +505,7 @@ async fn sub_path_never_takes_fast_path() {
     );
 
     let key = "sub@1.0.0\tbuilt";
-    let _ = GitHostedTarballFetcher {
+    let received = GitHostedTarballFetcher {
         cas_paths,
         path: Some("packages/sub"),
         allow_build: deny_all_builds(),
@@ -527,15 +529,27 @@ async fn sub_path_never_takes_fast_path() {
     drop(writer);
     writer_task.await.unwrap().unwrap();
 
+    // Output keys are relative to the sub-dir — never carrying the
+    // `packages/sub/` prefix. If the fast path had triggered
+    // (returning input `cas_paths` verbatim), the keys would still
+    // be the monorepo-prefixed paths.
+    let out_keys: Vec<&str> = received.cas_paths.keys().map(String::as_str).collect();
+    assert!(
+        !out_keys.iter().any(|k| k.contains("packages/")),
+        "slow path strips the sub-dir prefix: {out_keys:?}",
+    );
+    assert!(out_keys.contains(&"package.json"));
+    assert!(out_keys.contains(&"index.js"));
+
     let index = StoreIndex::open_in(&store_dir).unwrap();
-    let row = index.get(key).unwrap().expect("sub-path path takes slow path and writes a row");
-    // The slow path packlists relative to `pkg_dir = .../packages/sub`,
-    // so the row's file keys are relative to the sub-dir — not the
-    // monorepo root.
-    let keys: Vec<&str> = row.files.keys().map(String::as_str).collect();
-    assert!(keys.contains(&"package.json"), "sub-dir manifest");
-    assert!(keys.contains(&"index.js"), "sub-dir main");
-    assert!(!keys.iter().any(|k| k.contains("packages/")), "no monorepo prefixes in {keys:?}");
+    let row = index.get(key).unwrap().expect("sub-path takes slow path and writes a row");
+    let row_keys: Vec<&str> = row.files.keys().map(String::as_str).collect();
+    assert!(row_keys.contains(&"package.json"), "sub-dir manifest");
+    assert!(row_keys.contains(&"index.js"), "sub-dir main");
+    assert!(
+        !row_keys.iter().any(|k| k.contains("packages/")),
+        "no monorepo prefixes in {row_keys:?}",
+    );
 }
 
 /// `should_be_built && ignore_scripts` is the second fast-path

--- a/crates/git-fetcher/src/tarball_fetcher/tests.rs
+++ b/crates/git-fetcher/src/tarball_fetcher/tests.rs
@@ -350,6 +350,259 @@ async fn writes_index_row_when_writer_provided() {
     );
 }
 
+/// Fast path: when there's no sub-path, no build is needed, and the
+/// packlist returns every input file, the fetcher must skip
+/// `import_into_cas` and hand the input `cas_paths` straight back
+/// to the dispatcher. Mirrors upstream's
+/// [`gitHostedTarballFetcher.ts:88-100`](https://github.com/pnpm/pnpm/blob/94240bc046/fetching/tarball-fetcher/src/gitHostedTarballFetcher.ts#L88-L100)
+/// "raw → prepared" promotion.
+#[tokio::test(flavor = "multi_thread")]
+async fn fast_path_returns_input_cas_paths_when_no_build_needed() {
+    let store_root = tempdir().unwrap();
+    let store_dir = StoreDir::from(store_root.path().to_path_buf());
+
+    // No `files` field, no `prepare` script — packlist returns
+    // everything, `should_be_built` is false. All three input
+    // entries (package.json + index.js + README.md) survive
+    // packlist's always-included rules.
+    let cas_paths = write_to_cas(
+        &store_dir,
+        &[
+            ("package.json", br#"{"name":"x","version":"1.0.0","main":"index.js"}"#, false),
+            ("index.js", b"module.exports = 42;\n", false),
+            ("README.md", b"# x\n", false),
+        ],
+    );
+    let input_snapshot = cas_paths.clone();
+
+    let received = GitHostedTarballFetcher {
+        cas_paths,
+        path: None,
+        allow_build: deny_all_builds(),
+        ignore_scripts: false,
+        unsafe_perm: true,
+        user_agent: None,
+        scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+        script_shell: None,
+        node_execpath: None,
+        npm_execpath: None,
+        store_dir: &store_dir,
+        package_id: "x@1.0.0",
+        requester: "/test",
+        store_index_writer: None,
+        files_index_file: "x@1.0.0\tbuilt",
+    }
+    .run::<SilentReporter>()
+    .await
+    .unwrap();
+
+    // The returned map is the *exact* input — same keys, same CAS
+    // paths. The slow path would re-import and produce a fresh map
+    // that just happens to point at the same hashes; the fast path
+    // skips that work entirely.
+    assert!(!received.built);
+    assert_eq!(received.cas_paths, input_snapshot, "fast path returns input cas_paths verbatim");
+}
+
+/// When the fast path triggers and a writer is provided, the
+/// synthesized row must be queued at the final key with the same
+/// shape the slow path would have produced — same digests, same
+/// `requires_build: false`, same file set. A warm prefetch reading
+/// the row from `index.db` can't tell which path produced it.
+#[tokio::test(flavor = "multi_thread")]
+async fn fast_path_queues_synthesized_index_row() {
+    let store_root = tempdir().unwrap();
+    let store_dir = StoreDir::from(store_root.path().to_path_buf());
+    let (writer, writer_task) = StoreIndexWriter::spawn(&store_dir);
+
+    let cas_paths = write_to_cas(
+        &store_dir,
+        &[
+            ("package.json", br#"{"name":"x","version":"1.0.0","main":"index.js"}"#, false),
+            // Mark this one executable to confirm the synthesized
+            // row's `mode` bit round-trips through the `-exec` suffix.
+            ("bin/cli.js", b"#!/usr/bin/env node\nconsole.log('hi');\n", true),
+            ("index.js", b"module.exports = 42;\n", false),
+        ],
+    );
+    let bin_cas_path = cas_paths["bin/cli.js"].clone();
+
+    let key = "x@1.0.0\tbuilt";
+    let _received = GitHostedTarballFetcher {
+        cas_paths,
+        path: None,
+        allow_build: deny_all_builds(),
+        ignore_scripts: false,
+        unsafe_perm: true,
+        user_agent: None,
+        scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+        script_shell: None,
+        node_execpath: None,
+        npm_execpath: None,
+        store_dir: &store_dir,
+        package_id: "x@1.0.0",
+        requester: "/test",
+        store_index_writer: Some(&Arc::clone(&writer)),
+        files_index_file: key,
+    }
+    .run::<SilentReporter>()
+    .await
+    .unwrap();
+
+    drop(writer);
+    writer_task.await.unwrap().unwrap();
+
+    let index = StoreIndex::open_in(&store_dir).unwrap();
+    let row = index.get(key).unwrap().expect("fast path must still queue a row at the final key");
+    assert_eq!(row.requires_build, Some(false), "fast path implies no build needed");
+    assert_eq!(row.algo, "sha512");
+    let row_keys: Vec<&str> = row.files.keys().map(String::as_str).collect();
+    assert!(row_keys.contains(&"package.json"));
+    assert!(row_keys.contains(&"index.js"));
+    assert!(row_keys.contains(&"bin/cli.js"));
+
+    // The synthesized `bin/cli.js` entry must round-trip through
+    // `cas_file_path_by_mode` to the same path the input map points
+    // at — that's the property a warm prefetch relies on.
+    let bin_entry = row.files.get("bin/cli.js").expect("bin entry must exist");
+    assert_eq!(bin_entry.mode & 0o111, 0o111, "executable bit must survive the synthesis");
+    let resolved =
+        store_dir.cas_file_path_by_mode(&bin_entry.digest, bin_entry.mode).expect("valid digest");
+    assert_eq!(resolved, bin_cas_path, "synthesized digest must round-trip to the input CAS path");
+}
+
+/// Sub-path resolutions never qualify for the fast path: `cas_paths`
+/// covers the whole monorepo while `packlist` only walks the
+/// sub-dir, so the count check could only coincidentally pass on
+/// degenerate single-package monorepos. Pin the slow-path behavior
+/// to guard against a future refactor that loosens the `path.is_none()`
+/// guard.
+#[tokio::test(flavor = "multi_thread")]
+async fn sub_path_never_takes_fast_path() {
+    let store_root = tempdir().unwrap();
+    let store_dir = StoreDir::from(store_root.path().to_path_buf());
+    let (writer, writer_task) = StoreIndexWriter::spawn(&store_dir);
+
+    // Single-package "monorepo": one package.json at the root, one
+    // at `packages/sub`. If the fast-path guard ever dropped
+    // `path.is_none()`, this configuration would slip through —
+    // root manifest + sub manifest = 2 files at the top, packlist
+    // of `packages/sub` returns 1 file, no coincidental match. The
+    // test verifies the slow path re-imports under the sub-path.
+    let cas_paths = write_to_cas(
+        &store_dir,
+        &[
+            ("package.json", br#"{"name":"monorepo","version":"0.0.0","private":true}"#, false),
+            (
+                "packages/sub/package.json",
+                br#"{"name":"sub","version":"1.0.0","main":"index.js"}"#,
+                false,
+            ),
+            ("packages/sub/index.js", b"module.exports = 1;\n", false),
+        ],
+    );
+
+    let key = "sub@1.0.0\tbuilt";
+    let _ = GitHostedTarballFetcher {
+        cas_paths,
+        path: Some("packages/sub"),
+        allow_build: deny_all_builds(),
+        ignore_scripts: false,
+        unsafe_perm: true,
+        user_agent: None,
+        scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+        script_shell: None,
+        node_execpath: None,
+        npm_execpath: None,
+        store_dir: &store_dir,
+        package_id: "sub@1.0.0",
+        requester: "/test",
+        store_index_writer: Some(&Arc::clone(&writer)),
+        files_index_file: key,
+    }
+    .run::<SilentReporter>()
+    .await
+    .unwrap();
+
+    drop(writer);
+    writer_task.await.unwrap().unwrap();
+
+    let index = StoreIndex::open_in(&store_dir).unwrap();
+    let row = index.get(key).unwrap().expect("sub-path path takes slow path and writes a row");
+    // The slow path packlists relative to `pkg_dir = .../packages/sub`,
+    // so the row's file keys are relative to the sub-dir — not the
+    // monorepo root.
+    let keys: Vec<&str> = row.files.keys().map(String::as_str).collect();
+    assert!(keys.contains(&"package.json"), "sub-dir manifest");
+    assert!(keys.contains(&"index.js"), "sub-dir main");
+    assert!(!keys.iter().any(|k| k.contains("packages/")), "no monorepo prefixes in {keys:?}");
+}
+
+/// `should_be_built && ignore_scripts` is the second fast-path
+/// branch: scripts were suppressed (a warning fired earlier), the
+/// materialized tree is still untouched, so re-import is wasted
+/// work. Upstream specifically does *not* queue a final-key row
+/// here — subsequent installs must re-check the build gate. This
+/// test pins both halves: the input `cas_paths` is returned
+/// verbatim, and no row lands at the final key.
+#[tokio::test(flavor = "multi_thread")]
+async fn fast_path_ignore_scripts_returns_input_without_queueing_row() {
+    let store_root = tempdir().unwrap();
+    let store_dir = StoreDir::from(store_root.path().to_path_buf());
+    let (writer, writer_task) = StoreIndexWriter::spawn(&store_dir);
+
+    // `prepare` script triggers `should_be_built = true`, but
+    // `ignore_scripts: true` skips the actual execution. With no
+    // `files` field, packlist returns every input file — fast-path
+    // eligible.
+    let cas_paths = write_to_cas(
+        &store_dir,
+        &[
+            (
+                "package.json",
+                br#"{"name":"x","version":"1.0.0","main":"index.js","scripts":{"prepare":"tsc"}}"#,
+                false,
+            ),
+            ("index.js", b"module.exports = 1;\n", false),
+        ],
+    );
+    let input_snapshot = cas_paths.clone();
+
+    let key = "x@1.0.0\tbuilt";
+    let received = GitHostedTarballFetcher {
+        cas_paths,
+        path: None,
+        allow_build: deny_all_builds(),
+        ignore_scripts: true,
+        unsafe_perm: true,
+        user_agent: None,
+        scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+        script_shell: None,
+        node_execpath: None,
+        npm_execpath: None,
+        store_dir: &store_dir,
+        package_id: "x@1.0.0",
+        requester: "/test",
+        store_index_writer: Some(&Arc::clone(&writer)),
+        files_index_file: key,
+    }
+    .run::<SilentReporter>()
+    .await
+    .unwrap();
+
+    drop(writer);
+    writer_task.await.unwrap().unwrap();
+
+    assert!(received.built, "should_be_built stays true even when scripts were ignored");
+    assert_eq!(received.cas_paths, input_snapshot, "ignored-build fast path returns input as-is");
+
+    let index = StoreIndex::open_in(&store_dir).unwrap();
+    assert!(
+        index.get(key).unwrap().is_none(),
+        "ignored-build fast path must NOT queue a final-key row",
+    );
+}
+
 /// Ports pnpm's `prevent directory traversal attack when path is
 /// present` at
 /// <https://github.com/pnpm/pnpm/blob/94240bc046/fetching/tarball-fetcher/test/fetch.ts#L610>.


### PR DESCRIPTION
## Summary

Ports the post-packlist fast-path branch from upstream's [`gitHostedTarballFetcher.ts:88-100`](https://github.com/pnpm/pnpm/blob/94240bc046/fetching/tarball-fetcher/src/gitHostedTarballFetcher.ts#L88-L100) so a successful prepare on a git-hosted tarball doesn't re-hash every file back into the CAS when it doesn't need to.

When `resolution.path` is `None` **and** `packlist.len() == cas_paths.len()`:

- **`!should_be_built`** → queue a `PackageFilesIndex` row at the final key (synthesized from `cas_paths`), hand the input map straight back. Upstream copies the `\traw` row to the prepared key; pacquet's tarball download doesn't write a raw row at this key today, so we synthesize from the CAS layout instead — the actual CAS blobs are already in place from the tarball download.
- **`should_be_built && ignore_scripts`** → return input as-is **without** queueing a final-key row, so subsequent `--ignore-scripts` installs re-check the build gate (matches upstream's `storeIndex.delete(rawFilesIndexFile); return { filesMap, ignoredBuild: true }` branch).
- Otherwise → slow path (`import_into_cas`), unchanged.

The synthesized row's per-file digest is reconstructed from the v11 CAS layout (`files/XX/<rest>[-exec]` → shard byte + file stem); `size` comes from `fs::metadata`; `mode` from the `-exec` suffix via the same `is_executable` rule the read side uses (`cas_file_path_by_mode`). Skips the full file-read + SHA-512 cost per entry.

A `cas_io::synthesize_files_index` helper does the heavy lifting and gets its own unit tests for digest round-trip and exec-bit recovery.

## Test plan

- [x] `cargo nextest run -p pacquet-git-fetcher` — 72 tests pass (+8 new: 4 fast-path scenarios in `tarball_fetcher/tests.rs`, 4 helper tests in `cas_io/tests.rs`)
- [x] `just ready` — full workspace, 1026 tests pass
- [x] `just dylint` — perfectionist lints clean
- [x] `taplo format --check` — clean

### New fast-path tests
- `fast_path_returns_input_cas_paths_when_no_build_needed` — output is the input map verbatim when `!should_be_built && path.is_none() && packlist matches`.
- `fast_path_queues_synthesized_index_row` — synthesized row queued at final key; an executable entry's `(digest, mode)` round-trips through `cas_file_path_by_mode` to the input path.
- `fast_path_ignore_scripts_returns_input_without_queueing_row` — `should_be_built && ignore_scripts` branch returns input but does **not** queue a row.
- `sub_path_never_takes_fast_path` — sub-path always takes the slow path even on degenerate single-package monorepos.

### New helper tests (`cas_io`)
- `cas_path_digest_round_trips_through_write_cas_file` — anchored against the canonical write side.
- `cas_path_digest_rejects_malformed_paths` — wrong shape / non-hex shard / empty stem → `None`.
- `synthesize_files_index_recovers_digest_size_and_exec_bit` — `0o755` vs `0o644` synthesis matches the write side's round-trip rule.
- `synthesize_files_index_errors_on_malformed_cas_path` → `Io(InvalidData)`.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CAS fast-path that synthesizes file indexes from existing CAS entries to skip re-imports when rebuilds aren't needed, preserves executable flags and file sizes, and refines fast-path behavior for subpaths, build gating, and ignore-scripts.
* **Tests**
  * Added tests covering fast-path behavior, path-shape validation, executable/digest round-tripping, and error cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pacquet/pull/479)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->