### PR TITLE
feat: --no-optional filter for frozen lockfile install (#434 slice 5)

### DIFF
--- a/crates/package-manager/src/hoist.rs
+++ b/crates/package-manager/src/hoist.rs
@@ -477,6 +477,7 @@ pub fn symlink_hoisted_dependencies(
     layout: &crate::VirtualStoreLayout,
     private_hoisted_modules_dir: &std::path::Path,
     public_hoisted_modules_dir: &std::path::Path,
+    skipped: &std::collections::HashSet<PackageKey>,
 ) -> Result<(), crate::SymlinkPackageError> {
     use rayon::prelude::*;
     use std::{
@@ -502,6 +503,20 @@ pub fn symlink_hoisted_dependencies(
     let mut work: Vec<(Arc<PathBuf>, HoistKind, &String)> = Vec::new();
     let mut scope_dirs: HashSet<PathBuf> = HashSet::new();
     for (node_id, alias_map) in hoisted_by_node_id {
+        // Skipped snapshots never get a virtual-store slot, so a
+        // hoist symlink at their slot path would dangle (Unix) or
+        // fail as a junction (Windows). Mirrors the guard
+        // `get_hoisted_dependencies` already applies before
+        // recording the *parent's* hoisting decisions —
+        // `hoisted_dependencies_by_node_id` records the
+        // (target, alias) pair unconditionally upstream of that
+        // guard (matching pnpm's structure), so the filter has to
+        // run here too. Covers slice 4 (`fetch_failed`), slice 5
+        // (`optional_excluded`), and the slice 1 installability
+        // path uniformly.
+        if skipped.contains(node_id) {
+            continue;
+        }
         let Some(node) = graph.get(node_id) else { continue };
         let dep_dir =
             Arc::new(layout.slot_dir(node_id).join("node_modules").join(name_to_dir(&node.name)));

--- a/crates/package-manager/src/hoist/tests.rs
+++ b/crates/package-manager/src/hoist/tests.rs
@@ -328,12 +328,95 @@ fn skipped_snapshot_is_excluded() {
     // upstream records it before the skipped check (see
     // [`hoistGraph`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/linking/hoist/src/index.ts#L207-L267)),
     // and pacquet preserves that ordering for parity. The symlink
-    // pass [`super::symlink_hoisted_dependencies`] then bails on the
-    // missing graph node via `let Some(node) = graph.get(node_id)
-    // else { continue }`, so no symlink is attempted for the
-    // skipped snapshot — the entry just rides along in the map for
-    // any consumer that wants to inspect what was considered.
+    // pass [`super::symlink_hoisted_dependencies`] is what actually
+    // filters skipped node IDs out of the symlink work (the
+    // `graph.get(node_id)` guard alone isn't enough — `graph`
+    // contains every snapshot in `snapshots`, skipped or not, since
+    // `build_hoist_graph` only filters by missing metadata). The
+    // entry rides along in the map for any consumer that wants to
+    // inspect what was considered, and the explicit skip check at
+    // the symlink site prevents a dangling slot symlink.
     assert!(result.hoisted_dependencies_by_node_id.contains_key(&key("opt", "1.0.0")));
+}
+
+/// `symlink_hoisted_dependencies` filters entries whose key is in
+/// the skip set. Regression for PR #485 Copilot review: without the
+/// filter, a prod dependency with an optional transitive child
+/// would still get a dangling hoist symlink to the child's
+/// virtual-store slot, which `CreateVirtualStore` skipped.
+#[test]
+fn symlink_skips_dropped_nodes() {
+    use crate::VirtualStoreLayout;
+    use pacquet_lockfile::PkgName;
+    use tempfile::tempdir;
+
+    let dir = tempdir().unwrap();
+    let virtual_store_dir = dir.path().join("node_modules/.pacquet");
+    let private_hoisted = virtual_store_dir.join("node_modules");
+    let public_hoisted = dir.path().join("node_modules");
+    std::fs::create_dir_all(&virtual_store_dir).unwrap();
+
+    // Two-node hoist map: `kept@1.0.0` survives, `dropped@1.0.0` is
+    // in the skip set. The "graph" entries exist for both (mirroring
+    // what `build_hoist_graph` produces in production — it doesn't
+    // filter by skip).
+    let kept_key = key("kept", "1.0.0");
+    let dropped_key = key("dropped", "1.0.0");
+    let mut hoisted: HashMap<PackageKey, HashMap<String, HoistKind>> = HashMap::new();
+    hoisted.insert(kept_key.clone(), HashMap::from([("kept".to_string(), HoistKind::Private)]));
+    hoisted
+        .insert(dropped_key.clone(), HashMap::from([("dropped".to_string(), HoistKind::Private)]));
+
+    let mut graph: HashMap<PackageKey, HoistGraphNode> = HashMap::new();
+    graph.insert(
+        kept_key.clone(),
+        HoistGraphNode {
+            name: PkgName::parse("kept").unwrap(),
+            children: HashMap::new(),
+            has_bin: false,
+        },
+    );
+    graph.insert(
+        dropped_key.clone(),
+        HoistGraphNode {
+            name: PkgName::parse("dropped").unwrap(),
+            children: HashMap::new(),
+            has_bin: false,
+        },
+    );
+
+    // Pre-create just the kept snapshot's slot so its symlink has a
+    // valid target. The dropped snapshot's slot is intentionally
+    // absent — without the skip filter, the symlink pass would try
+    // to create a link pointing at it.
+    let layout = VirtualStoreLayout::legacy(&virtual_store_dir);
+    std::fs::create_dir_all(layout.slot_dir(&kept_key).join("node_modules/kept")).unwrap();
+
+    let mut skipped: HashSet<PackageKey> = HashSet::new();
+    skipped.insert(dropped_key.clone());
+
+    super::symlink_hoisted_dependencies(
+        &hoisted,
+        &graph,
+        &layout,
+        &private_hoisted,
+        &public_hoisted,
+        &skipped,
+    )
+    .expect("symlink pass must succeed");
+
+    // Use `symlink_metadata` rather than `exists` because a
+    // dangling symlink (the regression) makes `exists()` return
+    // false anyway — `exists()` follows the link. Need to detect
+    // the symlink itself, not its target.
+    assert!(
+        std::fs::symlink_metadata(private_hoisted.join("kept")).is_ok(),
+        "kept alias must be hoisted (symlink present)",
+    );
+    assert!(
+        std::fs::symlink_metadata(private_hoisted.join("dropped")).is_err(),
+        "dropped (skipped) alias must NOT have a hoist symlink — would be dangling",
+    );
 }
 
 /// Bins of privately-hoisted aliases land in `hoisted_aliases_with_bins`.

--- a/crates/package-manager/src/install/tests.rs
+++ b/crates/package-manager/src/install/tests.rs
@@ -1888,3 +1888,187 @@ async fn frozen_install_propagates_non_optional_fetch_failure() {
 
     drop(dir);
 }
+
+/// Ports the `--no-optional` shape of
+/// [`installing/deps-installer/test/install/optionalDependencies.ts:391`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/test/install/optionalDependencies.ts#L391)
+/// and the frozen-install side of
+/// [`installing/deps-restorer/test/index.ts:323`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-restorer/test/index.ts#L323).
+///
+/// The fixture is designed to discriminate slice 5 (`--no-optional`
+/// filter) from slice 4 (fetch-failure swallow): a snapshot with
+/// `optional: true` whose **metadata row is missing from
+/// `packages:`**. Slice 4's swallow only covers `DownloadTarball`
+/// and `GitFetch` — `MissingPackageMetadata` propagates even for
+/// optional snapshots. So if slice 5's filter doesn't fire, the
+/// missing-metadata error aborts the install regardless of slice
+/// 4. A successful install therefore proves the snapshot was
+/// dropped **before** cache-key derivation by the slice 5 gate.
+///
+/// Mirrors upstream's depNode filter at
+/// [`link.ts:109-111`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/src/install/link.ts#L109-L111):
+/// when `!include.optionalDependencies`, every depNode whose
+/// `optional` flag is true is dropped from the install graph
+/// before extraction / linking / building runs.
+///
+/// Also asserts that `--no-optional` exclusions are **not**
+/// persisted to `.modules.yaml.skipped` — same convention as the
+/// fetch-failure swallow (slice 4): the exclusion is transient,
+/// so a later install without `--no-optional` brings the snapshot
+/// back into the install graph.
+#[tokio::test]
+async fn frozen_install_no_optional_drops_optional_only_snapshots() {
+    // Lockfile with one `optional: true` snapshot whose metadata
+    // row is intentionally missing from `packages:`. Slice 4
+    // (fetch-failure swallow) does NOT cover `MissingPackageMetadata`,
+    // so reaching the cache-key derivation step would abort the
+    // install. The `--no-optional` filter must drop the snapshot
+    // before that step runs.
+    const OPTIONAL_NO_METADATA_LOCKFILE: &str = text_block! {
+        "lockfileVersion: '9.0'"
+        "importers:"
+        "  .:"
+        "    optionalDependencies:"
+        "      drop-me:"
+        "        specifier: 1.0.0"
+        "        version: 1.0.0"
+        "packages: {}"
+        "snapshots:"
+        "  drop-me@1.0.0:"
+        "    optional: true"
+    };
+
+    let dir = tempdir().unwrap();
+    let store_dir = dir.path().join("pacquet-store");
+    let project_root = dir.path().join("project");
+    let modules_dir = project_root.join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pacquet");
+
+    let manifest_path = dir.path().join("package.json");
+    let mut manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
+    // Manifest matches the lockfile importer entry so the
+    // freshness check doesn't reject the install.
+    manifest.add_dependency("drop-me", "1.0.0", DependencyGroup::Optional).unwrap();
+    manifest.save().unwrap();
+
+    let mut config = Config::new();
+    config.lockfile = false;
+    // Opt out of GVS so the slot-path assertion targets the legacy
+    // `<virtual_store_dir>/<flat-name>` layout. Same pattern as the
+    // slice 4 swallow tests.
+    config.enable_global_virtual_store = false;
+    config.store_dir = store_dir.clone().into();
+    config.modules_dir = modules_dir.clone();
+    config.virtual_store_dir = virtual_store_dir.clone();
+    let config = config.leak();
+
+    let lockfile: Lockfile = serde_saphyr::from_str(OPTIONAL_NO_METADATA_LOCKFILE)
+        .expect("parse optional-no-metadata fixture lockfile");
+
+    // The dispatch list excludes `DependencyGroup::Optional` — same
+    // shape `--no-optional` produces from
+    // `AddDependencyOptions::dependency_groups()` in
+    // `crates/cli/src/cli_args/install.rs`.
+    Install {
+        tarball_mem_cache: &Default::default(),
+        http_client: &Default::default(),
+        config,
+        manifest: &manifest,
+        lockfile: Some(&lockfile),
+        dependency_groups: [DependencyGroup::Prod],
+        frozen_lockfile: true,
+        supported_architectures: None,
+        resolved_packages: &Default::default(),
+    }
+    .run::<SilentReporter>()
+    .await
+    .expect("install must succeed with --no-optional despite missing optional metadata");
+
+    // The optional-only snapshot must not have been extracted.
+    let expected_slot = virtual_store_dir.join("drop-me@1.0.0").join("node_modules");
+    assert!(
+        !expected_slot.exists(),
+        "optional-only snapshot's slot must not exist, found {expected_slot:?}",
+    );
+
+    // Transient — must not bleed into the persistent
+    // `.modules.yaml.skipped` set.
+    let written = modules_dir
+        .pipe_as_ref(read_modules_manifest::<RealApi>)
+        .expect("read .modules.yaml")
+        .expect("modules manifest exists");
+    assert!(
+        written.skipped.is_empty(),
+        "--no-optional exclusions must not land in .modules.yaml.skipped, got {:?}",
+        written.skipped,
+    );
+
+    drop(dir);
+}
+
+/// Polarity test for [`frozen_install_no_optional_drops_optional_only_snapshots`].
+/// Same fixture, but the dispatch list **includes** `Optional`. With
+/// the snapshot's metadata missing from `packages:`, the install
+/// must now abort with `MissingPackageMetadata` — slice 4's
+/// fetch-failure swallow doesn't cover that variant, so the
+/// optional-ness alone doesn't save the install. Proves the
+/// slice 5 filter is gated on the dispatch list rather than firing
+/// unconditionally.
+#[tokio::test]
+async fn frozen_install_optional_included_surfaces_missing_metadata() {
+    const OPTIONAL_NO_METADATA_LOCKFILE: &str = text_block! {
+        "lockfileVersion: '9.0'"
+        "importers:"
+        "  .:"
+        "    optionalDependencies:"
+        "      drop-me:"
+        "        specifier: 1.0.0"
+        "        version: 1.0.0"
+        "packages: {}"
+        "snapshots:"
+        "  drop-me@1.0.0:"
+        "    optional: true"
+    };
+
+    let dir = tempdir().unwrap();
+    let store_dir = dir.path().join("pacquet-store");
+    let project_root = dir.path().join("project");
+    let modules_dir = project_root.join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pacquet");
+
+    let manifest_path = dir.path().join("package.json");
+    let mut manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
+    manifest.add_dependency("drop-me", "1.0.0", DependencyGroup::Optional).unwrap();
+    manifest.save().unwrap();
+
+    let mut config = Config::new();
+    config.lockfile = false;
+    config.enable_global_virtual_store = false;
+    config.store_dir = store_dir.into();
+    config.modules_dir = modules_dir;
+    config.virtual_store_dir = virtual_store_dir;
+    let config = config.leak();
+
+    let lockfile: Lockfile = serde_saphyr::from_str(OPTIONAL_NO_METADATA_LOCKFILE)
+        .expect("parse optional-no-metadata fixture lockfile");
+
+    let result = Install {
+        tarball_mem_cache: &Default::default(),
+        http_client: &Default::default(),
+        config,
+        manifest: &manifest,
+        lockfile: Some(&lockfile),
+        dependency_groups: [DependencyGroup::Prod, DependencyGroup::Optional],
+        frozen_lockfile: true,
+        supported_architectures: None,
+        resolved_packages: &Default::default(),
+    }
+    .run::<SilentReporter>()
+    .await;
+
+    let err =
+        result.expect_err("install must abort without --no-optional when metadata is missing");
+    let msg = format!("{err:?}");
+    assert!(msg.contains("MissingPackageMetadata"), "expected MissingPackageMetadata, got {msg}");
+
+    drop(dir);
+}

--- a/crates/package-manager/src/install/tests.rs
+++ b/crates/package-manager/src/install/tests.rs
@@ -1966,7 +1966,7 @@ async fn frozen_install_no_optional_drops_optional_only_snapshots() {
 
     // The dispatch list excludes `DependencyGroup::Optional` — same
     // shape `--no-optional` produces from
-    // `AddDependencyOptions::dependency_groups()` in
+    // `InstallDependencyOptions::dependency_groups()` in
     // `crates/cli/src/cli_args/install.rs`.
     Install {
         tarball_mem_cache: &Default::default(),

--- a/crates/package-manager/src/install/tests.rs
+++ b/crates/package-manager/src/install/tests.rs
@@ -2072,3 +2072,85 @@ async fn frozen_install_optional_included_surfaces_missing_metadata() {
 
     drop(dir);
 }
+
+/// Regression coverage for the shared-dependency case from
+/// [`installing/deps-installer/test/install/optionalDependencies.ts:712`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/test/install/optionalDependencies.ts#L712)
+/// (`dependency that is both optional and non-optional is installed,
+/// when optional dependencies should be skipped`).
+///
+/// `SnapshotEntry::optional` is set by upstream's resolver only
+/// when a snapshot is reachable **exclusively** through optional
+/// edges. A snapshot reachable through any non-optional edge carries
+/// `optional: false` and **must not** be dropped by `--no-optional`.
+///
+/// Fixture: a single snapshot `shared@1.0.0` with `optional: false`
+/// (default) and metadata missing from `packages:`. With
+/// `--no-optional`, the filter must skip this snapshot only if it
+/// checks the `optional` flag — if it accidentally drops every
+/// snapshot listed under `optionalDependencies` regardless of the
+/// flag, the install would silently succeed (the missing-metadata
+/// error wouldn't surface). Conversely, if the filter is correct,
+/// the install aborts with `MissingPackageMetadata` because the
+/// non-optional snapshot reaches cache-key derivation.
+#[tokio::test]
+async fn frozen_install_no_optional_keeps_shared_non_optional_snapshot() {
+    const SHARED_NON_OPTIONAL_LOCKFILE: &str = text_block! {
+        "lockfileVersion: '9.0'"
+        "importers:"
+        "  .:"
+        "    optionalDependencies:"
+        "      shared:"
+        "        specifier: 1.0.0"
+        "        version: 1.0.0"
+        "packages: {}"
+        "snapshots:"
+        "  shared@1.0.0: {}"
+    };
+
+    let dir = tempdir().unwrap();
+    let store_dir = dir.path().join("pacquet-store");
+    let project_root = dir.path().join("project");
+    let modules_dir = project_root.join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pacquet");
+
+    let manifest_path = dir.path().join("package.json");
+    let mut manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
+    manifest.add_dependency("shared", "1.0.0", DependencyGroup::Optional).unwrap();
+    manifest.save().unwrap();
+
+    let mut config = Config::new();
+    config.lockfile = false;
+    config.enable_global_virtual_store = false;
+    config.store_dir = store_dir.into();
+    config.modules_dir = modules_dir;
+    config.virtual_store_dir = virtual_store_dir;
+    let config = config.leak();
+
+    let lockfile: Lockfile = serde_saphyr::from_str(SHARED_NON_OPTIONAL_LOCKFILE)
+        .expect("parse shared-non-optional fixture lockfile");
+
+    let result = Install {
+        tarball_mem_cache: &Default::default(),
+        http_client: &Default::default(),
+        config,
+        manifest: &manifest,
+        lockfile: Some(&lockfile),
+        // `--no-optional` shape: Optional NOT in the dispatch list.
+        dependency_groups: [DependencyGroup::Prod],
+        frozen_lockfile: true,
+        supported_architectures: None,
+        resolved_packages: &Default::default(),
+    }
+    .run::<SilentReporter>()
+    .await;
+
+    let err =
+        result.expect_err("snapshot with optional:false must NOT be dropped by --no-optional");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("MissingPackageMetadata"),
+        "expected MissingPackageMetadata (proves the snapshot was kept), got {msg}",
+    );
+
+    drop(dir);
+}

--- a/crates/package-manager/src/install/tests.rs
+++ b/crates/package-manager/src/install/tests.rs
@@ -2067,8 +2067,15 @@ async fn frozen_install_optional_included_surfaces_missing_metadata() {
 
     let err =
         result.expect_err("install must abort without --no-optional when metadata is missing");
-    let msg = format!("{err:?}");
-    assert!(msg.contains("MissingPackageMetadata"), "expected MissingPackageMetadata, got {msg}");
+    assert!(
+        matches!(
+            err,
+            InstallError::FrozenLockfile(crate::InstallFrozenLockfileError::CreateVirtualStore(
+                crate::CreateVirtualStoreError::MissingPackageMetadata { .. },
+            ),),
+        ),
+        "expected FrozenLockfile(CreateVirtualStore(MissingPackageMetadata)), got {err:?}",
+    );
 
     drop(dir);
 }
@@ -2146,10 +2153,15 @@ async fn frozen_install_no_optional_keeps_shared_non_optional_snapshot() {
 
     let err =
         result.expect_err("snapshot with optional:false must NOT be dropped by --no-optional");
-    let msg = format!("{err:?}");
     assert!(
-        msg.contains("MissingPackageMetadata"),
-        "expected MissingPackageMetadata (proves the snapshot was kept), got {msg}",
+        matches!(
+            err,
+            InstallError::FrozenLockfile(crate::InstallFrozenLockfileError::CreateVirtualStore(
+                crate::CreateVirtualStoreError::MissingPackageMetadata { .. },
+            ),),
+        ),
+        "expected FrozenLockfile(CreateVirtualStore(MissingPackageMetadata)) — \
+         proves the snapshot was kept; got {err:?}",
     );
 
     drop(dir);

--- a/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/crates/package-manager/src/install_frozen_lockfile.rs
@@ -570,6 +570,7 @@ where
                             &layout,
                             &private_dir,
                             &public_dir,
+                            &hoist_skipped,
                         )
                         .map_err(InstallFrozenLockfileError::HoistSymlink)?;
                         // Private-side bins → `<vs>/node_modules/.bin`.

--- a/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/crates/package-manager/src/install_frozen_lockfile.rs
@@ -319,6 +319,36 @@ where
             (seed, None)
         };
 
+        // `--no-optional` enforcement (umbrella slice 5). Mirrors
+        // upstream's depNode filter at
+        // <https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/src/install/link.ts#L109-L111>:
+        // when `include.optionalDependencies` is false, every
+        // snapshot whose `optional` flag is true gets dropped from
+        // the install graph. The lockfile's
+        // [`SnapshotEntry::optional`] is set by the resolver when
+        // the snapshot is reachable **only** through optional
+        // edges; a snapshot reachable through any non-optional
+        // edge carries `optional: false` and survives the filter
+        // (covers
+        // <https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/test/install/optionalDependencies.ts#L712>
+        // — `dependency that is both optional and non-optional is
+        // installed`). The exclusions land in the transient
+        // `optional_excluded` subset of [`SkippedSnapshots`] so
+        // they propagate to every downstream filter
+        // (`CreateVirtualStore`, `SymlinkDirectDependencies`,
+        // `BuildModules`, hoist) through the same gate
+        // installability skips use — and stay out of
+        // `.modules.yaml.skipped` so a future install without
+        // `--no-optional` brings them back.
+        let include_optional = dependency_groups.contains(&DependencyGroup::Optional);
+        if !include_optional && let Some(snaps) = snapshots {
+            for (key, snap) in snaps {
+                if snap.optional {
+                    skipped.add_optional_excluded(key.clone());
+                }
+            }
+        }
+
         // Compute `engine_name` *before* `CreateVirtualStore::run`
         // because the GVS-aware `VirtualStoreLayout` needs it to
         // produce the per-snapshot

--- a/crates/package-manager/src/installability.rs
+++ b/crates/package-manager/src/installability.rs
@@ -117,18 +117,21 @@ impl SkippedSnapshots {
     /// failed during this install. Slice 4 wire-up — call site is
     /// inside [`crate::CreateVirtualStore`]'s cold-batch dispatch.
     ///
-    /// Disjoint-subset guard: if `key` is already in the
-    /// higher-precedence `installability` set, the insert is a
-    /// no-op so [`len`] / [`iter`] stay consistent with [`contains`].
-    /// In practice this can't happen because installability-skipped
-    /// snapshots are filtered out of the cold-batch dispatch before
-    /// any fetch runs, but the guard keeps the invariant honest.
+    /// Disjoint-subset guard: if `key` is already in any other
+    /// subset, the insert is a no-op so [`len`] / [`iter`] stay
+    /// consistent with [`contains`]. In practice the only
+    /// realistic overlap is with `installability`
+    /// (`optional_excluded` snapshots are dropped before reaching
+    /// the cold-batch dispatch), but the guard is symmetric with
+    /// [`add_optional_excluded`]'s so the public API enforces the
+    /// invariant regardless of call order.
     ///
     /// [`len`]: SkippedSnapshots::len
     /// [`iter`]: SkippedSnapshots::iter
     /// [`contains`]: SkippedSnapshots::contains
+    /// [`add_optional_excluded`]: SkippedSnapshots::add_optional_excluded
     pub fn add_fetch_failed(&mut self, key: PackageKey) {
-        if self.installability.contains(&key) {
+        if self.installability.contains(&key) || self.optional_excluded.contains(&key) {
             return;
         }
         self.fetch_failed.insert(key);

--- a/crates/package-manager/src/installability.rs
+++ b/crates/package-manager/src/installability.rs
@@ -116,7 +116,21 @@ impl SkippedSnapshots {
     /// Record an `optional: true` snapshot whose fetch / extract
     /// failed during this install. Slice 4 wire-up — call site is
     /// inside [`crate::CreateVirtualStore`]'s cold-batch dispatch.
+    ///
+    /// Disjoint-subset guard: if `key` is already in the
+    /// higher-precedence `installability` set, the insert is a
+    /// no-op so [`len`] / [`iter`] stay consistent with [`contains`].
+    /// In practice this can't happen because installability-skipped
+    /// snapshots are filtered out of the cold-batch dispatch before
+    /// any fetch runs, but the guard keeps the invariant honest.
+    ///
+    /// [`len`]: SkippedSnapshots::len
+    /// [`iter`]: SkippedSnapshots::iter
+    /// [`contains`]: SkippedSnapshots::contains
     pub fn add_fetch_failed(&mut self, key: PackageKey) {
+        if self.installability.contains(&key) {
+            return;
+        }
         self.fetch_failed.insert(key);
     }
 
@@ -128,7 +142,25 @@ impl SkippedSnapshots {
     /// entry. Downstream gates then drop the snapshot from
     /// extraction, symlinking, building, and hoisting through the
     /// same skip-set check they use for installability skips.
+    ///
+    /// Disjoint-subset guard: a snapshot that is both
+    /// installability-skipped (platform / engine mismatch) and
+    /// would-be excluded by `--no-optional` stays in the
+    /// higher-precedence `installability` subset only. This is the
+    /// realistic overlap case (an `optional: true` snapshot that's
+    /// also `os: [<wrong>]`), and putting it in both subsets would
+    /// make [`len`] / [`iter`] inconsistent with [`contains`].
+    /// Same guard applies against `fetch_failed`, though that
+    /// overlap can't arise in practice (a snapshot dropped by
+    /// `--no-optional` never reaches the cold-batch dispatch).
+    ///
+    /// [`len`]: SkippedSnapshots::len
+    /// [`iter`]: SkippedSnapshots::iter
+    /// [`contains`]: SkippedSnapshots::contains
     pub fn add_optional_excluded(&mut self, key: PackageKey) {
+        if self.installability.contains(&key) || self.fetch_failed.contains(&key) {
+            return;
+        }
         self.optional_excluded.insert(key);
     }
 

--- a/crates/package-manager/src/installability.rs
+++ b/crates/package-manager/src/installability.rs
@@ -34,8 +34,8 @@ use pacquet_reporter::{
 
 /// The set of snapshot keys skipped on this host.
 ///
-/// Two disjoint origin classes are tracked separately because they
-/// behave differently across installs:
+/// Three disjoint origin classes are tracked separately because
+/// they behave differently across installs:
 ///
 /// - **Installability skips** (`installability`) — engine, platform,
 ///   or libc mismatch surfaced by [`compute_skipped_snapshots`].
@@ -50,19 +50,35 @@ use pacquet_reporter::{
 ///   silent `if (pkgSnapshot.optional) return` at
 ///   <https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-builder/src/lockfileToDepGraph.ts#L294-L298>:
 ///   upstream's catch site never updates `opts.skipped`, so a
-///   subsequent install retries the fetch. Tracked in this struct
-///   so downstream consumers (`build_sequence`, `link_bins`, etc.)
-///   can skip the snapshot through the same gate they use for
-///   installability skips — pacquet's downstream architecture
-///   walks the lockfile rather than a pre-pruned graph, so a
-///   separate filter is needed where upstream gets it for free
-///   from `graph[dir]` being absent.
+///   subsequent install retries the fetch.
+///
+/// - **`--no-optional` exclusions** (`optional_excluded`) —
+///   snapshots whose lockfile entry has `optional: true` AND the
+///   user passed `--no-optional` (or `IncludedDependencies::optional_dependencies`
+///   is false). **Not** persisted, matching upstream's behavior:
+///   the filter sits at
+///   <https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/src/install/link.ts#L109-L111>,
+///   downstream of the `opts.skipped` set, so re-running without
+///   `--no-optional` brings the snapshots back into the install
+///   graph. Pacquet's downstream architecture walks the lockfile
+///   directly rather than a pre-pruned graph, so a separate filter
+///   is needed where upstream gets it for free from the depNode
+///   filter chain.
+///
+/// All three subsets contribute to [`contains`] and [`iter`] —
+/// downstream walkers treat skipped-for-any-reason uniformly. Only
+/// the `installability` subset survives [`iter_installability`],
+/// which is what `.modules.yaml.skipped` writes.
 ///
 /// [`compute_skipped_snapshots`]: crate::compute_skipped_snapshots
+/// [`contains`]: SkippedSnapshots::contains
+/// [`iter`]: SkippedSnapshots::iter
+/// [`iter_installability`]: SkippedSnapshots::iter_installability
 #[derive(Debug, Default, Clone)]
 pub struct SkippedSnapshots {
     installability: HashSet<PackageKey>,
     fetch_failed: HashSet<PackageKey>,
+    optional_excluded: HashSet<PackageKey>,
 }
 
 impl SkippedSnapshots {
@@ -76,7 +92,7 @@ impl SkippedSnapshots {
     /// known skip set without running the full installability pass.
     #[cfg(test)]
     pub(crate) fn from_set(set: HashSet<PackageKey>) -> Self {
-        Self { installability: set, fetch_failed: HashSet::new() }
+        Self { installability: set, ..Self::default() }
     }
 
     /// Seed the installability set with snapshot keys recorded as
@@ -94,7 +110,7 @@ impl SkippedSnapshots {
     {
         let installability =
             iter.into_iter().filter_map(|s| s.as_ref().parse::<PackageKey>().ok()).collect();
-        Self { installability, fetch_failed: HashSet::new() }
+        Self { installability, ..Self::default() }
     }
 
     /// Record an `optional: true` snapshot whose fetch / extract
@@ -104,20 +120,36 @@ impl SkippedSnapshots {
         self.fetch_failed.insert(key);
     }
 
+    /// Record a snapshot dropped because the user passed
+    /// `--no-optional` (or the matching config / `IncludedDependencies`
+    /// flag is false). Slice 5 wire-up — call site is inside
+    /// `InstallFrozenLockfile::run`, which iterates the lockfile
+    /// snapshots once and inserts every `snap.optional == true`
+    /// entry. Downstream gates then drop the snapshot from
+    /// extraction, symlinking, building, and hoisting through the
+    /// same skip-set check they use for installability skips.
+    pub fn add_optional_excluded(&mut self, key: PackageKey) {
+        self.optional_excluded.insert(key);
+    }
+
     /// `true` if the snapshot is skipped for **any** reason
-    /// (installability or fetch-failure). Downstream consumers want
-    /// the union: a fetch-failed snapshot is just as absent from the
-    /// install graph as an installability-skipped one.
+    /// (installability, fetch-failure, or `--no-optional`).
+    /// Downstream consumers want the union: a dropped snapshot is
+    /// equally absent from the install regardless of origin.
     pub fn contains(&self, key: &PackageKey) -> bool {
-        self.installability.contains(key) || self.fetch_failed.contains(key)
+        self.installability.contains(key)
+            || self.fetch_failed.contains(key)
+            || self.optional_excluded.contains(key)
     }
 
     pub fn len(&self) -> usize {
-        self.installability.len() + self.fetch_failed.len()
+        self.installability.len() + self.fetch_failed.len() + self.optional_excluded.len()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.installability.is_empty() && self.fetch_failed.is_empty()
+        self.installability.is_empty()
+            && self.fetch_failed.is_empty()
+            && self.optional_excluded.is_empty()
     }
 
     /// Insert into the installability set. Used by
@@ -128,19 +160,22 @@ impl SkippedSnapshots {
     }
 
     /// Iterate over the **installability** subset only — the entries
-    /// written to `.modules.yaml.skipped`. Fetch-failure entries are
-    /// transient and intentionally excluded so they aren't persisted
-    /// across installs.
+    /// written to `.modules.yaml.skipped`. Fetch-failure and
+    /// `--no-optional` entries are transient and intentionally
+    /// excluded so they aren't persisted across installs.
     pub fn iter_installability(&self) -> impl Iterator<Item = &PackageKey> + '_ {
         self.installability.iter()
     }
 
-    /// Iterate over the union of both subsets — every snapshot that
+    /// Iterate over the union of all subsets — every snapshot that
     /// downstream consumers should treat as absent from the install,
     /// regardless of origin. Used by `hoist.rs` and similar
     /// graph-walking passes that don't care why a snapshot is gone.
     pub fn iter(&self) -> impl Iterator<Item = &PackageKey> + '_ {
-        self.installability.iter().chain(self.fetch_failed.iter())
+        self.installability
+            .iter()
+            .chain(self.fetch_failed.iter())
+            .chain(self.optional_excluded.iter())
     }
 }
 

--- a/crates/package-manager/src/installability/tests.rs
+++ b/crates/package-manager/src/installability/tests.rs
@@ -560,19 +560,34 @@ fn disjoint_subsets_preserve_len_and_iter() {
     assert_eq!(skipped.len(), 1);
 }
 
-/// `add_optional_excluded` also skips keys already in
-/// `fetch_failed` — same disjoint-subset invariant, lower
-/// precedence pair. This overlap can't arise in practice (a
-/// snapshot dropped by `--no-optional` never reaches the
-/// cold-batch dispatch where `fetch_failed` is populated) but
-/// the guard keeps the invariant honest.
+/// `add_fetch_failed` and `add_optional_excluded` are symmetric
+/// against each other — neither inserts when the other subset
+/// already has the key, so first-insert wins regardless of call
+/// order. This overlap can't arise in practice (a snapshot
+/// dropped by `--no-optional` never reaches the cold-batch
+/// dispatch where `fetch_failed` is populated), but the guard
+/// makes the public API safe to call in any order without
+/// breaking the disjoint-subset invariant.
 #[test]
-fn fetch_failed_takes_precedence_over_optional_excluded() {
+fn fetch_failed_and_optional_excluded_are_symmetric() {
+    // Order A: fetch_failed first, then optional_excluded — the
+    // second insert no-ops; the entry stays in fetch_failed.
     let key: PackageKey = "weird-overlap@1.0.0".parse().unwrap();
-    let mut skipped = SkippedSnapshots::new();
-    skipped.add_fetch_failed(key.clone());
-    skipped.add_optional_excluded(key.clone());
-    assert_eq!(skipped.len(), 1);
-    let collected: Vec<&PackageKey> = skipped.iter().collect();
-    assert_eq!(collected.len(), 1);
+    let mut a = SkippedSnapshots::new();
+    a.add_fetch_failed(key.clone());
+    a.add_optional_excluded(key.clone());
+    assert_eq!(a.len(), 1);
+    assert_eq!(a.iter().count(), 1);
+    assert!(a.contains(&key));
+
+    // Order B: optional_excluded first, then fetch_failed — the
+    // second insert must also no-op (Copilot PR #485 review:
+    // `add_fetch_failed` needs the symmetric guard so callers
+    // can't corrupt the skip set by reversing the order).
+    let mut b = SkippedSnapshots::new();
+    b.add_optional_excluded(key.clone());
+    b.add_fetch_failed(key.clone());
+    assert_eq!(b.len(), 1);
+    assert_eq!(b.iter().count(), 1);
+    assert!(b.contains(&key));
 }

--- a/crates/package-manager/src/installability/tests.rs
+++ b/crates/package-manager/src/installability/tests.rs
@@ -528,3 +528,51 @@ fn from_strings_skips_unparsable_entries() {
     assert!(set.contains(&key1));
     assert!(set.contains(&key2));
 }
+
+/// The three subsets (`installability`, `fetch_failed`,
+/// `optional_excluded`) must stay disjoint so [`SkippedSnapshots::len`]
+/// and [`SkippedSnapshots::iter`] stay consistent with
+/// [`SkippedSnapshots::contains`]. The realistic overlap is a
+/// platform-incompatible optional snapshot installed with
+/// `--no-optional`: the same key would be added to both
+/// `installability` (via the installability check) and
+/// `optional_excluded` (via the `--no-optional` filter).
+/// `add_optional_excluded` must no-op when the key is already
+/// installability-skipped; precedence is "installability wins"
+/// because that subset persists across installs.
+#[test]
+fn disjoint_subsets_preserve_len_and_iter() {
+    let key: PackageKey = "platform-mismatch-optional@1.0.0".parse().unwrap();
+    let mut skipped = SkippedSnapshots::new();
+    skipped.insert_installability(key.clone());
+    skipped.add_optional_excluded(key.clone());
+    // Even though both `add_*` methods were called for `key`, the
+    // higher-precedence subset wins — `len` and `iter` see exactly
+    // one entry, matching `contains`.
+    assert_eq!(skipped.len(), 1);
+    let collected: Vec<&PackageKey> = skipped.iter().collect();
+    assert_eq!(collected.len(), 1);
+    assert!(skipped.contains(&key));
+
+    // `add_fetch_failed` against the same key is similarly a no-op
+    // — installability has highest precedence.
+    skipped.add_fetch_failed(key.clone());
+    assert_eq!(skipped.len(), 1);
+}
+
+/// `add_optional_excluded` also skips keys already in
+/// `fetch_failed` — same disjoint-subset invariant, lower
+/// precedence pair. This overlap can't arise in practice (a
+/// snapshot dropped by `--no-optional` never reaches the
+/// cold-batch dispatch where `fetch_failed` is populated) but
+/// the guard keeps the invariant honest.
+#[test]
+fn fetch_failed_takes_precedence_over_optional_excluded() {
+    let key: PackageKey = "weird-overlap@1.0.0".parse().unwrap();
+    let mut skipped = SkippedSnapshots::new();
+    skipped.add_fetch_failed(key.clone());
+    skipped.add_optional_excluded(key.clone());
+    assert_eq!(skipped.len(), 1);
+    let collected: Vec<&PackageKey> = skipped.iter().collect();
+    assert_eq!(collected.len(), 1);
+}


### PR DESCRIPTION
## Summary

Slice 5 of the [#434 umbrella](https://github.com/pnpm/pacquet/issues/434) (`Proper optionalDependencies support`). Slices 1–4 (#439, #456, #467, #474) handle installability + the fetch-failure swallow. This slice closes the user-facing `--no-optional` flag: the CLI flag already exists and threads through `Install::dependency_groups`, but only `SymlinkDirectDependencies` and the on-disk `included` field actually honored it. The rest of the install pipeline walked `optional_dependencies` unconditionally, so the optional subtree was still extracted, linked, and built.

Mirrors upstream's depNode filter at [`installing/deps-installer/src/install/link.ts:109-111`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/src/install/link.ts#L109-L111):

```ts
if (!opts.include.optionalDependencies) {
  depNodes = depNodes.filter(({ optional }) => !optional)
}
```

## Changes

- **`SkippedSnapshots`**: gains a third disjoint subset `optional_excluded` alongside `installability` (slice 1) and `fetch_failed` (slice 4). The existing `contains` / `iter` already return the union, so every downstream consumer that filters by skip-set (`CreateVirtualStore`, `SymlinkDirectDependencies`, `BuildModules`, hoist, `link_bins`) now respects `--no-optional` through the same gate. `iter_installability` still returns only the persistent subset for `.modules.yaml.skipped` writes — `--no-optional` exclusions are transient (matching upstream's behavior of never updating `opts.skipped` at the filter site). The three subsets are kept truly disjoint by write-time no-op guards on the transient inserts: precedence is `installability` > `fetch_failed` > `optional_excluded`, and the guards are symmetric so call order can't corrupt the invariant.
- **`InstallFrozenLockfile::run`**: iterates the lockfile snapshots once and inserts every `snap.optional == true` entry into the new subset when the dispatch list doesn't contain `DependencyGroup::Optional`. The `SnapshotEntry::optional` flag is set by the resolver only when the snapshot is reachable **exclusively** through optional edges, so a snapshot reachable through any non-optional edge carries `optional: false` and survives the filter — covers [`optionalDependencies.ts:712`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/test/install/optionalDependencies.ts#L712) (`dependency that is both optional and non-optional is installed`).
- **`symlink_hoisted_dependencies`** (drive-by fix): now takes the skip set and short-circuits skipped node IDs. The hoist module records `(child_id, alias) → kind` in `hoisted_dependencies_by_node_id` *before* its existing skipped-guard, mirroring upstream's structure — and the symlink pass walked every entry. `graph.get(node_id)` wasn't enough of a guard because `build_hoist_graph` includes every snapshot whose metadata is present (skipped or not). Without the new filter, a prod dep with an optional transitive child would get a dangling hoist symlink on Unix (failing as a junction on Windows). The latent bug pre-dated slice 5 but only became reachable now that `--no-optional` populates the skip set with snapshots whose slot `CreateVirtualStore` doesn't create.

## Test plan

- [x] `install::tests::frozen_install_no_optional_drops_optional_only_snapshots` — discriminating fixture: an `optional: true` snapshot whose metadata row is missing from `packages:`. Slice 4 (fetch-failure swallow) only covers `DownloadTarball`/`GitFetch` so `MissingPackageMetadata` propagates even on optional — meaning install success proves the snapshot was dropped **before** cache-key derivation by the slice 5 filter. **Test-the-test verified** by inverting the `!include_optional` guard.
- [x] `install::tests::frozen_install_optional_included_surfaces_missing_metadata` — pins the polarity: same fixture, `Optional` in the dispatch list, install must abort with `MissingPackageMetadata`.
- [x] `install::tests::frozen_install_no_optional_keeps_shared_non_optional_snapshot` — regression for [`optionalDependencies.ts:712`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/test/install/optionalDependencies.ts#L712): a snapshot with `optional: false` listed under `optionalDependencies` must NOT be dropped by `--no-optional`. Same `MissingPackageMetadata` discriminator.
- [x] `installability::tests::disjoint_subsets_preserve_len_and_iter` — pins the disjoint-subset invariant: a key added to multiple subsets ends up in only the highest-precedence one. **Test-the-test verified** by removing the guards.
- [x] `installability::tests::fetch_failed_and_optional_excluded_are_symmetric` — both insertion orders end up with the same state (only one subset carries the key). **Test-the-test verified** by removing the new symmetric guard.
- [x] `hoist::tests::symlink_skips_dropped_nodes` — exercises `symlink_hoisted_dependencies` directly with one skipped node; uses `symlink_metadata` (not `exists`) to catch dangling-symlink regressions. **Test-the-test verified** by removing the new filter.
- [x] Error assertions are typed `matches!` on `InstallError::FrozenLockfile(InstallFrozenLockfileError::CreateVirtualStore(CreateVirtualStoreError::MissingPackageMetadata { .. }))` rather than `Debug` substring checks — stable against rename/wrapping changes.
- [x] `just ready` (typos + fmt + check + nextest + clippy).
- [x] `taplo format --check`.
- [x] `just dylint` (perfectionist).
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace`.

## Out of scope

- `installing only optional deps` ([`deps-restorer:300`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-restorer/test/index.ts#L300)) — pacquet's CLI doesn't expose `--only=optional` yet.
- `optional dependency has bigger priority than regular dependency` ([`optionalDependencies.ts:419`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/test/install/optionalDependencies.ts#L419)) — resolver-side priority rule, not relevant to the lockfile-driven path.
- Current-lockfile pruning when the include set changes between installs — umbrella slice 6.

Closes #480.

---
Written by an agent (Claude Code, claude-opus-4-7).