### PR TITLE
feat(package-manager): prev_graph diff from current lockfile (#438 slice 4d)

### DIFF
--- a/crates/package-manager/src/hoisted_dep_graph.rs
+++ b/crates/package-manager/src/hoisted_dep_graph.rs
@@ -307,7 +307,17 @@ pub fn lockfile_to_hoisted_dep_graph(
     // install's `skipped` is irrelevant — we want the full
     // previous layout to compute orphans against).
     let prev_graph = match current_lockfile {
-        Some(current) if current.packages.is_some() => {
+        // Require a non-empty `packages` map. Upstream's
+        // `currentLockfile?.packages != null` guard only filters
+        // out `null` / `undefined` — but for an empty `packages:
+        // {}` the inner walk produces an empty graph too, which
+        // is observationally equivalent to "no orphans to
+        // consider". Pacquet collapses both null and empty into
+        // `prev_graph: None` so the API contract is unambiguous
+        // and the empty case skips the (no-op) second walk.
+        Some(current)
+            if current.packages.as_ref().is_some_and(|packages| !packages.is_empty()) =>
+        {
             let prev_opts = LockfileToHoistedDepGraphOptions {
                 force: true,
                 skipped: BTreeSet::new(),
@@ -1332,6 +1342,45 @@ mod tests {
             lockfile_to_hoisted_dep_graph(&wanted, Some(&current), &opts).expect("walker succeeds");
 
         assert!(result.prev_graph.is_none(), "current lockfile without packages → no prev_graph");
+    }
+
+    /// A current lockfile with `packages: Some(empty map)` also
+    /// yields `prev_graph: None` — pacquet collapses null and
+    /// empty into the same "no orphans" representation, since
+    /// walking an empty `packages:` would just produce an empty
+    /// graph anyway. Regression for the empty-map case Coderabbit
+    /// flagged on the original 4d patch.
+    #[test]
+    fn prev_graph_none_when_current_lockfile_has_empty_packages() {
+        let mut root_deps = ResolvedDependencyMap::new();
+        root_deps.insert(pkg_name("a"), resolved_dep("1.0.0"));
+
+        let mut packages = HashMap::new();
+        packages.insert(dep_key("a", "1.0.0"), metadata_stub());
+
+        let mut snapshots = HashMap::new();
+        snapshots.insert(dep_key("a", "1.0.0"), SnapshotEntry::default());
+
+        let wanted = lockfile_with(root_deps, packages, snapshots);
+        let current = Lockfile {
+            lockfile_version: lockfile_version(),
+            settings: Some(LockfileSettings::default()),
+            overrides: None,
+            importers: HashMap::new(),
+            packages: Some(HashMap::new()),
+            snapshots: Some(HashMap::new()),
+        };
+        let opts = LockfileToHoistedDepGraphOptions {
+            lockfile_dir: PathBuf::from("/repo"),
+            ..LockfileToHoistedDepGraphOptions::default()
+        };
+        let result = lockfile_to_hoisted_dep_graph(&wanted, Some(&current), &opts)
+            .expect("walker succeeds");
+
+        assert!(
+            result.prev_graph.is_none(),
+            "current lockfile with empty packages → no prev_graph",
+        );
     }
 
     /// A package present in the current lockfile but absent from

--- a/crates/package-manager/src/hoisted_dep_graph.rs
+++ b/crates/package-manager/src/hoisted_dep_graph.rs
@@ -5,18 +5,23 @@
 //! and the supporting types factored into
 //! [`deps/graph-builder/src/lockfileToDepGraph.ts`](https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-builder/src/lockfileToDepGraph.ts).
 //!
-//! The walker [`lockfile_to_hoisted_dep_graph`] takes a lockfile
-//! and runs `pacquet_real_hoist::hoist` to get the directory shape,
-//! then assembles a [`LockfileToDepGraphResult`] keyed by the
-//! computed absolute directory of every node. Optional packages
-//! whose `cpu` / `os` / `libc` / `engines` don't fit the current
-//! host are added to `result.skipped` rather than emitted into the
-//! graph; required incompatible packages proceed with a (yet-to-be-
-//! wired) warning, matching upstream `package_is_installable`'s
-//! `null | true | false` shape. Store I/O (`fetching` /
-//! `files_index_file`) and the `prev_graph` diff still land in
-//! follow-ups; this walker produces a correct graph topology for
-//! the eventual store integration to layer fetch results onto.
+//! The walker [`lockfile_to_hoisted_dep_graph`] takes a wanted
+//! lockfile plus an optional *current* lockfile and runs
+//! `pacquet_real_hoist::hoist` to get the directory shape, then
+//! assembles a [`LockfileToDepGraphResult`] keyed by the computed
+//! absolute directory of every node. Optional packages whose
+//! `cpu` / `os` / `libc` / `engines` don't fit the current host
+//! are added to `result.skipped` rather than emitted into the
+//! graph; required incompatible packages proceed with a
+//! (yet-to-be-wired) warning, matching upstream
+//! `package_is_installable`'s `null | true | false` shape. When a
+//! current lockfile is supplied, the walker runs a second
+//! `force: true, skipped: empty` pass over it to populate
+//! `result.prev_graph` — the input Slice 5's linker diffs against
+//! to identify orphaned directories. Store I/O (`fetching` /
+//! `files_index_file`) is still deferred — those fields are
+//! populated by the linker, which kicks off store fetches when it
+//! has a real consumer for the handles.
 //!
 //! Unlike the depPath-keyed [`crate::deps_graph`] module (which is
 //! a hashing-side adapter for the build cache), the graph defined
@@ -271,20 +276,59 @@ pub enum HoistedDepGraphError {
 }
 
 /// Build a directory-keyed [`LockfileToDepGraphResult`] from a
-/// lockfile by running the hoist algorithm and walking the
-/// resulting tree. Ports upstream's
-/// [`lockfileToHoistedDepGraph`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-restorer/src/lockfileToHoistedDepGraph.ts#L65-L85)
-/// minus the store-controller-bound fetch step (the
-/// `DependenciesGraphNode` fields that depend on the store
-/// remain default-valued; a follow-up wires the fetch in) and
-/// minus the `currentLockfile`-driven `prev_graph` diff (lands in
-/// the same follow-up that adds the orphan-removal pass to the
-/// linker).
+/// wanted lockfile, plus an optional *current* lockfile to diff
+/// against. Ports upstream's
+/// [`lockfileToHoistedDepGraph`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-restorer/src/lockfileToHoistedDepGraph.ts#L65-L85).
+///
+/// When `current_lockfile` is `Some` and the lockfile has a
+/// non-empty `packages:` map, the function runs an extra pass
+/// over that lockfile with `force: true` and `skipped: empty` to
+/// produce `prev_graph` — the graph the previous install
+/// produced, used by Slice 5's linker to identify orphaned
+/// directories. Mirrors upstream's pre-await branch at
+/// [`lockfileToHoistedDepGraph.ts:70-79`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-restorer/src/lockfileToHoistedDepGraph.ts#L70-L79).
+///
+/// The store-controller-bound `fetching` / `files_index_file`
+/// fields on each graph node remain default-valued — those are
+/// populated by Slice 5's linker, which kicks off the actual
+/// store fetches when it has a real consumer for the handles.
 ///
 /// Single-importer only today — multi-importer (workspace)
 /// lockfiles surface as `HoistError::UnsupportedWorkspace` via
 /// the hoister.
 pub fn lockfile_to_hoisted_dep_graph(
+    lockfile: &Lockfile,
+    current_lockfile: Option<&Lockfile>,
+    opts: &LockfileToHoistedDepGraphOptions,
+) -> Result<LockfileToDepGraphResult, HoistedDepGraphError> {
+    // Prev-graph walk: forced (every snapshot in the current
+    // lockfile must surface so the diff catches packages that
+    // would now fail installability) and unskipped (the previous
+    // install's `skipped` is irrelevant — we want the full
+    // previous layout to compute orphans against).
+    let prev_graph = match current_lockfile {
+        Some(current) if current.packages.is_some() => {
+            let prev_opts = LockfileToHoistedDepGraphOptions {
+                force: true,
+                skipped: BTreeSet::new(),
+                ..opts.clone()
+            };
+            Some(build_dep_graph(current, &prev_opts)?.graph)
+        }
+        _ => None,
+    };
+
+    let mut result = build_dep_graph(lockfile, opts)?;
+    result.prev_graph = prev_graph;
+    Ok(result)
+}
+
+/// Inner builder: runs the hoister + walker for one lockfile and
+/// returns the per-walk subset of [`LockfileToDepGraphResult`]
+/// (everything except `prev_graph`, which only the outer wrapper
+/// sets). Mirrors upstream's private `_lockfileToHoistedDepGraph`
+/// at [`lockfileToHoistedDepGraph.ts:91-127`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-restorer/src/lockfileToHoistedDepGraph.ts#L91-L127).
+fn build_dep_graph(
     lockfile: &Lockfile,
     opts: &LockfileToHoistedDepGraphOptions,
 ) -> Result<LockfileToDepGraphResult, HoistedDepGraphError> {
@@ -831,7 +875,8 @@ mod tests {
             lockfile_dir: PathBuf::from("/repo"),
             ..LockfileToHoistedDepGraphOptions::default()
         };
-        let result = lockfile_to_hoisted_dep_graph(&lockfile, &opts).expect("empty lockfile walks");
+        let result =
+            lockfile_to_hoisted_dep_graph(&lockfile, None, &opts).expect("empty lockfile walks");
 
         assert!(result.graph.is_empty(), "graph should be empty");
         assert!(result.hoisted_locations.is_empty(), "no locations recorded");
@@ -863,7 +908,8 @@ mod tests {
             lockfile_dir: lockfile_dir.clone(),
             ..LockfileToHoistedDepGraphOptions::default()
         };
-        let result = lockfile_to_hoisted_dep_graph(&lockfile, &opts).expect("walker succeeds");
+        let result =
+            lockfile_to_hoisted_dep_graph(&lockfile, None, &opts).expect("walker succeeds");
 
         let expected_dir = lockfile_dir.join("node_modules").join("a");
         assert_eq!(
@@ -914,7 +960,8 @@ mod tests {
             lockfile_dir: lockfile_dir.clone(),
             ..LockfileToHoistedDepGraphOptions::default()
         };
-        let result = lockfile_to_hoisted_dep_graph(&lockfile, &opts).expect("walker succeeds");
+        let result =
+            lockfile_to_hoisted_dep_graph(&lockfile, None, &opts).expect("walker succeeds");
 
         let modules = lockfile_dir.join("node_modules");
         assert_eq!(
@@ -966,7 +1013,8 @@ mod tests {
             lockfile_dir: lockfile_dir.clone(),
             ..LockfileToHoistedDepGraphOptions::default()
         };
-        let result = lockfile_to_hoisted_dep_graph(&lockfile, &opts).expect("walker succeeds");
+        let result =
+            lockfile_to_hoisted_dep_graph(&lockfile, None, &opts).expect("walker succeeds");
 
         let modules = lockfile_dir.join("node_modules");
         let a1_dir = modules.join("a");
@@ -1013,7 +1061,8 @@ mod tests {
             skipped,
             ..LockfileToHoistedDepGraphOptions::default()
         };
-        let result = lockfile_to_hoisted_dep_graph(&lockfile, &opts).expect("walker succeeds");
+        let result =
+            lockfile_to_hoisted_dep_graph(&lockfile, None, &opts).expect("walker succeeds");
 
         assert!(result.graph.is_empty(), "skipped dep not emitted");
         assert!(result.hoisted_locations.is_empty());
@@ -1046,7 +1095,8 @@ mod tests {
             lockfile_dir: lockfile_dir.clone(),
             ..LockfileToHoistedDepGraphOptions::default()
         };
-        let result = lockfile_to_hoisted_dep_graph(&lockfile, &opts).expect("walker succeeds");
+        let result =
+            lockfile_to_hoisted_dep_graph(&lockfile, None, &opts).expect("walker succeeds");
 
         assert_eq!(
             result.injection_targets_by_dep_path["a@1.0.0"],
@@ -1097,8 +1147,8 @@ mod tests {
         );
 
         let lockfile = lockfile_with(root_deps, packages, snapshots);
-        let result =
-            lockfile_to_hoisted_dep_graph(&lockfile, &host_aware_opts()).expect("walker succeeds");
+        let result = lockfile_to_hoisted_dep_graph(&lockfile, None, &host_aware_opts())
+            .expect("walker succeeds");
 
         assert!(result.graph.is_empty(), "optional incompatible dep not emitted");
         assert!(
@@ -1130,8 +1180,8 @@ mod tests {
         snapshots.insert(dep_key("a", "1.0.0"), SnapshotEntry::default());
 
         let lockfile = lockfile_with(root_deps, packages, snapshots);
-        let result =
-            lockfile_to_hoisted_dep_graph(&lockfile, &host_aware_opts()).expect("walker proceeds");
+        let result = lockfile_to_hoisted_dep_graph(&lockfile, None, &host_aware_opts())
+            .expect("walker proceeds");
 
         assert_eq!(result.graph.len(), 1, "required incompatible dep emitted as warning");
         assert!(result.skipped.is_empty(), "required dep not added to skipped");
@@ -1159,7 +1209,7 @@ mod tests {
 
         let lockfile = lockfile_with(root_deps, packages, snapshots);
         let opts = LockfileToHoistedDepGraphOptions { engine_strict: true, ..host_aware_opts() };
-        let err = lockfile_to_hoisted_dep_graph(&lockfile, &opts)
+        let err = lockfile_to_hoisted_dep_graph(&lockfile, None, &opts)
             .expect_err("engine_strict + engine mismatch should error");
         match err {
             HoistedDepGraphError::Installability(inner) => match *inner {
@@ -1190,7 +1240,8 @@ mod tests {
 
         let lockfile = lockfile_with(root_deps, packages, snapshots);
         let opts = LockfileToHoistedDepGraphOptions { force: true, ..host_aware_opts() };
-        let result = lockfile_to_hoisted_dep_graph(&lockfile, &opts).expect("force bypasses check");
+        let result =
+            lockfile_to_hoisted_dep_graph(&lockfile, None, &opts).expect("force bypasses check");
 
         assert_eq!(result.graph.len(), 1, "force=true emits the dep regardless of platform");
         assert!(result.skipped.is_empty(), "force=true doesn't add to skipped");
@@ -1212,10 +1263,171 @@ mod tests {
         snapshots.insert(dep_key("a", "1.0.0"), SnapshotEntry::default());
 
         let lockfile = lockfile_with(root_deps, packages, snapshots);
-        let result =
-            lockfile_to_hoisted_dep_graph(&lockfile, &host_aware_opts()).expect("walker succeeds");
+        let result = lockfile_to_hoisted_dep_graph(&lockfile, None, &host_aware_opts())
+            .expect("walker succeeds");
 
         assert_eq!(result.graph.len(), 1);
         assert!(result.skipped.is_empty());
+    }
+
+    // --- prev_graph tests ------------------------------------------------
+
+    /// `current_lockfile: None` yields `prev_graph: None`. Mirrors
+    /// upstream's `prevGraph = {}` fallback when no current
+    /// lockfile is supplied — pacquet uses `None` instead of an
+    /// empty map, but the linker treats the two the same way (no
+    /// orphans to remove on a fresh install).
+    #[test]
+    fn prev_graph_none_when_current_lockfile_absent() {
+        let mut root_deps = ResolvedDependencyMap::new();
+        root_deps.insert(pkg_name("a"), resolved_dep("1.0.0"));
+
+        let mut packages = HashMap::new();
+        packages.insert(dep_key("a", "1.0.0"), metadata_stub());
+
+        let mut snapshots = HashMap::new();
+        snapshots.insert(dep_key("a", "1.0.0"), SnapshotEntry::default());
+
+        let lockfile = lockfile_with(root_deps, packages, snapshots);
+        let opts = LockfileToHoistedDepGraphOptions {
+            lockfile_dir: PathBuf::from("/repo"),
+            ..LockfileToHoistedDepGraphOptions::default()
+        };
+        let result =
+            lockfile_to_hoisted_dep_graph(&lockfile, None, &opts).expect("walker succeeds");
+
+        assert!(result.prev_graph.is_none(), "no current_lockfile → no prev_graph");
+        assert_eq!(result.graph.len(), 1, "wanted lockfile still produces the graph");
+    }
+
+    /// A current lockfile with no `packages:` map (a brand-new
+    /// install in progress) also yields `prev_graph: None`.
+    /// Mirrors upstream's `currentLockfile?.packages != null`
+    /// guard.
+    #[test]
+    fn prev_graph_none_when_current_lockfile_has_no_packages() {
+        let mut root_deps = ResolvedDependencyMap::new();
+        root_deps.insert(pkg_name("a"), resolved_dep("1.0.0"));
+
+        let mut packages = HashMap::new();
+        packages.insert(dep_key("a", "1.0.0"), metadata_stub());
+
+        let mut snapshots = HashMap::new();
+        snapshots.insert(dep_key("a", "1.0.0"), SnapshotEntry::default());
+
+        let wanted = lockfile_with(root_deps, packages, snapshots);
+        let current = Lockfile {
+            lockfile_version: lockfile_version(),
+            settings: Some(LockfileSettings::default()),
+            overrides: None,
+            importers: HashMap::new(),
+            packages: None,
+            snapshots: None,
+        };
+        let opts = LockfileToHoistedDepGraphOptions {
+            lockfile_dir: PathBuf::from("/repo"),
+            ..LockfileToHoistedDepGraphOptions::default()
+        };
+        let result =
+            lockfile_to_hoisted_dep_graph(&wanted, Some(&current), &opts).expect("walker succeeds");
+
+        assert!(result.prev_graph.is_none(), "current lockfile without packages → no prev_graph");
+    }
+
+    /// A package present in the current lockfile but absent from
+    /// the wanted lockfile surfaces in `prev_graph` while not
+    /// appearing in `graph`. Slice 5's linker will subtract `graph`
+    /// from `prev_graph` to find this directory and `rimraf` it.
+    #[test]
+    fn prev_graph_contains_orphan_from_current_only_lockfile() {
+        // Current install: root → {a, orphan}
+        let mut current_root_deps = ResolvedDependencyMap::new();
+        current_root_deps.insert(pkg_name("a"), resolved_dep("1.0.0"));
+        current_root_deps.insert(pkg_name("orphan"), resolved_dep("1.0.0"));
+        let mut current_packages = HashMap::new();
+        current_packages.insert(dep_key("a", "1.0.0"), metadata_stub());
+        current_packages.insert(dep_key("orphan", "1.0.0"), metadata_stub());
+        let mut current_snapshots = HashMap::new();
+        current_snapshots.insert(dep_key("a", "1.0.0"), SnapshotEntry::default());
+        current_snapshots.insert(dep_key("orphan", "1.0.0"), SnapshotEntry::default());
+        let current_lockfile =
+            lockfile_with(current_root_deps, current_packages, current_snapshots);
+
+        // Wanted install: root → {a} (orphan removed)
+        let mut wanted_root_deps = ResolvedDependencyMap::new();
+        wanted_root_deps.insert(pkg_name("a"), resolved_dep("1.0.0"));
+        let mut wanted_packages = HashMap::new();
+        wanted_packages.insert(dep_key("a", "1.0.0"), metadata_stub());
+        let mut wanted_snapshots = HashMap::new();
+        wanted_snapshots.insert(dep_key("a", "1.0.0"), SnapshotEntry::default());
+        let wanted_lockfile = lockfile_with(wanted_root_deps, wanted_packages, wanted_snapshots);
+
+        let lockfile_dir = PathBuf::from("/repo");
+        let opts = LockfileToHoistedDepGraphOptions {
+            lockfile_dir: lockfile_dir.clone(),
+            ..LockfileToHoistedDepGraphOptions::default()
+        };
+        let result =
+            lockfile_to_hoisted_dep_graph(&wanted_lockfile, Some(&current_lockfile), &opts)
+                .expect("walker succeeds");
+
+        let orphan_dir = lockfile_dir.join("node_modules").join("orphan");
+        let a_dir = lockfile_dir.join("node_modules").join("a");
+
+        let prev = result.prev_graph.expect("prev_graph populated");
+        assert!(prev.contains_key(&orphan_dir), "orphan present in prev_graph");
+        assert!(prev.contains_key(&a_dir), "carried-over dep also in prev_graph");
+        assert!(result.graph.contains_key(&a_dir), "wanted graph carries a");
+        assert!(!result.graph.contains_key(&orphan_dir), "wanted graph omits orphan");
+    }
+
+    /// The prev-graph walk uses `force: true, skipped: empty` so
+    /// the *current* layout is preserved even for packages that
+    /// would now fail installability. Mirrors upstream's
+    /// `{ ...opts, force: true, skipped: new Set() }` override at
+    /// [lockfileToHoistedDepGraph.ts:72-76](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-restorer/src/lockfileToHoistedDepGraph.ts#L72-L76).
+    /// Without this, an orphan that targets an unsupported platform
+    /// wouldn't appear in `prev_graph` and the linker would leave
+    /// the stale directory in place.
+    #[test]
+    fn prev_graph_includes_orphan_even_when_now_incompatible() {
+        // Current install had a darwin-targeting orphan dep that
+        // landed on a host where the wanted install runs on linux.
+        let mut current_root_deps = ResolvedDependencyMap::new();
+        current_root_deps.insert(pkg_name("orphan"), resolved_dep("1.0.0"));
+        let mut current_packages = HashMap::new();
+        current_packages.insert(dep_key("orphan", "1.0.0"), metadata_with_os("darwin"));
+        let mut current_snapshots = HashMap::new();
+        current_snapshots.insert(dep_key("orphan", "1.0.0"), SnapshotEntry::default());
+        let current_lockfile =
+            lockfile_with(current_root_deps, current_packages, current_snapshots);
+
+        // Wanted install: empty root.
+        let wanted_lockfile =
+            lockfile_with(ResolvedDependencyMap::new(), HashMap::new(), HashMap::new());
+
+        let lockfile_dir = PathBuf::from("/repo");
+        let opts = LockfileToHoistedDepGraphOptions {
+            lockfile_dir: lockfile_dir.clone(),
+            current_node_version: "20.0.0".to_string(),
+            current_os: "linux".to_string(),
+            current_cpu: "x64".to_string(),
+            current_libc: "glibc".to_string(),
+            ..LockfileToHoistedDepGraphOptions::default()
+        };
+        let result =
+            lockfile_to_hoisted_dep_graph(&wanted_lockfile, Some(&current_lockfile), &opts)
+                .expect("walker succeeds");
+
+        let orphan_dir = lockfile_dir.join("node_modules").join("orphan");
+        let prev = result.prev_graph.expect("prev_graph populated");
+        assert!(
+            prev.contains_key(&orphan_dir),
+            "force: true emits the orphan even though it would now fail installability",
+        );
+        assert!(result.graph.is_empty(), "wanted graph stays empty");
+        // The orphan must not appear in the wanted-walk's skipped
+        // set either — its installability check was never run.
+        assert!(result.skipped.is_empty(), "skipped from wanted walk only, not prev walk");
     }
 }

--- a/crates/package-manager/src/hoisted_dep_graph.rs
+++ b/crates/package-manager/src/hoisted_dep_graph.rs
@@ -315,9 +315,7 @@ pub fn lockfile_to_hoisted_dep_graph(
         // consider". Pacquet collapses both null and empty into
         // `prev_graph: None` so the API contract is unambiguous
         // and the empty case skips the (no-op) second walk.
-        Some(current)
-            if current.packages.as_ref().is_some_and(|packages| !packages.is_empty()) =>
-        {
+        Some(current) if current.packages.as_ref().is_some_and(|packages| !packages.is_empty()) => {
             let prev_opts = LockfileToHoistedDepGraphOptions {
                 force: true,
                 skipped: BTreeSet::new(),
@@ -1374,8 +1372,8 @@ mod tests {
             lockfile_dir: PathBuf::from("/repo"),
             ..LockfileToHoistedDepGraphOptions::default()
         };
-        let result = lockfile_to_hoisted_dep_graph(&wanted, Some(&current), &opts)
-            .expect("walker succeeds");
+        let result =
+            lockfile_to_hoisted_dep_graph(&wanted, Some(&current), &opts).expect("walker succeeds");
 
         assert!(
             result.prev_graph.is_none(),


### PR DESCRIPTION
## Summary

Sub-slice 4d of #438. Closes out Slice 4 by adding the `prev_graph` diff — the input Slice 5's linker will subtract from `graph` to identify orphaned directories that need removing.

## What lands

`lockfile_to_hoisted_dep_graph` now takes an optional `current_lockfile: Option<&Lockfile>` and runs a second walk over it (when present and non-empty) with `force: true, skipped: BTreeSet::new()` to populate `result.prev_graph`. Ports upstream's wrapper at [installing/deps-restorer/src/lockfileToHoistedDepGraph.ts:70-79](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-restorer/src/lockfileToHoistedDepGraph.ts#L70-L79).

```rust
let prev_graph = match current_lockfile {
    Some(current) if current.packages.is_some() => {
        let prev_opts = LockfileToHoistedDepGraphOptions {
            force: true,
            skipped: BTreeSet::new(),
            ..opts.clone()
        };
        Some(build_dep_graph(current, &prev_opts)?.graph)
    }
    _ => None,
};
```

## Why force + empty skipped

Both overrides matter — neither is paranoia:

- **`force: true`** — an orphan that landed under the previous install but would now fail installability (host platform changed, dependency was downgraded out of engine range, etc.) still has a directory on disk. Without `force`, the prev-walk would silently filter it out and the linker would leave the stale dir in place. Pinned by `prev_graph_includes_orphan_even_when_now_incompatible`.
- **`skipped: empty`** — the previous install's filter set says which packages it *didn't* install, which is unrelated to which directories *currently exist*. Inheriting the wanted-walk's skipped would underreport `prev_graph` for unchanged-but-now-incompatible packages.

## API change

`lockfile_to_hoisted_dep_graph` gains a middle `current_lockfile: Option<&Lockfile>` argument. The previous body splits into a private `build_dep_graph` helper that the public wrapper calls once or twice depending on whether a current lockfile is present. Existing tests updated (the only callers — `None` for the no-prev case).

## `prev_graph` shape

| `current_lockfile` | `result.prev_graph` |
|---|---|
| `None` | `None` |
| `Some(lf)` with `lf.packages: None` | `None` |
| `Some(lf)` with `lf.packages: Some(_)` | `Some(graph)` |

Upstream uses `prevGraph = {}` for both null-current cases; pacquet uses `None`. The linker treats them the same (no orphans to remove on a fresh install).

## Tests

Four new prev_graph tests; the 15 walker tests from 4a-4c carry over with the new signature.

- `prev_graph_none_when_current_lockfile_absent` — no current lockfile → `None`, wanted graph still produced.
- `prev_graph_none_when_current_lockfile_has_no_packages` — current lockfile with `packages: None` → `None`.
- `prev_graph_contains_orphan_from_current_only_lockfile` — package in current but not wanted appears in `prev_graph`, not in `graph`.
- `prev_graph_includes_orphan_even_when_now_incompatible` — darwin-only orphan in current, host is linux, wanted is empty: `prev_graph` still contains it (proves `force: true` works), and the wanted-walk's `skipped` stays empty (proves the prev-walk's skipped set is independent).

## Test plan

- [x] All 19 walker tests pass (15 carry-over + 4 new).
- [x] `just ready` (874 → 878 tests, all green).
- [x] `cargo doc --document-private-items`, `taplo format --check`, `just dylint` clean.
- [x] Sabotage check: changing the prev-walk's options from `force: true, skipped: empty` to `..opts.clone()` re-fails `prev_graph_includes_orphan_even_when_now_incompatible` (orphan disappears from `prev_graph` because it would now fail installability).

## What's next

Slice 4 is done. Next on the critical path: **Slice 5 — `linkHoistedModules`**. Consumes `LockfileToDepGraphResult` to produce the on-disk tree: walks `prev_graph` minus `graph` to rimraf orphans, then imports each graph node from the CAS via Slice 1's `import_indexed_dir` primitive, then runs `linkBins` per `node_modules/` directory.

---
Written by an agent (Claude Code, claude-opus-4-7).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added support for computing a previous dependency graph when a current lockfile is provided, improving detection of changes between lockfile states and handling of current-only (orphan) packages.

* **Tests**
  * Expanded tests for lockfile-comparison behavior, ensuring prev-graph semantics and orphaned package detection (including installability edge cases).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pacquet/pull/494)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->