### PR TITLE
fix(config): default enableGlobalVirtualStore to false

### DIFF
--- a/crates/config/src/defaults.rs
+++ b/crates/config/src/defaults.rs
@@ -95,15 +95,25 @@ pub fn default_virtual_store_dir() -> PathBuf {
     env::current_dir().expect("current directory is unavailable").join("node_modules/.pnpm")
 }
 
-/// Default for `enableGlobalVirtualStore`. Mirrors pnpm v11's
-/// [`config/reader/src/index.ts:392-394`](https://github.com/pnpm/pnpm/blob/94240bc046/config/reader/src/index.ts#L392-L394),
-/// which sets the value to `true` when unset. The CI auto-detect branch
-/// at [`config/reader/src/index.ts:543-548`](https://github.com/pnpm/pnpm/blob/94240bc046/config/reader/src/index.ts#L543-L548)
-/// is intentionally not ported here — it depends on a CI-detection
-/// helper pacquet doesn't have yet and is tracked separately
-/// (pnpm/pacquet#432).
+/// Default for `enableGlobalVirtualStore`. Matches pnpm v11's
+/// effective default for regular installs: `false`.
+///
+/// The `true` assignment at
+/// [`config/reader/src/index.ts:392-394`](https://github.com/pnpm/pnpm/blob/94240bc046/config/reader/src/index.ts#L392-L394)
+/// lives entirely inside the
+/// [`if (cliOptions['global'])` block](https://github.com/pnpm/pnpm/blob/94240bc046/config/reader/src/index.ts#L348-L395)
+/// (the `pnpm install --global` path), surrounded by
+/// `CONFIG_CONFLICT_*_WITH_GLOBAL` errors and closed by
+/// `} else if (!pnpmConfig.bin)`. For regular `pnpm install` the
+/// value stays `null`/unset, which evaluates as `false` everywhere
+/// downstream. Pacquet doesn't have a `--global` CLI flag at all
+/// (only `install --frozen-lockfile`), so the only applicable
+/// upstream default is the `false` one.
+///
+/// pnpm/pacquet#444 originally cited the same `L392-L394` range but
+/// read it as an unconditional default — corrected here.
 pub fn default_enable_global_virtual_store() -> bool {
-    true
+    false
 }
 
 pub fn default_registry() -> String {

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1009,8 +1009,16 @@ mod tests {
     /// [`extendInstallOptions.ts:343-355`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/src/install/extendInstallOptions.ts#L343-L355).
     /// See [`Config::apply_global_virtual_store_derivation`] for why
     /// pacquet keeps the two fields separate.
+    ///
+    /// Default `enableGlobalVirtualStore` is `false` — matches pnpm
+    /// v11's effective default for regular installs (the `true`
+    /// assignment lives only inside the `--global` install branch;
+    /// see [`default_enable_global_virtual_store`]). Both
+    /// `virtual_store_dir` and `global_virtual_store_dir` still
+    /// derive cleanly so the downstream code can read either field
+    /// without first checking the toggle.
     #[test]
-    pub fn gvs_default_writes_links_into_global_virtual_store_dir() {
+    pub fn gvs_default_is_off_and_paths_derive_cleanly() {
         let tmp = tempdir().unwrap();
         let config = Config::current::<RealApi, _, _, _, _>(
             || tmp.path().to_path_buf().pipe(Ok::<_, ()>),
@@ -1018,7 +1026,10 @@ mod tests {
             Config::new,
         )
         .expect("workspace yaml absent => no error");
-        assert!(config.enable_global_virtual_store, "GVS defaults to true");
+        assert!(
+            !config.enable_global_virtual_store,
+            "GVS defaults to false (matches pnpm v11 for non-global installs)",
+        );
         // `virtual_store_dir` stays project-local. The
         // `<cwd>/node_modules/.pnpm` default has been re-anchored to
         // `tmp` by `Config::current` (see the cwd fixup block).
@@ -1048,7 +1059,7 @@ mod tests {
         assert_eq!(config.global_virtual_store_dir, config.store_dir.links());
     }
 
-    /// When the user pins `virtualStoreDir` *and* GVS is on,
+    /// When the user pins `virtualStoreDir` *and* opts into GVS,
     /// `globalVirtualStoreDir` mirrors that path — the user gets to
     /// pick where the shared store lives. `virtual_store_dir` itself
     /// still holds the pinned value (it's the same field the user
@@ -1059,7 +1070,7 @@ mod tests {
         let user_path = tmp.path().join("custom-links");
         fs::write(
             tmp.path().join("pnpm-workspace.yaml"),
-            format!("virtualStoreDir: {}\n", user_path.display()),
+            format!("enableGlobalVirtualStore: true\nvirtualStoreDir: {}\n", user_path.display()),
         )
         .expect("write to pnpm-workspace.yaml");
         let config = Config::current::<RealApi, _, _, _, _>(
@@ -1082,13 +1093,22 @@ mod tests {
     /// the same resolve-relative-to-workspace semantics. Without this
     /// preservation the value parses from yaml and then gets
     /// silently overwritten by the derivation.
+    ///
+    /// The fixture also enables GVS explicitly. Pacquet's default
+    /// is `enableGlobalVirtualStore: false` (matches pnpm v11 for
+    /// non-`--global` installs), so without the explicit opt-in the
+    /// GVS-on derivation path wouldn't run at all and the test
+    /// would say nothing about that path's behaviour.
     #[test]
     pub fn yaml_global_virtual_store_dir_wins_over_derivation() {
         let tmp = tempdir().unwrap();
         let yaml_gvs = tmp.path().join("my-shared-store");
         fs::write(
             tmp.path().join("pnpm-workspace.yaml"),
-            format!("globalVirtualStoreDir: {}\n", yaml_gvs.display()),
+            format!(
+                "enableGlobalVirtualStore: true\nglobalVirtualStoreDir: {}\n",
+                yaml_gvs.display(),
+            ),
         )
         .expect("write to pnpm-workspace.yaml");
         let config = Config::current::<RealApi, _, _, _, _>(
@@ -1097,7 +1117,7 @@ mod tests {
             Config::new,
         )
         .expect("yaml is valid");
-        assert!(config.enable_global_virtual_store, "GVS defaults to true");
+        assert!(config.enable_global_virtual_store);
         // `virtual_store_dir` stays at the project-local default,
         // because the user didn't pin `virtualStoreDir`.
         assert_eq!(config.virtual_store_dir, tmp.path().join("node_modules/.pnpm"));

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -215,9 +215,10 @@ pub struct Config {
     /// non-`--global` installs. The `true` assignment at
     /// [`config/reader/src/index.ts:392-394`](https://github.com/pnpm/pnpm/blob/94240bc046/config/reader/src/index.ts#L392-L394)
     /// applies only inside upstream's `if (cliOptions['global'])`
-    /// block (see [`default_enable_global_virtual_store`] for the
-    /// full reasoning). Pacquet has no `--global` flow, so the only
-    /// applicable upstream default is `false`.
+    /// block (see `default_enable_global_virtual_store` in
+    /// `crates/config/src/defaults.rs` for the full reasoning).
+    /// Pacquet has no `--global` flow, so the only applicable
+    /// upstream default is `false`.
     #[default(_code = "default_enable_global_virtual_store()")]
     pub enable_global_virtual_store: bool,
 
@@ -1005,7 +1006,7 @@ mod tests {
     /// `enableGlobalVirtualStore` defaults to `false` — matches pnpm
     /// v11's effective default for regular installs (the `true`
     /// assignment lives only inside the `--global` install branch;
-    /// see [`default_enable_global_virtual_store`]). The derivation
+    /// see [`Config::enable_global_virtual_store`]). The derivation
     /// still fires automatically from [`Config::current`] after yaml
     /// has been applied, writing `<store_dir>/links` into
     /// `global_virtual_store_dir` while leaving `virtual_store_dir`

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -209,13 +209,15 @@ pub struct Config {
     /// the machine: packages live under `<store_dir>/links/...` and each
     /// project registers itself at `<store_dir>/projects/<short-hash>`.
     /// When `false`, each project keeps its own virtual store at
-    /// `<project>/node_modules/.pnpm`. Default `true`, mirroring upstream's
-    /// [`config/reader/src/index.ts:392-394`](https://github.com/pnpm/pnpm/blob/94240bc046/config/reader/src/index.ts#L392-L394).
+    /// `<project>/node_modules/.pnpm`.
     ///
-    /// CI auto-detect ([`config/reader/src/index.ts:543-548`](https://github.com/pnpm/pnpm/blob/94240bc046/config/reader/src/index.ts#L543-L548))
-    /// is intentionally not ported here yet — it requires a CI-detection
-    /// helper pacquet doesn't have. Tracked as a follow-up of
-    /// pnpm/pacquet#432.
+    /// Default `false` — matches pnpm v11's effective default for
+    /// non-`--global` installs. The `true` assignment at
+    /// [`config/reader/src/index.ts:392-394`](https://github.com/pnpm/pnpm/blob/94240bc046/config/reader/src/index.ts#L392-L394)
+    /// applies only inside upstream's `if (cliOptions['global'])`
+    /// block (see [`default_enable_global_virtual_store`] for the
+    /// full reasoning). Pacquet has no `--global` flow, so the only
+    /// applicable upstream default is `false`.
     #[default(_code = "default_enable_global_virtual_store()")]
     pub enable_global_virtual_store: bool,
 
@@ -1000,23 +1002,19 @@ mod tests {
         assert!(!config.symlink);
     }
 
-    /// `enableGlobalVirtualStore` defaults to `true`. The derivation
-    /// fires automatically from [`Config::current`] after yaml has
-    /// been applied, writing `<store_dir>/links` into
-    /// `global_virtual_store_dir` while leaving `virtual_store_dir`
-    /// at its project-local default — pacquet's split-field variant
-    /// of upstream's
-    /// [`extendInstallOptions.ts:343-355`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/src/install/extendInstallOptions.ts#L343-L355).
-    /// See [`Config::apply_global_virtual_store_derivation`] for why
-    /// pacquet keeps the two fields separate.
-    ///
-    /// Default `enableGlobalVirtualStore` is `false` — matches pnpm
+    /// `enableGlobalVirtualStore` defaults to `false` — matches pnpm
     /// v11's effective default for regular installs (the `true`
     /// assignment lives only inside the `--global` install branch;
-    /// see [`default_enable_global_virtual_store`]). Both
-    /// `virtual_store_dir` and `global_virtual_store_dir` still
-    /// derive cleanly so the downstream code can read either field
-    /// without first checking the toggle.
+    /// see [`default_enable_global_virtual_store`]). The derivation
+    /// still fires automatically from [`Config::current`] after yaml
+    /// has been applied, writing `<store_dir>/links` into
+    /// `global_virtual_store_dir` while leaving `virtual_store_dir`
+    /// at its project-local default — both fields stay valid so the
+    /// downstream code can read either one without first checking
+    /// the toggle. Pacquet's split-field variant of upstream's
+    /// [`extendInstallOptions.ts:343-355`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/src/install/extendInstallOptions.ts#L343-L355);
+    /// see [`Config::apply_global_virtual_store_derivation`] for why
+    /// pacquet keeps them separate.
     #[test]
     pub fn gvs_default_is_off_and_paths_derive_cleanly() {
         let tmp = tempdir().unwrap();

--- a/crates/config/src/workspace_yaml.rs
+++ b/crates/config/src/workspace_yaml.rs
@@ -99,7 +99,10 @@ pub struct WorkspaceSettings {
     pub symlink: Option<bool>,
     pub virtual_store_dir: Option<String>,
     /// `enableGlobalVirtualStore` from `pnpm-workspace.yaml`. Default
-    /// applied in [`Config`] is `true`, matching pnpm v11. See
+    /// applied in [`Config`] is `false` — matches pnpm v11's
+    /// effective default for non-`--global` installs (upstream's
+    /// `true` assignment lives only inside the `pnpm install --global`
+    /// branch, and pacquet has no `--global` flow). See
     /// [`Config::enable_global_virtual_store`].
     pub enable_global_virtual_store: Option<bool>,
     /// `globalVirtualStoreDir` from `pnpm-workspace.yaml`. Resolved

--- a/crates/package-manager/src/install/tests.rs
+++ b/crates/package-manager/src/install/tests.rs
@@ -1291,9 +1291,10 @@ async fn frozen_lockfile_errors_when_lockfile_has_no_root_importer() {
 }
 
 /// GVS-on frozen-lockfile install. With
-/// `enable_global_virtual_store: true` (pacquet's default, matching
-/// upstream's
-/// [`config/reader/src/index.ts:392-394`](https://github.com/pnpm/pnpm/blob/94240bc046/config/reader/src/index.ts#L392-L394)),
+/// `enable_global_virtual_store: true` (an explicit opt-in;
+/// pacquet's default is `false`, matching pnpm v11's effective
+/// default for non-`--global` installs — see
+/// [`pacquet_config::default_enable_global_virtual_store`]),
 /// `Install::run` registers the project at
 /// `<store_dir>/projects/<short-hash>` (mirroring upstream's
 /// [`registerProject`](https://github.com/pnpm/pnpm/blob/94240bc046/store/controller/src/storeController/projectRegistry.ts))
@@ -1323,8 +1324,8 @@ async fn frozen_lockfile_under_gvs_registers_project_and_runs_clean() {
     let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
 
     let mut config = Config::new();
-    // Pacquet's default is `true`; pin it explicitly so the test
-    // doesn't silently degrade if the default flips someday.
+    // Pin GVS on explicitly — pacquet's default is `false`, so this
+    // test would test the wrong path otherwise.
     config.enable_global_virtual_store = true;
     config.lockfile = false;
     config.store_dir = store_dir.clone().into();

--- a/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/crates/package-manager/src/install_frozen_lockfile.rs
@@ -349,41 +349,62 @@ where
             }
         }
 
-        // Compute `engine_name` *before* `CreateVirtualStore::run`
-        // because the GVS-aware `VirtualStoreLayout` needs it to
-        // produce the per-snapshot
-        // `<scope>/<name>/<version>/<hash>` suffix that `pnpm` writes
-        // under `<store_dir>/links`. Same value also feeds
-        // `BuildModules`'s side-effects-cache key prefix.
+        // `engine_name` feeds two sites:
         //
-        // Two paths:
-        // - We already detected the host for the installability
-        //   check (constraint-bearing lockfile): reuse the cached
-        //   version. The synthetic-fallback case (`node_detected =
-        //   false`) yields `None` so a bogus `99999.0.0`-derived key
-        //   can't poison either the cache or the GVS hash.
-        // - We skipped the installability check (constraint-free
-        //   lockfile, the common case): no cached version. Fall
-        //   back to the legacy `detect_node_major` spawn. This used
-        //   to sit *after* `CreateVirtualStore::run` to overlap the
-        //   `node --version` cost with the install I/O, but the GVS
-        //   path now needs it earlier — the trade-off is a one-time
-        //   `node --version` spawn synchronous with install setup,
-        //   which is still tens of ms on the critical path. Users
-        //   who want the old overlap can opt out via
-        //   `enable_global_virtual_store: false`.
-        let engine_name: Option<String> = match &host_node {
-            Some((true, ver)) => parse_major_from_version(ver)
-                .map(|major| pacquet_graph_hasher::engine_name(major, None, None)),
-            Some((false, _)) => None,
-            None => tokio::task::spawn_blocking(|| {
-                pacquet_graph_hasher::detect_node_major()
-                    .map(|major| pacquet_graph_hasher::engine_name(major, None, None))
-            })
-            .await
-            .ok()
-            .flatten(),
+        // - The GVS-aware `VirtualStoreLayout` needs it *before*
+        //   `CreateVirtualStore::run` to produce per-snapshot
+        //   `<scope>/<name>/<version>/<hash>` suffixes under
+        //   `<store_dir>/links`. Only matters when GVS is on.
+        // - `BuildModules` uses it for the side-effects-cache key
+        //   prefix. Read by both the cache read-gate and the
+        //   write-gate (see `build_modules.rs:346-350`); when
+        //   `None`, both gates close and the cache is bypassed.
+        //
+        // Three paths:
+        // - Already detected the host for the installability check
+        //   (constraint-bearing lockfile): reuse the cached version
+        //   synchronously. Synthetic-fallback (`node_detected = false`)
+        //   yields `None` so a bogus `99999.0.0`-derived key can't
+        //   poison either the cache or the GVS hash.
+        // - GVS on, no host yet: spawn `node --version` synchronously
+        //   — layout construction below needs the result.
+        // - GVS off, no host yet: spawn into the blocking pool and
+        //   keep the join handle. The spawn runs concurrently with
+        //   `CreateVirtualStore::run`'s I/O, so the `node --version`
+        //   cost (~tens of ms) is hidden under the install. The
+        //   handle is awaited right before `BuildModules` —
+        //   `VirtualStoreLayout` is built with `None` here, which
+        //   is fine because GVS is off and the layout ignores the
+        //   field in that path.
+        let (initial_engine_name, deferred_engine_handle): (
+            Option<String>,
+            Option<tokio::task::JoinHandle<Option<String>>>,
+        ) = match &host_node {
+            Some((true, ver)) => (
+                parse_major_from_version(ver)
+                    .map(|major| pacquet_graph_hasher::engine_name(major, None, None)),
+                None,
+            ),
+            Some((false, _)) => (None, None),
+            None if config.enable_global_virtual_store => (
+                tokio::task::spawn_blocking(|| {
+                    pacquet_graph_hasher::detect_node_major()
+                        .map(|major| pacquet_graph_hasher::engine_name(major, None, None))
+                })
+                .await
+                .ok()
+                .flatten(),
+                None,
+            ),
+            None => (
+                None,
+                Some(tokio::task::spawn_blocking(|| {
+                    pacquet_graph_hasher::detect_node_major()
+                        .map(|major| pacquet_graph_hasher::engine_name(major, None, None))
+                })),
+            ),
         };
+        let engine_name = initial_engine_name;
 
         // Build the install-scoped slot-directory layout. When
         // `enable_global_virtual_store` is on the layout precomputes
@@ -686,6 +707,17 @@ where
             pacquet_config::ScriptsPrependNodePath::WarnOnly => {
                 ExecScriptsPrependNodePath::WarnOnly
             }
+        };
+
+        // Resolve the deferred `node --version` detection from the
+        // GVS-off path, if any. The handle was spawned before
+        // `CreateVirtualStore::run` so the `node` startup cost
+        // overlapped with install I/O. Falls back to the synchronous
+        // value when the spawn was never deferred (GVS on, or host
+        // already detected for the installability check).
+        let engine_name = match deferred_engine_handle {
+            Some(handle) => handle.await.ok().flatten(),
+            None => engine_name,
         };
 
         let ignored_builds = BuildModules {

--- a/tasks/integrated-benchmark/src/fixtures/pnpm-workspace.yaml
+++ b/tasks/integrated-benchmark/src/fixtures/pnpm-workspace.yaml
@@ -1,19 +1,19 @@
 storeDir: ./store-dir
 
-# Pin the virtual-store layout to the legacy project-local shape
+# Pin the virtual-store layout to the project-local shape
 # (`<project>/node_modules/.pnpm`) so the benchmark continues to
 # compare apples-to-apples across pacquet revisions.
 #
-# Pacquet's default flipped to `enableGlobalVirtualStore: true` in
-# pnpm/pacquet#432 (pnpm v11 parity), but the benchmark's job is
-# to track isolated-linker performance across `pacquet@HEAD` vs
-# `pacquet@main` vs `pnpm`. With GVS on, slot directories move to
-# `<storeDir>/links/<scope>/<name>/<version>/<hash>` — a different
-# disk layout from what pre-#432 revisions and pacquet's
-# project-local baseline produce, so leaving the default in place
-# would silently change what the numbers measure. Flip this to
-# `true` in a `--fixture-dir` override (or drop the line entirely)
-# to benchmark the GVS path on its own terms.
+# Pacquet's effective default is already `enableGlobalVirtualStore: false`
+# (matches pnpm v11 for non-`--global` installs — the `true`
+# assignment upstream lives only inside the `pnpm install --global`
+# branch). The pin is kept anyway so a future default flip surfaces
+# in CI rather than silently changing what the numbers measure:
+# with GVS on, slot directories move to
+# `<storeDir>/links/<scope>/<name>/<version>/<hash>`, a different
+# layout from the project-local baseline. Flip this to `true` in a
+# `--fixture-dir` override to benchmark the GVS path on its own
+# terms.
 enableGlobalVirtualStore: false
 
 # Force pnpm to install every optional dependency in the lockfile

--- a/tasks/integrated-benchmark/src/workspace_manifest.rs
+++ b/tasks/integrated-benchmark/src/workspace_manifest.rs
@@ -26,16 +26,17 @@ pub struct MinimalWorkspaceManifest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lockfile: Option<bool>,
     /// Mirrors pnpm's
-    /// [`enableGlobalVirtualStore`](https://github.com/pnpm/pnpm/blob/94240bc046/config/reader/src/index.ts#L392-L394)
-    /// (default `true` in v11). The benchmark fixture pins this to
-    /// `false` so existing revisions can be compared apples-to-apples
-    /// against the project-local virtual-store layout pacquet shipped
-    /// before pnpm/pacquet#432 — both `pacquet@HEAD` and `pacquet@main`
-    /// then sit on the same `<project>/node_modules/.pnpm` shape, and
-    /// pnpm on the other side of the comparison honours the same
-    /// override. A separate GVS-on benchmark variant lives behind a
-    /// caller-supplied `--fixture-dir` with the flag flipped to
-    /// `true` (or omitted to inherit the default).
+    /// [`enableGlobalVirtualStore`](https://github.com/pnpm/pnpm/blob/94240bc046/config/reader/src/index.ts#L392-L394).
+    /// Effective default is `false` for non-`--global` installs in
+    /// both pnpm v11 and pacquet (the `true` assignment in upstream
+    /// lives only inside the `pnpm install --global` branch). The
+    /// benchmark fixture still pins this to `false` so a future
+    /// default flip surfaces in CI rather than silently changing
+    /// the on-disk layout being measured: with GVS on, slot
+    /// directories move to `<storeDir>/links/<scope>/<name>/<version>/<hash>`,
+    /// a different shape from the project-local baseline. A
+    /// separate GVS-on benchmark variant lives behind a caller-
+    /// supplied `--fixture-dir` with the flag flipped to `true`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enable_global_virtual_store: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Summary

Pacquet's `default_enable_global_virtual_store()` returned `true` and cited upstream's [`config/reader/src/index.ts:392-394`](https://github.com/pnpm/pnpm/blob/94240bc046/config/reader/src/index.ts#L392-L394) as the authority. But that range lives entirely inside the [`if (cliOptions['global']) { ... }`](https://github.com/pnpm/pnpm/blob/94240bc046/config/reader/src/index.ts#L348-L395) block — surrounded by `CONFIG_CONFLICT_*_WITH_GLOBAL` errors and closed by `} else if (!pnpmConfig.bin) { ... }`. So in pnpm v11:

- `pnpm install --global foo` → `enableGlobalVirtualStore` defaults to `true`
- `pnpm install` (regular) → stays `null`/unset → effectively `false`

Pacquet doesn't have a `--global` CLI flag (only `install --frozen-lockfile`), so the applicable upstream default is the `false` one. Pre-fix, every pacquet install silently wrote slots to `<store>/links/...` and registered projects, even when the user never asked for GVS — and a project alternating between `pnpm install` and `pacquet install --frozen-lockfile` would see two different on-disk layouts.

The default introduced by #444 cited the same `L392-L394` range but read it as an unconditional default. Corrected here.

## Test changes

- `gvs_default_writes_links_into_global_virtual_store_dir` renamed to `gvs_default_is_off_and_paths_derive_cleanly` and inverted — now asserts the default-off behaviour. The path derivation still populates both `virtual_store_dir` and `global_virtual_store_dir` cleanly so downstream code can read either field without first checking the toggle.
- `gvs_user_pinned_virtual_store_routes_into_global_virtual_store_dir` and `yaml_global_virtual_store_dir_wins_over_derivation`: yaml now opts into GVS explicitly (`enableGlobalVirtualStore: true`) so the GVS-on derivation path is still exercised.
- `install/tests.rs` doc + inline comments updated to reflect that GVS-on tests need to pin the flag explicitly now.

## Benchmark

The bench fixture's explicit `enableGlobalVirtualStore: false` pin is kept (it's now redundant but future-proofs the bench against a default flip), with an updated comment explaining the design intent. Same for `MinimalWorkspaceManifest.enable_global_virtual_store` doc.

## Test plan

- [x] `just ready` (1078 tests pass, 2 skipped)
- [x] `taplo format --check`
- [x] `just dylint`

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Global virtual store is now disabled by default for non-global installations, aligning with upstream package manager. Configuration can still explicitly enable it when needed.

* **Documentation**
  * Docs and comments updated to clarify default behavior differences between global and non-global installs.

* **Tests**
  * Tests and benchmark fixtures adjusted to pin and verify the updated default behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pacquet/pull/489)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->