### PR TITLE
test(package-manager): variant-mismatch + --no-runtime install tests (#437 slice F)

### DIFF
--- a/crates/lockfile/src/pkg_name_ver_peer.rs
+++ b/crates/lockfile/src/pkg_name_ver_peer.rs
@@ -22,14 +22,18 @@ impl PkgNameVerPeer {
     ///
     /// This converts a v9 snapshot key (e.g. `react-dom@17.0.2(react@17.0.2)`)
     /// into the corresponding `packages:` key (e.g. `react-dom@17.0.2`), which
-    /// identifies the package version independent of peer context.
+    /// identifies the package version independent of peer context. The
+    /// scheme prefix (e.g. `runtime:` for pnpm v11 runtime entries) is
+    /// preserved so a runtime snapshot key like
+    /// `node@runtime:22.0.0(some@peer)` resolves to the matching
+    /// `packages:` entry `node@runtime:22.0.0` rather than the
+    /// non-existent `node@22.0.0`.
     pub fn without_peer(&self) -> PkgNameVerPeer {
-        let bare = self
-            .suffix
-            .version()
-            .to_string()
+        let prefix = self.suffix.prefix();
+        let bare_input = format!("{}{}", prefix, self.suffix.version());
+        let bare = bare_input
             .parse::<PkgVerPeer>()
-            .expect("a bare semver version is always a valid PkgVerPeer");
+            .expect("a prefix + bare semver version is always a valid PkgVerPeer");
         PkgNameVerPeer::new(self.name.clone(), bare)
     }
 }

--- a/crates/package-manager/src/install/tests.rs
+++ b/crates/package-manager/src/install/tests.rs
@@ -2392,4 +2392,187 @@ async fn hoisted_node_linker_does_not_create_virtual_store_root() {
         !virtual_store_dir.exists(),
         "hoisted install must not materialize the virtual-store root at {virtual_store_dir:?}",
     );
+
+    drop(dir);
+}
+
+/// Frozen-lockfile install with a `VariationsResolution` whose
+/// variants only target a platform pacquet CI never runs on
+/// (`aix/ppc64`) must surface
+/// [`crate::InstallPackageBySnapshotError::NoMatchingPlatformVariant`]
+/// from the cold-batch dispatcher. Variant selection happens
+/// before any network fetch, so the bogus URL on the variant is
+/// never read — the test stays hermetic.
+///
+/// Closes the variant-mismatch checkbox of #437 slice F.
+#[tokio::test]
+async fn frozen_lockfile_install_errors_when_no_variant_matches_host() {
+    let dir = tempdir().unwrap();
+    let store_dir = dir.path().join("pacquet-store");
+    let project_root = dir.path().join("project");
+    let modules_dir = project_root.join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pacquet");
+
+    let manifest_path = dir.path().join("package.json");
+    let mut manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
+    manifest.add_dependency("node", "runtime:22.0.0", DependencyGroup::Prod).unwrap();
+    manifest.save().unwrap();
+
+    let mut config = Config::new();
+    config.store_dir = store_dir.into();
+    config.modules_dir = modules_dir.to_path_buf();
+    config.virtual_store_dir = virtual_store_dir.clone();
+    let config = config.leak();
+
+    // Lockfile with a runtime entry whose variants only target a
+    // platform we're not running on. `runtime:22.0.0` is preserved
+    // through `PkgVerPeer`'s `Prefix::Runtime` (#511 / #512); the
+    // depPath round-trips correctly through pacquet's parser.
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "importers:"
+        "  .:"
+        "    dependencies:"
+        "      node:"
+        "        specifier: 'runtime:22.0.0'"
+        "        version: 'runtime:22.0.0'"
+        "packages:"
+        "  'node@runtime:22.0.0':"
+        "    hasBin: true"
+        "    resolution:"
+        "      type: variations"
+        "      variants:"
+        "        - resolution:"
+        "            type: binary"
+        "            url: 'https://example.test/node-aix-ppc64.tar.gz'"
+        "            integrity: 'sha512-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa=='"
+        "            bin: 'bin/node'"
+        "            archive: tarball"
+        "          targets:"
+        "            - os: aix"
+        "              cpu: ppc64"
+        "snapshots:"
+        "  'node@runtime:22.0.0': {}"
+    })
+    .expect("parse variant-mismatch fixture lockfile");
+
+    let err = Install {
+        tarball_mem_cache: &Default::default(),
+        http_client: &Default::default(),
+        config,
+        manifest: &manifest,
+        lockfile: Some(&lockfile),
+        dependency_groups: [DependencyGroup::Prod, DependencyGroup::Optional],
+        frozen_lockfile: true,
+        skip_runtimes: false,
+        supported_architectures: None,
+        resolved_packages: &Default::default(),
+        node_linker: pacquet_config::NodeLinker::default(),
+    }
+    .run::<SilentReporter>()
+    .await
+    .expect_err("variant-mismatch lockfile must surface a typed error");
+
+    let rendered = format!("{err:?}");
+    eprintln!("ERROR DEBUG:\n{rendered}");
+    assert!(
+        rendered.contains("NoMatchingPlatformVariant"),
+        "expected NoMatchingPlatformVariant in the error chain, got: {rendered}",
+    );
+    let displayed = err.to_string();
+    assert!(!displayed.is_empty(), "Display impl should produce a non-empty user-facing message");
+
+    drop(dir);
+}
+
+/// Same lockfile + manifest shape as
+/// [`frozen_lockfile_install_errors_when_no_variant_matches_host`],
+/// but with `skip_runtimes: true`. The `--no-runtime` filter
+/// iterates importer-direct deps, builds `node@runtime:22.0.0`
+/// from `(alias, version)`, sees the `@runtime:` substring, and
+/// adds the snapshot to the skip set — so variant selection
+/// never runs and the unmatchable-platform variant doesn't fail
+/// the install.
+///
+/// Closes the `--no-runtime` checkbox of #437 slice F.
+#[tokio::test]
+async fn frozen_lockfile_install_skips_runtime_when_skip_runtimes_set() {
+    let dir = tempdir().unwrap();
+    let store_dir = dir.path().join("pacquet-store");
+    let project_root = dir.path().join("project");
+    let modules_dir = project_root.join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pacquet");
+
+    let manifest_path = dir.path().join("package.json");
+    let mut manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
+    manifest.add_dependency("node", "runtime:22.0.0", DependencyGroup::Prod).unwrap();
+    manifest.save().unwrap();
+
+    let mut config = Config::new();
+    config.store_dir = store_dir.into();
+    config.modules_dir = modules_dir.to_path_buf();
+    config.virtual_store_dir = virtual_store_dir.clone();
+    let config = config.leak();
+
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "importers:"
+        "  .:"
+        "    dependencies:"
+        "      node:"
+        "        specifier: 'runtime:22.0.0'"
+        "        version: 'runtime:22.0.0'"
+        "packages:"
+        "  'node@runtime:22.0.0':"
+        "    hasBin: true"
+        "    resolution:"
+        "      type: variations"
+        "      variants:"
+        "        - resolution:"
+        "            type: binary"
+        "            url: 'https://example.test/node-aix-ppc64.tar.gz'"
+        "            integrity: 'sha512-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa=='"
+        "            bin: 'bin/node'"
+        "            archive: tarball"
+        "          targets:"
+        "            - os: aix"
+        "              cpu: ppc64"
+        "snapshots:"
+        "  'node@runtime:22.0.0': {}"
+    })
+    .expect("parse --no-runtime fixture lockfile");
+
+    Install {
+        tarball_mem_cache: &Default::default(),
+        http_client: &Default::default(),
+        config,
+        manifest: &manifest,
+        lockfile: Some(&lockfile),
+        dependency_groups: [DependencyGroup::Prod, DependencyGroup::Optional],
+        frozen_lockfile: true,
+        skip_runtimes: true,
+        supported_architectures: None,
+        resolved_packages: &Default::default(),
+        node_linker: pacquet_config::NodeLinker::default(),
+    }
+    .run::<SilentReporter>()
+    .await
+    .expect("--no-runtime should skip the unmatchable runtime entry and let the rest of the install succeed");
+
+    // The runtime slot must NOT exist under the virtual store —
+    // the snapshot was filtered out by the skip set.
+    let runtime_slot = virtual_store_dir.join("node@runtime:22.0.0");
+    assert!(
+        !runtime_slot.exists(),
+        "runtime slot should not be materialized under --no-runtime, got {runtime_slot:?}",
+    );
+    // Neither should the direct-dep symlink under the project's
+    // `node_modules/`.
+    let direct_dep = modules_dir.join("node");
+    assert!(
+        !direct_dep.exists(),
+        "direct-dep symlink for node should not be created under --no-runtime, got {direct_dep:?}",
+    );
+
+    drop(dir);
 }

--- a/crates/package-manager/src/install/tests.rs
+++ b/crates/package-manager/src/install/tests.rs
@@ -2561,16 +2561,23 @@ async fn frozen_lockfile_install_skips_runtime_when_skip_runtimes_set() {
 
     // The runtime slot must NOT exist under the virtual store —
     // the snapshot was filtered out by the skip set.
+    //
+    // Use `symlink_metadata` rather than `Path::exists()` so a
+    // *dangling* symlink fails the assertion too: `exists()`
+    // follows symlinks and reports `false` for a broken one, but
+    // a broken symlink at `<modules_dir>/node` would still mean
+    // the install created an entry the skip set was supposed to
+    // suppress.
     let runtime_slot = virtual_store_dir.join("node@runtime:22.0.0");
     assert!(
-        !runtime_slot.exists(),
+        std::fs::symlink_metadata(&runtime_slot).is_err(),
         "runtime slot should not be materialized under --no-runtime, got {runtime_slot:?}",
     );
     // Neither should the direct-dep symlink under the project's
-    // `node_modules/`.
+    // `node_modules/`. Same `symlink_metadata` rationale.
     let direct_dep = modules_dir.join("node");
     assert!(
-        !direct_dep.exists(),
+        std::fs::symlink_metadata(&direct_dep).is_err(),
         "direct-dep symlink for node should not be created under --no-runtime, got {direct_dep:?}",
     );
 


### PR DESCRIPTION
## Summary

Two end-to-end install tests for the runtime-dependency pipeline, now that [#512](https://github.com/pnpm/pacquet/pull/512) (`PkgVerPeer::Prefix::Runtime`) unblocked fixture-lockfile parsing. Closes two of [#437](https://github.com/pnpm/pacquet/issues/437)'s slice F checkboxes.

### Tests

- **`frozen_lockfile_install_errors_when_no_variant_matches_host`** — fixture lockfile with a `VariationsResolution` whose only variant targets `aix/ppc64` (a platform pacquet CI never runs on). Install fails with `NoMatchingPlatformVariant` from the cold-batch dispatcher. Variant selection runs before any network fetch, so the bogus archive URL is never read — the test stays hermetic.
- **`frozen_lockfile_install_skips_runtime_when_skip_runtimes_set`** — same lockfile but with `skip_runtimes: true`. The `--no-runtime` filter iterates importer-direct deps, builds `node@runtime:22.0.0` from `(alias, version)`, sees the `@runtime:` substring, and adds the snapshot to the skip set — variant selection never runs, install succeeds. Asserts both the runtime slot and the direct-dep symlink are absent.

Each test was verified to catch its regression: disabling the `--no-runtime` filter makes the second test fail with `NoMatchingPlatformVariant` instead of succeeding.

### Drive-by fix: `PkgNameVerPeer::without_peer` drops the runtime prefix

The existing implementation reconstructed the bare version from `self.suffix.version().to_string()` — which drops the `Prefix::Runtime` from #512. So a runtime snapshot key like `node@runtime:22.0.0(some@peer)` would resolve to the non-existent `node@22.0.0` `packages:` entry on lookup. The first test surfaces this: without the fix, `CreateVirtualStoreError::MissingPackageMetadata` fires before the variant selector ever runs. Fixed by preserving the prefix through the strip.

### Slice F's remaining work

Deferred to a follow-up (need a mock HTTP server + recorded archive fixture):

- [ ] Happy-path frozen-lockfile install with `VariationsResolution`
- [ ] Same with single `BinaryResolution`
- [ ] `npm`/`npx`/`corepack` paths absent end-to-end (currently only unit-tested at the filter level)
- [ ] Integrity mismatch
- [ ] Path-traversal (already unit-tested in `pacquet-tarball` from slice C)
- [ ] TEST_PORTING.md "Installation Of Runtimes" entries

## Test plan

- [x] `frozen_lockfile_install_errors_when_no_variant_matches_host` passes; verified by reverting the `Prefix::Runtime` preservation in `without_peer` — the test surfaces `MissingPackageMetadata` instead of `NoMatchingPlatformVariant`.
- [x] `frozen_lockfile_install_skips_runtime_when_skip_runtimes_set` passes; verified by disabling the `skip_runtimes` filter in `install_frozen_lockfile.rs` — the test fails with `NoMatchingPlatformVariant`.
- [x] All 109 `pacquet-lockfile` tests still pass (the `without_peer` change is covered).
- [x] `just ready`, `taplo format --check`, `just dylint`, `cargo doc -D warnings` green.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve scheme prefixes (e.g., `runtime:`) when parsing peer dependency versions to maintain snapshot key compatibility.
  * Improve error reporting when frozen lockfiles contain platform variants that don't match the host.

* **New Features**
  * Allow skipping runtime dependencies during locked installations (`skip_runtimes` behavior).

* **Tests**
  * Added integration tests for frozen-lockfile platform-variant selection and skip-runtime behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pacquet/pull/516)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->