### PR TITLE
fix(package-manager): use PkgIdWithPatchHash in CasPathsByPkgId after #481

### DIFF
--- a/crates/package-manager/src/link_hoisted_modules.rs
+++ b/crates/package-manager/src/link_hoisted_modules.rs
@@ -31,6 +31,7 @@ use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_cmd_shim::LinkBinsError;
 use pacquet_config::PackageImportMethod;
+use pacquet_lockfile::PkgIdWithPatchHash;
 use pacquet_reporter::Reporter;
 use rayon::prelude::*;
 use std::{
@@ -51,7 +52,13 @@ use std::{
 /// directories (version conflict → some dirs nest under siblings)
 /// and the CAS contents are the same regardless of where they're
 /// extracted to.
-pub type CasPathsByPkgId = HashMap<String, HashMap<String, PathBuf>>;
+///
+/// Keyed by the [`PkgIdWithPatchHash`] brand rather than a plain
+/// `String` so the type system tracks the same intent as
+/// [`DependenciesGraphNode::pkg_id_with_patch_hash`] — `#481`'s
+/// String → newtype migration. A `HashMap<String, _>` would let
+/// any string slip in and silently miss the lookup.
+pub type CasPathsByPkgId = HashMap<PkgIdWithPatchHash, HashMap<String, PathBuf>>;
 
 /// Inputs the linker reads from. Borrows everything so callers
 /// can keep ownership of the graph / CAS state — the linker
@@ -97,9 +104,9 @@ pub enum LinkHoistedModulesError {
     /// `cas_paths_by_pkg_id`. Indicates a bug in the caller
     /// (pre-fetch incomplete) — the linker can't conjure files
     /// it wasn't given.
-    #[display("Missing CAS paths for required package {pkg_id_with_patch_hash:?} at {dir:?}")]
+    #[display("Missing CAS paths for required package {pkg_id_with_patch_hash} at {dir:?}")]
     #[diagnostic(code(ERR_PACQUET_LINK_HOISTED_MISSING_CAS))]
-    MissingCasPaths { pkg_id_with_patch_hash: String, dir: PathBuf },
+    MissingCasPaths { pkg_id_with_patch_hash: PkgIdWithPatchHash, dir: PathBuf },
 
     /// A hierarchy entry referenced a directory that has no
     /// corresponding entry in `graph`. Slice 4's walker inserts

--- a/crates/package-manager/src/link_hoisted_modules/tests.rs
+++ b/crates/package-manager/src/link_hoisted_modules/tests.rs
@@ -10,7 +10,7 @@ use super::{
 };
 use crate::{DepHierarchy, DependenciesGraph, DependenciesGraphNode};
 use pacquet_config::PackageImportMethod;
-use pacquet_lockfile::{DirectoryResolution, LockfileResolution};
+use pacquet_lockfile::{DirectoryResolution, LockfileResolution, PkgIdWithPatchHash};
 use pacquet_modules_yaml::DepPath;
 use pacquet_reporter::SilentReporter;
 use pretty_assertions::assert_eq;
@@ -33,7 +33,7 @@ fn make_node(alias: &str, dep_path: &str, pkg_id: &str, dir: PathBuf) -> Depende
     DependenciesGraphNode {
         alias: Some(alias.to_string()),
         dep_path: DepPath::from(dep_path.to_string()),
-        pkg_id_with_patch_hash: pkg_id.to_string(),
+        pkg_id_with_patch_hash: PkgIdWithPatchHash::from(pkg_id),
         dir,
         modules,
         children: BTreeMap::new(),
@@ -98,7 +98,7 @@ fn flat_layout(
         let dir = modules.join(alias);
         graph.insert(dir.clone(), make_node(alias, dep_path, pkg_id, dir.clone()));
         hierarchy_children.insert(dir, DepHierarchy::default());
-        cas_paths.insert(pkg_id.to_string(), plant_package(cas_root, pkg_id, files));
+        cas_paths.insert(PkgIdWithPatchHash::from(*pkg_id), plant_package(cas_root, pkg_id, files));
     }
     let mut hierarchy = BTreeMap::new();
     hierarchy.insert(lockfile_dir.to_path_buf(), DepHierarchy(hierarchy_children));
@@ -213,11 +213,11 @@ fn nested_hierarchy_materializes_inner_node_modules() {
 
     let mut cas_paths = CasPathsByPkgId::new();
     cas_paths.insert(
-        "outer@1.0.0".to_string(),
+        PkgIdWithPatchHash::from("outer@1.0.0"),
         plant_package(&cas_root, "outer@1.0.0", &[("package/outer.js", b"// outer")]),
     );
     cas_paths.insert(
-        "inner@2.0.0".to_string(),
+        PkgIdWithPatchHash::from("inner@2.0.0"),
         plant_package(&cas_root, "inner@2.0.0", &[("package/inner.js", b"// inner")]),
     );
 
@@ -270,7 +270,7 @@ fn missing_cas_for_required_dep_errors() {
     let err = link_hoisted_modules::<SilentReporter>(&opts).expect_err("required dep needs CAS");
     match err {
         LinkHoistedModulesError::MissingCasPaths { pkg_id_with_patch_hash, .. } => {
-            assert_eq!(pkg_id_with_patch_hash, "a@1.0.0");
+            assert_eq!(pkg_id_with_patch_hash, PkgIdWithPatchHash::from("a@1.0.0"));
         }
         other => panic!("expected MissingCasPaths, got {other:?}"),
     }


### PR DESCRIPTION
## Problem

CI on `main` is failing across every job (Doc, Dylint, Lint and Test on macos / ubuntu / windows) — see [run 25831190878](https://github.com/pnpm/pacquet/actions/runs/25831190878/job/75896265070). Two errors in `link_hoisted_modules.rs`:

```
error[E0277]: the trait bound `String: Borrow<PkgIdWithPatchHash>` is not satisfied
   --> crates/package-manager/src/link_hoisted_modules.rs:255:56
255 | let Some(cas_paths) = opts.cas_paths_by_pkg_id.get(&node.pkg_id_with_patch_hash) else {

error[E0308]: mismatched types
   --> crates/package-manager/src/link_hoisted_modules.rs:260:37
260 |             pkg_id_with_patch_hash: node.pkg_id_with_patch_hash.clone(),
    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `String`, found `PkgIdWithPatchHash`
```

Two recently-merged PRs collided:

- **#504 (`fa418507`)** — `PkgIdWithPatchHash` newtype replaces `String` in dep-graph nodes (`DependenciesGraphNode.pkg_id_with_patch_hash` field type).
- **#505 (`d5b33e75`)** — `linkHoistedModules` linker (#438 slice 5) consumes `pkg_id_with_patch_hash` as `String`. Both PRs passed CI individually but the merge order leaves the linker consuming the old shape against the new field type.

## Fix

Update the linker to follow the brand:

- `CasPathsByPkgId` becomes `HashMap<PkgIdWithPatchHash, _>` (was `HashMap<String, _>`). The brand exists for type safety per `CLAUDE.md`'s branded-string-types section — keying the map by the brand matches `DependenciesGraphNode.pkg_id_with_patch_hash` and keeps the `.get()` lookup statically correct.
- `LinkHoistedModulesError::MissingCasPaths.pkg_id_with_patch_hash` switches from `String` to `PkgIdWithPatchHash`. The error message format string changes from `{...:?}` (debug) to `{...}` (Display) since `PkgIdWithPatchHash` impls Display to print the underlying string verbatim.
- Three test sites updated to construct `PkgIdWithPatchHash` via `From<&str>` rather than `String`.

## Test plan

- [x] `just ready` — 1186/1186 pass (matches the `Lint and Test` CI job that's currently failing on main)
- [x] `cargo doc --workspace --no-deps` with `RUSTDOCFLAGS="-D warnings"` — clean (matches the failing `Doc` job)
- [x] `just dylint` — clean (matches the failing `Dylint` job)
- [x] `taplo format --check` — clean

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to package identification type system for enhanced type safety and consistency.

* **Tests**
  * Updated test coverage to reflect package identification system changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pacquet/pull/510)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->