### PR TITLE
feat(lockfile): support `runtime:` specifiers in PkgVerPeer / PackageKey (#511)

### DIFF
--- a/crates/lockfile/src/pkg_ver_peer.rs
+++ b/crates/lockfile/src/pkg_ver_peer.rs
@@ -8,14 +8,32 @@ use std::{borrow::Cow, str::FromStr};
 ///
 /// Example: `1.21.3(@types/react@17.0.49)(react-dom@17.0.2)(react@17.0.2)`
 ///
+/// Also accepts an optional `runtime:` prefix for pnpm v11 runtime
+/// dependencies (`node@runtime:22.0.0`, `deno@runtime:1.x`,
+/// `bun@runtime:1`). The prefix is preserved through `Display` so
+/// the round-trip stays byte-stable. Mirrors upstream's depPath
+/// shape for `BinaryResolution` / `VariationsResolution` entries
+/// emitted by the runtime resolvers at
+/// <https://github.com/pnpm/pnpm/blob/94240bc046/engine/runtime>.
+///
 /// **NOTE:** The peer part isn't guaranteed to be correct. It is only assumed to be.
 #[derive(Debug, Display, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[display("{version}{peer}")]
+#[display("{}{version}{peer}", prefix.as_deref().unwrap_or(""))]
 #[serde(try_from = "Cow<'de, str>", into = "String")]
 pub struct PkgVerPeer {
+    /// `Some("runtime:")` for runtime depPaths, `None` for plain
+    /// semver. Preserved through `Display` so a round-trip
+    /// produces byte-stable output for the lockfile.
+    prefix: Option<String>,
     version: Version,
     peer: String,
 }
+
+/// `runtime:` is the only scheme prefix pacquet currently accepts.
+/// Defined here so call sites can match on it without re-spelling
+/// the literal everywhere. Other schemes (`tag:`, etc.) can be
+/// added later — see #511's "Out of scope" note.
+pub const RUNTIME_PREFIX: &str = "runtime:";
 
 impl PkgVerPeer {
     /// Get the version part.
@@ -28,9 +46,29 @@ impl PkgVerPeer {
         self.peer.as_str()
     }
 
+    /// Get the optional scheme prefix (e.g. `Some("runtime:")` for
+    /// `runtime:22.0.0`). Returns `None` for plain semver.
+    pub fn prefix(&self) -> Option<&'_ str> {
+        self.prefix.as_deref()
+    }
+
+    /// `true` when the prefix is `runtime:` — i.e. this entry
+    /// resolves through one of pnpm v11's runtime resolvers
+    /// (`node`/`deno`/`bun`). Typed replacement for the
+    /// `depPath.contains("@runtime:")` substring check upstream
+    /// uses at
+    /// <https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/src/install/index.ts#L1374-L1387>.
+    pub fn is_runtime(&self) -> bool {
+        self.prefix.as_deref() == Some(RUNTIME_PREFIX)
+    }
+
     /// Destructure the struct into a tuple of version and peer.
+    /// Drops the scheme prefix — only useful for plain-semver
+    /// callers that wouldn't have ended up with a non-`None`
+    /// prefix anyway. Callers that care about the prefix should
+    /// use [`PkgVerPeer::prefix`] instead.
     pub fn into_tuple(self) -> (Version, String) {
-        let PkgVerPeer { version, peer } = self;
+        let PkgVerPeer { prefix: _, version, peer } = self;
         (version, peer)
     }
 }
@@ -47,22 +85,30 @@ pub enum ParsePkgVerPeerError {
 impl FromStr for PkgVerPeer {
     type Err = ParsePkgVerPeerError;
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        if !value.ends_with(')') {
-            if value.find(['(', ')']).is_some() {
+        // Strip an optional `runtime:` prefix first. Only the
+        // literal `runtime:` is recognised today — other URL-style
+        // schemes (e.g. `tag:`) are out of scope per #511.
+        let (prefix, rest) = match value.strip_prefix(RUNTIME_PREFIX) {
+            Some(rest) => (Some(RUNTIME_PREFIX.to_string()), rest),
+            None => (None, value),
+        };
+
+        if !rest.ends_with(')') {
+            if rest.find(['(', ')']).is_some() {
                 return Err(ParsePkgVerPeerError::MismatchParenthesis);
             }
 
-            let version = value.parse().map_err(ParsePkgVerPeerError::ParseVersionFailure)?;
-            return Ok(PkgVerPeer { version, peer: String::new() });
+            let version = rest.parse().map_err(ParsePkgVerPeerError::ParseVersionFailure)?;
+            return Ok(PkgVerPeer { prefix, version, peer: String::new() });
         }
 
         let opening_parenthesis =
-            value.find('(').ok_or(ParsePkgVerPeerError::MismatchParenthesis)?;
-        let version = value[..opening_parenthesis]
+            rest.find('(').ok_or(ParsePkgVerPeerError::MismatchParenthesis)?;
+        let version = rest[..opening_parenthesis]
             .parse()
             .map_err(ParsePkgVerPeerError::ParseVersionFailure)?;
-        let peer = value[opening_parenthesis..].to_string();
-        Ok(PkgVerPeer { version, peer })
+        let peer = rest[opening_parenthesis..].to_string();
+        Ok(PkgVerPeer { prefix, version, peer })
     }
 }
 

--- a/crates/lockfile/src/pkg_ver_peer/tests.rs
+++ b/crates/lockfile/src/pkg_ver_peer/tests.rs
@@ -118,3 +118,81 @@ fn deserialize_serialize() {
     case("1.21.3");
     case("1.21.3-rc.0");
 }
+
+// ---------------------------------------------------------------------------
+// `runtime:` scheme prefix (#511 / #437 §F unblocker)
+// ---------------------------------------------------------------------------
+
+/// `runtime:22.0.0` parses with the prefix recorded separately
+/// from the version. The version part is the bare semver, the
+/// peer part is empty.
+#[test]
+fn parse_runtime_prefix_without_peer() {
+    let parsed: PkgVerPeer = "runtime:22.0.0".parse().expect("runtime: prefix must parse");
+    assert_eq!(parsed.prefix(), Some("runtime:"));
+    assert_eq!(parsed.version(), &Version::from((22, 0, 0)));
+    assert_eq!(parsed.peer(), "");
+    assert!(parsed.is_runtime());
+}
+
+/// Runtime entries can in principle carry a peer suffix too
+/// (no upstream example today, but the grammar admits it). The
+/// prefix doesn't disable the parenthesis handling.
+#[test]
+fn parse_runtime_prefix_with_peer() {
+    let parsed: PkgVerPeer =
+        "runtime:1.0.0(some-peer@1.0.0)".parse().expect("runtime:+peer must parse");
+    assert_eq!(parsed.prefix(), Some("runtime:"));
+    assert_eq!(parsed.version(), &Version::from((1, 0, 0)));
+    assert_eq!(parsed.peer(), "(some-peer@1.0.0)");
+    assert!(parsed.is_runtime());
+}
+
+/// Plain semver still parses with `prefix() == None`. Baseline
+/// sanity to ensure the new branch doesn't false-trigger.
+#[test]
+fn parse_plain_semver_has_no_prefix() {
+    let parsed: PkgVerPeer = "1.21.3".parse().unwrap();
+    assert_eq!(parsed.prefix(), None);
+    assert!(!parsed.is_runtime());
+}
+
+/// Display round-trip: `runtime:22.0.0` parses then displays to
+/// the same byte string. Required so `PackageKey::to_string()`
+/// produces the same depPath the lockfile uses.
+#[test]
+fn runtime_prefix_round_trips_through_display() {
+    for input in
+        ["runtime:22.0.0", "runtime:1.0.0-beta.1", "runtime:1.0.0(some-peer@1.0.0)", "1.21.3"]
+    {
+        let parsed: PkgVerPeer = input.parse().expect("parse");
+        let displayed = parsed.to_string();
+        assert_eq!(displayed, input, "round-trip mismatch for {input:?}");
+    }
+}
+
+/// Other URL-style prefixes (`tag:` etc.) aren't recognised yet
+/// — only `runtime:` is. A `tag:` input parses as a plain
+/// version-with-bad-format and errors out. Per #511's "Out of
+/// scope": land `runtime:` first, generalize later if needed.
+#[test]
+fn other_scheme_prefixes_are_not_recognised() {
+    let err = "tag:22.0.0".parse::<PkgVerPeer>().expect_err("tag: prefix must not parse yet");
+    assert!(
+        matches!(err, ParsePkgVerPeerError::ParseVersionFailure(_)),
+        "expected ParseVersionFailure for unrecognised scheme, got {err:?}",
+    );
+}
+
+/// `runtime:` works at the `PackageKey` level too — i.e. via
+/// `PkgNameVerPeer::parse`. The bug the parent issue calls out
+/// is that `"node@runtime:22.0.0".parse::<PackageKey>()` errors;
+/// after this fix it round-trips.
+#[test]
+fn package_key_runtime_round_trip() {
+    use crate::PackageKey;
+    let parsed: PackageKey =
+        "node@runtime:22.0.0".parse().expect("PackageKey must accept runtime: depPaths");
+    assert_eq!(parsed.to_string(), "node@runtime:22.0.0");
+    assert!(parsed.suffix.is_runtime());
+}

--- a/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/crates/package-manager/src/install_frozen_lockfile.rs
@@ -387,19 +387,21 @@ where
                     let Some(dep_map) = dep_map else { continue };
                     for (alias, spec) in dep_map {
                         let Some(version) = spec.version.as_regular() else { continue };
-                        // Build the candidate snapshot key from
-                        // (alias, version). For non-aliased deps
-                        // this is the depPath verbatim; aliased
-                        // runtime deps (unusual) won't match
-                        // `packages` here, matching pnpm's lookup
-                        // by depPath rather than by alias.
-                        let candidate = format!("{alias}@{version}");
-                        if !candidate.contains("@runtime:") {
+                        // Typed `runtime:` check via [`PkgVerPeer::is_runtime`]
+                        // (#511) — replaces the prior
+                        // `format!("{alias}@{version}").contains("@runtime:")`
+                        // string-search. The substring approach also
+                        // failed silently when the resulting key
+                        // couldn't `parse::<PackageKey>` (which is
+                        // exactly what runtime depPaths used to do
+                        // because `PkgVerPeer` rejected the
+                        // `runtime:` prefix), so `--no-runtime`
+                        // wasn't actually filtering anything before
+                        // #511 landed.
+                        if !version.is_runtime() {
                             continue;
                         }
-                        let Ok(key) = candidate.parse::<pacquet_lockfile::PackageKey>() else {
-                            continue;
-                        };
+                        let key = pacquet_lockfile::PackageKey::new(alias.clone(), version.clone());
                         if let Some(meta) = pkgs.get(&key)
                             && matches!(
                                 &meta.resolution,


### PR DESCRIPTION
## Summary

Pnpm v11's runtime resolvers ([`engine/runtime/{node,deno,bun}-resolver`](https://github.com/pnpm/pnpm/tree/94240bc046/engine/runtime)) emit lockfile depPaths of the form `node@runtime:22.0.0`. Pacquet's `PkgVerPeer` parser only accepted bare semver, so loading any v11 lockfile that pins a runtime entry errored out:

```rust
"node@runtime:22.0.0".parse::<pacquet_lockfile::PackageKey>()
// Err: Failed to parse the version part: Failed to parse version.
```

This was a complete blocker for #437's section F (integration tests for runtime dep install). Worse, the `--no-runtime` filter at `install_frozen_lockfile.rs:397` did `format!("{alias}@{version}").contains("@runtime:")` followed by `candidate.parse::<PackageKey>()` and silently `continue`'d on parse failure — so the filter was effectively a no-op for the only inputs it was supposed to catch.

## Changes

- **`pacquet-lockfile::PkgVerPeer`**: new `prefix: Option<String>` field set to `Some("runtime:")` when the input starts with that literal. `Display` prepends the prefix so the round-trip stays byte-stable. Two accessors: [`PkgVerPeer::prefix`] (`Option<&str>`) and [`PkgVerPeer::is_runtime`] (`bool`). Other URL-style prefixes (`tag:`, …) are out of scope per the issue and parse-fail with `ParseVersionFailure`.
- **`install_frozen_lockfile.rs`**: replace the substring + silent-skip-on-parse-fail dance with a typed `version.is_runtime()` check and an explicit `PackageKey::new(alias, version)`. `--no-runtime` now actually filters runtime deps.

## Test plan

- [x] 6 new unit tests: prefix parsing (with / without peer), plain-semver baseline, Display round-trip, scoped-prefix rejection, full `PackageKey` round-trip.
- [x] Test-the-test verified by stubbing `is_runtime` → false: `parse_runtime_prefix_without_peer` fails.
- [x] `just ready` (1203 tests, 0 failing).
- [x] `taplo format --check`.
- [x] `just dylint`.
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace`.

## Unblocks

#437 section F (integration tests for runtime dep install): fixture lockfiles with `node@runtime:22.0.0` snapshots can now be parsed.

Closes #511.

---
Written by an agent (Claude Code, claude-opus-4-7).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional `runtime:` prefix in version specifications for enhanced runtime version management.

* **Bug Fixes**
  * Improved `--no-runtime` filtering to use proper version detection instead of string matching, making runtime dependency exclusion more reliable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pacquet/pull/515)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->