### PR TITLE
fix(package-manager): link_hoisted_modules PkgIdWithPatchHash types

### DIFF
--- a/crates/package-manager/src/link_hoisted_modules.rs
+++ b/crates/package-manager/src/link_hoisted_modules.rs
@@ -31,6 +31,7 @@ use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_cmd_shim::LinkBinsError;
 use pacquet_config::PackageImportMethod;
+use pacquet_lockfile::PkgIdWithPatchHash;
 use pacquet_reporter::Reporter;
 use rayon::prelude::*;
 use std::{
@@ -51,7 +52,7 @@ use std::{
 /// directories (version conflict → some dirs nest under siblings)
 /// and the CAS contents are the same regardless of where they're
 /// extracted to.
-pub type CasPathsByPkgId = HashMap<String, HashMap<String, PathBuf>>;
+pub type CasPathsByPkgId = HashMap<PkgIdWithPatchHash, HashMap<String, PathBuf>>;
 
 /// Inputs the linker reads from. Borrows everything so callers
 /// can keep ownership of the graph / CAS state — the linker
@@ -99,7 +100,7 @@ pub enum LinkHoistedModulesError {
     /// it wasn't given.
     #[display("Missing CAS paths for required package {pkg_id_with_patch_hash:?} at {dir:?}")]
     #[diagnostic(code(ERR_PACQUET_LINK_HOISTED_MISSING_CAS))]
-    MissingCasPaths { pkg_id_with_patch_hash: String, dir: PathBuf },
+    MissingCasPaths { pkg_id_with_patch_hash: PkgIdWithPatchHash, dir: PathBuf },
 
     /// A hierarchy entry referenced a directory that has no
     /// corresponding entry in `graph`. Slice 4's walker inserts

--- a/crates/package-manager/src/link_hoisted_modules/tests.rs
+++ b/crates/package-manager/src/link_hoisted_modules/tests.rs
@@ -10,7 +10,7 @@ use super::{
 };
 use crate::{DepHierarchy, DependenciesGraph, DependenciesGraphNode};
 use pacquet_config::PackageImportMethod;
-use pacquet_lockfile::{DirectoryResolution, LockfileResolution};
+use pacquet_lockfile::{DirectoryResolution, LockfileResolution, PkgIdWithPatchHash};
 use pacquet_modules_yaml::DepPath;
 use pacquet_reporter::SilentReporter;
 use pretty_assertions::assert_eq;
@@ -33,7 +33,7 @@ fn make_node(alias: &str, dep_path: &str, pkg_id: &str, dir: PathBuf) -> Depende
     DependenciesGraphNode {
         alias: Some(alias.to_string()),
         dep_path: DepPath::from(dep_path.to_string()),
-        pkg_id_with_patch_hash: pkg_id.to_string(),
+        pkg_id_with_patch_hash: PkgIdWithPatchHash::from(pkg_id),
         dir,
         modules,
         children: BTreeMap::new(),
@@ -98,7 +98,7 @@ fn flat_layout(
         let dir = modules.join(alias);
         graph.insert(dir.clone(), make_node(alias, dep_path, pkg_id, dir.clone()));
         hierarchy_children.insert(dir, DepHierarchy::default());
-        cas_paths.insert(pkg_id.to_string(), plant_package(cas_root, pkg_id, files));
+        cas_paths.insert(PkgIdWithPatchHash::from(*pkg_id), plant_package(cas_root, pkg_id, files));
     }
     let mut hierarchy = BTreeMap::new();
     hierarchy.insert(lockfile_dir.to_path_buf(), DepHierarchy(hierarchy_children));
@@ -213,11 +213,11 @@ fn nested_hierarchy_materializes_inner_node_modules() {
 
     let mut cas_paths = CasPathsByPkgId::new();
     cas_paths.insert(
-        "outer@1.0.0".to_string(),
+        PkgIdWithPatchHash::from("outer@1.0.0"),
         plant_package(&cas_root, "outer@1.0.0", &[("package/outer.js", b"// outer")]),
     );
     cas_paths.insert(
-        "inner@2.0.0".to_string(),
+        PkgIdWithPatchHash::from("inner@2.0.0"),
         plant_package(&cas_root, "inner@2.0.0", &[("package/inner.js", b"// inner")]),
     );
 
@@ -270,7 +270,7 @@ fn missing_cas_for_required_dep_errors() {
     let err = link_hoisted_modules::<SilentReporter>(&opts).expect_err("required dep needs CAS");
     match err {
         LinkHoistedModulesError::MissingCasPaths { pkg_id_with_patch_hash, .. } => {
-            assert_eq!(pkg_id_with_patch_hash, "a@1.0.0");
+            assert_eq!(pkg_id_with_patch_hash, PkgIdWithPatchHash::from("a@1.0.0"));
         }
         other => panic!("expected MissingCasPaths, got {other:?}"),
     }


### PR DESCRIPTION
## Summary

Main is broken on `d5b33e75` — Slice 5 (#505) merged with `String` for `pkg_id_with_patch_hash` types after #504 had already switched the underlying `DependenciesGraphNode` field to the `PkgIdWithPatchHash` newtype. The GitHub auto-merge didn't surface the type mismatch.

`cargo check -p pacquet-package-manager` on `origin/main`:

```
error[E0277]: the trait bound `String: Borrow<PkgIdWithPatchHash>` is not satisfied
   --> crates/package-manager/src/link_hoisted_modules.rs:255:56
error[E0308]: mismatched types
   --> crates/package-manager/src/link_hoisted_modules.rs:260:37
expected `String`, found `PkgIdWithPatchHash`
```

## Fix

Switch the two slice-5-introduced surfaces to use `PkgIdWithPatchHash`:

- **`CasPathsByPkgId`** — `HashMap<String, _>` → `HashMap<PkgIdWithPatchHash, _>`. The CAS index now keys on the brand the graph node carries.
- **`LinkHoistedModulesError::MissingCasPaths.pkg_id_with_patch_hash`** — `String` → `PkgIdWithPatchHash`. Same type the graph node has, so the error round-trips the value without `.to_string()`.

Tests updated to construct `PkgIdWithPatchHash::from(...)` keys/fields.

## Test plan

- [x] All 8 linker tests pass on the fix branch.
- [x] `just ready` (893 tests, all green).
- [x] `cargo doc --document-private-items`, `taplo format --check`, `just dylint` clean.

---
Written by an agent (Claude Code, claude-opus-4-7).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal package manager data structures to use a more consistent identifier format for package metadata. This improves alignment between different parts of the system handling package information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pacquet/pull/508)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->