### PR TITLE
feat(config,cli,tarball): support `offline` / `preferOffline` settings

### DIFF
--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -39,8 +39,8 @@
 | Done | Command                     | Notes |
 | ---- | --------------------------- | ----- |
 |      | --force                     |       |
-|      | --offline                   |       |
-|      | --prefer-offline            |       |
+| ✅   | --offline                   | Frozen-install only: refuses network fetches; errors with `ERR_PACQUET_NO_OFFLINE_TARBALL` when a snapshot isn't cached. Stage 2 resolver will additionally gate metadata fetches like upstream's `pickPackage`. |
+| ✅   | --prefer-offline            | No-op on frozen-install (warm prefetch already prefers the local store). Reserved for Stage 2's resolver. |
 |      | --prod                      |       |
 | ✅   | --dev                       |       |
 | ✅   | --no-optional               |       |

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -39,7 +39,7 @@
 | Done | Command                     | Notes |
 | ---- | --------------------------- | ----- |
 |      | --force                     |       |
-| ✅   | --offline                   | Frozen-install only: refuses network fetches; errors with `ERR_PACQUET_NO_OFFLINE_TARBALL` when a snapshot isn't cached. Stage 2 resolver will additionally gate metadata fetches like upstream's `pickPackage`. |
+| ✅   | --offline                   | Frozen-install only: refuses network fetches; errors with `ERR_PACQUET_NO_OFFLINE_TARBALL` when a snapshot isn't cached. Stage 2 resolver will additionally gate metadata fetches like upstream's [`pickPackage`](https://github.com/pnpm/pnpm/blob/94240bc046/resolving/npm-resolver/src/pickPackage.ts). |
 | ✅   | --prefer-offline            | No-op on frozen-install (warm prefetch already prefers the local store). Reserved for Stage 2's resolver. |
 |      | --prod                      |       |
 | ✅   | --dev                       |       |

--- a/crates/cli/src/cli_args.rs
+++ b/crates/cli/src/cli_args.rs
@@ -129,8 +129,21 @@ impl CliArgs {
                 ReporterType::Silent => args.run::<SilentReporter>(state(false)?).await?,
             },
             CliCommand::Install(args) => {
+                // CLI overrides for `offline` / `prefer_offline` live
+                // alongside `--frozen-lockfile`: they upgrade an
+                // unset / `false` yaml value to `true`, but cannot
+                // turn an explicit yaml `true` back off. Matches
+                // pnpm's CLI semantics — the flags are "enable", not
+                // a toggle. Applied here (between `config()` and
+                // `State::init`) while the loaded `Config` is still
+                // mutable through `Config::leak`'s
+                // `&'static mut Config` return.
+                let cfg = config()?;
+                cfg.offline = cfg.offline || args.offline;
+                cfg.prefer_offline = cfg.prefer_offline || args.prefer_offline;
                 let require_lockfile = args.frozen_lockfile;
-                let state = state(require_lockfile)?;
+                let state = State::init(manifest_path(), cfg, require_lockfile)
+                    .wrap_err("initialize the state")?;
                 match reporter {
                     ReporterType::Ndjson => args.run::<NdjsonReporter>(state).await?,
                     ReporterType::Silent => args.run::<SilentReporter>(state).await?,

--- a/crates/cli/src/cli_args/install.rs
+++ b/crates/cli/src/cli_args/install.rs
@@ -98,6 +98,38 @@ pub struct InstallArgs {
     /// `node_modules/` layout, `pnp` selects Plug'n'Play.
     #[clap(long = "node-linker", value_enum)]
     pub node_linker: Option<NodeLinkerArg>,
+
+    /// Refuse network tarball / zip-archive fetches on a cache miss.
+    /// When the warm prefetch and the `index.db` lookup both miss
+    /// for a package, pacquet fails with
+    /// `ERR_PACQUET_NO_OFFLINE_TARBALL` rather than hitting the
+    /// registry. Mirrors pnpm's
+    /// [`--offline`](https://github.com/pnpm/pnpm/blob/94240bc046/resolving/npm-resolver/src/pickPackage.ts)
+    /// in spirit; upstream's flag gates the metadata-fetch path
+    /// (`ERR_PNPM_NO_OFFLINE_META`), which pacquet doesn't have on
+    /// the frozen-install flow (the lockfile pins every
+    /// resolution), so this flag is currently scoped to artifact
+    /// fetches. Stage 2's resolver will extend the gate to the
+    /// metadata path, matching upstream byte-for-byte.
+    ///
+    /// Overrides `offline` from `pnpm-workspace.yaml`: any
+    /// `--offline` upgrades a yaml `false` to `true`, but cannot
+    /// turn an explicit yaml `true` back off.
+    #[clap(long)]
+    pub offline: bool,
+
+    /// Prefer cached artifacts over network fetches when both have
+    /// what's needed. Mirrors pnpm's
+    /// [`--prefer-offline`](https://github.com/pnpm/pnpm/blob/94240bc046/resolving/npm-resolver/src/pickPackage.ts)
+    /// in spirit; upstream's flag biases the metadata resolver to
+    /// the cached copy past the freshness window. Pacquet's
+    /// frozen-install path already prefers the local store via the
+    /// warm prefetch + `index.db` lookups, so the flag is a no-op
+    /// for artifact fetches today. Field exists so yaml / CLI parse
+    /// cleanly; Stage 2's resolver will honor it on the metadata
+    /// path the way upstream does.
+    #[clap(long)]
+    pub prefer_offline: bool,
 }
 
 impl InstallArgs {
@@ -110,6 +142,8 @@ impl InstallArgs {
             frozen_lockfile,
             no_runtime,
             node_linker,
+            offline: _,
+            prefer_offline: _,
         } = self;
 
         // Merge CLI overrides with the yaml-derived value before

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -272,6 +272,42 @@ pub struct Config {
     /// with another pacquet binary) flip this to `true`.
     pub skip_runtimes: bool,
 
+    /// Refuse network requests during install. Mirrors pnpm's
+    /// [`offline`](https://github.com/pnpm/pnpm/blob/94240bc046/resolving/npm-resolver/src/pickPackage.ts)
+    /// flag — upstream gates the metadata-fetch path with
+    /// `ERR_PNPM_NO_OFFLINE_META` when no cached metadata exists for a
+    /// spec. Pacquet doesn't have a metadata-fetch path yet (no
+    /// resolver until Stage 2), so the same flag instead gates
+    /// pacquet's tarball-fetch fall-through: when both the warm
+    /// prefetch and the SQLite `index.db` lookup miss, the tarball
+    /// fetcher fails fast with `ERR_PACQUET_NO_OFFLINE_TARBALL`
+    /// rather than hitting the registry. The frozen-lockfile install
+    /// path needs no metadata, so the surface area collapses to
+    /// "every snapshot must already be in the local store".
+    ///
+    /// Pacquet's tarball-side gate has no exact upstream counterpart
+    /// (pnpm doesn't gate the tarball fetcher on `offline`), but it's
+    /// the most useful interpretation of the flag for a frozen
+    /// installer: surface a clear `offline` error rather than letting
+    /// the underlying `connection refused` / DNS error propagate.
+    /// The Stage 2 resolver will additionally honor the flag on the
+    /// metadata path.
+    pub offline: bool,
+
+    /// Prefer the local store on read, fall back to the network on a
+    /// cache miss. Mirrors pnpm's
+    /// [`preferOffline`](https://github.com/pnpm/pnpm/blob/94240bc046/resolving/npm-resolver/src/pickPackage.ts)
+    /// flag, which biases the resolver to use cached metadata when
+    /// available even past the freshness window.
+    ///
+    /// Pacquet's frozen-install path already prefers the local store
+    /// — the warm prefetch + SQLite-cache lookups always run before
+    /// any network fetch — so `prefer_offline` is effectively a no-op
+    /// today. The field exists so `.npmrc` / yaml / CLI all parse the
+    /// flag cleanly; Stage 2's resolver will honor it the same way
+    /// upstream does.
+    pub prefer_offline: bool,
+
     /// Add the full URL to the package's tarball to every entry in pnpm-lock.yaml.
     pub lockfile_include_tarball_url: bool,
 

--- a/crates/config/src/workspace_yaml.rs
+++ b/crates/config/src/workspace_yaml.rs
@@ -113,6 +113,8 @@ pub struct WorkspaceSettings {
     pub modules_cache_max_age: Option<u64>,
     pub lockfile: Option<bool>,
     pub prefer_frozen_lockfile: Option<bool>,
+    pub offline: Option<bool>,
+    pub prefer_offline: Option<bool>,
     pub lockfile_include_tarball_url: Option<bool>,
     pub registry: Option<String>,
     pub auto_install_peers: Option<bool>,
@@ -290,7 +292,8 @@ impl WorkspaceSettings {
         apply! {
             hoist, shamefully_hoist,
             node_linker, symlink, package_import_method, modules_cache_max_age,
-            lockfile, prefer_frozen_lockfile, lockfile_include_tarball_url,
+            lockfile, prefer_frozen_lockfile, offline, prefer_offline,
+            lockfile_include_tarball_url,
             auto_install_peers, dedupe_peer_dependents, strict_peer_dependencies,
             resolve_peers_from_workspace_root, verify_store_integrity,
             side_effects_cache, side_effects_cache_readonly,

--- a/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/crates/package-manager/src/install_package_by_snapshot.rs
@@ -218,6 +218,7 @@ impl<'a> InstallPackageBySnapshot<'a> {
                     retry_opts: retry_opts_from_config(config),
                     auth_headers: &config.auth_headers,
                     ignore_file_pattern: None,
+                    offline: config.offline,
                 }
                 .run_without_mem_cache::<R>()
                 .await
@@ -601,6 +602,7 @@ async fn fetch_binary_resolution_to_cas<R: Reporter>(
             retry_opts: retry_opts_from_config(config),
             auth_headers: &config.auth_headers,
             ignore_file_pattern,
+            offline: config.offline,
         }
         .run_without_mem_cache::<R>()
         .await
@@ -621,6 +623,7 @@ async fn fetch_binary_resolution_to_cas<R: Reporter>(
             auth_headers: &config.auth_headers,
             archive_prefix: binary.prefix.as_deref(),
             ignore_file_pattern,
+            offline: config.offline,
         }
         .run_without_mem_cache::<R>()
         .await

--- a/crates/package-manager/src/install_package_from_registry.rs
+++ b/crates/package-manager/src/install_package_from_registry.rs
@@ -163,6 +163,7 @@ impl<'a> InstallPackageFromRegistry<'a> {
             retry_opts: retry_opts_from_config(config),
             auth_headers: &config.auth_headers,
             ignore_file_pattern: None,
+            offline: config.offline,
         }
         .run_with_mem_cache::<R>(tarball_mem_cache)
         .await

--- a/crates/package-manager/src/install_package_from_registry/tests.rs
+++ b/crates/package-manager/src/install_package_from_registry/tests.rs
@@ -32,6 +32,8 @@ fn create_config(store_dir: &Path, modules_dir: &Path, virtual_store_dir: &Path)
         lockfile: false,
         prefer_frozen_lockfile: false,
         skip_runtimes: false,
+        offline: false,
+        prefer_offline: false,
         lockfile_include_tarball_url: false,
         registry: "https://registry.npmjs.com/".to_string(),
         auto_install_peers: false,

--- a/crates/tarball/src/lib.rs
+++ b/crates/tarball/src/lib.rs
@@ -264,6 +264,32 @@ pub enum TarballError {
         #[error(source)]
         source: std::io::Error,
     },
+
+    /// `offline: true` was set and the package's tarball wasn't
+    /// found in the local store. Pacquet refuses to fetch the
+    /// network. Upstream pnpm's `--offline` only gates the metadata
+    /// fetch in [`pickPackage`](https://github.com/pnpm/pnpm/blob/94240bc046/resolving/npm-resolver/src/pickPackage.ts);
+    /// pacquet has no metadata fetch on the frozen-install path, so
+    /// the same flag's most useful effect lands here: surface a
+    /// clear "the snapshot isn't cached" error rather than letting
+    /// the underlying network refusal propagate.
+    ///
+    /// `ERR_PACQUET_NO_OFFLINE_TARBALL` is a pacquet-specific code
+    /// (upstream has no exact equivalent); the message shape
+    /// follows upstream's
+    /// [`ERR_PNPM_NO_OFFLINE_META`](https://github.com/pnpm/pnpm/blob/94240bc046/resolving/npm-resolver/src/pickPackage.ts)
+    /// — "Failed to resolve `<pkg>` in package mirror `<dir>`".
+    #[from(ignore)]
+    #[display(
+        "Failed to fetch tarball for {package_id} from {url} in offline mode: snapshot not present in local store"
+    )]
+    #[diagnostic(
+        code(ERR_PACQUET_NO_OFFLINE_TARBALL),
+        help(
+            "Drop `--offline` (or `offline=true` in pnpm-workspace.yaml) or run an online install first to populate the store."
+        )
+    )]
+    NoOfflineTarball { package_id: String, url: String },
 }
 
 /// Per-package callback that decides whether a given archive entry
@@ -1252,6 +1278,16 @@ pub struct DownloadTarballToStore<'a> {
     /// Arc per retry attempt is cheap; the inner trait object
     /// is shared.
     pub ignore_file_pattern: Option<Arc<IgnoreEntryFilter>>,
+    /// `offline` from `Config`. When `true` and both the warm
+    /// prefetch (`prefetched_cas_paths`) and the SQLite `index.db`
+    /// lookup (`load_cached_cas_paths`) miss, the fetcher fails fast
+    /// with [`TarballError::NoOfflineTarball`] rather than hitting
+    /// the registry. The upstream `--offline` flag gates the
+    /// metadata-fetch path inside `pickPackage`; pacquet has no
+    /// metadata-fetch path on the frozen-install flow (the lockfile
+    /// pins every resolution), so this gate is pacquet's most useful
+    /// interpretation of the flag for frozen installs.
+    pub offline: bool,
 }
 
 /// Project [`TarballError`] onto pnpm's `requestRetryLogger`'s
@@ -1309,6 +1345,16 @@ fn tarball_error_to_request_retry(err: &TarballError) -> RequestRetryError {
         }
         TarballError::ReadZipArchive { .. } | TarballError::ReadZipEntries { .. } => {
             out.code = Some("ERR_PACQUET_ZIP".to_string());
+        }
+        TarballError::NoOfflineTarball { .. } => {
+            // The retry classifier sees this only if the offline gate
+            // were ever placed inside the retry loop (it isn't —
+            // `NoOfflineTarball` short-circuits before
+            // `fetch_and_extract_with_retry`). The arm exists for
+            // exhaustiveness; the `code` field mirrors the upstream
+            // shape so a future surface that does run this error
+            // through the retry logger renders the right code.
+            out.code = Some("ERR_PACQUET_NO_OFFLINE_TARBALL".to_string());
         }
     }
     out
@@ -1912,6 +1958,26 @@ impl<'a> DownloadTarballToStore<'a> {
             return Ok(cas_paths);
         }
 
+        // Offline-mode gate: both cache lookups missed. Upstream pnpm
+        // gates only its metadata path on `--offline`; pacquet has no
+        // metadata path on the frozen-install flow, so the gate lands
+        // here. Error rather than fall through to the network — same
+        // shape as upstream's `ERR_PNPM_NO_OFFLINE_META`, scoped to
+        // tarballs because that's what pacquet's frozen install needs
+        // network for.
+        if self.offline {
+            tracing::warn!(
+                target: "pacquet::download",
+                ?package_url,
+                ?package_id,
+                "offline mode: tarball missing from local store; refusing network fetch",
+            );
+            return Err(TarballError::NoOfflineTarball {
+                package_id: package_id.to_string(),
+                url: package_url.to_string(),
+            });
+        }
+
         tracing::info!(target: "pacquet::download", ?package_url, "New cache");
 
         // Run the full fetch + integrity + extract pipeline under
@@ -2256,6 +2322,12 @@ pub struct DownloadZipArchiveToStore<'a> {
     /// See [`DownloadTarballToStore::ignore_file_pattern`] — the
     /// per-fetch archive filter is shared by both archive types.
     pub ignore_file_pattern: Option<Arc<IgnoreEntryFilter>>,
+    /// See [`DownloadTarballToStore::offline`]. Same semantics for
+    /// the zip-archive path: when both cache lookups miss and
+    /// `offline` is `true`, the fetcher fails with
+    /// [`TarballError::NoOfflineTarball`] rather than hitting the
+    /// network.
+    pub offline: bool,
 }
 
 impl<'a> DownloadZipArchiveToStore<'a> {
@@ -2315,6 +2387,22 @@ impl<'a> DownloadZipArchiveToStore<'a> {
             tracing::info!(target: "pacquet::download", ?package_url, ?package_id, "Reusing cached CAFS entry — skipping zip download");
             emit_progress_found_in_store::<R>(package_id, requester);
             return Ok(cas_paths);
+        }
+
+        // Offline-mode gate (zip archive). Same shape as the tarball
+        // path above — see the matching comment there for the
+        // upstream rationale.
+        if self.offline {
+            tracing::warn!(
+                target: "pacquet::download",
+                ?package_url,
+                ?package_id,
+                "offline mode: zip archive missing from local store; refusing network fetch",
+            );
+            return Err(TarballError::NoOfflineTarball {
+                package_id: package_id.to_string(),
+                url: package_url.to_string(),
+            });
         }
 
         tracing::info!(target: "pacquet::download", ?package_url, "New cache (zip)");

--- a/crates/tarball/src/tests.rs
+++ b/crates/tarball/src/tests.rs
@@ -177,6 +177,7 @@ async fn packages_under_orgs_should_work() {
         retry_opts: test_retry_opts(),
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
+        offline: false,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -226,6 +227,7 @@ async fn should_throw_error_on_checksum_mismatch() {
         retry_opts: test_retry_opts(),
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
+        offline: false,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -302,6 +304,7 @@ async fn reuses_cached_cas_paths_when_index_entry_is_live() {
         retry_opts: test_retry_opts(),
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
+        offline: false,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -362,6 +365,7 @@ async fn reuses_prefetched_cas_paths_when_provided() {
         retry_opts: test_retry_opts(),
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
+        offline: false,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -590,6 +594,7 @@ async fn falls_through_when_cafs_file_missing() {
         retry_opts: test_retry_opts(),
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
+        offline: false,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -650,6 +655,7 @@ async fn falls_through_when_digest_is_malformed() {
         retry_opts: test_retry_opts(),
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
+        offline: false,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -713,6 +719,7 @@ async fn falls_through_when_cafs_path_is_a_directory() {
         retry_opts: test_retry_opts(),
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
+        offline: false,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -786,6 +793,7 @@ async fn falls_through_when_cafs_path_is_a_symlink() {
         retry_opts: test_retry_opts(),
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
+        offline: false,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -1343,6 +1351,7 @@ fn run_with_mem_cache_does_not_deadlock_on_dashmap_shard_contention() {
                     retry_opts: RetryOpts { retries: 0, ..RetryOpts::default() },
                     auth_headers,
                     ignore_file_pattern: None,
+                    offline: false,
                 };
 
                 // Spawn each task and yield once before the next so the
@@ -1588,6 +1597,7 @@ async fn mem_cache_hit_emits_found_in_store_for_second_requester() {
         retry_opts: test_retry_opts(),
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
+        offline: false,
     }
     .run_with_mem_cache::<RecordingReporter>(&mem_cache)
     .await
@@ -1615,6 +1625,7 @@ async fn mem_cache_hit_emits_found_in_store_for_second_requester() {
         retry_opts: test_retry_opts(),
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
+        offline: false,
     }
     .run_with_mem_cache::<RecordingReporter>(&mem_cache)
     .await
@@ -1704,6 +1715,7 @@ async fn run_with_mem_cache_recovers_from_owning_fetch_error() {
         retry_opts: test_retry_opts(),
         auth_headers,
         ignore_file_pattern: None,
+        offline: false,
     };
 
     // Drive both calls concurrently. Pre-fix: the first to hit the
@@ -1985,6 +1997,7 @@ async fn found_in_store_event_fires_on_cache_hit() {
         retry_opts: test_retry_opts(),
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
+        offline: false,
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -2022,6 +2035,7 @@ async fn found_in_store_event_fires_on_cache_hit() {
         retry_opts: test_retry_opts(),
         auth_headers: &AuthHeaders::default(),
         ignore_file_pattern: None,
+        offline: false,
     }
     .run_without_mem_cache::<RecordingReporter>()
     .await
@@ -2373,4 +2387,126 @@ fn extract_zip_normalizes_dot_segments_in_entry_paths() {
     assert!(!cas_paths.keys().any(|k| k.contains("/./")), "no entry should retain a `.` segment");
 
     drop(tempdir);
+}
+
+/// `offline: true` short-circuits the fetcher before any network
+/// request when the package isn't in the local store. Mocks a server
+/// with `.expect(0)` so the assertion fires *only* if the fetcher
+/// ever calls the mocked URL; the offline gate must keep it from
+/// ever reaching `fetch_and_extract_with_retry`.
+#[tokio::test]
+async fn offline_mode_skips_network_on_cache_miss() {
+    use pacquet_diagnostics::miette::Diagnostic;
+
+    let (store_dir_keep, store_path) = tempdir_with_leaked_path();
+    let mut server = mockito::Server::new_async().await;
+    // `.expect(0)` — if the fetcher attempts the network at all,
+    // mockito's drop checker fails the test on the `.assert_async`
+    // call below.
+    let must_not_fire =
+        server.mock("GET", "/pkg.tgz").with_status(200).expect(0).create_async().await;
+
+    let url = format!("{}/pkg.tgz", server.url());
+    let pkg_integrity = integrity(FASTIFY_ERROR_INTEGRITY);
+    let pkg_id = "@fastify/error@3.3.0";
+
+    let err = DownloadTarballToStore {
+        http_client: &Default::default(),
+        store_dir: store_path,
+        store_index: None,
+        store_index_writer: None,
+        verify_store_integrity: true,
+        verified_files_cache: SharedVerifiedFilesCache::default(),
+        package_integrity: &pkg_integrity,
+        package_unpacked_size: None,
+        package_url: &url,
+        package_id: pkg_id,
+        requester: "",
+        prefetched_cas_paths: None,
+        retry_opts: test_retry_opts(),
+        auth_headers: &AuthHeaders::default(),
+        ignore_file_pattern: None,
+        offline: true,
+    }
+    .run_without_mem_cache::<SilentReporter>()
+    .await
+    .expect_err("offline + cache miss must error before reaching the network");
+
+    // Variant shape + diagnostic code together. The `code` check
+    // pins the user-facing surface — `ERR_PACQUET_NO_OFFLINE_TARBALL`
+    // is part of the CLI contract, just like upstream's
+    // `ERR_PNPM_NO_OFFLINE_META`.
+    let TarballError::NoOfflineTarball { package_id, url: errored_url } = &err else {
+        panic!("expected NoOfflineTarball, got {err:?}");
+    };
+    assert_eq!(package_id, pkg_id);
+    assert_eq!(errored_url, &url);
+    let code = err.code().map(|c| c.to_string()).unwrap_or_default();
+    assert_eq!(
+        code, "ERR_PACQUET_NO_OFFLINE_TARBALL",
+        "diagnostic code is part of the user-facing surface; must stay stable",
+    );
+
+    // No network call was made — confirms the gate fired before any
+    // attempt at `fetch_and_extract_with_retry`.
+    must_not_fire.assert_async().await;
+
+    drop(store_dir_keep);
+}
+
+/// `offline: true` is *not* consulted when the local store already
+/// has the file: the prefetched-CAS-paths branch should still
+/// short-circuit happily, regardless of the offline flag. Without
+/// this guard, a regression that bumped the offline check above the
+/// prefetch lookup would break warm installs under `--offline`.
+#[tokio::test]
+async fn offline_mode_still_uses_prefetched_cache() {
+    let (store_dir_keep, store_path) = tempdir_with_leaked_path();
+    // Server with `.expect(0)` — the prefetched-CAS-paths branch must
+    // short-circuit before any HTTP call.
+    let mut server = mockito::Server::new_async().await;
+    let must_not_fire =
+        server.mock("GET", "/pkg.tgz").with_status(200).expect(0).create_async().await;
+
+    let url = format!("{}/pkg.tgz", server.url());
+    let pkg_integrity = integrity(FASTIFY_ERROR_INTEGRITY);
+    let pkg_id = "@fastify/error@3.3.0";
+
+    // Seed the prefetched cache with a placeholder entry for our
+    // (integrity, pkg_id) — value content doesn't matter; the gate
+    // we're exercising only checks key presence. `PrefetchedCasPaths`
+    // is a `HashMap` type alias, so a struct literal works directly.
+    let cache_key = store_index_key(&pkg_integrity.to_string(), pkg_id);
+    let mut prefetched: PrefetchedCasPaths = HashMap::new();
+    prefetched.insert(cache_key, Arc::new(HashMap::new()));
+
+    let cas_paths = DownloadTarballToStore {
+        http_client: &Default::default(),
+        store_dir: store_path,
+        store_index: None,
+        store_index_writer: None,
+        verify_store_integrity: true,
+        verified_files_cache: SharedVerifiedFilesCache::default(),
+        package_integrity: &pkg_integrity,
+        package_unpacked_size: None,
+        package_url: &url,
+        package_id: pkg_id,
+        requester: "",
+        prefetched_cas_paths: Some(&prefetched),
+        retry_opts: test_retry_opts(),
+        auth_headers: &AuthHeaders::default(),
+        ignore_file_pattern: None,
+        offline: true,
+    }
+    .run_without_mem_cache::<SilentReporter>()
+    .await
+    .expect("warm install under --offline must succeed when the package is prefetched");
+
+    // Prefetched seed used a placeholder empty map; the return must
+    // surface that empty map (the offline gate didn't fire, the
+    // prefetch lookup did).
+    assert!(cas_paths.is_empty(), "got the prefetched-empty map back: {cas_paths:?}");
+    must_not_fire.assert_async().await;
+
+    drop(store_dir_keep);
 }

--- a/tasks/micro-benchmark/src/main.rs
+++ b/tasks/micro-benchmark/src/main.rs
@@ -52,6 +52,7 @@ fn bench_tarball(c: &mut Criterion, server: &mut ServerGuard, fixtures_folder: &
                 retry_opts: RetryOpts::default(),
                 auth_headers: &AuthHeaders::default(),
                 ignore_file_pattern: None,
+                offline: false,
             }
             .run_without_mem_cache::<pacquet_reporter::SilentReporter>()
             .await


### PR DESCRIPTION
## Summary

Adds support for `offline` / `preferOffline` from `pnpm-workspace.yaml` and the matching `--offline` / `--prefer-offline` flags on `pacquet install`.

## Semantics

Upstream pnpm gates only the **metadata** path in [`pickPackage`](https://github.com/pnpm/pnpm/blob/94240bc046/resolving/npm-resolver/src/pickPackage.ts): `offline: true` errors with `ERR_PNPM_NO_OFFLINE_META` when no cached metadata exists; `preferOffline: true` biases the resolver toward the cached copy past the freshness window.

Pacquet's frozen-install path has **no metadata fetch** (the lockfile pins every resolution), so the upstream flag would be a no-op on pacquet's current flow. To make the flag actually useful for frozen installs, pacquet adds a **tarball-side gate** (no upstream equivalent — pnpm doesn't gate tarball downloads on `offline`):

- `--offline`: when both the warm prefetch and the SQLite `index.db` lookup miss, the fetcher fails fast with `ERR_PACQUET_NO_OFFLINE_TARBALL` rather than hitting the registry. Same shape as upstream's `ERR_PNPM_NO_OFFLINE_META`, scoped to tarballs because that's what pacquet's frozen install needs network for. Documented as a pacquet-specific divergence in the field's rustdoc.
- `--prefer-offline`: no-op today — the warm prefetch + `load_cached_cas_paths` already prefer the local store. Field exists so `.npmrc` / yaml / CLI parse cleanly; Stage 2's resolver will honour it on the metadata path.

## Wiring

- `Config.offline` / `Config.prefer_offline` — `bool`, default `false`.
- `WorkspaceYaml.offline` / `WorkspaceYaml.prefer_offline` — `Option<bool>`, applied through the existing `apply!` macro.
- `InstallArgs.offline` / `InstallArgs.prefer_offline` — CLI flags. Merged into `Config` in `cli_args.rs` between `config()` and `State::init` (boolean OR — flags upgrade yaml `false` to `true`, never the reverse).
- `DownloadTarballToStore.offline` / `DownloadZipArchiveToStore.offline` — bool fields. Threaded through the three production construction sites in `package-manager`.
- `TarballError::NoOfflineTarball { package_id, url }` — new variant with `code(ERR_PACQUET_NO_OFFLINE_TARBALL)`. `tarball_error_to_request_retry` updated for exhaustiveness.

## Test plan

- [x] `cargo nextest run -p pacquet-tarball offline_mode` — 2 new tests pass.
  - `offline_mode_skips_network_on_cache_miss` — `mockito` mock with `.expect(0)`; offline gate must fire before any network call. Asserts variant + diagnostic code.
  - `offline_mode_still_uses_prefetched_cache` — same `.expect(0)` guard but with a prefetched-cache hit; pins that the prefetch branch short-circuits before the offline check, so warm installs under `--offline` succeed.
- [x] Regression-catch verified: gating the gate behind `false &&` flipped `offline_mode_skips_network_on_cache_miss` red with the wrong-variant panic message. Reverted before commit.
- [x] `just ready` — workspace clean.
- [x] `just dylint` — perfectionist lints clean.

15 test/benchmark `DownloadTarballToStore` / `DownloadZipArchiveToStore` literals plus the `Config` literal in `install_package_from_registry/tests.rs` all get `offline: false` to match the prior implicit default — no behavior change in those sites.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--offline` and `--prefer-offline` install flags; CLI flags can enable (but not disable) workspace config values.
  * Offline mode now short-circuits on missing cached packages, returning `ERR_PACQUET_NO_OFFLINE_TARBALL`; cached artifacts still install successfully.

* **Documentation**
  * CLI README updated with notes describing `--offline` and `--prefer-offline` semantics and interactions.

* **Tests**
  * Added tests for offline fast-fail and cached-success scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pacquet/pull/513)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->