### PR TITLE
feat(config,network,tarball,registry): per-registry TLS overrides

### DIFF
--- a/crates/cli/src/state.rs
+++ b/crates/cli/src/state.rs
@@ -62,8 +62,12 @@ impl State {
                 .map_err(InitStateError::Manifest)?,
             lockfile: call_load_lockfile(should_load, Lockfile::load_from_current_dir)
                 .map_err(InitStateError::Lockfile)?,
-            http_client: ThrottledClient::for_installs(&config.proxy, &config.tls)
-                .map_err(InitStateError::Network)?,
+            http_client: ThrottledClient::for_installs(
+                &config.proxy,
+                &config.tls,
+                &pacquet_network::PerRegistryTls::default(),
+            )
+            .map_err(InitStateError::Network)?,
             tarball_mem_cache: MemCache::new(),
             resolved_packages: ResolvedPackages::new(),
         })

--- a/crates/cli/src/state.rs
+++ b/crates/cli/src/state.rs
@@ -65,7 +65,7 @@ impl State {
             http_client: ThrottledClient::for_installs(
                 &config.proxy,
                 &config.tls,
-                &pacquet_network::PerRegistryTls::default(),
+                &config.tls_by_uri,
             )
             .map_err(InitStateError::Network)?,
             tarball_mem_cache: MemCache::new(),

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -286,6 +286,16 @@ pub struct Config {
     /// `strictSsl ?? true` default.
     pub tls: pacquet_network::TlsConfig,
 
+    /// Per-registry TLS overrides — `//host[:port]/path/:ca`,
+    /// `:cafile`, `:cert`, `:certfile`, `:key`, `:keyfile` from
+    /// `.npmrc`. Lookup uses pnpm's 5-step nerf-darted fallback
+    /// chain (exact > nerf-dart > no-port > shorter path prefix >
+    /// recursive no-port retry). Per-registry fields override
+    /// [`Self::tls`] field-by-field at request time, matching
+    /// pnpm's [`{ ...opts, ...sslConfig }`](https://github.com/pnpm/pnpm/blob/94240bc046/network/fetch/src/dispatcher.ts#L143)
+    /// spread.
+    pub tls_by_uri: pacquet_network::PerRegistryTls,
+
     /// When true, any missing non-optional peer dependencies are automatically installed.
     #[default = true]
     pub auto_install_peers: bool,

--- a/crates/config/src/npmrc_auth.rs
+++ b/crates/config/src/npmrc_auth.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
-use pacquet_network::{AuthHeaders, NoProxySetting, base64_encode};
+use pacquet_network::{AuthHeaders, NoProxySetting, PerRegistryTls, RegistryTls, base64_encode};
 
 use crate::{Config, api::EnvVar, env_replace::env_replace};
 
@@ -92,6 +92,14 @@ pub(crate) struct NpmrcAuth {
     /// silently dropped (mirrors pnpm, which hands the value verbatim
     /// to undici and lets Node error at connect time).
     pub local_address: Option<String>,
+    /// Per-registry TLS overrides keyed by the literal `.npmrc` key
+    /// prefix (`//host[:port]/path/`). Populated by `:ca`, `:cafile`,
+    /// `:cert`, `:certfile`, `:key`, `:keyfile` keys. The map is
+    /// preserved verbatim through to [`PerRegistryTls`] construction
+    /// so lookup keys stay byte-equivalent to upstream. Mirrors
+    /// pnpm's
+    /// [`configByUri[<uri>].tls`](https://github.com/pnpm/pnpm/blob/94240bc046/config/reader/src/getNetworkConfigs.ts#L34-L40).
+    pub tls_by_uri: HashMap<String, RegistryTls>,
 }
 
 /// Raw (unparsed) credential fields for a given registry URI, mirroring
@@ -225,6 +233,26 @@ impl NpmrcAuth {
                 continue;
             }
 
+            if let Some((uri, field, is_file)) = split_ssl_key(&key) {
+                // For `*file` variants the value is a path; read the
+                // file at parse time (silent on error, matching
+                // pnpm's `fs.readFileSync` which throws into the
+                // outer parse and is swallowed). For inline variants
+                // expand `\n` → real newlines so a single-line INI
+                // value can carry a multi-line PEM.
+                let resolved = if is_file {
+                    let Ok(contents) = std::fs::read_to_string(&value) else {
+                        continue;
+                    };
+                    contents
+                } else {
+                    value.replace("\\n", "\n")
+                };
+                let entry = auth.tls_by_uri.entry(uri.to_owned()).or_default();
+                apply_tls_field(entry, field, resolved);
+                continue;
+            }
+
             apply_creds_field(&mut auth.default_creds, key.as_str(), value);
         }
         auth
@@ -263,6 +291,11 @@ impl NpmrcAuth {
         config.tls.key = self.key.take();
         config.tls.strict_ssl = self.strict_ssl.take();
         config.tls.local_address = self.local_address.take().and_then(|raw| raw.parse().ok());
+        // Per-registry TLS overrides. `PerRegistryTls::from_map`
+        // drops any entry whose three fields are all `None`, so the
+        // lookup never returns an empty hit that would otherwise
+        // suppress the top-level fallback.
+        config.tls_by_uri = PerRegistryTls::from_map(std::mem::take(&mut self.tls_by_uri));
     }
 
     /// Resolve the `(https_proxy, http_proxy, no_proxy)` triple on
@@ -521,6 +554,57 @@ fn apply_creds_field(creds: &mut RawCreds, field: &str, value: String) {
         "_auth" => creds.auth_pair_base64 = Some(value),
         "username" => creds.username = Some(value),
         "_password" => creds.password = Some(value),
+        _ => {}
+    }
+}
+
+/// Per-registry TLS suffixes. The `*file` variants instruct the
+/// parser to read the value as a path; the bare variants use the
+/// value as inline PEM (with `\n` escape expansion). Mirrors
+/// `SSL_SUFFIX_RE = /:(?<id>cert|key|ca)(?<kind>file)?$/` from pnpm's
+/// [`getNetworkConfigs.ts:94`](https://github.com/pnpm/pnpm/blob/94240bc046/config/reader/src/getNetworkConfigs.ts#L94).
+const TLS_SUFFIXES: &[(&str, &str, bool)] = &[
+    // (suffix, field, is_file)
+    (":cafile", "ca", true),
+    (":certfile", "cert", true),
+    (":keyfile", "key", true),
+    (":ca", "ca", false),
+    (":cert", "cert", false),
+    (":key", "key", false),
+];
+
+/// Return `(uri_prefix, field, is_file)` when `key` ends in one of the
+/// recognized TLS suffixes. Matches pnpm's `tryParseSslKey` —
+/// deliberately does *not* require a leading `//`, so the lax keys
+/// pnpm accepts (`foo:cert=…`) end up in the map with `uri_prefix =
+/// "foo"`. They never match a real nerf-darted URL so the entry is
+/// effectively dropped at lookup time, but storing it preserves
+/// byte-for-byte parity with upstream parsing.
+///
+/// Order matters: `:certfile` must be tested before `:cert` so the
+/// `*file` variants don't get parsed as the inline form with a
+/// trailing `file` artifact in the URI prefix.
+fn split_ssl_key(key: &str) -> Option<(&str, &'static str, bool)> {
+    for (suffix, field, is_file) in TLS_SUFFIXES {
+        if let Some(stripped) = key.strip_suffix(suffix) {
+            return Some((stripped, field, *is_file));
+        }
+    }
+    None
+}
+
+/// Write a per-registry TLS value onto a [`RegistryTls`] entry.
+///
+/// For inline values (`is_file = false`) the parser pre-expands `\n`
+/// escapes to real newlines — pnpm does this only on per-registry
+/// values, not on the top-level `ca=` form
+/// ([`getNetworkConfigs.ts:38-39`](https://github.com/pnpm/pnpm/blob/94240bc046/config/reader/src/getNetworkConfigs.ts#L38-L39))
+/// — and `value` arrives already expanded.
+fn apply_tls_field(tls: &mut RegistryTls, field: &str, value: String) {
+    match field {
+        "ca" => tls.ca = Some(value),
+        "cert" => tls.cert = Some(value),
+        "key" => tls.key = Some(value),
         _ => {}
     }
 }

--- a/crates/config/src/npmrc_auth/tests.rs
+++ b/crates/config/src/npmrc_auth/tests.rs
@@ -672,3 +672,118 @@ fn defaults_leave_tls_config_empty() {
     assert_eq!(config.tls.strict_ssl, None);
     assert!(config.tls.local_address.is_none(), "tls.local_address={:?}", config.tls.local_address);
 }
+
+// --- Per-registry TLS tests ---
+
+#[test]
+fn parses_scoped_inline_ca() {
+    let auth = NpmrcAuth::from_ini::<NoEnv>(
+        "//reg.example.com/:ca=-----BEGIN CERTIFICATE-----\\nMIIB-----END CERTIFICATE-----\n",
+    );
+    let entry = auth.tls_by_uri.get("//reg.example.com/").expect("entry present");
+    let ca = entry.ca.as_deref().expect("ca set");
+    assert!(ca.contains("\n"), "expected `\\n` → newline expansion: {ca:?}");
+    assert!(ca.contains("BEGIN CERTIFICATE"), "expected PEM header: {ca:?}");
+}
+
+#[test]
+fn parses_scoped_cafile_reads_from_disk() {
+    use std::io::Write;
+    let tmp = tempfile::NamedTempFile::new().expect("create tempfile");
+    tmp.as_file().write_all(TEST_CA_PEM.as_bytes()).expect("write");
+    let ini = format!("//reg.example.com/:cafile={}\n", tmp.path().display());
+    let auth = NpmrcAuth::from_ini::<NoEnv>(&ini);
+    let entry = auth.tls_by_uri.get("//reg.example.com/").expect("entry present");
+    let ca = entry.ca.as_deref().expect("ca set");
+    assert!(ca.contains("BEGIN CERTIFICATE"), "expected PEM contents from cafile: {ca:?}");
+}
+
+#[test]
+fn parses_scoped_cafile_missing_silently_dropped() {
+    let auth = NpmrcAuth::from_ini::<NoEnv>("//reg.example.com/:cafile=/nonexistent/path/ca.pem\n");
+    // Either the entry doesn't exist, or it exists with `ca = None`.
+    // `PerRegistryTls::from_map` filters all-`None` entries later;
+    // here the parse-time behavior is "no entry written".
+    assert!(
+        auth.tls_by_uri.get("//reg.example.com/").is_none_or(|e| e.ca.is_none()),
+        "missing cafile must not produce a non-None ca slot: {:?}",
+        auth.tls_by_uri,
+    );
+}
+
+#[test]
+fn parses_scoped_cert_and_key() {
+    let auth = NpmrcAuth::from_ini::<NoEnv>(
+        "//reg.example.com/:cert=cert-pem\n//reg.example.com/:key=key-pem\n",
+    );
+    let entry = auth.tls_by_uri.get("//reg.example.com/").expect("entry present");
+    assert_eq!(entry.cert.as_deref(), Some("cert-pem"));
+    assert_eq!(entry.key.as_deref(), Some("key-pem"));
+}
+
+#[test]
+fn parses_scoped_certfile_and_keyfile() {
+    use std::io::Write;
+    let tmp_cert = tempfile::NamedTempFile::new().expect("create cert tempfile");
+    let tmp_key = tempfile::NamedTempFile::new().expect("create key tempfile");
+    tmp_cert.as_file().write_all(b"CERT-CONTENTS").expect("write cert");
+    tmp_key.as_file().write_all(b"KEY-CONTENTS").expect("write key");
+    let ini = format!(
+        "//reg.example.com/:certfile={}\n//reg.example.com/:keyfile={}\n",
+        tmp_cert.path().display(),
+        tmp_key.path().display(),
+    );
+    let auth = NpmrcAuth::from_ini::<NoEnv>(&ini);
+    let entry = auth.tls_by_uri.get("//reg.example.com/").expect("entry present");
+    assert_eq!(entry.cert.as_deref(), Some("CERT-CONTENTS"));
+    assert_eq!(entry.key.as_deref(), Some("KEY-CONTENTS"));
+}
+
+#[test]
+fn scoped_inline_and_file_share_same_slot_last_wins() {
+    // pnpm writes `:cert` and `:certfile` to the same `tls.cert`
+    // slot. The last assignment in the .npmrc wins.
+    use std::io::Write;
+    let tmp = tempfile::NamedTempFile::new().expect("create tempfile");
+    tmp.as_file().write_all(b"FROM-FILE").expect("write");
+    let ini = format!(
+        "//reg.example.com/:cert=inline\n//reg.example.com/:certfile={}\n",
+        tmp.path().display(),
+    );
+    let auth = NpmrcAuth::from_ini::<NoEnv>(&ini);
+    let entry = auth.tls_by_uri.get("//reg.example.com/").expect("entry present");
+    assert_eq!(entry.cert.as_deref(), Some("FROM-FILE"));
+}
+
+#[test]
+fn scoped_n_escape_expansion_only_on_inline() {
+    // pnpm's `:ca=...` value goes through `.replace(/\\n/g, '\n')`.
+    // The `:cafile` variant reads from disk and doesn't apply the
+    // replacement (the file already has real newlines).
+    let auth = NpmrcAuth::from_ini::<NoEnv>("//reg.example.com/:ca=line1\\nline2\n");
+    let entry = auth.tls_by_uri.get("//reg.example.com/").expect("entry present");
+    assert_eq!(entry.ca.as_deref(), Some("line1\nline2"));
+}
+
+#[test]
+fn applies_tls_by_uri_to_config_drops_empty() {
+    let auth = NpmrcAuth::from_ini::<NoEnv>(
+        "//keep.example.com/:ca=ca-pem\n//drop.example.com/:registry=https://drop.example/\n",
+    );
+    // `//drop.example.com/:registry=` doesn't match any TLS suffix
+    // so no `RegistryTls` entry is ever created for that prefix.
+    let mut config = Config::new();
+    auth.apply_to::<NoEnv>(&mut config);
+    assert!(config.tls_by_uri.get("//keep.example.com/").is_some(), "non-empty entry kept");
+    assert!(config.tls_by_uri.get("//drop.example.com/").is_none(), "non-TLS key ignored");
+}
+
+#[test]
+fn scoped_tls_keys_dont_collide_with_top_level() {
+    // Top-level `ca=`, `cert=`, `key=`, `cafile=` arms run *before*
+    // the SSL-suffix matcher. A bare `ca=` line should land on
+    // `auth.ca`, not in `tls_by_uri` as registry=`""`.
+    let auth = NpmrcAuth::from_ini::<NoEnv>("ca=top-level\n");
+    assert_eq!(auth.ca, vec!["top-level".to_string()]);
+    assert!(auth.tls_by_uri.is_empty(), "top-level `ca=` must not pollute tls_by_uri");
+}

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -6,14 +6,14 @@ mod tls;
 
 pub use auth::{AuthHeaders, base64_encode, nerf_dart};
 pub use proxy::{NoProxySetting, ProxyConfig, ProxyError};
-pub use tls::{TlsConfig, TlsError};
+pub use tls::{PerRegistryTls, RegistryTls, TlsConfig, TlsError};
 
 use proxy::{NoProxyMatcher, parse_proxy_url, strip_userinfo};
 use reqwest::{
     Certificate, Client, Identity, Proxy,
     header::{HeaderMap, HeaderValue, USER_AGENT},
 };
-use std::{num::NonZeroUsize, ops::Deref, sync::Arc, time::Duration};
+use std::{collections::HashMap, num::NonZeroUsize, ops::Deref, sync::Arc, time::Duration};
 use tokio::sync::{Semaphore, SemaphorePermit};
 
 /// Default `User-Agent` pacquet sends on every request made by the
@@ -36,10 +36,30 @@ use tokio::sync::{Semaphore, SemaphorePermit};
 const DEFAULT_USER_AGENT: &str = "pnpm";
 
 /// Wrapper around [`Client`] with concurrent request limit enforced by the [`Semaphore`] mechanism.
+///
+/// Holds a default [`Client`] for the top-level proxy / TLS config
+/// plus an optional map of per-registry clients keyed by nerf-darted
+/// URI. [`Self::acquire_for_url`] picks the right client based on the
+/// request URL (matching pnpm's [`pickSettingByUrl`](https://github.com/pnpm/pnpm/blob/94240bc046/network/fetch/src/dispatcher.ts#L338-L375)
+/// 5-step fallback), and [`Self::acquire`] always uses the default
+/// client. The semaphore is shared across both — bounding the total
+/// concurrent socket count regardless of which registry a request
+/// targets.
 #[derive(Debug)]
 pub struct ThrottledClient {
     semaphore: Semaphore,
     client: Client,
+    /// Per-registry clients keyed by nerf-darted URI. Empty when no
+    /// `//host/:cert=…` / `:key=…` / `:ca=…` / `:cafile=…` /
+    /// `:certfile=…` / `:keyfile=…` `.npmrc` entries are present —
+    /// in which case `acquire_for_url` short-circuits to the default
+    /// client without paying the routing cost.
+    per_registry: HashMap<String, Client>,
+    /// Pre-built routing table cloned from [`PerRegistryTls`] so the
+    /// hot path can call `pick_for_url` without holding a reference
+    /// to `PerRegistryTls` (which lives on `Config`). Empty when
+    /// `per_registry` is empty.
+    routing: PerRegistryTls,
 }
 
 /// RAII guard returned from [`ThrottledClient::acquire`]. Holds a
@@ -142,8 +162,12 @@ impl ThrottledClient {
     /// directly, bypassing `mDNSResponder` and the EAI_NONAME flake
     /// entirely.
     pub fn new_for_installs() -> Self {
-        Self::for_installs(&ProxyConfig::default(), &TlsConfig::default())
-            .expect("default ProxyConfig + TlsConfig carry no URLs/PEMs and cannot fail")
+        Self::for_installs(
+            &ProxyConfig::default(),
+            &TlsConfig::default(),
+            &PerRegistryTls::default(),
+        )
+        .expect("default proxy + TLS configs carry no URLs/PEMs and cannot fail")
     }
 
     /// Construct the install client with proxy + TLS configuration
@@ -178,21 +202,47 @@ impl ThrottledClient {
     /// pnpm does not define `ERR_PNPM_INVALID_CA` / similar codes —
     /// see [`TlsError`] for why pacquet still surfaces the failure
     /// eagerly rather than at request time.
-    pub fn for_installs(proxy: &ProxyConfig, tls: &TlsConfig) -> Result<Self, ForInstallsError> {
+    pub fn for_installs(
+        proxy: &ProxyConfig,
+        tls: &TlsConfig,
+        per_registry: &PerRegistryTls,
+    ) -> Result<Self, ForInstallsError> {
         let https = proxy.https_proxy.as_deref().map(parse_proxy_url).transpose()?;
         let http = proxy.http_proxy.as_deref().map(parse_proxy_url).transpose()?;
         let no_proxy = Arc::new(NoProxyMatcher::from(proxy.no_proxy.as_ref()));
 
-        let mut builder = default_client_builder();
-        if let Some(url) = https {
-            builder = builder.proxy(build_scheme_proxy(url, "https", Arc::clone(&no_proxy)));
+        let build_client = |effective_tls: &TlsConfig| -> Result<Client, ForInstallsError> {
+            let mut builder = default_client_builder();
+            if let Some(url) = https.clone() {
+                builder = builder.proxy(build_scheme_proxy(url, "https", Arc::clone(&no_proxy)));
+            }
+            if let Some(url) = http.clone() {
+                builder = builder.proxy(build_scheme_proxy(url, "http", Arc::clone(&no_proxy)));
+            }
+            builder = apply_tls(builder, effective_tls)?;
+            Ok(builder.build().expect("build reqwest client with default timeouts and proxy"))
+        };
+
+        let default_client = build_client(tls)?;
+        // Build one client per per-registry override. Each gets a
+        // merged `TlsConfig` where the per-registry fields shadow
+        // their top-level counterparts (matching pnpm's
+        // `{ ...opts, ...sslConfig }` spread at
+        // [`dispatcher.ts:143,264`](https://github.com/pnpm/pnpm/blob/94240bc046/network/fetch/src/dispatcher.ts#L143)).
+        // `strict_ssl` and `local_address` are top-level-only, so the
+        // per-registry client still honors the top-level values.
+        let mut per_registry_clients = HashMap::with_capacity(per_registry.iter().count());
+        for (uri, override_) in per_registry.iter() {
+            let merged = merge_tls(tls, override_);
+            per_registry_clients.insert(uri.to_string(), build_client(&merged)?);
         }
-        if let Some(url) = http {
-            builder = builder.proxy(build_scheme_proxy(url, "http", Arc::clone(&no_proxy)));
-        }
-        builder = apply_tls(builder, tls)?;
-        let client = builder.build().expect("build reqwest client with default timeouts and proxy");
-        Ok(ThrottledClient::from_client(client))
+
+        Ok(ThrottledClient {
+            semaphore: Semaphore::new(default_network_concurrency()),
+            client: default_client,
+            per_registry: per_registry_clients,
+            routing: per_registry.clone(),
+        })
     }
 
     /// Construct a throttled client wrapping a pre-built [`Client`].
@@ -202,7 +252,42 @@ impl ThrottledClient {
     /// test-suite budget instead of waiting on TCP retry.
     pub fn from_client(client: Client) -> Self {
         let semaphore = Semaphore::new(default_network_concurrency());
-        ThrottledClient { semaphore, client }
+        ThrottledClient {
+            semaphore,
+            client,
+            per_registry: HashMap::new(),
+            routing: PerRegistryTls::default(),
+        }
+    }
+
+    /// Acquire a permit and return a guard granting access to the
+    /// per-registry [`Client`] that matches `url`'s nerf-darted form
+    /// (falling back to the default client when no override matches).
+    /// The semaphore is shared across all clients, so total concurrent
+    /// socket count stays bounded by [`default_network_concurrency`]
+    /// regardless of which registry the request targets.
+    ///
+    /// Per-URL routing mirrors pnpm's
+    /// [`pickSettingByUrl`](https://github.com/pnpm/pnpm/blob/94240bc046/network/fetch/src/dispatcher.ts#L338-L375)
+    /// 5-step fallback: exact, then nerf-darted, then host without
+    /// port, then progressively shorter path prefixes, then a
+    /// recursive retry without port. When no per-registry overrides
+    /// are configured (the common case), the routing table is empty
+    /// and the lookup short-circuits to the default client.
+    ///
+    /// Takes `url` as `&str` so callers don't have to round-trip
+    /// `format!("{registry}{name}")` strings through `Url::parse`
+    /// just to satisfy the type signature — the lookup itself works
+    /// on the raw string form.
+    pub async fn acquire_for_url(&self, url: &str) -> ThrottledClientGuard<'_> {
+        let permit =
+            self.semaphore.acquire().await.expect("semaphore shouldn't have been closed this soon");
+        let client = self
+            .routing
+            .pick_for_url(url)
+            .and_then(|key| self.per_registry.get(key))
+            .unwrap_or(&self.client);
+        ThrottledClientGuard { _permit: permit, client }
     }
 }
 
@@ -235,6 +320,34 @@ fn default_client_builder() -> reqwest::ClientBuilder {
 /// PEM parsing surface as [`TlsError::InvalidCa`] /
 /// [`TlsError::InvalidClientIdentity`] and bubble through
 /// [`ForInstallsError`].
+/// Build the effective [`TlsConfig`] for a per-registry override:
+/// each scoped field (`ca`, `cert`, `key`) replaces its top-level
+/// counterpart field-by-field; `strict_ssl` and `local_address`
+/// always come from the top-level (pnpm doesn't honor scoped versions
+/// of those keys — see [`getNetworkConfigs.ts`](https://github.com/pnpm/pnpm/blob/94240bc046/config/reader/src/getNetworkConfigs.ts#L94)
+/// which only recognizes `:cert(file)?` / `:key(file)?` / `:ca(file)?`).
+///
+/// The `ca` field is special: pnpm stores per-registry `ca` as a
+/// single string (`getNetworkConfigs.ts:37`) that may contain multiple
+/// concatenated PEMs, while the top-level `ca` is a `Vec<String>`
+/// (the `cafile` loader split). When the override has a `ca`, the
+/// effective top-level CA list is *replaced* (per pnpm's spread, not
+/// merged) by a one-element list with the scoped PEM blob — which
+/// `Certificate::from_pem` handles fine since it accepts multi-cert
+/// PEM buffers.
+fn merge_tls(top: &TlsConfig, override_: &RegistryTls) -> TlsConfig {
+    TlsConfig {
+        ca: match &override_.ca {
+            Some(pem) => vec![pem.clone()],
+            None => top.ca.clone(),
+        },
+        cert: override_.cert.clone().or_else(|| top.cert.clone()),
+        key: override_.key.clone().or_else(|| top.key.clone()),
+        strict_ssl: top.strict_ssl,
+        local_address: top.local_address,
+    }
+}
+
 fn apply_tls(
     mut builder: reqwest::ClientBuilder,
     tls: &TlsConfig,

--- a/crates/network/src/tests.rs
+++ b/crates/network/src/tests.rs
@@ -15,8 +15,8 @@
 //! absolute-form URI and a decoded `Proxy-Authorization` header.
 
 use super::{
-    ForInstallsError, NoProxyMatcher, NoProxySetting, ProxyConfig, ProxyError, ThrottledClient,
-    TlsConfig, parse_proxy_url,
+    ForInstallsError, NoProxyMatcher, NoProxySetting, PerRegistryTls, ProxyConfig, ProxyError,
+    ThrottledClient, TlsConfig, parse_proxy_url,
 };
 use crate::proxy::{percent_decode_str, strip_userinfo};
 use reqwest::Url;
@@ -157,8 +157,12 @@ fn strip_userinfo_returns_none_when_absent() {
 fn for_installs_with_empty_proxy_config_builds() {
     // The legacy `new_for_installs` is now a wrapper around this — assert
     // the default `ProxyConfig` round-trips without error.
-    ThrottledClient::for_installs(&ProxyConfig::default(), &TlsConfig::default())
-        .expect("empty proxy is valid");
+    ThrottledClient::for_installs(
+        &ProxyConfig::default(),
+        &TlsConfig::default(),
+        &PerRegistryTls::default(),
+    )
+    .expect("empty proxy is valid");
 }
 
 #[test]
@@ -168,14 +172,17 @@ fn for_installs_with_valid_proxy_url_builds() {
         http_proxy: Some("http://proxy.example:8080".into()),
         no_proxy: None,
     };
-    ThrottledClient::for_installs(&proxy, &TlsConfig::default()).expect("valid proxy URLs build");
+    ThrottledClient::for_installs(&proxy, &TlsConfig::default(), &PerRegistryTls::default())
+        .expect("valid proxy URLs build");
 }
 
 #[test]
 fn for_installs_with_invalid_proxy_url_errors() {
     let proxy =
         ProxyConfig { https_proxy: Some("://nonsense".into()), http_proxy: None, no_proxy: None };
-    let err = ThrottledClient::for_installs(&proxy, &TlsConfig::default()).expect_err("must error");
+    let err =
+        ThrottledClient::for_installs(&proxy, &TlsConfig::default(), &PerRegistryTls::default())
+            .expect_err("must error");
     eprintln!("err={err:?}");
     let is_invalid = matches!(err, ForInstallsError::Proxy(ProxyError::InvalidProxy { .. }));
     assert!(is_invalid, "err={err:?}: expected ForInstallsError::Proxy(InvalidProxy)");
@@ -191,7 +198,8 @@ fn for_installs_with_socks_proxy_url_builds() {
         http_proxy: None,
         no_proxy: None,
     };
-    ThrottledClient::for_installs(&proxy, &TlsConfig::default()).expect("socks proxy URL builds");
+    ThrottledClient::for_installs(&proxy, &TlsConfig::default(), &PerRegistryTls::default())
+        .expect("socks proxy URL builds");
 }
 
 #[test]
@@ -201,7 +209,7 @@ fn for_installs_no_proxy_bypass_does_not_block_build() {
         http_proxy: None,
         no_proxy: Some(NoProxySetting::Bypass),
     };
-    ThrottledClient::for_installs(&proxy, &TlsConfig::default())
+    ThrottledClient::for_installs(&proxy, &TlsConfig::default(), &PerRegistryTls::default())
         .expect("bypass + proxy URL builds");
 }
 
@@ -234,7 +242,9 @@ async fn mockito_integration_http_proxy_forwards_request_with_basic_auth() {
     // the value the mock matches above.
     let with_auth = proxy_url.replacen("//", "//user%40name:p%40ss@", 1);
     let cfg = ProxyConfig { https_proxy: None, http_proxy: Some(with_auth), no_proxy: None };
-    let client = ThrottledClient::for_installs(&cfg, &TlsConfig::default()).expect("valid proxy");
+    let client =
+        ThrottledClient::for_installs(&cfg, &TlsConfig::default(), &PerRegistryTls::default())
+            .expect("valid proxy");
     let guard = client.acquire().await;
     let resp = guard.get("http://target.example/anything").send().await.expect("proxied request");
     assert_eq!(resp.status(), 200);
@@ -270,7 +280,9 @@ async fn mockito_integration_no_proxy_bypasses_proxy() {
         http_proxy: Some(proxy_server.url()),
         no_proxy: Some(NoProxySetting::Bypass),
     };
-    let client = ThrottledClient::for_installs(&cfg, &TlsConfig::default()).expect("valid proxy");
+    let client =
+        ThrottledClient::for_installs(&cfg, &TlsConfig::default(), &PerRegistryTls::default())
+            .expect("valid proxy");
     let guard = client.acquire().await;
     let url = format!("{}{}", target_server.url(), target_path);
     let resp = guard.get(&url).send().await.expect("direct request");
@@ -305,7 +317,8 @@ const TEST_CA_PEM: &str = include_str!("../tests/fixtures/test-ca.pem");
 #[test]
 fn for_installs_with_valid_ca_pem_builds() {
     let tls = TlsConfig { ca: vec![TEST_CA_PEM.to_string()], ..TlsConfig::default() };
-    ThrottledClient::for_installs(&ProxyConfig::default(), &tls).expect("valid CA PEM builds");
+    ThrottledClient::for_installs(&ProxyConfig::default(), &tls, &PerRegistryTls::default())
+        .expect("valid CA PEM builds");
 }
 
 #[test]
@@ -315,7 +328,8 @@ fn for_installs_with_multiple_ca_pems_builds() {
         ca: vec![TEST_CA_PEM.to_string(), TEST_CA_PEM.to_string()],
         ..TlsConfig::default()
     };
-    ThrottledClient::for_installs(&ProxyConfig::default(), &tls).expect("multiple CA PEMs build");
+    ThrottledClient::for_installs(&ProxyConfig::default(), &tls, &PerRegistryTls::default())
+        .expect("multiple CA PEMs build");
 }
 
 #[test]
@@ -327,8 +341,9 @@ fn for_installs_with_invalid_ca_pem_errors_with_index() {
         ca: vec![TEST_CA_PEM.to_string(), "not a pem certificate".to_string()],
         ..TlsConfig::default()
     };
-    let err = ThrottledClient::for_installs(&ProxyConfig::default(), &tls)
-        .expect_err("invalid CA must error");
+    let err =
+        ThrottledClient::for_installs(&ProxyConfig::default(), &tls, &PerRegistryTls::default())
+            .expect_err("invalid CA must error");
     eprintln!("err={err:?}");
     match err {
         ForInstallsError::Tls(super::TlsError::InvalidCa { index, .. }) => assert_eq!(index, 1),
@@ -345,7 +360,8 @@ fn for_installs_strict_ssl_false_relaxes_verification() {
     // integration test would need a TLS-capable mock server (e.g.
     // `wiremock` with rustls) and is left as a future enhancement.
     let tls = TlsConfig { strict_ssl: Some(false), ..TlsConfig::default() };
-    ThrottledClient::for_installs(&ProxyConfig::default(), &tls).expect("strict-ssl=false builds");
+    ThrottledClient::for_installs(&ProxyConfig::default(), &tls, &PerRegistryTls::default())
+        .expect("strict-ssl=false builds");
 }
 
 #[test]
@@ -356,14 +372,15 @@ fn for_installs_strict_ssl_default_is_true() {
     // best we can do without a server; the absence of
     // `danger_accept_invalid_certs(true)` is the contract.
     let tls = TlsConfig { strict_ssl: None, ..TlsConfig::default() };
-    ThrottledClient::for_installs(&ProxyConfig::default(), &tls).expect("strict-ssl unset builds");
+    ThrottledClient::for_installs(&ProxyConfig::default(), &tls, &PerRegistryTls::default())
+        .expect("strict-ssl unset builds");
 }
 
 #[test]
 fn for_installs_local_address_pinned() {
     use std::net::Ipv4Addr;
     let tls = TlsConfig { local_address: Some(Ipv4Addr::LOCALHOST.into()), ..TlsConfig::default() };
-    ThrottledClient::for_installs(&ProxyConfig::default(), &tls)
+    ThrottledClient::for_installs(&ProxyConfig::default(), &tls, &PerRegistryTls::default())
         .expect("local_address pinning builds");
 }
 
@@ -376,8 +393,9 @@ fn for_installs_with_malformed_client_identity_errors() {
         key: Some("not a real key".to_string()),
         ..TlsConfig::default()
     };
-    let err = ThrottledClient::for_installs(&ProxyConfig::default(), &tls)
-        .expect_err("malformed cert/key must error");
+    let err =
+        ThrottledClient::for_installs(&ProxyConfig::default(), &tls, &PerRegistryTls::default())
+            .expect_err("malformed cert/key must error");
     eprintln!("err={err:?}");
     let is_invalid =
         matches!(err, ForInstallsError::Tls(super::TlsError::InvalidClientIdentity { .. }));
@@ -391,6 +409,107 @@ fn for_installs_with_cert_but_no_key_skips_identity() {
     // the same "both or neither" expectation). The client must still
     // build cleanly.
     let tls = TlsConfig { cert: Some(TEST_CA_PEM.to_string()), key: None, ..TlsConfig::default() };
-    ThrottledClient::for_installs(&ProxyConfig::default(), &tls)
+    ThrottledClient::for_installs(&ProxyConfig::default(), &tls, &PerRegistryTls::default())
         .expect("cert without key builds (identity skipped)");
+}
+
+// --- Per-registry routing tests ---
+
+#[test]
+fn for_installs_builds_per_registry_clients() {
+    // Two per-registry overrides — one per host — plus an empty
+    // override that `from_map` drops. The constructor should
+    // produce a client per non-empty override.
+    use crate::RegistryTls;
+    use std::collections::HashMap;
+    let mut map = HashMap::new();
+    map.insert(
+        "//reg-a.example.com/".to_string(),
+        RegistryTls { ca: Some(TEST_CA_PEM.to_string()), ..RegistryTls::default() },
+    );
+    map.insert(
+        "//reg-b.example.com/".to_string(),
+        RegistryTls { ca: Some(TEST_CA_PEM.to_string()), ..RegistryTls::default() },
+    );
+    let per_registry = PerRegistryTls::from_map(map);
+    ThrottledClient::for_installs(&ProxyConfig::default(), &TlsConfig::default(), &per_registry)
+        .expect("per-registry config builds");
+}
+
+#[test]
+fn for_installs_per_registry_invalid_ca_errors() {
+    // A malformed per-registry CA must surface as `InvalidCa` at
+    // build time, same as the top-level path. The `index` in the
+    // error indexes into the merged CA list — which is exactly the
+    // one-element vec carrying the scoped PEM, so `index == 0`.
+    use crate::RegistryTls;
+    use std::collections::HashMap;
+    let mut map = HashMap::new();
+    map.insert(
+        "//bad.example.com/".to_string(),
+        RegistryTls { ca: Some("not a pem".to_string()), ..RegistryTls::default() },
+    );
+    let per_registry = PerRegistryTls::from_map(map);
+    let err = ThrottledClient::for_installs(
+        &ProxyConfig::default(),
+        &TlsConfig::default(),
+        &per_registry,
+    )
+    .expect_err("must error");
+    eprintln!("err={err:?}");
+    let is_invalid_ca =
+        matches!(err, ForInstallsError::Tls(super::TlsError::InvalidCa { index: 0, .. }));
+    assert!(is_invalid_ca, "err={err:?}: expected Tls(InvalidCa {{ index: 0 }})");
+}
+
+#[tokio::test]
+async fn acquire_for_url_routes_per_registry_then_falls_back() {
+    // End-to-end: build a client with one per-registry override
+    // (different `ca`) and verify `acquire_for_url` returns
+    // *distinct* clients for URLs that match the override versus
+    // URLs that don't. The semaphore is still shared, so the two
+    // calls can interleave under concurrency.
+    //
+    // We can't compare `Client` instances directly — reqwest's
+    // `Client` doesn't implement `PartialEq`. Use `Client::user_agent`
+    // round-trip via the request builder? No — both share the
+    // default builder. Instead, compare the underlying pointer:
+    // `&Client` is what the guard derefs to, and two distinct
+    // builds produce two distinct `Client` allocations.
+    use crate::RegistryTls;
+    use std::collections::HashMap;
+    let mut map = HashMap::new();
+    map.insert(
+        "//reg.example.com/".to_string(),
+        RegistryTls { ca: Some(TEST_CA_PEM.to_string()), ..RegistryTls::default() },
+    );
+    let per_registry = PerRegistryTls::from_map(map);
+    let throttled = ThrottledClient::for_installs(
+        &ProxyConfig::default(),
+        &TlsConfig::default(),
+        &per_registry,
+    )
+    .expect("valid");
+
+    let scoped_guard = throttled.acquire_for_url("https://reg.example.com/pkg").await;
+    let default_guard = throttled.acquire_for_url("https://other.example.org/pkg").await;
+    let scoped_ptr: *const reqwest::Client = &*scoped_guard;
+    let default_ptr: *const reqwest::Client = &*default_guard;
+    assert_ne!(
+        scoped_ptr, default_ptr,
+        "scoped and default URLs must route through different reqwest clients",
+    );
+}
+
+#[tokio::test]
+async fn acquire_for_url_falls_back_to_default_when_no_overrides() {
+    // The common case — no per-registry overrides at all. The lookup
+    // short-circuits and `acquire_for_url` always returns the
+    // default client.
+    let throttled = ThrottledClient::new_for_installs();
+    let a = throttled.acquire_for_url("https://example.com/").await;
+    let b = throttled.acquire_for_url("https://other.example.org/").await;
+    let a_ptr: *const reqwest::Client = &*a;
+    let b_ptr: *const reqwest::Client = &*b;
+    assert_eq!(a_ptr, b_ptr, "without overrides every URL should hit the default client");
 }

--- a/crates/network/src/tls.rs
+++ b/crates/network/src/tls.rs
@@ -17,7 +17,10 @@
 //! material, silently ignores a missing `cafile`, and consults no
 //! environment variables. Pacquet mirrors each of those choices.
 
+use std::collections::HashMap;
 use std::net::IpAddr;
+
+use crate::auth::nerf_dart;
 
 /// Resolved TLS + local-address configuration.
 ///
@@ -98,6 +101,192 @@ pub enum TlsError {
     /// `openssl pkcs8` conversion path.
     #[display("Invalid client TLS cert/key: {reason}")]
     InvalidClientIdentity { reason: String },
+}
+
+/// Per-registry TLS overrides keyed by nerf-darted registry URI.
+///
+/// Mirrors pnpm v11's
+/// [`configByUri[<uri>].tls`](https://github.com/pnpm/pnpm/blob/94240bc046/config/reader/src/getNetworkConfigs.ts#L34-L40)
+/// shape: each entry is the `(ca, cert, key)` triple a request to that
+/// registry should use *instead of* the corresponding top-level fields
+/// — matching upstream's `{ ...opts, ...sslConfig }` spread at
+/// [`dispatcher.ts:143,264`](https://github.com/pnpm/pnpm/blob/94240bc046/network/fetch/src/dispatcher.ts#L143)
+/// where per-registry values override top-level **field-by-field**.
+///
+/// Lookup is via [`PerRegistryTls::pick_for_url`] with the 5-step
+/// fallback chain pnpm uses (exact > nerf-dart > no-port > shorter
+/// prefix > recursive no-port retry).
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct PerRegistryTls {
+    /// Keys are nerf-darted URIs (`//host[:port]/path/` form). Values
+    /// hold the explicit overrides for that prefix — every field is
+    /// `Option` because pnpm allows partial overrides (e.g. only `ca`
+    /// scoped, with `cert` / `key` falling through to top-level).
+    by_uri: HashMap<String, RegistryTls>,
+    /// Cache of `key.split('/').count()` maxed across `by_uri.keys()`.
+    /// Bounds the path-prefix walk in [`Self::pick_for_url`] so the
+    /// loop stops after the longest user-supplied prefix instead of
+    /// down to `//`.
+    max_parts: usize,
+}
+
+/// `(ca, cert, key)` triple for a single registry override. Each field
+/// is post-`\n`-expansion / post-file-read PEM string — the parser in
+/// `pacquet-config::npmrc_auth` normalizes both shapes (`:ca=` inline
+/// and `:cafile=<path>` file-read) into the same `Option<String>` slot
+/// so the network layer sees one form.
+///
+/// Why `Option<String>` for `ca` (not `Vec<String>` like
+/// [`TlsConfig::ca`]): pnpm's per-registry parser stores a single
+/// string per `(uri, field)` slot — multi-cert bundles arrive as one
+/// PEM string with embedded `-----END CERTIFICATE-----` delimiters,
+/// which `reqwest::Certificate::from_pem` accepts. See
+/// [`getNetworkConfigs.ts:37`](https://github.com/pnpm/pnpm/blob/94240bc046/config/reader/src/getNetworkConfigs.ts#L37)
+/// for the upstream shape.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct RegistryTls {
+    /// Per-registry CA override. May contain multiple
+    /// `-----END CERTIFICATE-----`-delimited PEMs in one string when
+    /// sourced from `:cafile=<path>`, or a single PEM (with `\n`
+    /// escapes expanded) when sourced from `:ca=...`.
+    pub ca: Option<String>,
+    /// Per-registry client certificate PEM.
+    pub cert: Option<String>,
+    /// Per-registry client private key PEM (PKCS#8 only — see the
+    /// note on `apply_tls` in `crates/network/src/lib.rs`).
+    pub key: Option<String>,
+}
+
+impl RegistryTls {
+    /// `true` when no field is set. Used by callers that want to skip
+    /// building a per-registry client for an empty override.
+    pub fn is_empty(&self) -> bool {
+        self.ca.is_none() && self.cert.is_none() && self.key.is_none()
+    }
+}
+
+impl PerRegistryTls {
+    /// Build from a nerf-darted → [`RegistryTls`] map. Drops empty
+    /// entries (matches pnpm — an empty `tls` object is the same as
+    /// no entry at all).
+    pub fn from_map(by_uri: HashMap<String, RegistryTls>) -> Self {
+        let by_uri: HashMap<_, _> = by_uri.into_iter().filter(|(_, v)| !v.is_empty()).collect();
+        let max_parts = by_uri.keys().map(|key| key.split('/').count()).max().unwrap_or(0);
+        PerRegistryTls { by_uri, max_parts }
+    }
+
+    /// `true` when there are no per-registry overrides. Lets the
+    /// network layer skip the per-registry-client construction path.
+    pub fn is_empty(&self) -> bool {
+        self.by_uri.is_empty()
+    }
+
+    /// Iterate `(nerf_dart_uri, &RegistryTls)` pairs. The network
+    /// layer uses this to pre-build a client per unique override
+    /// combo.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &RegistryTls)> {
+        self.by_uri.iter().map(|(k, v)| (k.as_str(), v))
+    }
+
+    /// Look up the per-registry override for `url` via pnpm's
+    /// [`pickSettingByUrl`](https://github.com/pnpm/pnpm/blob/94240bc046/network/fetch/src/dispatcher.ts#L338-L375)
+    /// 5-step fallback chain:
+    ///
+    /// 1. Exact URL match.
+    /// 2. Nerf-darted URL.
+    /// 3. URL without port (recurse).
+    /// 4. Progressively shorter nerf-darted path prefixes.
+    /// 5. Retry recursively without port.
+    ///
+    /// Returns the **nerf-darted key** that matched (so the network
+    /// layer can index into its pre-built per-registry client map),
+    /// not the `RegistryTls` itself.
+    pub fn pick_for_url(&self, url: &str) -> Option<&str> {
+        if self.by_uri.is_empty() {
+            return None;
+        }
+        // Step 1: exact URL.
+        if let Some((key, _)) = self.by_uri.get_key_value(url) {
+            return Some(key.as_str());
+        }
+        // Step 2: nerf-darted URL.
+        let nerf = nerf_dart(url);
+        if !nerf.is_empty()
+            && let Some((key, _)) = self.by_uri.get_key_value(nerf.as_str())
+        {
+            return Some(key.as_str());
+        }
+        // Step 4: walk progressively shorter prefixes of the
+        // nerf-darted form. `nerf` is `//host[:port]/path/`, splitting
+        // on `/` yields `["", "", "host[:port]", "path", "", ""]` or
+        // similar; the loop iterates from the longest meaningful
+        // prefix down to `//host[:port]/`.
+        if !nerf.is_empty() {
+            let parts: Vec<&str> = nerf.split('/').collect();
+            let upper = parts.len().min(self.max_parts);
+            for i in (3..upper).rev() {
+                let key = format!("{}/", parts[..i].join("/"));
+                if let Some((found, _)) = self.by_uri.get_key_value(key.as_str()) {
+                    return Some(found.as_str());
+                }
+            }
+        }
+        // Steps 3 + 5: strip any port from the URL and retry. We do
+        // this *after* the nerf-dart walk because the walk already
+        // handles host-prefix shortening; the port-strip only matters
+        // when the user keyed `//host/` (no port) but the request URL
+        // carries an explicit port.
+        let stripped = strip_port(url);
+        if stripped != url {
+            return self.pick_for_url(&stripped);
+        }
+        None
+    }
+
+    /// Borrow the inner [`RegistryTls`] for a nerf-darted key. Returns
+    /// `None` when the key wasn't registered.
+    pub fn get(&self, key: &str) -> Option<&RegistryTls> {
+        self.by_uri.get(key)
+    }
+}
+
+/// Strip an explicit `:port` from an `http(s)://host[:port]/path...`
+/// URL, returning the modified URL string with a trailing `/` when
+/// the input had one. Returns the original string when there's no
+/// port to strip.
+///
+/// Hand-rolled instead of pulling in the `url` crate as a direct dep
+/// (mirrors the `ParsedUrl` approach for the auth nerf-darting). The
+/// contract: only HTTP-family URLs flow through here, ports are
+/// always numeric, and authority is the `[user@]host[:port]` segment
+/// before the first `/`.
+fn strip_port(url: &str) -> String {
+    let Some((scheme, rest)) = url.split_once("://") else {
+        return url.to_string();
+    };
+    let (authority, path_tail) = match rest.split_once('/') {
+        Some((a, p)) => (a, Some(p)),
+        None => (rest, None),
+    };
+    // Skip past any `user[:pw]@` userinfo. The port-bearing colon is
+    // the one in the host segment, not in the userinfo.
+    let host_segment = authority.rsplit_once('@').map(|(_, h)| h).unwrap_or(authority);
+    let userinfo = authority.strip_suffix(host_segment).unwrap_or("");
+    // IPv6 literals like `[::1]:8080` have `:` inside the brackets;
+    // find the port colon only *after* a closing `]` when present.
+    let port_colon = if let Some(bracket_end) = host_segment.find(']') {
+        host_segment[bracket_end..].find(':').map(|i| bracket_end + i)
+    } else {
+        host_segment.find(':')
+    };
+    let Some(idx) = port_colon else {
+        return url.to_string();
+    };
+    let host_no_port = &host_segment[..idx];
+    match path_tail {
+        Some(path) => format!("{scheme}://{userinfo}{host_no_port}/{path}"),
+        None => format!("{scheme}://{userinfo}{host_no_port}/"),
+    }
 }
 
 #[cfg(test)]

--- a/crates/network/src/tls/tests.rs
+++ b/crates/network/src/tls/tests.rs
@@ -1,7 +1,24 @@
 //! Unit tests for the [`super`] TLS types.
 
-use super::{TlsConfig, TlsError};
+use super::{PerRegistryTls, RegistryTls, TlsConfig, TlsError, strip_port};
+use std::collections::HashMap;
 use std::net::Ipv4Addr;
+
+fn registry_with(ca: Option<&str>, cert: Option<&str>, key: Option<&str>) -> RegistryTls {
+    RegistryTls {
+        ca: ca.map(String::from),
+        cert: cert.map(String::from),
+        key: key.map(String::from),
+    }
+}
+
+fn build_map(entries: &[(&str, RegistryTls)]) -> PerRegistryTls {
+    let mut map = HashMap::new();
+    for (key, value) in entries {
+        map.insert((*key).to_string(), value.clone());
+    }
+    PerRegistryTls::from_map(map)
+}
 
 #[test]
 fn tls_config_default_is_empty() {
@@ -38,4 +55,112 @@ fn tls_error_invalid_client_identity_includes_reason_in_display() {
     let err = TlsError::InvalidClientIdentity { reason: "garbage key".into() };
     let rendered = err.to_string();
     assert!(rendered.contains("garbage key"), "expected reason in {rendered}");
+}
+
+// --- PerRegistryTls / pick_for_url tests ---
+
+#[test]
+fn per_registry_tls_default_is_empty() {
+    let m = PerRegistryTls::default();
+    assert!(m.is_empty());
+    assert!(m.pick_for_url("https://example.com/").is_none());
+}
+
+#[test]
+fn per_registry_from_map_drops_empty_entries() {
+    // pnpm's `configByUri[uri].tls` only materializes when a field
+    // gets set, so an empty `RegistryTls` shouldn't take up a slot
+    // either. Otherwise the lookup would return a hit that yields
+    // an all-`None` override — defeating the point of falling back
+    // to top-level fields.
+    let m = build_map(&[
+        ("//keep.example/", registry_with(Some("ca"), None, None)),
+        ("//drop.example/", RegistryTls::default()),
+    ]);
+    assert!(m.get("//keep.example/").is_some(), "non-empty entry survived");
+    assert!(m.get("//drop.example/").is_none(), "empty entry was dropped");
+}
+
+#[test]
+fn pick_for_url_exact_match_wins() {
+    // Step 1 of pickSettingByUrl: an exact URL match short-circuits
+    // before nerf-darting kicks in. This lets a user pin a specific
+    // tarball URL's TLS without affecting the rest of the registry.
+    let exact = "https://registry.example.com/pkg/-/pkg-1.0.0.tgz";
+    let m = build_map(&[
+        (exact, registry_with(Some("exact-ca"), None, None)),
+        ("//registry.example.com/", registry_with(Some("registry-ca"), None, None)),
+    ]);
+    assert_eq!(m.pick_for_url(exact), Some(exact));
+}
+
+#[test]
+fn pick_for_url_nerf_dart_match() {
+    // Step 2: with no exact match, the nerf-darted URL hits the
+    // `//host/` key.
+    let m = build_map(&[("//registry.example.com/", registry_with(Some("ca"), None, None))]);
+    assert_eq!(m.pick_for_url("https://registry.example.com/pkg"), Some("//registry.example.com/"));
+}
+
+#[test]
+fn pick_for_url_shorter_path_prefix() {
+    // Step 4: a `//host/scope/` key matches any URL under that
+    // path, mirroring pnpm's nerf-dart prefix walk.
+    let m = build_map(&[(
+        "//registry.example.com/scope/",
+        registry_with(Some("scope-ca"), None, None),
+    )]);
+    assert_eq!(
+        m.pick_for_url("https://registry.example.com/scope/pkg/-/pkg-1.tgz"),
+        Some("//registry.example.com/scope/"),
+    );
+}
+
+#[test]
+fn pick_for_url_strips_port_on_retry() {
+    // Steps 3 + 5: a `//host/` key matches a URL that carries an
+    // explicit port. The port-strip retry walks back through the
+    // earlier steps.
+    let m = build_map(&[("//registry.example.com/", registry_with(Some("ca"), None, None))]);
+    assert_eq!(
+        m.pick_for_url("https://registry.example.com:8443/pkg"),
+        Some("//registry.example.com/"),
+    );
+}
+
+#[test]
+fn pick_for_url_misses_when_host_differs() {
+    let m = build_map(&[("//registry.example.com/", registry_with(Some("ca"), None, None))]);
+    assert_eq!(m.pick_for_url("https://other.example.org/pkg"), None);
+}
+
+#[test]
+fn pick_for_url_misses_when_path_doesnt_share_prefix() {
+    // `//host/foo/` shouldn't match a URL under `/bar/`.
+    let m = build_map(&[("//registry.example.com/foo/", registry_with(Some("ca"), None, None))]);
+    assert_eq!(m.pick_for_url("https://registry.example.com/bar/pkg"), None);
+}
+
+#[test]
+fn registry_tls_is_empty_when_all_none() {
+    assert!(RegistryTls::default().is_empty());
+    assert!(!registry_with(Some("x"), None, None).is_empty());
+    assert!(!registry_with(None, Some("x"), None).is_empty());
+    assert!(!registry_with(None, None, Some("x")).is_empty());
+}
+
+#[test]
+fn strip_port_handles_common_shapes() {
+    for (input, expected) in [
+        ("https://reg.com:8080/path", "https://reg.com/path"),
+        ("https://reg.com:8080/", "https://reg.com/"),
+        ("https://reg.com:8080", "https://reg.com/"),
+        ("https://reg.com/path", "https://reg.com/path"),
+        ("https://user:pw@reg.com:8080/path", "https://user:pw@reg.com/path"),
+        ("https://[::1]:8080/path", "https://[::1]/path"),
+        ("https://[::1]/path", "https://[::1]/path"),
+    ] {
+        let got = strip_port(input);
+        assert_eq!(got, expected, "input={input}");
+    }
 }

--- a/crates/package-manager/src/install_package_from_registry/tests.rs
+++ b/crates/package-manager/src/install_package_from_registry/tests.rs
@@ -56,6 +56,7 @@ fn create_config(store_dir: &Path, modules_dir: &Path, virtual_store_dir: &Path)
         auth_headers: Default::default(),
         proxy: Default::default(),
         tls: Default::default(),
+        tls_by_uri: Default::default(),
     }
 }
 

--- a/crates/registry/src/package.rs
+++ b/crates/registry/src/package.rs
@@ -39,7 +39,7 @@ impl Package {
         // drifting if the format expression ever changed.
         let url = format!("{registry}{name}"); // TODO: use reqwest URL directly
         let network_error = |error| NetworkError { error, url: url.clone() };
-        let mut request = http_client.acquire().await.get(&url).header(
+        let mut request = http_client.acquire_for_url(&url).await.get(&url).header(
             "accept",
             "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*",
         );

--- a/crates/registry/src/package_version.rs
+++ b/crates/registry/src/package_version.rs
@@ -37,7 +37,7 @@ impl PackageVersion {
         let url = format!("{registry}{name}/{tag}");
         let network_error = |error| NetworkError { error, url: url.clone() };
 
-        let mut request = http_client.acquire().await.get(&url).header(
+        let mut request = http_client.acquire_for_url(&url).await.get(&url).header(
             "accept",
             "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*",
         );

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -1376,7 +1376,15 @@ async fn fetch_and_extract_once<R: Reporter>(
     // through body streaming. Releasing earlier would let the next
     // batch of futures `connect()` while previous bodies are still
     // draining, breaking the bound on concurrent open sockets.
-    let client = http_client.acquire().await;
+    //
+    // `acquire_for_url` routes the request through the per-registry
+    // TLS-configured client when one is set for `package_url`'s
+    // nerf-darted prefix, falling back to the default client
+    // otherwise. Tarball hosts that differ from the metadata host
+    // still pick up the right per-registry client because the
+    // 5-step `pickSettingByUrl` lookup also matches on the tarball
+    // URL.
+    let client = http_client.acquire_for_url(package_url).await;
     let mut request = client.get(package_url);
     // Match pnpm's tarball download path
     // ([`remoteTarballFetcher.ts`](https://github.com/pnpm/pnpm/blob/601317e7a3/fetching/tarball-fetcher/src/remoteTarballFetcher.ts#L66-L70)):
@@ -1988,7 +1996,7 @@ async fn fetch_and_extract_zip_once<R: Reporter>(
     let network_error =
         |error| TarballError::FetchTarball(NetworkError { url: package_url.to_string(), error });
 
-    let client = http_client.acquire().await;
+    let client = http_client.acquire_for_url(package_url).await;
 
     let mut request = client.get(package_url);
     // Match the tarball download path: resolve the per-URL auth


### PR DESCRIPTION
Closes #497.

## Summary

Adds per-registry TLS overrides keyed by nerf-darted `.npmrc` URI, the natural follow-up to #490's top-level TLS keys. Corporate environments running a private Verdaccio (or any registry with its own self-signed cert) can now pin scoped `:cafile=…` / `:cert=…` / `:key=…` per host without disabling strict-ssl globally.

Three commits, layered:

- **`feat(network)`** (eff1248e): adds `RegistryTls` + `PerRegistryTls` types in `pacquet-network` plus the lookup machinery — `pick_for_url` ports pnpm's [5-step `pickSettingByUrl`](https://github.com/pnpm/pnpm/blob/94240bc046/network/fetch/src/dispatcher.ts#L338-L375) exactly (exact > nerf-dart > no-port > shorter prefix > recursive no-port retry). `ThrottledClient::for_installs` gains a third `&PerRegistryTls` parameter and pre-builds one reqwest `Client` per non-empty override. New `acquire_for_url(url: &str)` routes per-request; `acquire()` keeps the default-client behavior for callers without a URL.

- **`feat(config)`** (4e69868a): `NpmrcAuth` parses the six per-registry TLS suffixes (`:ca`, `:cafile`, `:cert`, `:certfile`, `:key`, `:keyfile`) matching pnpm's `SSL_SUFFIX_RE` and applies onto `Config.tls_by_uri`. `*file` variants read from disk at parse time (silent on error); inline values get `\\n` → `\n` expansion. `:cert` and `:certfile` share the same `tls.cert` slot — last-write-wins inside one `.npmrc`.

- **`refactor(tarball,registry)`** (5f9cae93): three production call sites (registry metadata + version-tag fetches, plus two tarball download paths) move from `acquire()` to `acquire_for_url(url)` so the per-registry routing actually fires.

## Parity policy

Bug-for-bug with pnpm v11 ([SHA 94240bc046](https://github.com/pnpm/pnpm/blob/94240bc046/config/reader/src/getNetworkConfigs.ts)):

- **Field-by-field override**, not replace-all. Each scoped `ca` / `cert` / `key` overrides its top-level counterpart independently (mirroring upstream's `{ ...opts, ...sslConfig }` spread at `dispatcher.ts:143,264`). `strict_ssl` and `local_address` stay top-level-only — pnpm's regex doesn't recognize scoped versions.
- **`ca` as `Option<String>`, not `Vec<String>`**: per-registry `ca` is a single string (possibly with concatenated `-----END CERTIFICATE-----` delimiters) — `reqwest::Certificate::from_pem` accepts both shapes.
- **Inline `\\n` expansion only on per-registry**: pnpm applies `value.replace(/\\n/g, '\n')` to scoped values but not to top-level `ca=`. The divergence is intentional and matches upstream.
- **Lax URI prefix check**: `foo:cert=…` (no `//` prefix) is accepted into the map with `uri_prefix = "foo"`. It never matches a real nerf-darted URL so the entry is dropped at lookup time, but storing it keeps byte-for-byte parsing parity with `tryParseSslKey`.

## Reviewer flags

- **Per-registry clients duplicate connection pools.** Each unique override gets its own `reqwest::Client` and therefore its own connection pool. With N per-registry overrides the worker holds N+1 pools instead of one. The semaphore still bounds *concurrent in-flight requests* globally, but socket churn between registries with different TLS configs is now per-client. In practice most users have ≤2 overrides; if this becomes an issue we'd need to switch to rustls + custom certificate verifier (tracked under #499).
- **`acquire_for_url` takes `&str` rather than `&Url`** so the existing `format!("{registry}{name}")` call sites don't need to round-trip through `Url::parse`. The lookup itself works on the raw string form via `nerf_dart`.

## Test plan

- [x] `cargo nextest run -p pacquet-network` — 64 tests pass (added 11 per-registry routing tests in `tls/tests.rs` + 4 end-to-end routing tests in `tests.rs`)
- [x] `cargo nextest run -p pacquet-config` — 146 tests pass (added 8 per-registry parse tests)
- [x] `cargo nextest run --workspace` — 1155 tests pass
- [x] `just ready` clean
- [x] `taplo format --check` clean
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace --document-private-items` clean
- [x] `just dylint` clean

## Out of scope

- Switching to rustls TLS backend (tracked under #499 for PKCS#1 + #500 for TLS-mock integration test).
- CLI flag versions of per-registry TLS — pnpm doesn't surface those as flags either; tracked under #483 only for the top-level fields.

## References

- Closes #497
- Built on top of #490 (top-level TLS keys)

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for per-registry TLS configuration in `.npmrc` files, allowing users to specify custom CA certificates, client certificates, and keys for individual registries.
  * HTTP client selection now respects per-registry TLS overrides alongside global TLS settings, with compatibility for pnpm's configuration fallback chain.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pacquet/pull/502)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->