### PR TITLE
feat(package-manager): NODE_EXTRAS ignore filter for runtime archives (#437 slice D2)

### DIFF
--- a/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/crates/package-manager/src/install_package_by_snapshot.rs
@@ -19,7 +19,8 @@ use pacquet_store_dir::{
     git_hosted_store_index_key,
 };
 use pacquet_tarball::{
-    DownloadTarballToStore, DownloadZipArchiveToStore, PrefetchedCasPaths, TarballError,
+    DownloadTarballToStore, DownloadZipArchiveToStore, IgnoreEntryFilter, PrefetchedCasPaths,
+    TarballError,
 };
 use pipe_trait::Pipe;
 use std::{
@@ -277,6 +278,7 @@ impl<'a> InstallPackageBySnapshot<'a> {
                     prefetched_cas_paths,
                     &package_id,
                     requester,
+                    archive_filter_for(package_key),
                 )
                 .await?
             }
@@ -331,6 +333,7 @@ impl<'a> InstallPackageBySnapshot<'a> {
                     prefetched_cas_paths,
                     &package_id,
                     requester,
+                    archive_filter_for(package_key),
                 )
                 .await?
             }
@@ -441,6 +444,93 @@ pub(crate) fn host_platform_selector() -> PlatformSelector {
     PlatformSelector { os: host_platform().to_string(), cpu: host_arch().to_string(), libc }
 }
 
+/// Hand-coded port of upstream's
+/// [`NODE_EXTRAS_IGNORE_PATTERN`](https://github.com/pnpm/pnpm/blob/94240bc046/engine/runtime/node-resolver/src/index.ts)
+/// regex (`^(?:(?:lib/)?node_modules/(?:npm|corepack)(?:/|$)|bin/(?:npm|npx|corepack)$|(?:npm|npx|corepack)(?:\.(?:cmd|ps1))?$)`).
+/// Used as the archive-entry filter when extracting a Node.js
+/// runtime archive: pnpm bundles `npm` + `corepack` in the tarball,
+/// but pacquet (and pnpm) install pnpm itself as the package
+/// manager, so the bundled tooling is dead weight and would also
+/// shadow the user's pnpm via `node_modules/.bin/`. Stripping these
+/// entries during the CAS write keeps the runtime artifact in the
+/// store free of the bundled tooling without a post-hoc cleanup.
+///
+/// Pacquet uses a hand-coded matcher rather than the upstream regex
+/// so [`pacquet_tarball`] doesn't have to pull in a regex engine.
+/// The three branches below mirror the regex alternation exactly;
+/// every path the regex matches is matched here, and nothing else.
+fn node_extras_filter(path: &str) -> bool {
+    // ^(?:(?:lib/)?node_modules/(?:npm|corepack)(?:/|$))
+    //
+    // Strip an optional leading `lib/` so the `lib/node_modules/...`
+    // and `node_modules/...` shapes converge into one check; the
+    // `node_modules/` prefix is mandatory after the optional `lib/`.
+    let after_lib = path.strip_prefix("lib/").unwrap_or(path);
+    if let Some(rest) = after_lib.strip_prefix("node_modules/") {
+        for name in ["npm", "corepack"] {
+            if rest == name || rest.starts_with(&format!("{name}/")) {
+                return true;
+            }
+        }
+    }
+    // ^bin/(?:npm|npx|corepack)$
+    //
+    // The `$` anchors the regex to an exact match — `bin/npm/foo`
+    // doesn't trip this arm (and the `node_modules` arm above
+    // wouldn't catch it either since it doesn't start with `bin/`).
+    if let Some(rest) = path.strip_prefix("bin/")
+        && matches!(rest, "npm" | "npx" | "corepack")
+    {
+        return true;
+    }
+    // ^(?:npm|npx|corepack)(?:\.(?:cmd|ps1))?$
+    //
+    // Top-level shim files; `.cmd` / `.ps1` cover Windows. Note
+    // these are *not* under `bin/` — they live at the runtime
+    // archive root after the `node-vX.Y.Z-<platform>-<arch>/`
+    // prefix strip.
+    for name in ["npm", "npx", "corepack"] {
+        if path == name {
+            return true;
+        }
+        for ext in [".cmd", ".ps1"] {
+            if path.len() == name.len() + ext.len() && path.starts_with(name) && path.ends_with(ext)
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Build the per-fetch [`IgnoreEntryFilter`] for the package being
+/// installed. Returns `Some(NODE_EXTRAS_IGNORE_PATTERN)` for
+/// unscoped `node` (matching upstream's
+/// [`archiveFilters: { node: NODE_EXTRAS_IGNORE_PATTERN }`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/client/src/index.ts)
+/// keyed by `pkg.name`); everything else returns `None` and the
+/// full archive contents land in the CAS unfiltered.
+///
+/// The filter is cached in a [`std::sync::OnceLock`] so per-snapshot
+/// `Arc::clone`s share one trait object — `IgnoreEntryFilter` is
+/// a `dyn Fn`, so cheap to clone, and we don't want to allocate
+/// the Arc once per runtime install.
+fn archive_filter_for(package_key: &PackageKey) -> Option<Arc<IgnoreEntryFilter>> {
+    if package_key.name.scope.is_some() || package_key.name.bare != "node" {
+        return None;
+    }
+    static FILTER: std::sync::OnceLock<Arc<IgnoreEntryFilter>> = std::sync::OnceLock::new();
+    let filter = FILTER.get_or_init(|| {
+        // `fn(&str) -> bool` implements `Fn(&str) -> bool + Send +
+        // Sync`, so an `Arc<fn(...)>` unsizes to
+        // `Arc<dyn Fn(...) + Send + Sync>` (the trait-object type
+        // `IgnoreEntryFilter` aliases). The explicit type
+        // annotation drives the unsizing coercion.
+        let f: Arc<IgnoreEntryFilter> = Arc::new(node_extras_filter);
+        f
+    });
+    Some(Arc::clone(filter))
+}
+
 /// Fetch a [`BinaryResolution`] into the CAS, returning the
 /// per-file `{relative_path → cas_path}` map the snapshot's virtual
 /// directory needs. Dispatches on the archive type:
@@ -473,6 +563,7 @@ async fn fetch_binary_resolution_to_cas<R: Reporter>(
     prefetched_cas_paths: Option<&PrefetchedCasPaths>,
     package_id: &str,
     requester: &str,
+    ignore_file_pattern: Option<Arc<IgnoreEntryFilter>>,
 ) -> Result<HashMap<String, PathBuf>, InstallPackageBySnapshotError> {
     match binary.archive {
         BinaryArchive::Tarball => DownloadTarballToStore {
@@ -490,7 +581,7 @@ async fn fetch_binary_resolution_to_cas<R: Reporter>(
             prefetched_cas_paths,
             retry_opts: retry_opts_from_config(config),
             auth_headers: &config.auth_headers,
-            ignore_file_pattern: None,
+            ignore_file_pattern,
         }
         .run_without_mem_cache::<R>()
         .await
@@ -510,7 +601,7 @@ async fn fetch_binary_resolution_to_cas<R: Reporter>(
             retry_opts: retry_opts_from_config(config),
             auth_headers: &config.auth_headers,
             archive_prefix: binary.prefix.as_deref(),
-            ignore_file_pattern: None,
+            ignore_file_pattern,
         }
         .run_without_mem_cache::<R>()
         .await

--- a/crates/package-manager/src/install_package_by_snapshot/tests.rs
+++ b/crates/package-manager/src/install_package_by_snapshot/tests.rs
@@ -1,6 +1,11 @@
-use super::{emit_progress_resolved, host_platform_selector, render_variant_targets};
+use super::{
+    archive_filter_for, emit_progress_resolved, host_platform_selector, node_extras_filter,
+    render_variant_targets,
+};
 use pacquet_graph_hasher::{host_arch, host_libc, host_platform};
-use pacquet_lockfile::{LockfileResolution, PlatformAssetResolution, PlatformAssetTarget};
+use pacquet_lockfile::{
+    LockfileResolution, PackageKey, PlatformAssetResolution, PlatformAssetTarget,
+};
 use pacquet_reporter::{LogEvent, ProgressMessage, Reporter};
 use pretty_assertions::assert_eq;
 use std::sync::Mutex;
@@ -105,4 +110,100 @@ fn render_variant_targets_formats_each_triple_with_optional_libc() {
 
     let rendered = render_variant_targets(&variants);
     assert_eq!(rendered, "darwin/arm64, linux/x64+musl, win32/x64");
+}
+
+/// `node_extras_filter` is the hand-coded port of upstream's
+/// `NODE_EXTRAS_IGNORE_PATTERN` regex
+/// (`^(?:(?:lib/)?node_modules/(?:npm|corepack)(?:/|$)|bin/(?:npm|npx|corepack)$|(?:npm|npx|corepack)(?:\.(?:cmd|ps1))?$)`).
+/// Pin each branch of the alternation, including the negative
+/// cases the regex deliberately doesn't match — a regression
+/// (e.g. matching `lib/node_modules/yarn/...` because someone
+/// forgot the `npm|corepack` alternation) would slip past tests
+/// that only checked positive matches.
+#[test]
+fn node_extras_filter_matches_upstream_regex_alternations() {
+    // Branch 1: `^(?:lib/)?node_modules/(?:npm|corepack)(?:/|$)`
+    for path in [
+        "lib/node_modules/npm",
+        "lib/node_modules/npm/",
+        "lib/node_modules/npm/package.json",
+        "lib/node_modules/corepack",
+        "lib/node_modules/corepack/dist/manager.js",
+        "node_modules/npm",
+        "node_modules/npm/package.json",
+        "node_modules/corepack/dist/manager.js",
+    ] {
+        assert!(node_extras_filter(path), "expected match: {path}");
+    }
+    // Same branch, negative cases: other package names under
+    // `node_modules/` must not be stripped.
+    for path in [
+        "lib/node_modules/yarn",
+        "lib/node_modules/yarn/package.json",
+        "node_modules/yarn",
+        "node_modules/typescript/lib/tsc.js",
+        // `node_modules` without the `lib/` prefix at a nested
+        // depth shouldn't match the regex either (the `^` anchor).
+        "src/node_modules/npm/foo",
+    ] {
+        assert!(!node_extras_filter(path), "expected no match: {path}");
+    }
+
+    // Branch 2: `^bin/(?:npm|npx|corepack)$`
+    for path in ["bin/npm", "bin/npx", "bin/corepack"] {
+        assert!(node_extras_filter(path), "expected match: {path}");
+    }
+    // Same branch, negative cases: the `$` anchors the regex —
+    // `bin/npm/foo` doesn't match, neither does an extension on
+    // the `bin/` form.
+    for path in ["bin/npm/foo", "bin/npm.cmd", "bin/yarn", "bin/", "binnpm"] {
+        assert!(!node_extras_filter(path), "expected no match: {path}");
+    }
+
+    // Branch 3: `^(?:npm|npx|corepack)(?:\.(?:cmd|ps1))?$`
+    for path in [
+        "npm",
+        "npx",
+        "corepack",
+        "npm.cmd",
+        "npx.cmd",
+        "corepack.cmd",
+        "npm.ps1",
+        "npx.ps1",
+        "corepack.ps1",
+    ] {
+        assert!(node_extras_filter(path), "expected match: {path}");
+    }
+    // Same branch, negative cases: unsupported extensions and
+    // unrelated names at the root.
+    for path in ["npm.bat", "npm.exe", "node", "yarn", "npmrc", "npm.cmd.bak"] {
+        assert!(!node_extras_filter(path), "expected no match: {path}");
+    }
+}
+
+/// `archive_filter_for` is the per-package filter dispatcher —
+/// returns `Some(NODE_EXTRAS)` only for the unscoped `node`
+/// package (mirroring upstream's `archiveFilters: { node: ... }`
+/// keyed by `pkg.name`). `@foo/node` and any other package must
+/// get `None` so the full archive contents land in the CAS
+/// unfiltered.
+#[test]
+fn archive_filter_for_only_returns_filter_for_unscoped_node() {
+    let key_node: PackageKey = "node@22.0.0".parse().expect("parse node key");
+    assert!(archive_filter_for(&key_node).is_some(), "node must get the filter");
+
+    let key_scoped_node: PackageKey = "@foo/node@22.0.0".parse().expect("parse @foo/node key");
+    assert!(
+        archive_filter_for(&key_scoped_node).is_none(),
+        "scoped `@foo/node` must not get the filter; upstream `archiveFilters` is keyed by pkg.name and only matches the unscoped string `node`",
+    );
+
+    let key_react: PackageKey = "react@18.0.0".parse().expect("parse react key");
+    assert!(archive_filter_for(&key_react).is_none());
+
+    let key_bun: PackageKey = "bun@1.0.0".parse().expect("parse bun key");
+    assert!(
+        archive_filter_for(&key_bun).is_none(),
+        "bun runtime has no bundled-tooling filter upstream (yet); leaving it `None` matches",
+    );
 }


### PR DESCRIPTION
## Summary

Slice D2 of [#437](https://github.com/pnpm/pacquet/issues/437) — wires the per-archive ignore filter at the install dispatcher. Matches upstream's [`archiveFilters: { node: NODE_EXTRAS_IGNORE_PATTERN }`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/client/src/index.ts) per-package-name table.

For unscoped `node`, the filter strips bundled `npm` / `corepack` from the Node.js runtime archive during the CAS write. pnpm (and pacquet) install pnpm itself as the package manager, so the bundled tooling is dead weight and would also shadow the user's pnpm via `node_modules/.bin/`. Every other package gets `None` and the full archive lands in the CAS unfiltered.

- `node_extras_filter` is a hand-coded port of upstream's [`NODE_EXTRAS_IGNORE_PATTERN`](https://github.com/pnpm/pnpm/blob/94240bc046/engine/runtime/node-resolver/src/index.ts) regex (`^(?:(?:lib/)?node_modules/(?:npm|corepack)(?:/|$)|bin/(?:npm|npx|corepack)$|(?:npm|npx|corepack)(?:\.(?:cmd|ps1))?$)`). Hand-coded so `pacquet-tarball` doesn't need a regex engine; the three branches mirror the alternation exactly.
- `archive_filter_for(&PackageKey)` is the per-package dispatcher. Returns `Some(NODE_EXTRAS)` only for unscoped `node`; everything else gets `None`. `OnceLock`-cached so per-snapshot `Arc::clone`s share one trait object.

## What's not in this slice

- **D3** — bin-link cmd-shims for runtime executables (`BinaryResolution::bin`), `@runtime:` substring handling in skip lists / reporter prefixes.
- **E** — `--no-runtime` flag.
- **F** — end-to-end runtime install fixtures.

## Test plan

- [x] `node_extras_filter_matches_upstream_regex_alternations` — every positive case for each branch *plus* the negative cases the regex deliberately doesn't match (e.g. `lib/node_modules/yarn/...`, `bin/npm.cmd`, `npm.bat`, `src/node_modules/npm/foo`). Verified by temporarily collapsing the `bin/` branch to a no-op; the test fails as expected.
- [x] `archive_filter_for_only_returns_filter_for_unscoped_node` — pins the `pkg.name == "node"` (unscoped) key match. `@foo/node`, `react`, `bun` all get `None`.
- [x] All 5 `install_package_by_snapshot` tests pass.
- [x] `just ready`, `taplo format --check`, `just dylint`, `cargo doc -D warnings` green.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Node.js package installation by filtering out bundled artifacts (npm and corepack) from runtime archives, ensuring cleaner installations for the unscoped `node` package.

* **Tests**
  * Added test coverage to verify artifact filtering behavior and package detection logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pacquet/pull/496)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->