### PR TITLE
feat(cli): --node-linker flag (#438 slice 8)

### DIFF
--- a/crates/cli/src/cli_args/install.rs
+++ b/crates/cli/src/cli_args/install.rs
@@ -1,10 +1,34 @@
 use crate::State;
 use crate::cli_args::supported_architectures::SupportedArchitecturesArgs;
-use clap::Args;
+use clap::{Args, ValueEnum};
 use miette::Context;
+use pacquet_config::NodeLinker;
 use pacquet_package_manager::Install;
 use pacquet_package_manifest::DependencyGroup;
 use pacquet_reporter::Reporter;
+
+/// `--node-linker` value parser. CLI mirror of
+/// [`pacquet_config::NodeLinker`] so the config crate stays free
+/// of `clap` as a dependency. Converted to the canonical enum at
+/// the CLI/Install boundary via [`Self::into_config`].
+#[derive(Debug, Clone, Copy, ValueEnum)]
+#[clap(rename_all = "kebab-case")]
+pub enum NodeLinkerArg {
+    Isolated,
+    Hoisted,
+    Pnp,
+}
+
+impl NodeLinkerArg {
+    #[inline]
+    fn into_config(self) -> NodeLinker {
+        match self {
+            NodeLinkerArg::Isolated => NodeLinker::Isolated,
+            NodeLinkerArg::Hoisted => NodeLinker::Hoisted,
+            NodeLinkerArg::Pnp => NodeLinker::Pnp,
+        }
+    }
+}
 
 #[derive(Debug, Args)]
 pub struct InstallDependencyOptions {
@@ -64,6 +88,16 @@ pub struct InstallArgs {
     /// normally. Mirrors pnpm's `--no-runtime` flag.
     #[clap(long = "no-runtime")]
     pub no_runtime: bool,
+
+    /// Override `nodeLinker` from `pnpm-workspace.yaml` /
+    /// `.npmrc`. Mirrors upstream pnpm's `--node-linker` flag.
+    /// `None` (flag not passed) leaves the config's value
+    /// untouched; otherwise the CLI value wins for this invocation
+    /// and is what gets written to `.modules.yaml.nodeLinker`.
+    /// `isolated` is the default, `hoisted` selects the flat
+    /// `node_modules/` layout, `pnp` selects Plug'n'Play.
+    #[clap(long = "node-linker", value_enum)]
+    pub node_linker: Option<NodeLinkerArg>,
 }
 
 impl InstallArgs {
@@ -75,6 +109,7 @@ impl InstallArgs {
             supported_architectures,
             frozen_lockfile,
             no_runtime,
+            node_linker,
         } = self;
 
         // Merge CLI overrides with the yaml-derived value before
@@ -91,6 +126,11 @@ impl InstallArgs {
         // to override yaml's `true` back to `false` from the CLI,
         // matching pnpm's stance on the same flag.
         let skip_runtimes = config.skip_runtimes || no_runtime;
+
+        // `--node-linker` flag (if passed) overrides the
+        // yaml/npmrc value for this invocation. Mirrors pnpm's
+        // override-on-explicit-flag semantics.
+        let node_linker = node_linker.map(NodeLinkerArg::into_config).unwrap_or(config.node_linker);
         Install {
             tarball_mem_cache,
             http_client,
@@ -102,6 +142,7 @@ impl InstallArgs {
             skip_runtimes,
             resolved_packages,
             supported_architectures,
+            node_linker,
         }
         .run::<R>()
         .await

--- a/crates/cli/src/cli_args/install/tests.rs
+++ b/crates/cli/src/cli_args/install/tests.rs
@@ -1,4 +1,6 @@
-use super::InstallDependencyOptions;
+use super::{InstallArgs, InstallDependencyOptions, NodeLinkerArg};
+use clap::Parser;
+use pacquet_config::NodeLinker;
 use pacquet_package_manifest::DependencyGroup;
 use pretty_assertions::assert_eq;
 
@@ -54,4 +56,74 @@ fn dependency_options_to_dependency_groups() {
         create_list(InstallDependencyOptions { prod: true, dev: true, no_optional: true }),
         [Prod, Dev],
     );
+}
+
+/// Helper test wrapper so the `--node-linker` parser tests can
+/// drive `clap::Parser::try_parse_from` against `InstallArgs`
+/// without needing the full `pacquet install` CLI surface.
+#[derive(Debug, clap::Parser)]
+struct InstallArgsHarness {
+    #[clap(flatten)]
+    args: InstallArgs,
+}
+
+#[test]
+fn node_linker_default_is_none() {
+    let parsed = InstallArgsHarness::try_parse_from(["pacquet-test"]).expect("parses");
+    assert!(parsed.args.node_linker.is_none(), "flag absent → field is None");
+}
+
+#[test]
+fn node_linker_hoisted() {
+    let parsed = InstallArgsHarness::try_parse_from(["pacquet-test", "--node-linker", "hoisted"])
+        .expect("parses --node-linker hoisted");
+    let resolved = parsed.args.node_linker.expect("flag present").into_config();
+    assert_eq!(resolved, NodeLinker::Hoisted);
+}
+
+#[test]
+fn node_linker_isolated() {
+    let parsed = InstallArgsHarness::try_parse_from(["pacquet-test", "--node-linker", "isolated"])
+        .expect("parses --node-linker isolated");
+    let resolved = parsed.args.node_linker.expect("flag present").into_config();
+    assert_eq!(resolved, NodeLinker::Isolated);
+}
+
+#[test]
+fn node_linker_pnp() {
+    let parsed = InstallArgsHarness::try_parse_from(["pacquet-test", "--node-linker", "pnp"])
+        .expect("parses --node-linker pnp");
+    let resolved = parsed.args.node_linker.expect("flag present").into_config();
+    assert_eq!(resolved, NodeLinker::Pnp);
+}
+
+/// Unknown values are rejected by clap, matching pnpm's CLI
+/// behavior on `--node-linker something-else`. The error contains
+/// the bad value so the user can fix the typo without consulting
+/// docs.
+#[test]
+fn node_linker_invalid_value_rejected() {
+    let err = InstallArgsHarness::try_parse_from(["pacquet-test", "--node-linker", "bogus"])
+        .expect_err("invalid value rejected");
+    let msg = err.to_string();
+    assert!(msg.contains("bogus"), "error mentions bad value: {msg}");
+}
+
+/// `NodeLinkerArg::into_config` maps every variant 1:1 to the
+/// canonical `pacquet_config::NodeLinker` enum. Tied to the
+/// `ValueEnum` derive's kebab-case rename — if a future variant
+/// is added, this test starts failing at compile time as a
+/// reminder to update the mapping.
+#[test]
+fn node_linker_arg_into_config_matches_every_variant() {
+    use clap::ValueEnum;
+    for variant in NodeLinkerArg::value_variants() {
+        let canonical = variant.into_config();
+        match (variant, canonical) {
+            (NodeLinkerArg::Isolated, NodeLinker::Isolated)
+            | (NodeLinkerArg::Hoisted, NodeLinker::Hoisted)
+            | (NodeLinkerArg::Pnp, NodeLinker::Pnp) => {}
+            other => panic!("mapping mismatch: {other:?}"),
+        }
+    }
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -29,7 +29,7 @@ pub use workspace_yaml::{
     LoadWorkspaceYamlError, WORKSPACE_MANIFEST_FILENAME, WorkspaceSettings, workspace_root_or,
 };
 
-#[derive(Debug, Deserialize, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Deserialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum NodeLinker {
     /// dependencies are symlinked from a virtual store at node_modules/.pnpm.

--- a/crates/package-manager/src/add.rs
+++ b/crates/package-manager/src/add.rs
@@ -91,6 +91,7 @@ where
             skip_runtimes: config.skip_runtimes,
             resolved_packages,
             supported_architectures,
+            node_linker: config.node_linker,
         }
         .run::<R>()
         .await

--- a/crates/package-manager/src/install.rs
+++ b/crates/package-manager/src/install.rs
@@ -60,6 +60,16 @@ where
     /// override merge happens in the caller and lands here as a
     /// fully-resolved value.
     pub supported_architectures: Option<pacquet_package_is_installable::SupportedArchitectures>,
+    /// `nodeLinker` value to honor for *this* invocation. The CLI
+    /// layer applies any `--node-linker` override here; absent a
+    /// flag, this equals `config.node_linker`. Threaded as a
+    /// separate field for the same reason
+    /// [`Self::supported_architectures`] is: `state.config` is a
+    /// shared `&'static Config`, so the CLI override merge happens
+    /// in the caller and lands here as a fully-resolved value.
+    /// Used today for the `.modules.yaml.nodeLinker` write and
+    /// (in Slice 6) for the install-pipeline branch.
+    pub node_linker: pacquet_config::NodeLinker,
 }
 
 /// Error type of [`Install`].
@@ -149,6 +159,7 @@ where
             frozen_lockfile,
             skip_runtimes,
             supported_architectures,
+            node_linker,
         } = self;
 
         // Collect once so the same set drives both the install dispatch
@@ -430,7 +441,13 @@ where
         // tool) can detect a layout change and prune accordingly.
         write_modules_manifest::<RealApi>(
             &config.modules_dir,
-            build_modules_manifest(config, included, hoisted_dependencies, &frozen_skipped),
+            build_modules_manifest(
+                config,
+                node_linker,
+                included,
+                hoisted_dependencies,
+                &frozen_skipped,
+            ),
         )
         .map_err(InstallError::WriteModules)?;
 
@@ -518,6 +535,7 @@ fn map_node_linker(linker: &NodeLinker) -> ModulesNodeLinker {
 /// [`write_modules_manifest`]: pacquet_modules_yaml::write_modules_manifest
 fn build_modules_manifest(
     config: &Config,
+    node_linker: NodeLinker,
     included: IncludedDependencies,
     hoisted_dependencies: HoistedDependencies,
     skipped: &crate::SkippedSnapshots,
@@ -527,7 +545,7 @@ fn build_modules_manifest(
         hoisted_dependencies,
         included,
         layout_version: Some(LayoutVersion),
-        node_linker: Some(map_node_linker(&config.node_linker)),
+        node_linker: Some(map_node_linker(&node_linker)),
         // `${name}@${version}` per upstream. `CARGO_PKG_VERSION`
         // resolves at compile time to this crate's package version.
         package_manager: concat!("pacquet@", env!("CARGO_PKG_VERSION")).to_string(),

--- a/crates/package-manager/src/install/tests.rs
+++ b/crates/package-manager/src/install/tests.rs
@@ -55,6 +55,7 @@ async fn should_install_dependencies() {
         frozen_lockfile: false,
         skip_runtimes: false,
         supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -109,6 +110,7 @@ async fn should_error_when_frozen_lockfile_is_requested_but_none_exists() {
         frozen_lockfile: true,
         skip_runtimes: false,
         supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -146,6 +148,7 @@ async fn should_error_when_writable_lockfile_mode_is_used() {
         frozen_lockfile: false,
         skip_runtimes: false,
         supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -212,6 +215,7 @@ async fn frozen_lockfile_flag_overrides_config_lockfile_false() {
         frozen_lockfile: true,
         skip_runtimes: false,
         supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -271,6 +275,7 @@ async fn npm_alias_dependency_installs_under_alias_key() {
         frozen_lockfile: false,
         skip_runtimes: false,
         supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -347,6 +352,7 @@ async fn unversioned_npm_alias_defaults_to_latest() {
         frozen_lockfile: false,
         skip_runtimes: false,
         supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -408,6 +414,7 @@ async fn frozen_lockfile_flag_with_no_lockfile_errors() {
         frozen_lockfile: true,
         skip_runtimes: false,
         supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -489,6 +496,7 @@ async fn install_emits_pnpm_event_sequence() {
         frozen_lockfile: true,
         skip_runtimes: false,
         supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
         resolved_packages: &Default::default(),
     }
     .run::<RecordingReporter>()
@@ -627,6 +635,7 @@ async fn install_writes_modules_yaml() {
         frozen_lockfile: true,
         skip_runtimes: false,
         supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -721,6 +730,7 @@ async fn install_optional_failing_postinstall_dep_via_registry_mock_succeeds() {
         frozen_lockfile: false,
         skip_runtimes: false,
         supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -837,6 +847,7 @@ async fn warm_reinstall_skips_snapshot_when_current_lockfile_matches() {
         frozen_lockfile: true,
         skip_runtimes: false,
         supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -928,6 +939,7 @@ async fn warm_reinstall_emits_broken_modules_when_dir_is_missing() {
         frozen_lockfile: true,
         skip_runtimes: false,
         supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
         resolved_packages: &Default::default(),
     }
     .run::<RecordingReporter>()
@@ -1027,6 +1039,7 @@ async fn context_log_reflects_current_lockfile_after_first_install() {
         frozen_lockfile: true,
         skip_runtimes: false,
         supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
         resolved_packages: &Default::default(),
     }
     .run::<RecordingReporter>()
@@ -1070,6 +1083,7 @@ async fn context_log_reflects_current_lockfile_after_first_install() {
         frozen_lockfile: true,
         skip_runtimes: false,
         supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
         resolved_packages: &Default::default(),
     }
     .run::<RecordingReporter>()
@@ -1155,6 +1169,7 @@ async fn warm_reinstall_reports_added_zero_and_emits_no_imported_events() {
         frozen_lockfile: true,
         skip_runtimes: false,
         supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
         resolved_packages: &Default::default(),
     }
     .run::<RecordingReporter>()
@@ -1243,6 +1258,7 @@ async fn frozen_lockfile_errors_when_manifest_drifts_from_lockfile() {
         skip_runtimes: false,
         resolved_packages: &Default::default(),
         supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
     }
     .run::<SilentReporter>()
     .await;
@@ -1294,6 +1310,7 @@ async fn frozen_lockfile_errors_when_lockfile_has_no_root_importer() {
         skip_runtimes: false,
         resolved_packages: &Default::default(),
         supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
     }
     .run::<SilentReporter>()
     .await;
@@ -1375,6 +1392,7 @@ async fn frozen_lockfile_under_gvs_registers_project_and_runs_clean() {
         skip_runtimes: false,
         resolved_packages: &Default::default(),
         supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
     }
     .run::<SilentReporter>()
     .await
@@ -1446,6 +1464,7 @@ async fn frozen_lockfile_with_gvs_off_skips_project_registry() {
         skip_runtimes: false,
         resolved_packages: &Default::default(),
         supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
     }
     .run::<SilentReporter>()
     .await
@@ -1523,6 +1542,7 @@ async fn frozen_lockfile_under_gvs_registers_each_workspace_importer() {
         skip_runtimes: false,
         resolved_packages: &Default::default(),
         supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
     }
     .run::<SilentReporter>()
     .await
@@ -1591,7 +1611,13 @@ fn build_modules_manifest_serializes_skipped_set() {
         dev_dependencies: false,
         optional_dependencies: true,
     };
-    let manifest = super::build_modules_manifest(config, included, Default::default(), &skipped);
+    let manifest = super::build_modules_manifest(
+        config,
+        pacquet_config::NodeLinker::default(),
+        included,
+        Default::default(),
+        &skipped,
+    );
 
     // Compare as sets — `build_modules_manifest` does not sort.
     // Sort-on-write happens later inside `write_modules_manifest`,
@@ -1622,6 +1648,7 @@ fn build_modules_manifest_skipped_is_empty_on_empty_set() {
 
     let manifest = super::build_modules_manifest(
         config,
+        pacquet_config::NodeLinker::default(),
         IncludedDependencies::default(),
         Default::default(),
         &SkippedSnapshots::new(),
@@ -1700,6 +1727,7 @@ async fn frozen_install_preserves_seeded_skipped_across_reinstall() {
         frozen_lockfile: true,
         skip_runtimes: false,
         supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -1810,6 +1838,7 @@ async fn frozen_install_silently_swallows_unreachable_optional_tarball() {
         frozen_lockfile: true,
         skip_runtimes: false,
         supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -1903,6 +1932,7 @@ async fn frozen_install_propagates_non_optional_fetch_failure() {
         frozen_lockfile: true,
         skip_runtimes: false,
         supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -2002,6 +2032,7 @@ async fn frozen_install_no_optional_drops_optional_only_snapshots() {
         frozen_lockfile: true,
         skip_runtimes: false,
         supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -2086,6 +2117,7 @@ async fn frozen_install_optional_included_surfaces_missing_metadata() {
         frozen_lockfile: true,
         skip_runtimes: false,
         supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -2173,6 +2205,7 @@ async fn frozen_install_no_optional_keeps_shared_non_optional_snapshot() {
         frozen_lockfile: true,
         skip_runtimes: false,
         supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()


### PR DESCRIPTION
## Summary

Slice 8 of #438. Adds `--node-linker [isolated|hoisted|pnp]` to `pacquet install`, mirroring [pnpm's flag](https://pnpm.io/cli/install). The flag overrides `nodeLinker` from `pnpm-workspace.yaml`/`.npmrc` for the invocation; absent flag → config's value wins.

## Implementation

- **CLI mirror enum.** `NodeLinkerArg` in the CLI crate, derives `clap::ValueEnum`, converts to `pacquet_config::NodeLinker` via `into_config()`. Keeps `pacquet-config` free of `clap` as a dependency (separation of concerns: config knows nothing about CLI parsing).
- **Install runner field.** New `Install.node_linker: NodeLinker`. Matches the pattern `supported_architectures` already uses — `state.config` is `&'static`, so the override-merge happens at the CLI layer and lands as a fully-resolved value. `build_modules_manifest` consumes it on the `.modules.yaml.nodeLinker` write.
- **`pacquet add`** uses `config.node_linker` directly (no `--node-linker` exposure on `add` per the umbrella scope; Slice 6's pipeline integration can revisit).
- **`NodeLinker` derives** `Clone + Copy + Eq` so it threads by value into `Install` and matches in tests.

## Behavior

| Invocation | `Install.node_linker` |
|---|---|
| `pacquet install` | `config.node_linker` (from yaml/npmrc, default `isolated`) |
| `pacquet install --node-linker hoisted` | `Hoisted` (overrides config) |
| `pacquet install --node-linker bogus` | clap error: "invalid value 'bogus'" |

## Tests

5 new tests in `cli_args/install/tests.rs`:

- `node_linker_default_is_none` — flag absent → `InstallArgs.node_linker` is `None`.
- `node_linker_hoisted`/`isolated`/`pnp` — each value parses and round-trips through `into_config()`.
- `node_linker_invalid_value_rejected` — clap rejects unknown values; error mentions the bad value.
- `node_linker_arg_into_config_matches_every_variant` — iterates `ValueEnum::value_variants()` to catch future variants that forget the canonical mapping.

## Test plan

- [x] All 6 new tests pass (dependency-options test still passes).
- [x] `just ready` (workspace tests all green).
- [x] `cargo doc --document-private-items`, `taplo format --check`, `just dylint` clean.
- [x] Sabotage check: changing `into_config` to misroute `Hoisted` → `Isolated` re-fails `node_linker_hoisted` AND `node_linker_arg_into_config_matches_every_variant` (the latter is the compile-time-coverage canary).

## Note on observed effect today

Until Slice 6 wires the install pipeline to branch on `node_linker`, this flag only affects the **persisted** `.modules.yaml.nodeLinker` value — the actual install behavior is still the isolated layout regardless. The setting is recorded faithfully so that:
- When Slice 6 lands, the persisted value is already correct.
- Slice 7's rebuild path reads it from `.modules.yaml` (already wired).

---
Written by an agent (Claude Code, claude-opus-4-7).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--node-linker` CLI flag to the install command, enabling users to override the configured node linker strategy (Isolated, Hoisted, or Pnp) on a per-install basis.

* **Tests**
  * Added comprehensive tests for node linker flag parsing and validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pacquet/pull/514)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->