### PR TITLE
feat(lockfile): support runtime: prefix on PkgVerPeer (#511)

### DIFF
--- a/crates/lockfile/src/pkg_ver_peer.rs
+++ b/crates/lockfile/src/pkg_ver_peer.rs
@@ -1,24 +1,76 @@
 use derive_more::{Display, Error};
 use node_semver::{SemverError, Version};
 use serde::{Deserialize, Serialize};
-use std::{borrow::Cow, str::FromStr};
+use std::{borrow::Cow, fmt, str::FromStr};
 
 /// Suffix type of [`PkgNameVerPeer`](crate::PkgNameVerPeer) and
 /// type of [`ResolvedDependencySpec::version`](crate::ResolvedDependencySpec::version).
 ///
 /// Example: `1.21.3(@types/react@17.0.49)(react-dom@17.0.2)(react@17.0.2)`
 ///
+/// Runtime entries (pnpm v11's `node@runtime:` /  `deno@runtime:` /
+/// `bun@runtime:` deps) carry a `runtime:` prefix in front of the
+/// version part (e.g. `runtime:22.0.0`). Pacquet preserves that
+/// prefix through [`Prefix`] so a round-trip stays byte-stable
+/// against pnpm's `pnpm-lock.yaml` output. Mirrors upstream's
+/// depPath shape at
+/// [`engine/runtime/node-resolver`](https://github.com/pnpm/pnpm/blob/94240bc046/engine/runtime/node-resolver/src/index.ts).
+///
 /// **NOTE:** The peer part isn't guaranteed to be correct. It is only assumed to be.
 #[derive(Debug, Display, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[display("{version}{peer}")]
+#[display("{prefix}{version}{peer}")]
 #[serde(try_from = "Cow<'de, str>", into = "String")]
 pub struct PkgVerPeer {
+    /// Scheme prefix (e.g. `runtime:`) preserved verbatim through
+    /// the round-trip. [`Prefix::None`] for plain semver — the only
+    /// shape pacquet recognises before pnpm v11.
+    prefix: Prefix,
     version: Version,
     peer: String,
 }
 
+/// Optional scheme prefix on a [`PkgVerPeer`].
+///
+/// Pnpm v11 introduces `runtime:` for runtime dependencies; pacquet
+/// preserves the substring so the resulting depPath
+/// (e.g. `node@runtime:22.0.0`) round-trips correctly and downstream
+/// consumers (the `--no-runtime` filter, the install dispatcher)
+/// can discriminate runtime entries by their prefix instead of
+/// substring-searching the depPath.
+///
+/// The enum is closed because pnpm only defines this one scheme so
+/// far; if upstream adds another (e.g. `tag:`), add a variant here
+/// rather than turning the prefix into an unbounded string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Prefix {
+    /// No prefix — plain semver, the default before pnpm v11.
+    None,
+    /// `runtime:` — runtime dependency specifier (`node@runtime:`,
+    /// `deno@runtime:`, `bun@runtime:`).
+    Runtime,
+}
+
+impl Prefix {
+    /// String form, including the trailing `:` for non-`None`
+    /// variants. Round-trips through the parser.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Prefix::None => "",
+            Prefix::Runtime => "runtime:",
+        }
+    }
+}
+
+impl fmt::Display for Prefix {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 impl PkgVerPeer {
-    /// Get the version part.
+    /// Get the version part. The `runtime:` prefix (if any) is
+    /// stripped — callers that need to discriminate runtime
+    /// entries should consult [`PkgVerPeer::prefix`] instead.
     pub fn version(&self) -> &'_ Version {
         &self.version
     }
@@ -28,9 +80,18 @@ impl PkgVerPeer {
         self.peer.as_str()
     }
 
+    /// Get the prefix variant.
+    pub fn prefix(&self) -> Prefix {
+        self.prefix
+    }
+
     /// Destructure the struct into a tuple of version and peer.
+    /// The prefix (if any) is dropped — keep the call shape
+    /// backward-compatible with pre-runtime consumers. New callers
+    /// that need the prefix should access it via
+    /// [`PkgVerPeer::prefix`] before destructuring.
     pub fn into_tuple(self) -> (Version, String) {
-        let PkgVerPeer { version, peer } = self;
+        let PkgVerPeer { prefix: _, version, peer } = self;
         (version, peer)
     }
 }
@@ -47,22 +108,33 @@ pub enum ParsePkgVerPeerError {
 impl FromStr for PkgVerPeer {
     type Err = ParsePkgVerPeerError;
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        if !value.ends_with(')') {
-            if value.find(['(', ')']).is_some() {
+        // Strip a leading `runtime:` (or future scheme) before
+        // anything else. Pnpm v11 writes the depPath with the
+        // scheme prefix flush against the semver, e.g.
+        // `runtime:22.0.0` — splitting it off here keeps the
+        // parenthesis-based peer-suffix detection below unchanged.
+        let (prefix, body) = if let Some(rest) = value.strip_prefix(Prefix::Runtime.as_str()) {
+            (Prefix::Runtime, rest)
+        } else {
+            (Prefix::None, value)
+        };
+
+        if !body.ends_with(')') {
+            if body.find(['(', ')']).is_some() {
                 return Err(ParsePkgVerPeerError::MismatchParenthesis);
             }
 
-            let version = value.parse().map_err(ParsePkgVerPeerError::ParseVersionFailure)?;
-            return Ok(PkgVerPeer { version, peer: String::new() });
+            let version = body.parse().map_err(ParsePkgVerPeerError::ParseVersionFailure)?;
+            return Ok(PkgVerPeer { prefix, version, peer: String::new() });
         }
 
         let opening_parenthesis =
-            value.find('(').ok_or(ParsePkgVerPeerError::MismatchParenthesis)?;
-        let version = value[..opening_parenthesis]
+            body.find('(').ok_or(ParsePkgVerPeerError::MismatchParenthesis)?;
+        let version = body[..opening_parenthesis]
             .parse()
             .map_err(ParsePkgVerPeerError::ParseVersionFailure)?;
-        let peer = value[opening_parenthesis..].to_string();
-        Ok(PkgVerPeer { version, peer })
+        let peer = body[opening_parenthesis..].to_string();
+        Ok(PkgVerPeer { prefix, version, peer })
     }
 }
 

--- a/crates/lockfile/src/pkg_ver_peer/tests.rs
+++ b/crates/lockfile/src/pkg_ver_peer/tests.rs
@@ -1,4 +1,4 @@
-use super::{ParsePkgVerPeerError, PkgVerPeer};
+use super::{ParsePkgVerPeerError, PkgVerPeer, Prefix};
 use node_semver::Version;
 use pretty_assertions::assert_eq;
 
@@ -117,4 +117,75 @@ fn deserialize_serialize() {
     case("1.21.3-rc.0(react@17.0.2)");
     case("1.21.3");
     case("1.21.3-rc.0");
+}
+
+/// Pnpm v11 writes runtime depPaths with a `runtime:` prefix in
+/// front of the semver (e.g. `node@runtime:22.0.0` in the
+/// lockfile's `packages:` / `snapshots:` keys). Pacquet's parser
+/// must accept the prefix and preserve it through Display so a
+/// `serde_saphyr` round-trip stays byte-stable. Pre-runtime
+/// callers that only read `version()` continue to see the bare
+/// semver — the prefix is exposed separately via
+/// [`PkgVerPeer::prefix`].
+#[test]
+fn parse_runtime_prefix_round_trips() {
+    let parsed: PkgVerPeer = "runtime:22.0.0".parse().expect("parse runtime version");
+    dbg!(&parsed);
+    assert_eq!(parsed.prefix(), Prefix::Runtime);
+    assert_eq!(parsed.version(), &"22.0.0".parse::<Version>().unwrap());
+    assert_eq!(parsed.peer(), "");
+    assert_eq!(parsed.to_string(), "runtime:22.0.0");
+}
+
+/// The `runtime:` prefix composes with the peer-dependency suffix.
+/// In real lockfiles a runtime entry never carries a peer (pnpm
+/// doesn't write one), but pacquet's parser doesn't need to make
+/// that assumption — pin the combinatorial behavior here so a
+/// future runtime-with-peer fixture parses cleanly rather than
+/// erroring.
+#[test]
+fn parse_runtime_prefix_with_peer_suffix() {
+    let parsed: PkgVerPeer =
+        "runtime:22.0.0(node@22.0.0)".parse().expect("parse runtime with peer");
+    dbg!(&parsed);
+    assert_eq!(parsed.prefix(), Prefix::Runtime);
+    assert_eq!(parsed.version(), &"22.0.0".parse::<Version>().unwrap());
+    assert_eq!(parsed.peer(), "(node@22.0.0)");
+    assert_eq!(parsed.to_string(), "runtime:22.0.0(node@22.0.0)");
+}
+
+/// Bare semver (the only shape pre-pnpm-v11) has
+/// `Prefix::None` and Display omits the prefix.
+#[test]
+fn parse_bare_semver_has_no_prefix() {
+    let parsed: PkgVerPeer = "1.21.3".parse().expect("parse bare");
+    assert_eq!(parsed.prefix(), Prefix::None);
+    assert_eq!(parsed.to_string(), "1.21.3");
+}
+
+/// A version string that *looks* like a prefix mid-name (i.e.
+/// `1.21.3-runtime:`) must NOT be parsed as a `runtime:` prefix —
+/// the prefix detection is anchored at the start. This pins the
+/// `strip_prefix` choice (vs. e.g. `contains`) so a regression
+/// can't accidentally widen the match.
+#[test]
+fn parse_runtime_substring_in_version_is_not_a_prefix() {
+    // `1.21.3-runtime` is a valid semver pre-release tag.
+    let parsed: PkgVerPeer = "1.21.3-runtime".parse().expect("parse semver pre-release");
+    assert_eq!(parsed.prefix(), Prefix::None);
+    assert_eq!(parsed.version(), &"1.21.3-runtime".parse::<Version>().unwrap());
+}
+
+/// Serde round-trip on a runtime version — pacquet stores
+/// `PkgVerPeer` inside `ResolvedDependencySpec`, `PkgNameVerPeer`,
+/// and others; their serde proxies through `PkgVerPeer`'s
+/// `try_from = "Cow<str>"` / `into = "String"` impls, so this
+/// test pins the wire shape end-to-end.
+#[test]
+fn serde_round_trip_runtime_prefix() {
+    let parsed: PkgVerPeer = serde_saphyr::from_str("runtime:22.0.0").expect("deserialize runtime");
+    assert_eq!(parsed.prefix(), Prefix::Runtime);
+    assert_eq!(parsed.version(), &"22.0.0".parse::<Version>().unwrap());
+    let serialized = serde_saphyr::to_string(&parsed).expect("serialize").trim().to_string();
+    assert_eq!(serialized, "runtime:22.0.0");
 }


### PR DESCRIPTION
## Summary

Closes [#511](https://github.com/pnpm/pacquet/issues/511). Pnpm v11 writes runtime depPaths with a scheme prefix in front of the semver — e.g. `node@runtime:22.0.0` in `packages:` / `snapshots:` keys, and `runtime:22.0.0` as importer-`dependencies:` values. Pacquet's `PkgVerPeer` parser previously accepted only bare semver and rejected the prefix, so it couldn't load any v11 lockfile containing a runtime dependency.

Unblocks slice F of [#437](https://github.com/pnpm/pacquet/issues/437) (end-to-end install fixtures — variant-mismatch, `--no-runtime` integration, integrity-mismatch).

## Approach

- New closed enum `Prefix { None, Runtime }` — `runtime:` is the only scheme pnpm defines so far; future schemes (e.g. `tag:`) add a variant rather than turning the prefix into an unbounded string.
- `PkgVerPeer::from_str` strips a leading `runtime:` once up front; the existing parenthesis-based peer-suffix detection runs on the remainder unchanged.
- `Display` and `serde` proxy through the prefix so a round-trip stays byte-stable.
- `PkgVerPeer::prefix()` accessor exposes the variant for downstream consumers (the `--no-runtime` filter currently substring-searches `@runtime:` on the constructed depPath; a follow-up can switch to `prefix()`).
- `PkgVerPeer::into_tuple()` continues to return `(Version, String)` — pre-runtime callers don't see the prefix.

## Test plan

5 new unit tests + 5 existing — all pass:

- [x] `parse_runtime_prefix_round_trips` — bare `runtime:22.0.0` parses, Display round-trips, prefix == `Runtime`.
- [x] `parse_runtime_prefix_with_peer_suffix` — `runtime:22.0.0(node@22.0.0)` parses both prefix and peer.
- [x] `parse_bare_semver_has_no_prefix` — bare `1.21.3` → `Prefix::None`, Display omits prefix.
- [x] `parse_runtime_substring_in_version_is_not_a_prefix` — `1.21.3-runtime` (semver pre-release tag) parses as bare semver, not `Runtime` prefix. Pins the `strip_prefix` choice (vs. e.g. `contains`).
- [x] `serde_round_trip_runtime_prefix` — wire round-trip via `serde_saphyr`.
- [x] All 100 existing `pacquet-lockfile` tests still pass (`PkgVerPeer::version()` and `peer()` semantics unchanged).
- [x] `just ready`, `taplo format --check`, `just dylint`, `cargo doc -D warnings` green.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Package version specifications in lockfiles now support the "runtime:" prefix format
  * Parser recognizes and correctly processes runtime-prefixed version strings
  * String representation includes the prefix when applicable
  * Full backward compatibility maintained for non-prefixed versions

* **Tests**
  * New test suite validates parsing, serialization, and round-trip conversion of runtime-prefixed versions
  * Confirms prefix handling with peer dependencies and across serialization formats

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pacquet/pull/512)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->