### PR TITLE
feat(package-manager): dispatch Binary/Variations to runtime fetchers (#437 slice D1)

### DIFF
--- a/crates/package-manager/src/create_virtual_store.rs
+++ b/crates/package-manager/src/create_virtual_store.rs
@@ -1,6 +1,6 @@
 use crate::{
     InstallPackageBySnapshot, InstallPackageBySnapshotError, SkippedSnapshots,
-    store_init::init_store_dir_best_effort,
+    install_package_by_snapshot::host_platform_selector, store_init::init_store_dir_best_effort,
 };
 use derive_more::{Display, Error};
 use futures_util::future;
@@ -8,6 +8,7 @@ use miette::Diagnostic;
 use pacquet_config::Config;
 use pacquet_lockfile::{
     LockfileResolution, PackageKey, PackageMetadata, PkgNameVerPeer, SnapshotEntry,
+    select_platform_variant,
 };
 use pacquet_network::ThrottledClient;
 use pacquet_reporter::{
@@ -788,18 +789,42 @@ fn snapshot_cache_key(
             // whether the snapshot is already in `index.db`.
             Ok(Some(git_hosted_store_index_key(&pkg_id, true)))
         }
-        // Slice A of #437 wires the lockfile types; the warm-batch
-        // store-index key for `Binary` will compose through the same
-        // `store_index_key(integrity, pkg_id)` shape the registry /
-        // tarball arms use once Slice D wires the fetcher.
-        // `Variations` is a meta-shape: its integrity (and target
-        // platforms) live on the picked variant, so a warm key only
-        // makes sense after variant selection has run. Treat both as
-        // cold by returning `Ok(None)` until Slice D adds variant
-        // selection + fetcher dispatch; the cold path in
-        // [`InstallPackageBySnapshot`] then raises the typed
-        // `UnsupportedResolution` for either kind.
-        LockfileResolution::Binary(_) | LockfileResolution::Variations(_) => Ok(None),
+        // Runtime artifacts (Node.js / Bun / Deno): the per-archive
+        // integrity is the warm-cache key, same shape as the
+        // registry / tarball arms above. Mirrors the per-snapshot
+        // dispatch in [`InstallPackageBySnapshot::run`]; the cold
+        // path's variant selector + binary fetcher writes the row
+        // under this key when it succeeds, so a re-install hits
+        // here instead of cold-fetching the runtime archive again.
+        LockfileResolution::Binary(binary) => {
+            Ok(Some(store_index_key(&binary.integrity.to_string(), &pkg_id)))
+        }
+        // `Variations` is a meta-shape: its integrity lives on the
+        // *picked* variant, not the wrapper. Run the same host-
+        // matching selector the cold path runs so the warm key
+        // resolves to the variant that would actually be installed.
+        // No variant matched → return `Ok(None)` and let the cold
+        // path surface the typed `NoMatchingPlatformVariant` error
+        // (a warm-key miss is the right shape; the warm prefetch
+        // is best-effort and the cold path is where errors are
+        // raised).
+        LockfileResolution::Variations(variations) => {
+            let selector = host_platform_selector();
+            let Some(variant) = select_platform_variant(&variations.variants, &selector) else {
+                return Ok(None);
+            };
+            match &variant.resolution {
+                LockfileResolution::Binary(binary) => {
+                    Ok(Some(store_index_key(&binary.integrity.to_string(), &pkg_id)))
+                }
+                // Non-`Binary` variant (corrupt lockfile, or a
+                // future shape pacquet doesn't recognise). The
+                // cold path raises the typed
+                // `VariantHasNonBinaryResolution` error; we just
+                // skip the warm key.
+                _ => Ok(None),
+            }
+        }
     }
 }
 

--- a/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/crates/package-manager/src/install_package_by_snapshot.rs
@@ -7,14 +7,20 @@ use miette::Diagnostic;
 use pacquet_config::Config;
 use pacquet_executor::ScriptsPrependNodePath as ExecScriptsPrependNodePath;
 use pacquet_git_fetcher::{GitFetchOutput, GitFetcher, GitFetcherError, GitHostedTarballFetcher};
-use pacquet_lockfile::{LockfileResolution, PackageKey, PackageMetadata, SnapshotEntry};
+use pacquet_graph_hasher::{host_arch, host_libc, host_platform};
+use pacquet_lockfile::{
+    BinaryArchive, BinaryResolution, LockfileResolution, PackageKey, PackageMetadata,
+    PlatformSelector, SnapshotEntry, select_platform_variant,
+};
 use pacquet_network::ThrottledClient;
 use pacquet_reporter::{LogEvent, LogLevel, ProgressLog, ProgressMessage, Reporter};
 use pacquet_store_dir::{
     SharedReadonlyStoreIndex, SharedVerifiedFilesCache, StoreIndexWriter,
     git_hosted_store_index_key,
 };
-use pacquet_tarball::{DownloadTarballToStore, PrefetchedCasPaths, TarballError};
+use pacquet_tarball::{
+    DownloadTarballToStore, DownloadZipArchiveToStore, PrefetchedCasPaths, TarballError,
+};
 use pipe_trait::Pipe;
 use std::{
     borrow::Cow,
@@ -94,6 +100,42 @@ pub enum InstallPackageBySnapshotError {
     /// every fetcher path that exits through `pacquet-git-fetcher`.
     #[diagnostic(transparent)]
     GitFetch(#[error(source)] GitFetcherError),
+
+    /// No variant in a [`LockfileResolution::Variations`] matches the
+    /// host triple `(os, cpu, libc?)`. Surfaces with the host triple
+    /// plus the list of advertised target triples so the user can see
+    /// at a glance whether they're running on an unsupported platform
+    /// or whether the lockfile was generated without the host's
+    /// architecture in mind.
+    #[display(
+        "Package `{package_key}` is a runtime dependency, but none of its declared variants matches the host triple (os = `{host_os}`, cpu = `{host_cpu}`, libc = `{host_libc:?}`). Available variants: {available_targets}"
+    )]
+    #[diagnostic(code(pacquet_package_manager::no_matching_platform_variant))]
+    NoMatchingPlatformVariant {
+        package_key: String,
+        host_os: &'static str,
+        host_cpu: &'static str,
+        host_libc: Option<&'static str>,
+        /// Pre-rendered list of the lockfile's advertised target
+        /// triples, formatted as `os/cpu[+libc]`. Lives in the error
+        /// payload rather than the lockfile (which is borrowed from
+        /// the install request) so the error stays cheap to construct
+        /// at the rejection site and isn't tied to the lockfile's
+        /// lifetime.
+        available_targets: String,
+    },
+
+    /// A variant inside a [`LockfileResolution::Variations`] carries
+    /// a resolution other than [`LockfileResolution::Binary`].
+    /// Upstream contract guarantees variants are atomic
+    /// `BinaryResolution`s; this variant catches lockfile corruption
+    /// or a future shape pacquet doesn't recognise rather than
+    /// silently routing through and confusing the install pipeline.
+    #[display(
+        "Package `{package_key}` carries a runtime variant whose inner resolution is `{inner_kind}` rather than `binary`; pacquet only knows how to install binary-shaped variants."
+    )]
+    #[diagnostic(code(pacquet_package_manager::variant_has_non_binary_resolution))]
+    VariantHasNonBinaryResolution { package_key: String, inner_kind: &'static str },
 }
 
 impl<'a> InstallPackageBySnapshot<'a> {
@@ -217,22 +259,80 @@ impl<'a> InstallPackageBySnapshot<'a> {
             // dispatch for `Binary` / `Variations` lands in Slice D.
             // Until then, surface the kind via the typed
             // `UnsupportedResolution` error so a v11 lockfile with a
-            // runtime entry fails with a clear, structured message.
-            // (Without these arms, adding the new `LockfileResolution`
-            // variants would surface as a compile-time
-            // non-exhaustive-match error rather than building cleanly
-            // — these arms are what makes Slice A standalone.)
-            LockfileResolution::Binary(_) => {
-                return Err(InstallPackageBySnapshotError::UnsupportedResolution {
-                    package_key: package_key.to_string(),
-                    resolution_kind: "binary",
-                });
+            // Runtime artifacts (Node.js / Bun / Deno) — `Binary`
+            // and `Variations` carry a `BinaryResolution` describing
+            // the archive to fetch. `Variations` is the multi-
+            // platform wrapper: pick the variant whose `targets`
+            // includes the host triple, then route through the same
+            // `BinaryResolution` extractor (mirrors upstream's
+            // [`binary-fetcher/src/index.ts`](https://github.com/pnpm/pnpm/blob/94240bc046/fetching/binary-fetcher/src/index.ts)).
+            LockfileResolution::Binary(binary) => {
+                fetch_binary_resolution_to_cas::<R>(
+                    binary,
+                    http_client,
+                    config,
+                    store_index,
+                    store_index_writer,
+                    verified_files_cache,
+                    prefetched_cas_paths,
+                    &package_id,
+                    requester,
+                )
+                .await?
             }
-            LockfileResolution::Variations(_) => {
-                return Err(InstallPackageBySnapshotError::UnsupportedResolution {
-                    package_key: package_key.to_string(),
-                    resolution_kind: "variations",
-                });
+            LockfileResolution::Variations(variations) => {
+                let selector = host_platform_selector();
+                let Some(variant) = select_platform_variant(&variations.variants, &selector) else {
+                    return Err(InstallPackageBySnapshotError::NoMatchingPlatformVariant {
+                        package_key: package_key.to_string(),
+                        host_os: host_platform(),
+                        host_cpu: host_arch(),
+                        host_libc: match host_libc() {
+                            "unknown" => None,
+                            other => Some(other),
+                        },
+                        available_targets: render_variant_targets(&variations.variants),
+                    });
+                };
+                // Upstream's `PlatformAssetResolution.resolution`
+                // is always atomic (`BinaryResolution`); pacquet's
+                // type widens to the full `LockfileResolution` for
+                // serde uniformity but `select_platform_variant`'s
+                // docs spell out that nested `Variations` would just
+                // route their picked variant's inner shape back
+                // through this dispatcher (no infinite recursion
+                // because this arm doesn't call back into the
+                // variant selector). The match below only
+                // recognises `Binary`; anything else is either a
+                // corrupt lockfile or a future shape pacquet hasn't
+                // learned about yet, so reject loudly rather than
+                // silently route through.
+                let LockfileResolution::Binary(binary) = &variant.resolution else {
+                    return Err(InstallPackageBySnapshotError::VariantHasNonBinaryResolution {
+                        package_key: package_key.to_string(),
+                        inner_kind: match &variant.resolution {
+                            LockfileResolution::Tarball(_) => "tarball",
+                            LockfileResolution::Registry(_) => "registry",
+                            LockfileResolution::Directory(_) => "directory",
+                            LockfileResolution::Git(_) => "git",
+                            LockfileResolution::Variations(_) => "variations",
+                            // Already matched above; reach is unreachable.
+                            LockfileResolution::Binary(_) => "binary",
+                        },
+                    });
+                };
+                fetch_binary_resolution_to_cas::<R>(
+                    binary,
+                    http_client,
+                    config,
+                    store_index,
+                    store_index_writer,
+                    verified_files_cache,
+                    prefetched_cas_paths,
+                    &package_id,
+                    requester,
+                )
+                .await?
             }
             LockfileResolution::Git(git_resolution) => {
                 // Same `built = true` rationale as the git-hosted
@@ -320,6 +420,119 @@ fn tarball_url_and_integrity<'a>(
             unreachable!("tarball_url_and_integrity called with non-tarball resolution");
         }
     }
+}
+
+/// Build the host's [`PlatformSelector`] for runtime-variant
+/// matching. Mirrors pnpm's call shape at the binary-fetcher
+/// dispatch site: `{ os: process.platform, cpu: process.arch, libc:
+/// process.platform === 'linux' ? family : null }`.
+///
+/// `host_libc()` returns `"unknown"` on every non-Linux host and
+/// `"glibc"` / `"musl"` on Linux. Translate `"unknown"` to `None`
+/// so [`select_platform_variant`]'s asymmetric libc rule applies
+/// the same way upstream's does: `None` and `Some("glibc")` both
+/// require the variant to omit `libc`, and `Some("musl")` requires
+/// an exact match.
+pub(crate) fn host_platform_selector() -> PlatformSelector {
+    let libc = match host_libc() {
+        "unknown" => None,
+        other => Some(other.to_string()),
+    };
+    PlatformSelector { os: host_platform().to_string(), cpu: host_arch().to_string(), libc }
+}
+
+/// Fetch a [`BinaryResolution`] into the CAS, returning the
+/// per-file `{relative_path → cas_path}` map the snapshot's virtual
+/// directory needs. Dispatches on the archive type:
+///
+/// - [`BinaryArchive::Tarball`] uses [`DownloadTarballToStore`]
+///   with `package_unpacked_size: None` (binary archives don't
+///   carry that hint upstream either).
+/// - [`BinaryArchive::Zip`] uses [`DownloadZipArchiveToStore`]
+///   with `archive_prefix: binary.prefix.as_deref()` so the runtime
+///   archive's top-level wrapper (e.g.
+///   `node-v22.0.0-darwin-arm64/`) is stripped before the CAS keys
+///   are written.
+///
+/// The Node-runtime `NODE_EXTRAS_IGNORE_PATTERN` filter that strips
+/// bundled `npm` / `corepack` from the archive will land in Slice
+/// D2; for now the filter slot stays `None` and the full archive
+/// contents are imported. Bin-link cmd-shims for the runtime
+/// executables likewise wait for Slice D2.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "matches the field set DownloadTarballToStore / DownloadZipArchiveToStore need"
+)]
+async fn fetch_binary_resolution_to_cas<R: Reporter>(
+    binary: &BinaryResolution,
+    http_client: &ThrottledClient,
+    config: &'static Config,
+    store_index: Option<&SharedReadonlyStoreIndex>,
+    store_index_writer: Option<&Arc<StoreIndexWriter>>,
+    verified_files_cache: &SharedVerifiedFilesCache,
+    prefetched_cas_paths: Option<&PrefetchedCasPaths>,
+    package_id: &str,
+    requester: &str,
+) -> Result<HashMap<String, PathBuf>, InstallPackageBySnapshotError> {
+    match binary.archive {
+        BinaryArchive::Tarball => DownloadTarballToStore {
+            http_client,
+            store_dir: &config.store_dir,
+            store_index: store_index.cloned(),
+            store_index_writer: store_index_writer.cloned(),
+            verify_store_integrity: config.verify_store_integrity,
+            verified_files_cache: Arc::clone(verified_files_cache),
+            package_integrity: &binary.integrity,
+            package_unpacked_size: None,
+            package_url: &binary.url,
+            package_id,
+            requester,
+            prefetched_cas_paths,
+            retry_opts: retry_opts_from_config(config),
+            auth_headers: &config.auth_headers,
+            ignore_file_pattern: None,
+        }
+        .run_without_mem_cache::<R>()
+        .await
+        .map_err(InstallPackageBySnapshotError::DownloadTarball),
+        BinaryArchive::Zip => DownloadZipArchiveToStore {
+            http_client,
+            store_dir: &config.store_dir,
+            store_index: store_index.cloned(),
+            store_index_writer: store_index_writer.cloned(),
+            verify_store_integrity: config.verify_store_integrity,
+            verified_files_cache: Arc::clone(verified_files_cache),
+            package_integrity: &binary.integrity,
+            package_url: &binary.url,
+            package_id,
+            requester,
+            prefetched_cas_paths,
+            retry_opts: retry_opts_from_config(config),
+            auth_headers: &config.auth_headers,
+            archive_prefix: binary.prefix.as_deref(),
+            ignore_file_pattern: None,
+        }
+        .run_without_mem_cache::<R>()
+        .await
+        .map_err(InstallPackageBySnapshotError::DownloadTarball),
+    }
+}
+
+/// Render a variant's target list as a human-readable string for
+/// inclusion in the [`InstallPackageBySnapshotError::NoMatchingPlatformVariant`]
+/// error. Each target is rendered as `os/cpu` or `os/cpu+libc`,
+/// joined with `, `.
+fn render_variant_targets(variants: &[pacquet_lockfile::PlatformAssetResolution]) -> String {
+    let mut entries: Vec<String> = Vec::new();
+    for variant in variants {
+        for target in &variant.targets {
+            match &target.libc {
+                Some(libc) => entries.push(format!("{}/{}+{libc}", target.os, target.cpu)),
+                None => entries.push(format!("{}/{}", target.os, target.cpu)),
+            }
+        }
+    }
+    entries.join(", ")
 }
 
 /// `pnpm:progress` `resolved` for a frozen-lockfile snapshot the

--- a/crates/package-manager/src/install_package_by_snapshot/tests.rs
+++ b/crates/package-manager/src/install_package_by_snapshot/tests.rs
@@ -1,5 +1,8 @@
-use super::emit_progress_resolved;
+use super::{emit_progress_resolved, host_platform_selector, render_variant_targets};
+use pacquet_graph_hasher::{host_arch, host_libc, host_platform};
+use pacquet_lockfile::{LockfileResolution, PlatformAssetResolution, PlatformAssetTarget};
 use pacquet_reporter::{LogEvent, ProgressMessage, Reporter};
+use pretty_assertions::assert_eq;
 use std::sync::Mutex;
 
 /// `emit_progress_resolved` fires exactly one `pnpm:progress`
@@ -31,4 +34,75 @@ fn emits_resolved_with_supplied_identifiers() {
         ),
         "expected a single Resolved event with matching identifiers; got {captured:?}",
     );
+}
+
+/// `host_platform_selector` builds the selector that drives runtime-
+/// variant matching. The `os` / `cpu` fields are always populated
+/// (from `host_platform()` / `host_arch()`); `libc` is the
+/// interesting one — pacquet must translate the
+/// "non-Linux ⇒ no libc constraint" rule pnpm enforces:
+/// `process.platform === 'linux' ? family : null`.
+///
+/// Asserting platform-specific shape directly would mean four
+/// `cfg`-gated tests; instead, run the live `host_*` functions and
+/// pin the *relationship* — `host_libc() == "unknown"` iff the
+/// selector's `libc` field is `None`. The relationship covers both
+/// the macOS / Windows / BSD non-Linux case (`libc` always `None`)
+/// and the Linux case (`libc` always `Some("glibc")` /
+/// `Some("musl")`).
+#[test]
+fn host_platform_selector_omits_libc_on_non_linux_hosts() {
+    let selector = host_platform_selector();
+    let libc_known = host_libc() != "unknown";
+    assert_eq!(selector.os, host_platform());
+    assert_eq!(selector.cpu, host_arch());
+    assert_eq!(
+        selector.libc.is_some(),
+        libc_known,
+        "selector.libc should be Some iff host_libc() reports glibc/musl (Linux); got selector={selector:?}, host_libc={:?}",
+        host_libc(),
+    );
+    if libc_known {
+        assert_eq!(selector.libc.as_deref(), Some(host_libc()));
+    }
+}
+
+/// `render_variant_targets` renders the lockfile's advertised
+/// target triples for inclusion in the
+/// `NoMatchingPlatformVariant` error message. Each target lands as
+/// `os/cpu` with an optional `+libc` suffix, joined with `, ` so
+/// the rendered list is greppable from terminal output.
+#[test]
+fn render_variant_targets_formats_each_triple_with_optional_libc() {
+    let variants = vec![
+        PlatformAssetResolution {
+            // Inner resolution is unused by the renderer; pick any
+            // shape that round-trips through serde (Directory keeps
+            // the fixture light).
+            resolution: LockfileResolution::Directory(pacquet_lockfile::DirectoryResolution {
+                directory: "fixture".into(),
+            }),
+            targets: vec![
+                PlatformAssetTarget { os: "darwin".into(), cpu: "arm64".into(), libc: None },
+                PlatformAssetTarget {
+                    os: "linux".into(),
+                    cpu: "x64".into(),
+                    libc: Some("musl".into()),
+                },
+            ],
+        },
+        PlatformAssetResolution {
+            resolution: LockfileResolution::Directory(pacquet_lockfile::DirectoryResolution {
+                directory: "fixture".into(),
+            }),
+            targets: vec![PlatformAssetTarget {
+                os: "win32".into(),
+                cpu: "x64".into(),
+                libc: None,
+            }],
+        },
+    ];
+
+    let rendered = render_variant_targets(&variants);
+    assert_eq!(rendered, "darwin/arm64, linux/x64+musl, win32/x64");
 }


### PR DESCRIPTION
## Summary

Slice D1 of [#437](https://github.com/pnpm/pacquet/issues/437) — wires the runtime fetchers landed in slice C (#472) into the install dispatcher. Replaces the `Binary` / `Variations` arms in `install_package_by_snapshot.rs` and `create_virtual_store.rs::snapshot_cache_key`. After this slice a frozen-lockfile install can dispatch a runtime resolution end-to-end through the existing CAS-write pipeline (just without the per-archive ignore filter or bin-link cmd-shims yet — see D2 below).

- `LockfileResolution::Binary(b)` dispatches on `b.archive`: tarball uses `DownloadTarballToStore`, zip uses `DownloadZipArchiveToStore` with `archive_prefix: b.prefix.as_deref()`.
- `LockfileResolution::Variations(v)` builds a `PlatformSelector` from `pacquet_graph_hasher::{host_platform, host_arch, host_libc}`, runs `select_platform_variant`, and routes the matched variant's inner `BinaryResolution` through the same dispatcher. A non-`Binary` inner shape (corrupt lockfile or future shape) raises a typed error rather than silently routing.
- `snapshot_cache_key` returns the proper warm-cache key for both new arms — `Binary` uses `store_index_key(integrity, pkg_id)`; `Variations` runs the same selector and keys off the picked variant.
- Two new error variants on `InstallPackageBySnapshotError`:
  - `NoMatchingPlatformVariant` — carries the host triple + rendered available-target list so the user can see at a glance why selection failed.
  - `VariantHasNonBinaryResolution` — defensive guard.

## What's not in this slice

Splitting the issue's Slice D into smaller PRs (per the established cadence). Follow-up slices:

- **D2** — `NODE_EXTRAS_IGNORE_PATTERN` filter for `pkg.name == "node"` (strip bundled `npm` / `corepack`); bin-link cmd-shims for the runtime executables (`bin` field on `BinaryResolution`); `@runtime:` substring handling in skip lists / reporter prefixes.
- **E** — `--no-runtime` flag.
- **F** — end-to-end install fixtures (host-match, variant mismatch, `--no-runtime`, integrity mismatch, path-traversal).

## Test plan

- [x] `host_platform_selector_omits_libc_on_non_linux_hosts` — pins the `host_libc() == "unknown"` ⇔ `selector.libc.is_none()` relationship (covers both Linux and non-Linux hosts via the same assertion).
- [x] `render_variant_targets_formats_each_triple_with_optional_libc` — locks in the `os/cpu[+libc]` rendering used by `NoMatchingPlatformVariant`.
- [x] `just ready` green
- [x] `taplo format --check`, `just dylint`, `cargo doc -D warnings` green

End-to-end runtime install tests live in slice F (the slice's whole point is to fixture them once the rest of the pipeline is in place).

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for binary and variation-based package resolutions during installation
  * Implemented platform-aware variant selection for multi-platform compatibility

* **Improvements**
  * Enhanced cache prefetching for additional lockfile resolution types
  * Improved error reporting when no matching platform variant is found, displaying available targets and host specifications

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pacquet/pull/492)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->