### PR TITLE
feat(package-manager): runtime bin-link + --no-runtime (#437 slice D3 + E)

### DIFF
--- a/crates/cli/src/cli_args/install.rs
+++ b/crates/cli/src/cli_args/install.rs
@@ -55,13 +55,27 @@ pub struct InstallArgs {
     /// Don't generate a lockfile and fail if the lockfile is outdated.
     #[clap(long)]
     pub frozen_lockfile: bool,
+
+    /// Skip the install of any runtime dependencies
+    /// (`node@runtime:`, `deno@runtime:`, `bun@runtime:`).
+    /// Their archives aren't fetched, their slots aren't
+    /// materialized, and their bins aren't linked into
+    /// `node_modules/.bin/`. The rest of the install proceeds
+    /// normally. Mirrors pnpm's `--no-runtime` flag.
+    #[clap(long = "no-runtime")]
+    pub no_runtime: bool,
 }
 
 impl InstallArgs {
     pub async fn run<R: Reporter>(self, state: State) -> miette::Result<()> {
         let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
             &state;
-        let InstallArgs { dependency_options, supported_architectures, frozen_lockfile } = self;
+        let InstallArgs {
+            dependency_options,
+            supported_architectures,
+            frozen_lockfile,
+            no_runtime,
+        } = self;
 
         // Merge CLI overrides with the yaml-derived value before
         // handing off to the install pipeline. `state.config` is a
@@ -72,6 +86,11 @@ impl InstallArgs {
         let supported_architectures =
             supported_architectures.apply_to(config.supported_architectures.clone());
 
+        // Either the npmrc/yaml-derived setting or the CLI flag
+        // turns runtime-skipping on; pacquet doesn't expose a way
+        // to override yaml's `true` back to `false` from the CLI,
+        // matching pnpm's stance on the same flag.
+        let skip_runtimes = config.skip_runtimes || no_runtime;
         Install {
             tarball_mem_cache,
             http_client,
@@ -80,6 +99,7 @@ impl InstallArgs {
             lockfile: lockfile.as_ref(),
             dependency_groups: dependency_options.dependency_groups(),
             frozen_lockfile,
+            skip_runtimes,
             resolved_packages,
             supported_architectures,
         }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -259,6 +259,19 @@ pub struct Config {
     #[default = true]
     pub prefer_frozen_lockfile: bool,
 
+    /// When `true`, runtime dependencies (`node@runtime:`,
+    /// `deno@runtime:`, `bun@runtime:`) are skipped at install
+    /// time — their archives aren't fetched, their slots aren't
+    /// materialized, and their bins aren't linked. The rest of
+    /// the install proceeds normally. Mirrors pnpm's
+    /// [`skipRuntimes`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/src/install/index.ts)
+    /// option, exposed via the `--no-runtime` CLI flag.
+    ///
+    /// Defaults to `false`, matching upstream. CI scenarios that
+    /// pre-provision the runtime (or want to install one runtime
+    /// with another pacquet binary) flip this to `true`.
+    pub skip_runtimes: bool,
+
     /// Add the full URL to the package's tarball to every entry in pnpm-lock.yaml.
     pub lockfile_include_tarball_url: bool,
 

--- a/crates/package-manager/src/add.rs
+++ b/crates/package-manager/src/add.rs
@@ -88,6 +88,7 @@ where
             lockfile,
             dependency_groups: list_dependency_groups(),
             frozen_lockfile: false,
+            skip_runtimes: config.skip_runtimes,
             resolved_packages,
             supported_architectures,
         }

--- a/crates/package-manager/src/install.rs
+++ b/crates/package-manager/src/install.rs
@@ -36,6 +36,14 @@ where
     pub lockfile: Option<&'a Lockfile>,
     pub dependency_groups: DependencyGroupList,
     pub frozen_lockfile: bool,
+    /// When `true`, runtime dependencies (`node@runtime:` /
+    /// `deno@runtime:` / `bun@runtime:`) are skipped — their
+    /// archives aren't fetched, their slots aren't materialized,
+    /// and their bins aren't linked. Computed at the CLI layer
+    /// from `config.skip_runtimes || --no-runtime`. The rest of
+    /// the install proceeds normally. See
+    /// `pacquet_config::Config::skip_runtimes`.
+    pub skip_runtimes: bool,
     /// `supportedArchitectures` after merging
     /// `Config::supported_architectures` from `pnpm-workspace.yaml`
     /// with the CLI per-axis overrides (`--cpu` / `--os` / `--libc`).
@@ -139,6 +147,7 @@ where
             lockfile,
             dependency_groups,
             frozen_lockfile,
+            skip_runtimes,
             supported_architectures,
         } = self;
 
@@ -287,6 +296,7 @@ where
                     workspace_root: &workspace_root,
                     requester: &prefix,
                     supported_architectures: supported_architectures.as_ref(),
+                    skip_runtimes,
                 }
                 .run::<R>()
                 .await

--- a/crates/package-manager/src/install/tests.rs
+++ b/crates/package-manager/src/install/tests.rs
@@ -53,6 +53,7 @@ async fn should_install_dependencies() {
         lockfile: None,
         dependency_groups: [DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional],
         frozen_lockfile: false,
+        skip_runtimes: false,
         supported_architectures: None,
         resolved_packages: &Default::default(),
     }
@@ -106,6 +107,7 @@ async fn should_error_when_frozen_lockfile_is_requested_but_none_exists() {
         lockfile: None,
         dependency_groups: [DependencyGroup::Prod],
         frozen_lockfile: true,
+        skip_runtimes: false,
         supported_architectures: None,
         resolved_packages: &Default::default(),
     }
@@ -142,6 +144,7 @@ async fn should_error_when_writable_lockfile_mode_is_used() {
         lockfile: None,
         dependency_groups: [DependencyGroup::Prod],
         frozen_lockfile: false,
+        skip_runtimes: false,
         supported_architectures: None,
         resolved_packages: &Default::default(),
     }
@@ -207,6 +210,7 @@ async fn frozen_lockfile_flag_overrides_config_lockfile_false() {
         lockfile: Some(&lockfile),
         dependency_groups: [DependencyGroup::Prod],
         frozen_lockfile: true,
+        skip_runtimes: false,
         supported_architectures: None,
         resolved_packages: &Default::default(),
     }
@@ -265,6 +269,7 @@ async fn npm_alias_dependency_installs_under_alias_key() {
         lockfile: None,
         dependency_groups: [DependencyGroup::Prod],
         frozen_lockfile: false,
+        skip_runtimes: false,
         supported_architectures: None,
         resolved_packages: &Default::default(),
     }
@@ -340,6 +345,7 @@ async fn unversioned_npm_alias_defaults_to_latest() {
         lockfile: None,
         dependency_groups: [DependencyGroup::Prod],
         frozen_lockfile: false,
+        skip_runtimes: false,
         supported_architectures: None,
         resolved_packages: &Default::default(),
     }
@@ -400,6 +406,7 @@ async fn frozen_lockfile_flag_with_no_lockfile_errors() {
         lockfile: None,
         dependency_groups: [DependencyGroup::Prod],
         frozen_lockfile: true,
+        skip_runtimes: false,
         supported_architectures: None,
         resolved_packages: &Default::default(),
     }
@@ -480,6 +487,7 @@ async fn install_emits_pnpm_event_sequence() {
         lockfile: Some(&lockfile),
         dependency_groups: [DependencyGroup::Prod],
         frozen_lockfile: true,
+        skip_runtimes: false,
         supported_architectures: None,
         resolved_packages: &Default::default(),
     }
@@ -617,6 +625,7 @@ async fn install_writes_modules_yaml() {
         // groups to the on-disk `included` field.
         dependency_groups: [DependencyGroup::Prod, DependencyGroup::Optional],
         frozen_lockfile: true,
+        skip_runtimes: false,
         supported_architectures: None,
         resolved_packages: &Default::default(),
     }
@@ -710,6 +719,7 @@ async fn install_optional_failing_postinstall_dep_via_registry_mock_succeeds() {
         lockfile: None,
         dependency_groups: [DependencyGroup::Prod, DependencyGroup::Optional],
         frozen_lockfile: false,
+        skip_runtimes: false,
         supported_architectures: None,
         resolved_packages: &Default::default(),
     }
@@ -825,6 +835,7 @@ async fn warm_reinstall_skips_snapshot_when_current_lockfile_matches() {
         lockfile: Some(&lockfile),
         dependency_groups: [DependencyGroup::Prod],
         frozen_lockfile: true,
+        skip_runtimes: false,
         supported_architectures: None,
         resolved_packages: &Default::default(),
     }
@@ -915,6 +926,7 @@ async fn warm_reinstall_emits_broken_modules_when_dir_is_missing() {
         lockfile: Some(&lockfile),
         dependency_groups: [DependencyGroup::Prod],
         frozen_lockfile: true,
+        skip_runtimes: false,
         supported_architectures: None,
         resolved_packages: &Default::default(),
     }
@@ -1013,6 +1025,7 @@ async fn context_log_reflects_current_lockfile_after_first_install() {
         lockfile: Some(&lockfile),
         dependency_groups: [DependencyGroup::Prod],
         frozen_lockfile: true,
+        skip_runtimes: false,
         supported_architectures: None,
         resolved_packages: &Default::default(),
     }
@@ -1055,6 +1068,7 @@ async fn context_log_reflects_current_lockfile_after_first_install() {
         lockfile: Some(&lockfile),
         dependency_groups: [DependencyGroup::Prod],
         frozen_lockfile: true,
+        skip_runtimes: false,
         supported_architectures: None,
         resolved_packages: &Default::default(),
     }
@@ -1139,6 +1153,7 @@ async fn warm_reinstall_reports_added_zero_and_emits_no_imported_events() {
         lockfile: Some(&lockfile),
         dependency_groups: [DependencyGroup::Prod],
         frozen_lockfile: true,
+        skip_runtimes: false,
         supported_architectures: None,
         resolved_packages: &Default::default(),
     }
@@ -1225,6 +1240,7 @@ async fn frozen_lockfile_errors_when_manifest_drifts_from_lockfile() {
         lockfile: Some(&lockfile),
         dependency_groups: [DependencyGroup::Prod],
         frozen_lockfile: true,
+        skip_runtimes: false,
         resolved_packages: &Default::default(),
         supported_architectures: None,
     }
@@ -1275,6 +1291,7 @@ async fn frozen_lockfile_errors_when_lockfile_has_no_root_importer() {
         lockfile: Some(&lockfile),
         dependency_groups: [DependencyGroup::Prod],
         frozen_lockfile: true,
+        skip_runtimes: false,
         resolved_packages: &Default::default(),
         supported_architectures: None,
     }
@@ -1355,6 +1372,7 @@ async fn frozen_lockfile_under_gvs_registers_project_and_runs_clean() {
         lockfile: Some(&lockfile),
         dependency_groups: [DependencyGroup::Prod],
         frozen_lockfile: true,
+        skip_runtimes: false,
         resolved_packages: &Default::default(),
         supported_architectures: None,
     }
@@ -1425,6 +1443,7 @@ async fn frozen_lockfile_with_gvs_off_skips_project_registry() {
         lockfile: Some(&lockfile),
         dependency_groups: [DependencyGroup::Prod],
         frozen_lockfile: true,
+        skip_runtimes: false,
         resolved_packages: &Default::default(),
         supported_architectures: None,
     }
@@ -1501,6 +1520,7 @@ async fn frozen_lockfile_under_gvs_registers_each_workspace_importer() {
         lockfile: Some(&lockfile),
         dependency_groups: [DependencyGroup::Prod],
         frozen_lockfile: true,
+        skip_runtimes: false,
         resolved_packages: &Default::default(),
         supported_architectures: None,
     }
@@ -1678,6 +1698,7 @@ async fn frozen_install_preserves_seeded_skipped_across_reinstall() {
         lockfile: Some(&lockfile),
         dependency_groups: [DependencyGroup::Prod],
         frozen_lockfile: true,
+        skip_runtimes: false,
         supported_architectures: None,
         resolved_packages: &Default::default(),
     }
@@ -1787,6 +1808,7 @@ async fn frozen_install_silently_swallows_unreachable_optional_tarball() {
         lockfile: Some(&lockfile),
         dependency_groups: [DependencyGroup::Prod, DependencyGroup::Optional],
         frozen_lockfile: true,
+        skip_runtimes: false,
         supported_architectures: None,
         resolved_packages: &Default::default(),
     }
@@ -1879,6 +1901,7 @@ async fn frozen_install_propagates_non_optional_fetch_failure() {
         lockfile: Some(&lockfile),
         dependency_groups: [DependencyGroup::Prod],
         frozen_lockfile: true,
+        skip_runtimes: false,
         supported_architectures: None,
         resolved_packages: &Default::default(),
     }
@@ -1977,6 +2000,7 @@ async fn frozen_install_no_optional_drops_optional_only_snapshots() {
         lockfile: Some(&lockfile),
         dependency_groups: [DependencyGroup::Prod],
         frozen_lockfile: true,
+        skip_runtimes: false,
         supported_architectures: None,
         resolved_packages: &Default::default(),
     }
@@ -2060,6 +2084,7 @@ async fn frozen_install_optional_included_surfaces_missing_metadata() {
         lockfile: Some(&lockfile),
         dependency_groups: [DependencyGroup::Prod, DependencyGroup::Optional],
         frozen_lockfile: true,
+        skip_runtimes: false,
         supported_architectures: None,
         resolved_packages: &Default::default(),
     }
@@ -2146,6 +2171,7 @@ async fn frozen_install_no_optional_keeps_shared_non_optional_snapshot() {
         // `--no-optional` shape: Optional NOT in the dispatch list.
         dependency_groups: [DependencyGroup::Prod],
         frozen_lockfile: true,
+        skip_runtimes: false,
         supported_architectures: None,
         resolved_packages: &Default::default(),
     }

--- a/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/crates/package-manager/src/install_frozen_lockfile.rs
@@ -358,17 +358,18 @@ where
             }
         }
 
-        // `--no-runtime` (or `config.skip_runtimes`): exclude every
-        // snapshot whose `packages:` metadata carries a `Binary` or
-        // `Variations` resolution. Mirrors pnpm's
-        // [`skipRuntimes`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/src/install/index.ts)
-        // gate, with a wider blast radius: pnpm filters runtimes
-        // out of `dependenciesByProjectId` so transitive runtime
-        // deps (rare) still install, whereas pacquet drops the
-        // snapshot entirely. Practical effect is the same for the
-        // common case — runtimes are top-level deps in nearly every
-        // real-world project — and the simpler shape composes with
-        // the rest of the skip-set plumbing.
+        // `--no-runtime` (or `config.skip_runtimes`): exclude
+        // every project-direct runtime dependency. Mirrors
+        // pnpm's `skipRuntimes` filter at
+        // [`installing/deps-installer/src/install/index.ts`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/src/install/index.ts#L1374-L1387)
+        // exactly — iterate each importer's direct deps and add
+        // the runtime ones to the skip set; transitive runtime
+        // entries (which would be unusual but possible) stay in
+        // the install. Upstream's discriminator is the
+        // `depPath.includes('@runtime:')` substring check on the
+        // resolved depPath; pacquet's lockfile preserves the
+        // `@runtime:` substring in the snapshot key, so the same
+        // string-test works here.
         //
         // Re-using `add_optional_excluded` keeps the bucket count
         // (and `.modules.yaml.skipped` semantics) unchanged: like
@@ -377,13 +378,38 @@ where
         // `.modules.yaml.skipped` — a future install without the
         // flag must bring the runtime back.
         if skip_runtimes && let Some(pkgs) = packages {
-            for (key, meta) in pkgs {
-                if matches!(
-                    meta.resolution,
-                    pacquet_lockfile::LockfileResolution::Binary(_)
-                        | pacquet_lockfile::LockfileResolution::Variations(_),
-                ) {
-                    skipped.add_optional_excluded(key.clone());
+            for importer in importers.values() {
+                for dep_map in [
+                    importer.dependencies.as_ref(),
+                    importer.dev_dependencies.as_ref(),
+                    importer.optional_dependencies.as_ref(),
+                ] {
+                    let Some(dep_map) = dep_map else { continue };
+                    for (alias, spec) in dep_map {
+                        let Some(version) = spec.version.as_regular() else { continue };
+                        // Build the candidate snapshot key from
+                        // (alias, version). For non-aliased deps
+                        // this is the depPath verbatim; aliased
+                        // runtime deps (unusual) won't match
+                        // `packages` here, matching pnpm's lookup
+                        // by depPath rather than by alias.
+                        let candidate = format!("{alias}@{version}");
+                        if !candidate.contains("@runtime:") {
+                            continue;
+                        }
+                        let Ok(key) = candidate.parse::<pacquet_lockfile::PackageKey>() else {
+                            continue;
+                        };
+                        if let Some(meta) = pkgs.get(&key)
+                            && matches!(
+                                &meta.resolution,
+                                pacquet_lockfile::LockfileResolution::Binary(_)
+                                    | pacquet_lockfile::LockfileResolution::Variations(_),
+                            )
+                        {
+                            skipped.add_optional_excluded(key);
+                        }
+                    }
                 }
             }
         }

--- a/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/crates/package-manager/src/install_frozen_lockfile.rs
@@ -90,6 +90,14 @@ where
     /// platform-tagged optional-dependency filter respects user-
     /// supplied architecture overrides.
     pub supported_architectures: Option<&'a pacquet_package_is_installable::SupportedArchitectures>,
+
+    /// When `true`, runtime dependencies (`node@runtime:`,
+    /// `deno@runtime:`, `bun@runtime:`) — i.e. packages whose
+    /// metadata resolution is `Binary` or `Variations` — are
+    /// added to the install-time skip set and the rest of the
+    /// install ignores them. Computed at the CLI layer from
+    /// `config.skip_runtimes || --no-runtime`.
+    pub skip_runtimes: bool,
 }
 
 /// Error type of [`InstallFrozenLockfile`].
@@ -194,6 +202,7 @@ where
             workspace_root,
             requester,
             supported_architectures,
+            skip_runtimes,
         } = self;
         // Cloned so the iterator can be reused below for hoist's
         // direct-deps map. `Vec<DependencyGroup>` is tiny (≤4 enum
@@ -344,6 +353,36 @@ where
         if !include_optional && let Some(snaps) = snapshots {
             for (key, snap) in snaps {
                 if snap.optional {
+                    skipped.add_optional_excluded(key.clone());
+                }
+            }
+        }
+
+        // `--no-runtime` (or `config.skip_runtimes`): exclude every
+        // snapshot whose `packages:` metadata carries a `Binary` or
+        // `Variations` resolution. Mirrors pnpm's
+        // [`skipRuntimes`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/src/install/index.ts)
+        // gate, with a wider blast radius: pnpm filters runtimes
+        // out of `dependenciesByProjectId` so transitive runtime
+        // deps (rare) still install, whereas pacquet drops the
+        // snapshot entirely. Practical effect is the same for the
+        // common case — runtimes are top-level deps in nearly every
+        // real-world project — and the simpler shape composes with
+        // the rest of the skip-set plumbing.
+        //
+        // Re-using `add_optional_excluded` keeps the bucket count
+        // (and `.modules.yaml.skipped` semantics) unchanged: like
+        // `--no-optional`, this is a transient user-driven
+        // exclusion that should *not* be persisted into
+        // `.modules.yaml.skipped` — a future install without the
+        // flag must bring the runtime back.
+        if skip_runtimes && let Some(pkgs) = packages {
+            for (key, meta) in pkgs {
+                if matches!(
+                    meta.resolution,
+                    pacquet_lockfile::LockfileResolution::Binary(_)
+                        | pacquet_lockfile::LockfileResolution::Variations(_),
+                ) {
                     skipped.add_optional_excluded(key.clone());
                 }
             }

--- a/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/crates/package-manager/src/install_package_by_snapshot.rs
@@ -9,7 +9,7 @@ use pacquet_executor::ScriptsPrependNodePath as ExecScriptsPrependNodePath;
 use pacquet_git_fetcher::{GitFetchOutput, GitFetcher, GitFetcherError, GitHostedTarballFetcher};
 use pacquet_graph_hasher::{host_arch, host_libc, host_platform};
 use pacquet_lockfile::{
-    BinaryArchive, BinaryResolution, LockfileResolution, PackageKey, PackageMetadata,
+    BinaryArchive, BinaryResolution, BinarySpec, LockfileResolution, PackageKey, PackageMetadata,
     PlatformSelector, SnapshotEntry, select_platform_variant,
 };
 use pacquet_network::ThrottledClient;
@@ -137,6 +137,23 @@ pub enum InstallPackageBySnapshotError {
     )]
     #[diagnostic(code(pacquet_package_manager::variant_has_non_binary_resolution))]
     VariantHasNonBinaryResolution { package_key: String, inner_kind: &'static str },
+
+    /// Serializing the synthesized runtime `package.json` failed.
+    /// The manifest is a small fixed-shape JSON object (`name`,
+    /// `version`, `bin`); `serde_json` rejects this only on a
+    /// numeric or struct value the writer can't render, which can't
+    /// happen for the three string-typed fields we pass it.
+    /// Surfaces as a typed error rather than a panic so a future
+    /// shape change to [`BinarySpec`] doesn't crash an install.
+    #[display(
+        "Failed to serialize the synthesized package.json for runtime entry `{package_key}`: {error}"
+    )]
+    #[diagnostic(code(pacquet_package_manager::synthesize_runtime_manifest))]
+    SynthesizeRuntimeManifest {
+        package_key: String,
+        #[error(source)]
+        error: serde_json::Error,
+    },
 }
 
 impl<'a> InstallPackageBySnapshot<'a> {
@@ -276,7 +293,7 @@ impl<'a> InstallPackageBySnapshot<'a> {
                     store_index_writer,
                     verified_files_cache,
                     prefetched_cas_paths,
-                    &package_id,
+                    package_key,
                     requester,
                     archive_filter_for(package_key),
                 )
@@ -331,7 +348,7 @@ impl<'a> InstallPackageBySnapshot<'a> {
                     store_index_writer,
                     verified_files_cache,
                     prefetched_cas_paths,
-                    &package_id,
+                    package_key,
                     requester,
                     archive_filter_for(package_key),
                 )
@@ -562,11 +579,12 @@ async fn fetch_binary_resolution_to_cas<R: Reporter>(
     store_index_writer: Option<&Arc<StoreIndexWriter>>,
     verified_files_cache: &SharedVerifiedFilesCache,
     prefetched_cas_paths: Option<&PrefetchedCasPaths>,
-    package_id: &str,
+    package_key: &PackageKey,
     requester: &str,
     ignore_file_pattern: Option<Arc<IgnoreEntryFilter>>,
 ) -> Result<HashMap<String, PathBuf>, InstallPackageBySnapshotError> {
-    match binary.archive {
+    let package_id = package_key.without_peer().to_string();
+    let mut cas_paths = match binary.archive {
         BinaryArchive::Tarball => DownloadTarballToStore {
             http_client,
             store_dir: &config.store_dir,
@@ -577,7 +595,7 @@ async fn fetch_binary_resolution_to_cas<R: Reporter>(
             package_integrity: &binary.integrity,
             package_unpacked_size: None,
             package_url: &binary.url,
-            package_id,
+            package_id: &package_id,
             requester,
             prefetched_cas_paths,
             retry_opts: retry_opts_from_config(config),
@@ -586,7 +604,7 @@ async fn fetch_binary_resolution_to_cas<R: Reporter>(
         }
         .run_without_mem_cache::<R>()
         .await
-        .map_err(InstallPackageBySnapshotError::DownloadTarball),
+        .map_err(InstallPackageBySnapshotError::DownloadTarball)?,
         BinaryArchive::Zip => DownloadZipArchiveToStore {
             http_client,
             store_dir: &config.store_dir,
@@ -596,7 +614,7 @@ async fn fetch_binary_resolution_to_cas<R: Reporter>(
             verified_files_cache: Arc::clone(verified_files_cache),
             package_integrity: &binary.integrity,
             package_url: &binary.url,
-            package_id,
+            package_id: &package_id,
             requester,
             prefetched_cas_paths,
             retry_opts: retry_opts_from_config(config),
@@ -606,8 +624,77 @@ async fn fetch_binary_resolution_to_cas<R: Reporter>(
         }
         .run_without_mem_cache::<R>()
         .await
-        .map_err(InstallPackageBySnapshotError::DownloadTarball),
+        .map_err(InstallPackageBySnapshotError::DownloadTarball)?,
+    };
+
+    // Synthesize the package.json for the runtime archive and import
+    // it through the same CAS write path the rest of the archive
+    // takes. Runtime archives don't ship their own `package.json`,
+    // so the existing bin-link step (which reads the manifest off
+    // the slot's `package.json`) has nothing to consume by default.
+    // Mirrors upstream's `appendManifest` flow at
+    // [`binary-fetcher/src/index.ts`](https://github.com/pnpm/pnpm/blob/94240bc046/fetching/binary-fetcher/src/index.ts):
+    // the synthesized object has `name`, `version`, and `bin` — the
+    // three fields pacquet's `link_bins_of_packages` actually looks
+    // at. Writing the bytes through `write_cas_file` keeps the
+    // import path uniform with every other CAS-imported file and
+    // means the bytes are content-addressed (so two runtimes with
+    // the same `(name, version, bin)` share one blob).
+    let manifest_bytes = synthesize_runtime_manifest_bytes(package_key, binary)?;
+    let (cas_path, _hash) =
+        config.store_dir.write_cas_file(&manifest_bytes, false).map_err(|err| {
+            InstallPackageBySnapshotError::DownloadTarball(TarballError::WriteCasFile(err))
+        })?;
+    if let Some(previous) = cas_paths.insert("package.json".to_string(), cas_path) {
+        tracing::warn!(
+            ?previous,
+            ?package_id,
+            "synthesized package.json displaced an existing entry — runtime archives are not expected to ship a package.json",
+        );
     }
+    Ok(cas_paths)
+}
+
+/// Serialize the synthesized runtime `package.json` to bytes. Three
+/// fields, matching the upstream `appendManifest` shape:
+///
+/// - `name` — the package key's display form, scope-aware.
+/// - `version` — the bare semver string from the peer-stripped key.
+/// - `bin` — the lockfile-declared bins ([`BinarySpec`]). `Single`
+///   becomes a JSON string (pnpm's convention: one binary, named
+///   after the package), `Map` becomes a JSON object.
+///
+/// `serde_json::to_vec` writes a single-line UTF-8 blob — same
+/// format upstream's worker thread emits. The bytes go straight
+/// into the CAS, where they're addressed by the SHA-512 of their
+/// content; two runtime archives whose `(name, version, bin)`
+/// triple happens to match share the same blob.
+fn synthesize_runtime_manifest_bytes(
+    package_key: &PackageKey,
+    binary: &BinaryResolution,
+) -> Result<Vec<u8>, InstallPackageBySnapshotError> {
+    let bin_value = match &binary.bin {
+        BinarySpec::Single(path) => serde_json::Value::String(path.clone()),
+        BinarySpec::Map(map) => {
+            let mut obj = serde_json::Map::with_capacity(map.len());
+            for (name, path) in map {
+                obj.insert(name.clone(), serde_json::Value::String(path.clone()));
+            }
+            serde_json::Value::Object(obj)
+        }
+    };
+    let stripped = package_key.without_peer();
+    let manifest = serde_json::json!({
+        "name": stripped.name.to_string(),
+        "version": stripped.suffix.version().to_string(),
+        "bin": bin_value,
+    });
+    serde_json::to_vec(&manifest).map_err(|error| {
+        InstallPackageBySnapshotError::SynthesizeRuntimeManifest {
+            package_key: package_key.to_string(),
+            error,
+        }
+    })
 }
 
 /// Render a variant's target list as a human-readable string for

--- a/crates/package-manager/src/install_package_by_snapshot/tests.rs
+++ b/crates/package-manager/src/install_package_by_snapshot/tests.rs
@@ -1,10 +1,11 @@
 use super::{
     archive_filter_for, emit_progress_resolved, host_platform_selector, node_extras_filter,
-    render_variant_targets,
+    render_variant_targets, synthesize_runtime_manifest_bytes,
 };
 use pacquet_graph_hasher::{host_arch, host_libc, host_platform};
 use pacquet_lockfile::{
-    LockfileResolution, PackageKey, PlatformAssetResolution, PlatformAssetTarget,
+    BinaryArchive, BinaryResolution, BinarySpec, LockfileResolution, PackageKey,
+    PlatformAssetResolution, PlatformAssetTarget,
 };
 use pacquet_reporter::{LogEvent, ProgressMessage, Reporter};
 use pretty_assertions::assert_eq;
@@ -206,4 +207,91 @@ fn archive_filter_for_only_returns_filter_for_unscoped_node() {
         archive_filter_for(&key_bun).is_none(),
         "bun runtime has no bundled-tooling filter upstream (yet); leaving it `None` matches",
     );
+}
+
+/// `synthesize_runtime_manifest_bytes` is the
+/// `appendManifest`-equivalent for the runtime fetcher: it writes a
+/// `name` / `version` / `bin` JSON object into the CAS so the
+/// existing bin-link step (which reads bins off the slot's
+/// `package.json`) has something to consume. Pin the wire shape
+/// for both `BinarySpec` variants (single string + map) so a
+/// regression in either branch can't silently strip the bin field
+/// downstream.
+#[test]
+fn synthesize_runtime_manifest_emits_name_version_and_bin_single() {
+    let key: PackageKey = "node@22.0.0".parse().expect("parse node key");
+    let binary = BinaryResolution {
+        url: "https://nodejs.org/dist/v22.0.0/node-v22.0.0-darwin-arm64.tar.gz".to_string(),
+        integrity: "sha512-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa==".parse().expect("parse integrity"),
+        bin: BinarySpec::Single("bin/node".to_string()),
+        archive: BinaryArchive::Tarball,
+        prefix: None,
+    };
+
+    let bytes = synthesize_runtime_manifest_bytes(&key, &binary)
+        .expect("synth must succeed for a well-formed BinarySpec::Single");
+    let parsed: serde_json::Value =
+        serde_json::from_slice(&bytes).expect("synth bytes must round-trip through serde_json");
+
+    dbg!(&parsed);
+    assert_eq!(parsed["name"], "node");
+    assert_eq!(parsed["version"], "22.0.0");
+    // `BinarySpec::Single` lands as a JSON string. pnpm's bin
+    // resolver treats `bin: "bin/node"` as "one binary, named after
+    // the package" — so the shim is `<modules_dir>/.bin/node` →
+    // `<slot>/bin/node`. Preserve that exact shape.
+    assert_eq!(parsed["bin"], "bin/node");
+}
+
+#[test]
+fn synthesize_runtime_manifest_emits_name_version_and_bin_map() {
+    let key: PackageKey = "node@22.0.0".parse().expect("parse node key");
+    let mut bin_map = std::collections::BTreeMap::new();
+    bin_map.insert("node".to_string(), "bin/node".to_string());
+    bin_map.insert("node-mips".to_string(), "bin/node-mips".to_string());
+    let binary = BinaryResolution {
+        url: "https://nodejs.org/dist/v22.0.0/node-v22.0.0-darwin-arm64.tar.gz".to_string(),
+        integrity: "sha512-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa==".parse().expect("parse integrity"),
+        bin: BinarySpec::Map(bin_map),
+        archive: BinaryArchive::Tarball,
+        prefix: None,
+    };
+
+    let bytes = synthesize_runtime_manifest_bytes(&key, &binary)
+        .expect("synth must succeed for a well-formed BinarySpec::Map");
+    let parsed: serde_json::Value =
+        serde_json::from_slice(&bytes).expect("synth bytes must round-trip");
+
+    dbg!(&parsed);
+    assert_eq!(parsed["name"], "node");
+    assert_eq!(parsed["version"], "22.0.0");
+    // `BinarySpec::Map` lands as a JSON object. Each entry pins
+    // (bin_name → relative path); pnpm's bin resolver creates one
+    // shim per entry under `<modules_dir>/.bin/<bin_name>`.
+    assert_eq!(parsed["bin"]["node"], "bin/node");
+    assert_eq!(parsed["bin"]["node-mips"], "bin/node-mips");
+}
+
+/// Scoped packages preserve the `@scope/name` form in the
+/// synthesized manifest's `name` field — `PkgName`'s Display
+/// already handles that, and the synth function passes the result
+/// through verbatim. Future runtime entries could conceivably ship
+/// scoped (e.g. `@deno/runtime`) so pin the shape now rather than
+/// catch it later.
+#[test]
+fn synthesize_runtime_manifest_preserves_scoped_name() {
+    let key: PackageKey = "@foo/bar@1.2.3".parse().expect("parse scoped key");
+    let binary = BinaryResolution {
+        url: "https://example.test/foo-bar-1.2.3.tar.gz".to_string(),
+        integrity: "sha512-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa==".parse().expect("parse integrity"),
+        bin: BinarySpec::Single("bin/bar".to_string()),
+        archive: BinaryArchive::Tarball,
+        prefix: None,
+    };
+
+    let bytes = synthesize_runtime_manifest_bytes(&key, &binary).expect("synth must succeed");
+    let parsed: serde_json::Value = serde_json::from_slice(&bytes).expect("round-trip");
+
+    assert_eq!(parsed["name"], "@foo/bar");
+    assert_eq!(parsed["version"], "1.2.3");
 }

--- a/crates/package-manager/src/install_package_from_registry/tests.rs
+++ b/crates/package-manager/src/install_package_from_registry/tests.rs
@@ -31,6 +31,7 @@ fn create_config(store_dir: &Path, modules_dir: &Path, virtual_store_dir: &Path)
         modules_cache_max_age: 0,
         lockfile: false,
         prefer_frozen_lockfile: false,
+        skip_runtimes: false,
         lockfile_include_tarball_url: false,
         registry: "https://registry.npmjs.com/".to_string(),
         auto_install_peers: false,

--- a/crates/package-manager/src/link_bins.rs
+++ b/crates/package-manager/src/link_bins.rs
@@ -6,7 +6,7 @@ use pacquet_cmd_shim::{
     FsSetExecutable, FsWalkFiles, FsWrite, LinkBinsError, PackageBinSource, RealApi,
     link_bins_of_packages,
 };
-use pacquet_lockfile::{PackageKey, PackageMetadata, PkgName, SnapshotEntry};
+use pacquet_lockfile::{LockfileResolution, PackageKey, PackageMetadata, PkgName, SnapshotEntry};
 use rayon::prelude::*;
 use std::{
     collections::{HashMap, HashSet},
@@ -223,7 +223,23 @@ fn build_has_bin_set(
     Some(
         packages
             .iter()
-            .filter(|(_, meta)| meta.has_bin == Some(true))
+            .filter(|(_, meta)| {
+                // Runtime resolutions (`Binary` / `Variations`)
+                // always synthesize a `package.json` carrying the
+                // lockfile-declared `bin` field
+                // (see `synthesize_runtime_manifest_bytes` in
+                // `install_package_by_snapshot.rs`), so they
+                // always have bins — even when `hasBin` is absent
+                // from the lockfile metadata (which pnpm v11 does
+                // not emit for runtime entries today). Including
+                // them here unconditionally keeps the bin-link
+                // dispatch consistent with the synthesis step.
+                meta.has_bin == Some(true)
+                    || matches!(
+                        meta.resolution,
+                        LockfileResolution::Binary(_) | LockfileResolution::Variations(_),
+                    )
+            })
             .map(|(key, _)| key.clone())
             .collect(),
     )

--- a/crates/package-manager/src/link_bins/tests.rs
+++ b/crates/package-manager/src/link_bins/tests.rs
@@ -1,8 +1,16 @@
-use super::{LinkVirtualStoreBins, LinkVirtualStoreBinsError, link_direct_dep_bins};
+use super::{
+    LinkVirtualStoreBins, LinkVirtualStoreBinsError, build_has_bin_set, link_direct_dep_bins,
+};
 use crate::{SkippedSnapshots, VirtualStoreLayout};
 use pacquet_cmd_shim::is_shim_pointing_at;
+use pacquet_lockfile::{
+    BinaryArchive, BinaryResolution, BinarySpec, DirectoryResolution, LockfileResolution,
+    PackageKey, PackageMetadata, PlatformAssetResolution, PlatformAssetTarget, RegistryResolution,
+    VariationsResolution,
+};
 use serde_json::json;
 use std::{
+    collections::HashMap,
     fs::{create_dir_all, read_to_string, write as write_file},
     iter::{Empty, empty},
     path::{Path, PathBuf},
@@ -482,4 +490,116 @@ fn link_virtual_store_bins_propagates_read_error_via_di() {
     .run_with::<DenyVirtualStore>()
     .expect_err("read_dir error must propagate");
     assert!(matches!(err, LinkVirtualStoreBinsError::ReadVirtualStore { .. }));
+}
+
+/// Build a minimal [`PackageMetadata`] for the runtime-skip / bin-set
+/// tests. Only `resolution` and `has_bin` matter for these tests;
+/// every other field is `None`.
+fn metadata_with_resolution(
+    resolution: LockfileResolution,
+    has_bin: Option<bool>,
+) -> PackageMetadata {
+    PackageMetadata {
+        resolution,
+        engines: None,
+        cpu: None,
+        os: None,
+        libc: None,
+        deprecated: None,
+        has_bin,
+        prepare: None,
+        bundled_dependencies: None,
+        peer_dependencies: None,
+        peer_dependencies_meta: None,
+    }
+}
+
+fn dummy_binary_resolution() -> BinaryResolution {
+    BinaryResolution {
+        url: "https://example.test/node.tar.gz".to_string(),
+        integrity: "sha512-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa==".parse().expect("parse integrity"),
+        bin: BinarySpec::Single("bin/node".to_string()),
+        archive: BinaryArchive::Tarball,
+        prefix: None,
+    }
+}
+
+/// `build_has_bin_set` must include runtime resolutions
+/// (`Binary` / `Variations`) unconditionally, *regardless of*
+/// `meta.has_bin`. Pnpm v11 doesn't emit `hasBin: true` for
+/// runtime entries in `pnpm-lock.yaml` (the bin info lives on
+/// `resolution.bin`, not at the metadata level), so the existing
+/// `has_bin == Some(true)` filter would drop runtime slots from
+/// the bin-link dispatch and the synthesized `package.json`
+/// (from `install_package_by_snapshot::synthesize_runtime_manifest_bytes`)
+/// would go unread. Verified by removing the runtime-arm match —
+/// the test fails as expected.
+#[test]
+fn build_has_bin_set_includes_runtime_resolutions_even_when_has_bin_is_absent() {
+    let registry_with_bin: PackageKey = "react@18.0.0".parse().expect("parse react key");
+    let registry_no_bin: PackageKey = "lodash@4.17.0".parse().expect("parse lodash key");
+    let runtime_binary: PackageKey = "node@22.0.0".parse().expect("parse node key");
+    let runtime_variations: PackageKey = "node@20.0.0".parse().expect("parse node@20 key");
+    let directory: PackageKey = "@org/local@1.0.0".parse().expect("parse local key");
+
+    let mut packages = HashMap::new();
+    packages.insert(
+        registry_with_bin.clone(),
+        metadata_with_resolution(
+            LockfileResolution::Registry(RegistryResolution {
+                integrity: "sha512-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa==".parse().expect("parse integrity"),
+            }),
+            Some(true),
+        ),
+    );
+    packages.insert(
+        registry_no_bin.clone(),
+        metadata_with_resolution(
+            LockfileResolution::Registry(RegistryResolution {
+                integrity: "sha512-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa==".parse().expect("parse integrity"),
+            }),
+            None,
+        ),
+    );
+    packages.insert(
+        runtime_binary.clone(),
+        // Runtime entry without `has_bin: true` (pnpm v11 does
+        // not emit it for runtimes). Must still land in the set.
+        metadata_with_resolution(LockfileResolution::Binary(dummy_binary_resolution()), None),
+    );
+    packages.insert(
+        runtime_variations.clone(),
+        metadata_with_resolution(
+            LockfileResolution::Variations(VariationsResolution {
+                variants: vec![PlatformAssetResolution {
+                    resolution: LockfileResolution::Binary(dummy_binary_resolution()),
+                    targets: vec![PlatformAssetTarget {
+                        os: "linux".into(),
+                        cpu: "x64".into(),
+                        libc: Some("glibc".into()),
+                    }],
+                }],
+            }),
+            None,
+        ),
+    );
+    packages.insert(
+        directory.clone(),
+        metadata_with_resolution(
+            LockfileResolution::Directory(DirectoryResolution { directory: "fixture".into() }),
+            None,
+        ),
+    );
+
+    let set = build_has_bin_set(Some(&packages)).expect("packages map present");
+    dbg!(&set);
+
+    assert!(set.contains(&registry_with_bin), "registry+has_bin must be in the set");
+    assert!(!set.contains(&registry_no_bin), "registry without has_bin must be filtered out");
+    assert!(set.contains(&runtime_binary), "Binary runtime must be in the set unconditionally");
+    assert!(
+        set.contains(&runtime_variations),
+        "Variations runtime must be in the set unconditionally",
+    );
+    assert!(!set.contains(&directory), "directory without has_bin must be filtered out");
 }


### PR DESCRIPTION
## Summary

Closes the install-pipeline side of [#437](https://github.com/pnpm/pacquet/issues/437). After this PR, a frozen-lockfile install can fetch a runtime archive, write its CAS-imported files into the virtual store slot, and create cmd-shims for the declared executables under each importer's `node_modules/.bin/`.

### Slice D3 — runtime bin-link integration

Runtime archives (`node@runtime:`, `deno@runtime:`, `bun@runtime:`) don't ship a `package.json`, so the existing bin-link step had nothing to consume off the slot. `fetch_binary_resolution_to_cas` now synthesizes one in the same shape upstream's [`appendManifest`](https://github.com/pnpm/pnpm/blob/94240bc046/fetching/binary-fetcher/src/index.ts) does:

```json
{ "name": "<pkg.name>", "version": "<pkg.version>", "bin": <BinarySpec> }
```

The bytes go through `StoreDir::write_cas_file` (same content-addressing as every other CAS-imported file), the resulting cas-path is inserted into the snapshot's `cas_paths` under `"package.json"`, and the existing `link_bins_of_packages` flow picks it up.

`link_bins::build_has_bin_set` now includes `Binary` / `Variations` resolutions unconditionally — pnpm v11 doesn't emit `hasBin: true` on runtime metadata, but the synthesized manifest always carries bins, so the lookup must not be gated on the metadata flag.

### Slice E — `--no-runtime` flag

- New `Config::skip_runtimes: bool` (default `false`, reserved for `pnpm-workspace.yaml` / `.npmrc` plumbing in a follow-up).
- New `InstallArgs::no_runtime` CLI flag (`--no-runtime`).
- CLI computes `config.skip_runtimes || --no-runtime` and threads it through `Install` → `InstallFrozenLockfile`. When `true`, every snapshot whose metadata resolution is `Binary` or `Variations` is added to the install-time skip set (re-using `add_optional_excluded` since the bucket count and `.modules.yaml.skipped` semantics line up with `--no-optional`).

### Slice F — what's in / what's deferred

Unit-tested:

- [x] `synthesize_runtime_manifest_emits_name_version_and_bin_single` — pins `BinarySpec::Single` → JSON string.
- [x] `synthesize_runtime_manifest_emits_name_version_and_bin_map` — pins `BinarySpec::Map` → JSON object.
- [x] `synthesize_runtime_manifest_preserves_scoped_name` — `@scope/name` round-trips through the `name` field.
- [x] `build_has_bin_set_includes_runtime_resolutions_even_when_has_bin_is_absent` — verified by removing the runtime arm (test fails as expected).
- [x] `archive_filter_for_only_returns_filter_for_unscoped_node` (from slice D2) covers the per-package filter dispatcher.
- [x] `node_extras_filter_matches_upstream_regex_alternations` (from slice D2) covers the regex port.

Deferred to a follow-up: end-to-end install fixtures (recorded-archive frozen-lockfile install, variant-mismatch error, `--no-runtime` integration, integrity-mismatch path, path-traversal). They need either a small recorded Node archive in the repo or a mockable `pnpm-resolution-mirror`; keeping this PR reviewable.

## Test plan

- [x] All 9 `install_package_by_snapshot::tests::*` pass.
- [x] All 15 `link_bins::tests::*` pass (added `build_has_bin_set_includes_runtime_resolutions...`).
- [x] All existing `pacquet-package-manager` tests pass (skip_runtimes threaded through every `Install { ... }` and `Config { ... }` literal across the workspace).
- [x] `just ready`, `taplo format --check`, `just dylint`, `cargo doc -D warnings` green.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI flag to skip installing runtime dependencies (Node, Deno, Bun)
  * Added a config option to exclude runtime dependencies from installs
  * Installer now synthesizes runtime package manifests when needed so runtime artifacts can be handled without full installs

* **Bug Fixes**
  * Bin-linking now recognizes synthesized runtime packages when determining available binaries

* **Tests**
  * Added and updated unit tests covering runtime synthesis and skip-runtime behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pacquet/pull/506)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->