### PR TITLE
feat(package-manager): wire nodeLinker=hoisted into install pipeline (#438 slice 6)

### DIFF
--- a/crates/package-manager/src/create_virtual_store.rs
+++ b/crates/package-manager/src/create_virtual_store.rs
@@ -83,7 +83,7 @@ pub struct CreateVirtualStoreOutput {
     /// Per-package CAS index, populated only when
     /// [`CreateVirtualStore::node_linker`] is
     /// [`NodeLinker::Hoisted`]. Threaded into
-    /// [`crate::link_hoisted_modules`] which materializes the
+    /// [`crate::link_hoisted_modules()`] which materializes the
     /// hoisted `node_modules/` tree directly from these CAS paths
     /// — there is no virtual store under hoisted, so this is the
     /// only output that survives into the link phase. `None` for
@@ -144,7 +144,7 @@ pub struct CreateVirtualStore<'a> {
     /// populate per-snapshot virtual-store slot directories. Under
     /// [`NodeLinker::Hoisted`] the slot writes are skipped entirely
     /// — the hoisted linker
-    /// ([`crate::link_hoisted_modules`]) consumes the per-package
+    /// ([`crate::link_hoisted_modules()`]) consumes the per-package
     /// CAS index threaded through
     /// [`CreateVirtualStoreOutput::cas_paths_by_pkg_id`] instead.
     /// Tarball downloads and CAS writes still happen for both
@@ -784,7 +784,7 @@ impl<'a> CreateVirtualStore<'a> {
         // [`linkHoistedModules`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-restorer/src/linkHoistedModules.ts)
         // awaits it at link time. Pacquet's fetcher and walker run
         // independently, so the CAS index is collected here and
-        // handed to the linker in [`crate::link_hoisted_modules`]
+        // handed to the linker in [`crate::link_hoisted_modules()`]
         // through this output field.
         //
         // Key shape: [`PkgIdWithPatchHash`] mirrors the

--- a/crates/package-manager/src/create_virtual_store.rs
+++ b/crates/package-manager/src/create_virtual_store.rs
@@ -1,14 +1,14 @@
 use crate::{
-    InstallPackageBySnapshot, InstallPackageBySnapshotError, SkippedSnapshots,
+    CasPathsByPkgId, InstallPackageBySnapshot, InstallPackageBySnapshotError, SkippedSnapshots,
     install_package_by_snapshot::host_platform_selector, store_init::init_store_dir_best_effort,
 };
 use derive_more::{Display, Error};
 use futures_util::future;
 use miette::Diagnostic;
-use pacquet_config::Config;
+use pacquet_config::{Config, NodeLinker};
 use pacquet_lockfile::{
-    LockfileResolution, PackageKey, PackageMetadata, PkgNameVerPeer, SnapshotEntry,
-    select_platform_variant,
+    LockfileResolution, PackageKey, PackageMetadata, PkgIdWithPatchHash, PkgNameVerPeer,
+    SnapshotEntry, select_platform_variant,
 };
 use pacquet_network::ThrottledClient;
 use pacquet_reporter::{
@@ -80,6 +80,19 @@ pub struct CreateVirtualStoreOutput {
     pub package_manifests: PackageManifests,
     pub side_effects_maps_by_snapshot: SideEffectsMapsBySnapshot,
     pub fetch_failed: HashSet<PackageKey>,
+    /// Per-package CAS index, populated only when
+    /// [`CreateVirtualStore::node_linker`] is
+    /// [`NodeLinker::Hoisted`]. Threaded into
+    /// [`crate::link_hoisted_modules`] which materializes the
+    /// hoisted `node_modules/` tree directly from these CAS paths
+    /// — there is no virtual store under hoisted, so this is the
+    /// only output that survives into the link phase. `None` for
+    /// the isolated and pnp linkers (their slot directories are
+    /// the bridge into the link phase instead). Mirrors upstream's
+    /// `lockfileToHoistedDepGraph` populating per-node `fetching`
+    /// handles inside the walk; pacquet decouples fetch and walk,
+    /// so the index is built here at fetch time.
+    pub cas_paths_by_pkg_id: Option<CasPathsByPkgId>,
 }
 
 /// This subroutine generates filesystem layout for the virtual store at `node_modules/.pacquet`.
@@ -126,6 +139,17 @@ pub struct CreateVirtualStore<'a> {
     /// behavior of materializing only non-skipped snapshots in the
     /// graph passed to the build phase.
     pub skipped: &'a SkippedSnapshots,
+    /// Selects between the isolated and hoisted install layouts.
+    /// Under [`NodeLinker::Isolated`] the warm and cold batches
+    /// populate per-snapshot virtual-store slot directories. Under
+    /// [`NodeLinker::Hoisted`] the slot writes are skipped entirely
+    /// — the hoisted linker
+    /// ([`crate::link_hoisted_modules`]) consumes the per-package
+    /// CAS index threaded through
+    /// [`CreateVirtualStoreOutput::cas_paths_by_pkg_id`] instead.
+    /// Tarball downloads and CAS writes still happen for both
+    /// linkers; only the slot-materialization step differs.
+    pub node_linker: NodeLinker,
 }
 
 /// Error type of [`CreateVirtualStore`].
@@ -168,7 +192,10 @@ impl<'a> CreateVirtualStore<'a> {
             store_index_writer,
             allow_build_policy,
             skipped,
+            node_linker,
         } = self;
+
+        let is_hoisted = matches!(node_linker, NodeLinker::Hoisted);
 
         let Some(snapshots) = snapshots else {
             // No snapshots to install. If the lockfile also has no project deps
@@ -178,6 +205,7 @@ impl<'a> CreateVirtualStore<'a> {
                 package_manifests: PackageManifests::new(),
                 side_effects_maps_by_snapshot: SideEffectsMapsBySnapshot::new(),
                 fetch_failed: HashSet::new(),
+                cas_paths_by_pkg_id: is_hoisted.then(CasPathsByPkgId::new),
             });
         };
         let packages = packages.ok_or(CreateVirtualStoreError::MissingPackagesSection)?;
@@ -564,8 +592,25 @@ impl<'a> CreateVirtualStore<'a> {
             }
         }
 
+        // Hoisted-mode CAS index assembly. Collected here, *before*
+        // the warm-batch closure consumes `warm` under the
+        // isolated branch below, so the borrow checker doesn't
+        // need to reason across the two branches. Cold-batch
+        // entries are appended at the bottom of the function once
+        // the cold-batch fetch finishes.
+        let mut cas_paths_by_pkg_id: Option<CasPathsByPkgId> = if is_hoisted {
+            let mut map = CasPathsByPkgId::with_capacity(warm.len());
+            for (snapshot_key, _snapshot, cas_paths) in &warm {
+                let pkg_id = PkgIdWithPatchHash::from(snapshot_key.to_string());
+                map.entry(pkg_id).or_insert_with(|| (***cas_paths).clone());
+            }
+            Some(map)
+        } else {
+            None
+        };
+
         let import_method = config.package_import_method;
-        {
+        if !is_hoisted {
             use rayon::prelude::*;
             // Driving the warm batch from inside an `async fn` means
             // the `par_iter` blocks the calling tokio worker for the
@@ -580,6 +625,14 @@ impl<'a> CreateVirtualStore<'a> {
             // matching how the rest of the test suite already runs
             // sync work directly on the test thread (Copilot review on
             // #292).
+            //
+            // Hoisted skips this batch entirely: no virtual-store slot
+            // gets written, so there's no per-snapshot link work to
+            // do — the CAS paths captured below are the only output
+            // the link phase consumes. Mirrors upstream's
+            // `nodeLinker === 'hoisted'` guard at
+            // <https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-restorer/src/index.ts#L411-L425>
+            // which routes all link work into `linkHoistedModules`.
             let warm_work = move || {
                 warm.par_iter().try_for_each(|(snapshot_key, snapshot, cas_paths)| {
                     let package_id = snapshot_key.without_peer().to_string();
@@ -610,25 +663,45 @@ impl<'a> CreateVirtualStore<'a> {
             } else {
                 warm_work()?;
             }
+        } else {
+            // Hoisted still wants the progress reporter to fire so
+            // `pnpm:progress imported`-style updates render the warm
+            // hits — the link work just happens later, in
+            // `link_hoisted_modules`.
+            for (snapshot_key, _, _) in &warm {
+                let package_id = snapshot_key.without_peer().to_string();
+                emit_warm_snapshot_progress::<R>(&package_id, requester);
+            }
         }
 
         // Cold batch: snapshots that didn't prefetch — fall through to the
         // existing tokio + download path.
         //
-        // Per-snapshot result is `Option<PackageKey>`: `Some(key)` flags
-        // a fetch/extract failure that was silently swallowed because
-        // the snapshot is `optional: true`. Mirrors upstream's
-        // `if (pkgSnapshot.optional) return; throw err;` at
-        // <https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-builder/src/lockfileToDepGraph.ts#L294-L298>.
-        // Aggregated into `fetch_failed` for the caller to fold into
-        // its [`crate::SkippedSnapshots`] so downstream walkers
-        // (`build_sequence`, `link_bins`, hoist) treat the snapshot
-        // as absent.
+        // Per-snapshot result is `(Option<PackageKey>, Option<HashMap>)`:
+        // - `Some(key)` in the first slot flags a fetch/extract failure
+        //   that was silently swallowed because the snapshot is
+        //   `optional: true`. Mirrors upstream's
+        //   `if (pkgSnapshot.optional) return; throw err;` at
+        //   <https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-builder/src/lockfileToDepGraph.ts#L294-L298>.
+        //   Aggregated into `fetch_failed` for the caller to fold into
+        //   its [`crate::SkippedSnapshots`] so downstream walkers
+        //   (`build_sequence`, `link_bins`, hoist) treat the snapshot
+        //   as absent.
+        // - The second slot is the per-snapshot CAS index returned by
+        //   [`InstallPackageBySnapshot::run`], threaded into
+        //   `cas_paths_by_pkg_id` under hoisted (the linker consumes
+        //   it directly). `None` for the isolated linker — its
+        //   per-slot import has already happened by the time the
+        //   future returns; under hoisted no slot was written and the
+        //   CAS index is the only output.
         let mut fetch_failed: HashSet<PackageKey> = HashSet::new();
+        let mut cold_cas_paths: Vec<(&PackageKey, HashMap<String, PathBuf>)> = Vec::new();
         if !cold.is_empty() {
             let prefetched_ref = Some(&prefetched);
             let verified_files_cache_ref = &verified_files_cache;
-            let outcomes: Vec<Option<PackageKey>> = cold
+            type ColdOutcome<'a> =
+                (Option<PackageKey>, Option<(&'a PackageKey, HashMap<String, PathBuf>)>);
+            let outcomes: Vec<ColdOutcome<'_>> = cold
                 .iter()
                 .map(|(snapshot_key, snapshot)| async move {
                     let metadata_key = snapshot_key.without_peer();
@@ -652,11 +725,15 @@ impl<'a> CreateVirtualStore<'a> {
                         metadata,
                         snapshot,
                         allow_build_policy,
+                        node_linker,
                     }
                     .run::<R>()
                     .await;
                     match result {
-                        Ok(()) => Ok(None),
+                        Ok(cas_paths) => {
+                            let captured = is_hoisted.then_some((*snapshot_key, cas_paths));
+                            Ok((None, captured))
+                        }
                         Err(err) if snapshot.optional && is_fetch_side_failure(&err) => {
                             // Silent swallow, matching upstream. `tracing::warn!`
                             // gives operator visibility without polluting
@@ -683,14 +760,58 @@ impl<'a> CreateVirtualStore<'a> {
                                 error = %err,
                                 "optional snapshot fetch/extract failed; dropping from install",
                             );
-                            Ok(Some((*snapshot_key).clone()))
+                            Ok((Some((*snapshot_key).clone()), None))
                         }
                         Err(err) => Err(CreateVirtualStoreError::InstallPackageBySnapshot(err)),
                     }
                 })
                 .pipe(future::try_join_all)
                 .await?;
-            fetch_failed.extend(outcomes.into_iter().flatten());
+            for (failure, captured) in outcomes {
+                if let Some(key) = failure {
+                    fetch_failed.insert(key);
+                }
+                if let Some(captured) = captured {
+                    cold_cas_paths.push(captured);
+                }
+            }
+        }
+
+        // Build the per-pkg CAS index when the install is targeting
+        // the hoisted linker. Upstream's
+        // [`lockfileToHoistedDepGraph`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-restorer/src/lockfileToHoistedDepGraph.ts)
+        // populates a per-node `fetching` handle inside the walk and
+        // [`linkHoistedModules`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-restorer/src/linkHoistedModules.ts)
+        // awaits it at link time. Pacquet's fetcher and walker run
+        // independently, so the CAS index is collected here and
+        // handed to the linker in [`crate::link_hoisted_modules`]
+        // through this output field.
+        //
+        // Key shape: [`PkgIdWithPatchHash`] mirrors the
+        // `pkg_id_with_patch_hash` field that the slice 4 walker
+        // assigns to each [`crate::DependenciesGraphNode`] (see
+        // [`crate::hoisted_dep_graph`]). Until pacquet has end-to-end
+        // patch support, the value equals the snapshot key including
+        // any peer suffix; that matches what the walker writes, so
+        // `<linker>.cas_paths_by_pkg_id.get(&node.pkg_id_with_patch_hash)`
+        // hits.
+        //
+        // Peer-variants of the same package share a single
+        // [`std::sync::Arc<HashMap>`] in the warm batch (see
+        // `package_manifests` at the loop above for the same Arc
+        // sharing pattern). The linker takes an owned
+        // `HashMap<String, PathBuf>` per package, so each variant
+        // gets a (cheap) clone of the underlying map — `PathBuf`
+        // clones are short string copies, and the per-variant
+        // duplication only matters when the lockfile has many
+        // peer-resolved variants, which is a small fraction of any
+        // real install.
+        if let Some(map) = cas_paths_by_pkg_id.as_mut() {
+            map.reserve(cold_cas_paths.len());
+            for (snapshot_key, paths) in cold_cas_paths {
+                let pkg_id = PkgIdWithPatchHash::from(snapshot_key.to_string());
+                map.entry(pkg_id).or_insert(paths);
+            }
         }
 
         // The writer is owned by the caller now. They drop their
@@ -703,6 +824,7 @@ impl<'a> CreateVirtualStore<'a> {
             package_manifests,
             side_effects_maps_by_snapshot,
             fetch_failed,
+            cas_paths_by_pkg_id,
         })
     }
 }

--- a/crates/package-manager/src/install.rs
+++ b/crates/package-manager/src/install.rs
@@ -269,158 +269,176 @@ where
         //    normally generate / update a lockfile, which pacquet
         //    doesn't support yet → `UnsupportedLockfileMode`. `false`
         //    means "lockfile disabled, resolve from registry".
-        let (hoisted_dependencies, frozen_skipped): (HoistedDependencies, crate::SkippedSnapshots) =
-            if frozen_lockfile {
-                let Some(lockfile) = lockfile else {
-                    return Err(InstallError::NoLockfile);
-                };
-                let Lockfile { lockfile_version, importers, packages, snapshots, .. } = lockfile;
-                assert_eq!(lockfile_version.major, 9); // compatibility check already happens at serde, but this still helps preventing programmer mistakes.
-
-                // Freshness check: verify the on-disk `package.json`
-                // still matches the lockfile's importer entry before we
-                // commit to materializing `node_modules` from it. Mirrors
-                // upstream's `satisfiesPackageManifest` gate at
-                // <https://github.com/pnpm/pnpm/blob/94240bc046/pkg-manager/core/src/install/index.ts#L808-L832>.
-                // Pacquet has only one importer today (#431 tracks
-                // workspaces), so the root project is the only thing to
-                // verify; once workspaces land this becomes a per-project
-                // loop over `importers`.
-                let importer = importers.get(Lockfile::ROOT_IMPORTER_KEY).ok_or_else(|| {
-                    InstallError::NoImporter {
-                        importer_id: Lockfile::ROOT_IMPORTER_KEY.to_string(),
-                    }
-                })?;
-                // Outdated-settings gate (umbrella #434 slice 7): check
-                // `ignoredOptionalDependencies` drift between the
-                // lockfile-recorded set and the current config before
-                // the per-importer specifier check. Mirrors upstream's
-                // [`getOutdatedLockfileSetting`](https://github.com/pnpm/pnpm/blob/94240bc046/lockfile/settings-checker/src/getOutdatedLockfileSetting.ts).
-                // Upstream flips `needsFullResolution` and re-runs the
-                // resolver; pacquet has no resolver, so the matching
-                // action is to abort with `OutdatedLockfile`.
-                pacquet_lockfile::check_lockfile_settings(
-                    lockfile,
-                    config.ignored_optional_dependencies.as_deref(),
-                )
-                .map_err(|reason| InstallError::OutdatedLockfile { reason })?;
-                // Build the `ignoredOptionalDependencies` filter set.
-                // Mirrors upstream's
-                // [`createOptionalDependenciesRemover`](https://github.com/pnpm/pnpm/blob/94240bc046/hooks/read-package-hook/src/createOptionalDependenciesRemover.ts):
-                // the hook iterates `manifest.optionalDependencies`
-                // and deletes matches from BOTH the `optional` and
-                // `dependencies` maps. A name only present in
-                // `dependencies` (not `optionalDependencies`) that
-                // happens to match the pattern is NOT removed —
-                // that's why the predicate is set-based ("name was
-                // in optionalDependencies AND matched") rather than
-                // pure pattern matching. `devDependencies` is
-                // untouched on purpose; the group gate inside
-                // `satisfies_package_manifest` enforces that.
-                let ignored_set: std::collections::HashSet<String> = config
-                    .ignored_optional_dependencies
-                    .as_deref()
-                    .filter(|patterns| !patterns.is_empty())
-                    .map(|patterns| {
-                        let matcher = pacquet_config::matcher::create_matcher(patterns);
-                        manifest
-                            .dependencies([pacquet_package_manifest::DependencyGroup::Optional])
-                            .filter(|(name, _)| matcher.matches(name))
-                            .map(|(name, _)| name.to_string())
-                            .collect()
-                    })
-                    .unwrap_or_default();
-                let is_ignored_optional: &dyn Fn(&str) -> bool =
-                    &|name: &str| ignored_set.contains(name);
-                satisfies_package_manifest(
-                    importer,
-                    manifest,
-                    Lockfile::ROOT_IMPORTER_KEY,
-                    is_ignored_optional,
-                )
-                .map_err(|reason| InstallError::OutdatedLockfile { reason })?;
-
-                let frozen_result = InstallFrozenLockfile {
-                    http_client,
-                    config,
-                    importers,
-                    packages: packages.as_ref(),
-                    snapshots: snapshots.as_ref(),
-                    current_snapshots: current_lockfile.as_ref().and_then(|l| l.snapshots.as_ref()),
-                    current_packages: current_lockfile.as_ref().and_then(|l| l.packages.as_ref()),
-                    dependency_groups,
-                    logged_methods: &logged_methods,
-                    workspace_root: &workspace_root,
-                    requester: &prefix,
-                    supported_architectures: supported_architectures.as_ref(),
-                    skip_runtimes,
-                }
-                .run::<R>()
-                .await
-                .map_err(InstallError::FrozenLockfile)?;
-
-                // Register every importer against the shared store now
-                // that the install has materialized their `node_modules/`.
-                // Mirrors upstream's call into `@pnpm/store.controller`'s
-                // [`registerProject`](https://github.com/pnpm/pnpm/blob/94240bc046/store/controller/src/storeController/projectRegistry.ts),
-                // which runs once per importer — a workspace ends up with
-                // one symlink in `<store_dir>/projects/` per package, so
-                // `pacquet store prune` (tracked separately) can find
-                // every reachable consumer of `<store_dir>/links/...`.
-                //
-                // Gated on `frozen_lockfile && enable_global_virtual_store`:
-                // `InstallWithoutLockfile` keeps the project-local virtual
-                // store via `VirtualStoreLayout::legacy`, and a registry
-                // entry for it would point at a project that never
-                // touches the shared store.
-                //
-                // Best-effort: a registry write failure shouldn't fail
-                // the install. Surface as `tracing::warn!` so the failure
-                // is diagnosable but the install carries on. Validation
-                // of importer keys is done by
-                // [`crate::SymlinkDirectDependencies::run`] before we get
-                // here, so by this point every key is known-safe.
-                if config.enable_global_virtual_store {
-                    for importer_id in importers.keys() {
-                        let project_dir = crate::symlink_direct_dependencies::importer_root_dir(
-                            &workspace_root,
-                            importer_id,
-                        );
-                        if let Err(error) =
-                            pacquet_store_dir::register_project(&config.store_dir, &project_dir)
-                        {
-                            tracing::warn!(
-                                target: "pacquet::install",
-                                ?error,
-                                importer_id = %importer_id,
-                                "Failed to register importer in the global-virtual-store registry; install continues",
-                            );
-                        }
-                    }
-                }
-
-                (frozen_result.hoisted_dependencies, frozen_result.skipped)
-            } else if config.lockfile {
-                return Err(InstallError::UnsupportedLockfileMode);
-            } else {
-                // The no-lockfile path has no installability check (no
-                // `packages:` metadata to evaluate constraints against),
-                // so its skip set is empty by construction.
-                let hd = InstallWithoutLockfile {
-                    tarball_mem_cache,
-                    resolved_packages,
-                    http_client,
-                    config,
-                    manifest,
-                    dependency_groups,
-                    logged_methods: &logged_methods,
-                    requester: &prefix,
-                }
-                .run::<R>()
-                .await
-                .map_err(InstallError::WithoutLockfile)?;
-                (hd, crate::SkippedSnapshots::new())
+        // The third tuple element is `hoisted_locations`: the
+        // per-depPath list of lockfile-relative directories the
+        // hoisted linker placed each package at. Empty under the
+        // isolated linker (and under the no-lockfile path); non-
+        // empty only when the frozen-lockfile install runs with
+        // `nodeLinker: hoisted`. Threaded into
+        // `build_modules_manifest` so the field is persisted into
+        // `.modules.yaml.hoisted_locations` for the next install
+        // and for the rebuild path (which throws
+        // `MISSING_HOISTED_LOCATIONS` when this field is gone).
+        let (hoisted_dependencies, hoisted_locations, frozen_skipped): (
+            HoistedDependencies,
+            BTreeMap<String, Vec<String>>,
+            crate::SkippedSnapshots,
+        ) = if frozen_lockfile {
+            let Some(lockfile) = lockfile else {
+                return Err(InstallError::NoLockfile);
             };
+            let Lockfile { lockfile_version, importers, packages, snapshots, .. } = lockfile;
+            assert_eq!(lockfile_version.major, 9); // compatibility check already happens at serde, but this still helps preventing programmer mistakes.
+
+            // Freshness check: verify the on-disk `package.json`
+            // still matches the lockfile's importer entry before we
+            // commit to materializing `node_modules` from it. Mirrors
+            // upstream's `satisfiesPackageManifest` gate at
+            // <https://github.com/pnpm/pnpm/blob/94240bc046/pkg-manager/core/src/install/index.ts#L808-L832>.
+            // Pacquet has only one importer today (#431 tracks
+            // workspaces), so the root project is the only thing to
+            // verify; once workspaces land this becomes a per-project
+            // loop over `importers`.
+            let importer = importers.get(Lockfile::ROOT_IMPORTER_KEY).ok_or_else(|| {
+                InstallError::NoImporter { importer_id: Lockfile::ROOT_IMPORTER_KEY.to_string() }
+            })?;
+            // Outdated-settings gate (umbrella #434 slice 7): check
+            // `ignoredOptionalDependencies` drift between the
+            // lockfile-recorded set and the current config before
+            // the per-importer specifier check. Mirrors upstream's
+            // [`getOutdatedLockfileSetting`](https://github.com/pnpm/pnpm/blob/94240bc046/lockfile/settings-checker/src/getOutdatedLockfileSetting.ts).
+            // Upstream flips `needsFullResolution` and re-runs the
+            // resolver; pacquet has no resolver, so the matching
+            // action is to abort with `OutdatedLockfile`.
+            pacquet_lockfile::check_lockfile_settings(
+                lockfile,
+                config.ignored_optional_dependencies.as_deref(),
+            )
+            .map_err(|reason| InstallError::OutdatedLockfile { reason })?;
+            // Build the `ignoredOptionalDependencies` filter set.
+            // Mirrors upstream's
+            // [`createOptionalDependenciesRemover`](https://github.com/pnpm/pnpm/blob/94240bc046/hooks/read-package-hook/src/createOptionalDependenciesRemover.ts):
+            // the hook iterates `manifest.optionalDependencies`
+            // and deletes matches from BOTH the `optional` and
+            // `dependencies` maps. A name only present in
+            // `dependencies` (not `optionalDependencies`) that
+            // happens to match the pattern is NOT removed —
+            // that's why the predicate is set-based ("name was
+            // in optionalDependencies AND matched") rather than
+            // pure pattern matching. `devDependencies` is
+            // untouched on purpose; the group gate inside
+            // `satisfies_package_manifest` enforces that.
+            let ignored_set: std::collections::HashSet<String> = config
+                .ignored_optional_dependencies
+                .as_deref()
+                .filter(|patterns| !patterns.is_empty())
+                .map(|patterns| {
+                    let matcher = pacquet_config::matcher::create_matcher(patterns);
+                    manifest
+                        .dependencies([pacquet_package_manifest::DependencyGroup::Optional])
+                        .filter(|(name, _)| matcher.matches(name))
+                        .map(|(name, _)| name.to_string())
+                        .collect()
+                })
+                .unwrap_or_default();
+            let is_ignored_optional: &dyn Fn(&str) -> bool =
+                &|name: &str| ignored_set.contains(name);
+            satisfies_package_manifest(
+                importer,
+                manifest,
+                Lockfile::ROOT_IMPORTER_KEY,
+                is_ignored_optional,
+            )
+            .map_err(|reason| InstallError::OutdatedLockfile { reason })?;
+
+            let frozen_result = InstallFrozenLockfile {
+                http_client,
+                config,
+                importers,
+                packages: packages.as_ref(),
+                snapshots: snapshots.as_ref(),
+                lockfile,
+                current_lockfile: current_lockfile.as_ref(),
+                current_snapshots: current_lockfile.as_ref().and_then(|l| l.snapshots.as_ref()),
+                current_packages: current_lockfile.as_ref().and_then(|l| l.packages.as_ref()),
+                dependency_groups,
+                logged_methods: &logged_methods,
+                workspace_root: &workspace_root,
+                requester: &prefix,
+                supported_architectures: supported_architectures.as_ref(),
+                skip_runtimes,
+                node_linker,
+            }
+            .run::<R>()
+            .await
+            .map_err(InstallError::FrozenLockfile)?;
+
+            // Register every importer against the shared store now
+            // that the install has materialized their `node_modules/`.
+            // Mirrors upstream's call into `@pnpm/store.controller`'s
+            // [`registerProject`](https://github.com/pnpm/pnpm/blob/94240bc046/store/controller/src/storeController/projectRegistry.ts),
+            // which runs once per importer — a workspace ends up with
+            // one symlink in `<store_dir>/projects/` per package, so
+            // `pacquet store prune` (tracked separately) can find
+            // every reachable consumer of `<store_dir>/links/...`.
+            //
+            // Gated on `frozen_lockfile && enable_global_virtual_store`:
+            // `InstallWithoutLockfile` keeps the project-local virtual
+            // store via `VirtualStoreLayout::legacy`, and a registry
+            // entry for it would point at a project that never
+            // touches the shared store.
+            //
+            // Best-effort: a registry write failure shouldn't fail
+            // the install. Surface as `tracing::warn!` so the failure
+            // is diagnosable but the install carries on. Validation
+            // of importer keys is done by
+            // [`crate::SymlinkDirectDependencies::run`] before we get
+            // here, so by this point every key is known-safe.
+            if config.enable_global_virtual_store {
+                for importer_id in importers.keys() {
+                    let project_dir = crate::symlink_direct_dependencies::importer_root_dir(
+                        &workspace_root,
+                        importer_id,
+                    );
+                    if let Err(error) =
+                        pacquet_store_dir::register_project(&config.store_dir, &project_dir)
+                    {
+                        tracing::warn!(
+                            target: "pacquet::install",
+                            ?error,
+                            importer_id = %importer_id,
+                            "Failed to register importer in the global-virtual-store registry; install continues",
+                        );
+                    }
+                }
+            }
+
+            (
+                frozen_result.hoisted_dependencies,
+                frozen_result.hoisted_locations,
+                frozen_result.skipped,
+            )
+        } else if config.lockfile {
+            return Err(InstallError::UnsupportedLockfileMode);
+        } else {
+            // The no-lockfile path has no installability check (no
+            // `packages:` metadata to evaluate constraints against),
+            // so its skip set is empty by construction.
+            let hd = InstallWithoutLockfile {
+                tarball_mem_cache,
+                resolved_packages,
+                http_client,
+                config,
+                manifest,
+                dependency_groups,
+                logged_methods: &logged_methods,
+                requester: &prefix,
+            }
+            .run::<R>()
+            .await
+            .map_err(InstallError::WithoutLockfile)?;
+            (hd, BTreeMap::new(), crate::SkippedSnapshots::new())
+        };
 
         tracing::info!(target: "pacquet::install", "Complete all");
 
@@ -446,6 +464,7 @@ where
                 node_linker,
                 included,
                 hoisted_dependencies,
+                hoisted_locations,
                 &frozen_skipped,
             ),
         )
@@ -515,13 +534,25 @@ fn map_node_linker(linker: &NodeLinker) -> ModulesNodeLinker {
 /// `injectedDeps`, `ignoredBuilds`, `allowBuilds`) default to empty
 /// / unset.
 ///
-/// `hoistedDependencies` is produced by the hoist pass in
-/// `InstallFrozenLockfile::run` and threaded in here — empty for the
-/// no-lockfile path and for installs where both hoist patterns are
-/// `None`. Persisting it lets a subsequent install detect a hoist
-/// pattern change and re-hoist appropriately (the partial-install
-/// path tracked at pnpm/pacquet#433 will consume it; today every
-/// install does the full hoist anyway).
+/// `hoistedDependencies` is produced by the isolated-linker hoist
+/// pass in [`crate::InstallFrozenLockfile::run`] and threaded in
+/// here — empty for the no-lockfile path, for installs where both
+/// hoist patterns are `None`, and under `nodeLinker: hoisted` (the
+/// hoisted linker uses `hoisted_locations` instead). Persisting it
+/// lets a subsequent install detect a hoist pattern change and
+/// re-hoist appropriately (the partial-install path tracked at
+/// pnpm/pacquet#433 will consume it; today every install does the
+/// full hoist anyway).
+///
+/// `hoisted_locations` is the per-depPath list of lockfile-relative
+/// directory paths the hoisted linker placed each package at. Empty
+/// for the isolated linker (the field is hoisted-only on disk and
+/// only meaningful when `nodeLinker: hoisted`). Persisted into
+/// [`Modules::hoisted_locations`] when non-empty so the next
+/// install's walker can short-circuit re-fetching packages already
+/// present on disk and the rebuild path can locate every hoisted
+/// directory; absent persistence is what surfaces upstream's
+/// `MISSING_HOISTED_LOCATIONS` error during rebuild.
 ///
 /// `skipped` is the depPath list pnpm writes at
 /// <https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/src/install/index.ts#L1625>:
@@ -538,11 +569,17 @@ fn build_modules_manifest(
     node_linker: NodeLinker,
     included: IncludedDependencies,
     hoisted_dependencies: HoistedDependencies,
+    hoisted_locations: BTreeMap<String, Vec<String>>,
     skipped: &crate::SkippedSnapshots,
 ) -> Modules {
     Modules {
         hoist_pattern: config.hoist_pattern.clone(),
         hoisted_dependencies,
+        // `Some(empty)` would round-trip on disk as
+        // `hoistedLocations: {}`, which differs from upstream's
+        // unset-when-empty behavior. Drop the field when empty so
+        // an isolated install doesn't produce a hoisted-only key.
+        hoisted_locations: (!hoisted_locations.is_empty()).then_some(hoisted_locations),
         included,
         layout_version: Some(LayoutVersion),
         node_linker: Some(map_node_linker(&node_linker)),

--- a/crates/package-manager/src/install/tests.rs
+++ b/crates/package-manager/src/install/tests.rs
@@ -1616,6 +1616,7 @@ fn build_modules_manifest_serializes_skipped_set() {
         pacquet_config::NodeLinker::default(),
         included,
         Default::default(),
+        Default::default(),
         &skipped,
     );
 
@@ -1651,9 +1652,14 @@ fn build_modules_manifest_skipped_is_empty_on_empty_set() {
         pacquet_config::NodeLinker::default(),
         IncludedDependencies::default(),
         Default::default(),
+        Default::default(),
         &SkippedSnapshots::new(),
     );
     assert!(manifest.skipped.is_empty());
+    // Empty `hoisted_locations` is dropped to `None` so an
+    // isolated install doesn't write a `hoistedLocations: {}` key
+    // (which would falsely look like a stale hoisted-mode write).
+    assert!(manifest.hoisted_locations.is_none());
 }
 
 /// End-to-end read → seed → write loop. Pre-write
@@ -2225,4 +2231,165 @@ async fn frozen_install_no_optional_keeps_shared_non_optional_snapshot() {
     );
 
     drop(dir);
+}
+
+/// Wiring proof for the new `nodeLinker: hoisted` install branch
+/// (umbrella #438 slice 6). Empty lockfile drives the cheapest
+/// successful install path:
+///
+/// 1. `Install::run` dispatches into `InstallFrozenLockfile::run`.
+/// 2. `is_hoisted` flips on, the slot-creation in
+///    [`crate::CreateVirtualStore`] is skipped, and the
+///    [`crate::SymlinkDirectDependencies`] +
+///    [`crate::LinkVirtualStoreBins`] passes are bypassed.
+/// 3. [`crate::lockfile_to_hoisted_dep_graph`] returns an empty
+///    walker result against the empty `snapshots:` map.
+/// 4. [`crate::link_hoisted_modules`] is called with an empty
+///    graph (no-op).
+/// 5. `BuildModules` is skipped under hoisted (slice 7 retargets
+///    it onto `hoistedLocations`).
+/// 6. `.modules.yaml` is written with `nodeLinker: hoisted` and
+///    `hoisted_locations: None` (the field is dropped when empty
+///    so an isolated install never produces a hoisted-only key).
+///
+/// The empty-lockfile shape exercises every branch on `is_hoisted`
+/// without needing a real package fetch — proving the wiring
+/// composes with the existing pipeline phases. End-to-end coverage
+/// against the registry-mock with a real package is left to a
+/// follow-up CLI integration test.
+#[tokio::test]
+async fn hoisted_node_linker_empty_lockfile_writes_modules_yaml() {
+    let dir = tempdir().unwrap();
+    let store_dir = dir.path().join("pacquet-store");
+    let project_root = dir.path().join("project");
+    let modules_dir = project_root.join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pacquet");
+
+    std::fs::create_dir_all(&project_root).expect("create project root");
+    let manifest_path = project_root.join("package.json");
+    let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
+
+    let mut config = Config::new();
+    config.lockfile = false;
+    config.store_dir = store_dir.into();
+    config.modules_dir = modules_dir.clone();
+    config.virtual_store_dir = virtual_store_dir;
+    let config = config.leak();
+
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "importers:"
+        "  .:"
+        "    dependencies: {}"
+        "packages: {}"
+        "snapshots: {}"
+    })
+    .expect("parse minimal v9 lockfile");
+
+    Install {
+        tarball_mem_cache: &Default::default(),
+        http_client: &Default::default(),
+        config,
+        manifest: &manifest,
+        lockfile: Some(&lockfile),
+        dependency_groups: [DependencyGroup::Prod],
+        frozen_lockfile: true,
+        skip_runtimes: false,
+        supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::Hoisted,
+        resolved_packages: &Default::default(),
+    }
+    .run::<SilentReporter>()
+    .await
+    .expect("hoisted-linker install with empty lockfile should succeed");
+
+    let written = modules_dir
+        .pipe_as_ref(read_modules_manifest::<RealApi>)
+        .expect("read .modules.yaml")
+        .expect("modules manifest exists");
+
+    assert_eq!(written.node_linker, Some(NodeLinker::Hoisted));
+    // Empty walker output → no hoisted_locations to persist. The
+    // field is `None`-when-empty so the isolated linker doesn't
+    // accidentally write a stale `hoistedLocations: {}` key.
+    assert!(
+        written.hoisted_locations.is_none(),
+        "empty lockfile produces no hoisted_locations: {:?}",
+        written.hoisted_locations,
+    );
+    assert!(
+        written.hoisted_dependencies.is_empty(),
+        "hoisted-linker leaves hoisted_dependencies empty (no isolated-mode adapter shape): {:?}",
+        written.hoisted_dependencies,
+    );
+
+    drop(dir);
+}
+
+/// Hoisted install must NOT create the virtual-store slot
+/// directories the isolated linker would write — that's the whole
+/// point of skipping [`crate::CreateVirtualDirBySnapshot`] under
+/// hoisted. With no snapshots in the lockfile the assertion is
+/// vacuous (the directory is empty regardless of linker choice),
+/// but pinning the absence here documents the contract so a
+/// future regression that re-enables slot writes under hoisted
+/// surfaces immediately.
+///
+/// `node_modules/.pacquet/` not being present is the proof: the
+/// virtual-store root only gets created on demand by
+/// [`CreateVirtualDirBySnapshot::run`]; under hoisted that helper
+/// is never called, so the directory is never materialized.
+#[tokio::test]
+async fn hoisted_node_linker_does_not_create_virtual_store_root() {
+    let dir = tempdir().unwrap();
+    let store_dir = dir.path().join("pacquet-store");
+    let project_root = dir.path().join("project");
+    let modules_dir = project_root.join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pacquet");
+
+    std::fs::create_dir_all(&project_root).expect("create project root");
+    let manifest_path = project_root.join("package.json");
+    let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
+
+    let mut config = Config::new();
+    config.lockfile = false;
+    config.store_dir = store_dir.into();
+    config.modules_dir = modules_dir.clone();
+    config.virtual_store_dir = virtual_store_dir.clone();
+    let config = config.leak();
+
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "importers:"
+        "  .:"
+        "    dependencies: {}"
+        "packages: {}"
+        "snapshots: {}"
+    })
+    .expect("parse minimal v9 lockfile");
+
+    Install {
+        tarball_mem_cache: &Default::default(),
+        http_client: &Default::default(),
+        config,
+        manifest: &manifest,
+        lockfile: Some(&lockfile),
+        dependency_groups: [DependencyGroup::Prod],
+        frozen_lockfile: true,
+        skip_runtimes: false,
+        supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::Hoisted,
+        resolved_packages: &Default::default(),
+    }
+    .run::<SilentReporter>()
+    .await
+    .expect("hoisted-linker install should succeed");
+
+    // `<project>/node_modules/.pacquet` only gets created when
+    // CreateVirtualDirBySnapshot lays down a slot. Hoisted skips
+    // that helper, so the dir must remain absent.
+    assert!(
+        !virtual_store_dir.exists(),
+        "hoisted install must not materialize the virtual-store root at {virtual_store_dir:?}",
+    );
 }

--- a/crates/package-manager/src/install/tests.rs
+++ b/crates/package-manager/src/install/tests.rs
@@ -2244,7 +2244,7 @@ async fn frozen_install_no_optional_keeps_shared_non_optional_snapshot() {
 ///    [`crate::LinkVirtualStoreBins`] passes are bypassed.
 /// 3. [`crate::lockfile_to_hoisted_dep_graph`] returns an empty
 ///    walker result against the empty `snapshots:` map.
-/// 4. [`crate::link_hoisted_modules`] is called with an empty
+/// 4. [`crate::link_hoisted_modules()`] is called with an empty
 ///    graph (no-op).
 /// 5. `BuildModules` is skipped under hoisted (slice 7 retargets
 ///    it onto `hoistedLocations`).

--- a/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/crates/package-manager/src/install_frozen_lockfile.rs
@@ -1,18 +1,20 @@
 use crate::{
     AllowBuildPolicy, BuildModules, BuildModulesError, CreateVirtualStore, CreateVirtualStoreError,
-    CreateVirtualStoreOutput, HoistedDependencies, InstallabilityHost, LinkVirtualStoreBins,
-    LinkVirtualStoreBinsError, SkippedSnapshots, SymlinkDirectDependencies,
-    SymlinkDirectDependenciesError, SymlinkPackageError, VersionPolicyError, VirtualStoreLayout,
-    any_installability_constraint, build_direct_deps_by_importer, build_hoist_graph,
-    compute_skipped_snapshots, get_hoisted_dependencies, link_direct_dep_bins,
-    symlink_hoisted_dependencies,
+    CreateVirtualStoreOutput, HoistedDepGraphError, HoistedDependencies, InstallabilityHost,
+    LinkHoistedModulesError, LinkHoistedModulesOpts, LinkVirtualStoreBins,
+    LinkVirtualStoreBinsError, LockfileToHoistedDepGraphOptions, SkippedSnapshots,
+    SymlinkDirectDependencies, SymlinkDirectDependenciesError, SymlinkPackageError,
+    VersionPolicyError, VirtualStoreLayout, any_installability_constraint,
+    build_direct_deps_by_importer, build_hoist_graph, compute_skipped_snapshots,
+    get_hoisted_dependencies, link_direct_dep_bins, link_hoisted_modules,
+    lockfile_to_hoisted_dep_graph, symlink_hoisted_dependencies,
 };
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_cmd_shim::LinkBinsError;
-use pacquet_config::{Config, matcher::create_matcher};
+use pacquet_config::{Config, NodeLinker, matcher::create_matcher};
 use pacquet_executor::ScriptsPrependNodePath as ExecScriptsPrependNodePath;
-use pacquet_lockfile::{PackageKey, PackageMetadata, ProjectSnapshot, SnapshotEntry};
+use pacquet_lockfile::{Lockfile, PackageKey, PackageMetadata, ProjectSnapshot, SnapshotEntry};
 use pacquet_modules_yaml::{RealApi, read_modules_manifest};
 use pacquet_network::ThrottledClient;
 use pacquet_package_manifest::DependencyGroup;
@@ -22,7 +24,7 @@ use pacquet_patching::{
 use pacquet_reporter::{IgnoredScriptsLog, LogEvent, LogLevel, Reporter, Stage, StageLog};
 use pacquet_store_dir::StoreIndexWriter;
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     path::Path,
     sync::atomic::AtomicU8,
 };
@@ -46,6 +48,21 @@ where
     pub importers: &'a HashMap<String, ProjectSnapshot>,
     pub packages: Option<&'a HashMap<PackageKey, PackageMetadata>>,
     pub snapshots: Option<&'a HashMap<PackageKey, SnapshotEntry>>,
+    /// The fully-deserialized wanted lockfile. Carried alongside
+    /// the destructured `importers` / `packages` / `snapshots`
+    /// references because the hoisted-linker walker
+    /// ([`crate::lockfile_to_hoisted_dep_graph`]) takes a
+    /// `&Lockfile` (it threads the lockfile into
+    /// [`pacquet_real_hoist::hoist`] which needs every importer's
+    /// direct deps plus the full `packages` / `snapshots` maps in
+    /// one borrow). Isolated installs ignore the field.
+    pub lockfile: &'a Lockfile,
+    /// The previous install's persisted current lockfile, threaded
+    /// through to the hoisted walker for `prev_graph` (orphan
+    /// diff). Mirrors upstream's
+    /// [`currentLockfile`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-restorer/src/lockfileToHoistedDepGraph.ts#L70-L79)
+    /// argument. `None` on a first install.
+    pub current_lockfile: Option<&'a Lockfile>,
     /// Snapshots from the previous install's `lock.yaml`, if present.
     /// Threaded through to [`crate::CreateVirtualStore`] to drive the
     /// per-snapshot skip decision (a snapshot whose wiring and
@@ -98,6 +115,27 @@ where
     /// install ignores them. Computed at the CLI layer from
     /// `config.skip_runtimes || --no-runtime`.
     pub skip_runtimes: bool,
+
+    /// `nodeLinker` value to honor for *this* invocation. Threaded
+    /// from the [`crate::Install`] caller (which has already
+    /// applied any `--node-linker` CLI override on top of
+    /// [`pacquet_config::Config::node_linker`]).
+    ///
+    /// Under [`NodeLinker::Hoisted`] the install pipeline routes
+    /// through [`crate::lockfile_to_hoisted_dep_graph`] +
+    /// [`crate::link_hoisted_modules`] instead of the isolated
+    /// linker's [`crate::SymlinkDirectDependencies`] +
+    /// [`crate::LinkVirtualStoreBins`] + [`crate::get_hoisted_dependencies`]
+    /// chain. Mirrors upstream's
+    /// [`nodeLinker === 'hoisted'`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-restorer/src/index.ts#L369-L425)
+    /// branch in `headlessInstall`.
+    ///
+    /// Pacquet's [`NodeLinker::Pnp`] is a config / serde
+    /// placeholder today; an install request with `Pnp` reaches
+    /// the isolated linker in this branch (no PnP code path
+    /// exists yet). Upstream's `nodeLinker: 'pnp'` is also
+    /// out-of-scope for #438; tracked separately.
+    pub node_linker: NodeLinker,
 }
 
 /// Error type of [`InstallFrozenLockfile`].
@@ -170,6 +208,23 @@ pub enum InstallFrozenLockfileError {
     ///   <https://github.com/pnpm/pnpm/blob/94240bc046/config/package-is-installable/src/index.ts#L63>.
     #[diagnostic(transparent)]
     Installability(#[error(source)] Box<pacquet_package_is_installable::InstallabilityError>),
+
+    /// Surfaces failures from
+    /// [`crate::lockfile_to_hoisted_dep_graph`] when the install is
+    /// running under `nodeLinker: hoisted`. Includes invalid
+    /// snapshot references, multi-importer lockfiles (workspace
+    /// support is tracked separately), and installability errors
+    /// on required (non-optional) packages.
+    #[diagnostic(transparent)]
+    HoistedDepGraph(#[error(source)] HoistedDepGraphError),
+
+    /// Surfaces failures from [`crate::link_hoisted_modules`]
+    /// while materializing the on-disk hoisted tree. Includes
+    /// missing CAS-paths entries for required packages,
+    /// hierarchy/graph mismatches, file-import I/O failures, and
+    /// bin-link errors.
+    #[diagnostic(transparent)]
+    LinkHoistedModules(#[error(source)] LinkHoistedModulesError),
 }
 
 impl<'a, DependencyGroupList> InstallFrozenLockfile<'a, DependencyGroupList>
@@ -195,6 +250,8 @@ where
             importers,
             packages,
             snapshots,
+            lockfile,
+            current_lockfile,
             current_snapshots,
             current_packages,
             dependency_groups,
@@ -203,7 +260,9 @@ where
             requester,
             supported_architectures,
             skip_runtimes,
+            node_linker,
         } = self;
+        let is_hoisted = matches!(node_linker, NodeLinker::Hoisted);
         // Cloned so the iterator can be reused below for hoist's
         // direct-deps map. `Vec<DependencyGroup>` is tiny (≤4 enum
         // variants) so the clone is essentially free.
@@ -492,6 +551,7 @@ where
             package_manifests,
             side_effects_maps_by_snapshot,
             fetch_failed,
+            cas_paths_by_pkg_id,
         } = CreateVirtualStore {
             http_client,
             config,
@@ -505,6 +565,7 @@ where
             store_index_writer: &store_index_writer,
             allow_build_policy: &allow_build_policy,
             skipped: &skipped,
+            node_linker,
         }
         .run::<R>()
         .await
@@ -523,36 +584,134 @@ where
             skipped.add_fetch_failed(key);
         }
 
-        SymlinkDirectDependencies {
-            config,
-            layout: &layout,
-            importers,
-            dependency_groups: dependency_groups.iter().copied(),
-            workspace_root,
-            skipped: &skipped,
-        }
-        .run::<R>()
-        .map_err(InstallFrozenLockfileError::SymlinkDirectDependencies)?;
+        if !is_hoisted {
+            SymlinkDirectDependencies {
+                config,
+                layout: &layout,
+                importers,
+                dependency_groups: dependency_groups.iter().copied(),
+                workspace_root,
+                skipped: &skipped,
+            }
+            .run::<R>()
+            .map_err(InstallFrozenLockfileError::SymlinkDirectDependencies)?;
 
-        // Link the bins of each virtual-store slot's children into the
-        // slot's own `node_modules/.bin`. Pnpm runs this from
-        // `linkBinsOfDependencies` during the headless install. See
-        // <https://github.com/pnpm/pnpm/blob/4750fd370c/building/during-install/src/index.ts#L258-L309>.
-        // Done before `importing_done` so reporters see the import phase
-        // close only after every link (including per-slot bins) is in
-        // place. The manifest map threaded from `CreateVirtualStore`
-        // lets the linker hit `pkgFilesIndex.manifest` directly
-        // (matching pnpm's `bundledManifest`-from-CAFS path) instead
-        // of re-reading every child's `package.json` from disk.
-        LinkVirtualStoreBins {
-            layout: &layout,
-            snapshots,
-            packages,
-            package_manifests: &package_manifests,
-            skipped: &skipped,
+            // Link the bins of each virtual-store slot's children into the
+            // slot's own `node_modules/.bin`. Pnpm runs this from
+            // `linkBinsOfDependencies` during the headless install. See
+            // <https://github.com/pnpm/pnpm/blob/4750fd370c/building/during-install/src/index.ts#L258-L309>.
+            // Done before `importing_done` so reporters see the import phase
+            // close only after every link (including per-slot bins) is in
+            // place. The manifest map threaded from `CreateVirtualStore`
+            // lets the linker hit `pkgFilesIndex.manifest` directly
+            // (matching pnpm's `bundledManifest`-from-CAFS path) instead
+            // of re-reading every child's `package.json` from disk.
+            //
+            // Both passes are gated by `!is_hoisted`: under
+            // `nodeLinker: hoisted` there is no virtual store
+            // (`CreateVirtualStore` skipped slot writes), and the
+            // bin links go into `<parent>/node_modules/.bin` for
+            // every hoist location instead. The hoisted linker
+            // ([`crate::link_hoisted_modules`], called below) does
+            // its own per-`node_modules` bin pass while walking the
+            // hierarchy. Mirrors upstream's `nodeLinker === 'hoisted'`
+            // branch at
+            // <https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-restorer/src/index.ts#L411-L425>
+            // which routes both link phases through `linkHoistedModules`.
+            LinkVirtualStoreBins {
+                layout: &layout,
+                snapshots,
+                packages,
+                package_manifests: &package_manifests,
+                skipped: &skipped,
+            }
+            .run()
+            .map_err(InstallFrozenLockfileError::LinkVirtualStoreBins)?;
         }
-        .run()
-        .map_err(InstallFrozenLockfileError::LinkVirtualStoreBins)?;
+
+        // Hoisted-linker materialization. Replaces the isolated
+        // [`crate::SymlinkDirectDependencies`] +
+        // [`crate::LinkVirtualStoreBins`] pair when
+        // `nodeLinker: hoisted` is in effect: the dep-graph walker
+        // computes per-package directories (with conflict-aware
+        // nesting), and the linker imports CAS files into those
+        // directories from
+        // [`CreateVirtualStoreOutput::cas_paths_by_pkg_id`] which
+        // was populated above with `node_linker = Hoisted`.
+        //
+        // `hoisted_locations` is the per-depPath list of
+        // lockfile-relative directories the walker emits. Threaded
+        // through [`InstallFrozenLockfileOutput`] so
+        // [`crate::Install::run`] can persist it into
+        // `.modules.yaml.hoisted_locations` (rebuild reads it back
+        // and surfaces `MISSING_HOISTED_LOCATIONS` if it's gone).
+        //
+        // Mirrors upstream's hoisted branch at
+        // [`installing/deps-restorer/src/index.ts:369-427`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-restorer/src/index.ts#L369-L427).
+        let hoisted_locations: BTreeMap<String, Vec<String>> = if is_hoisted {
+            // Walker installability inputs come straight from the
+            // optional `host_node` we built earlier for the
+            // `compute_skipped_snapshots` pass. When `host_node` is
+            // `None` no per-snapshot constraint exists, so the
+            // host triple values pass through as defaults that the
+            // walker won't actually consult.
+            let host_for_walker = host_node.as_ref();
+            let walker_skipped: BTreeSet<String> =
+                skipped.iter().map(|key| key.to_string()).collect();
+            let walker_opts = LockfileToHoistedDepGraphOptions {
+                lockfile_dir: workspace_root.to_path_buf(),
+                auto_install_peers: config.auto_install_peers,
+                skipped: walker_skipped,
+                force: false,
+                // Pacquet's [`Config`] does not yet expose
+                // `engineStrict` (tracked separately); default to
+                // `false` so the walker matches
+                // `compute_skipped_snapshots` upthread, which uses
+                // [`InstallabilityHost::detect`]'s `false` default.
+                // Promotes engine mismatches to skip-optional rather
+                // than hard errors, in line with pacquet's
+                // production posture.
+                engine_strict: false,
+                current_node_version: host_for_walker
+                    .map(|(_, ver)| ver.clone())
+                    .unwrap_or_default(),
+                current_os: pacquet_graph_hasher::host_platform().to_string(),
+                current_cpu: pacquet_graph_hasher::host_arch().to_string(),
+                current_libc: pacquet_graph_hasher::host_libc().to_string(),
+                supported_architectures: supported_architectures.cloned(),
+            };
+            let walker_result =
+                lockfile_to_hoisted_dep_graph(lockfile, current_lockfile, &walker_opts)
+                    .map_err(InstallFrozenLockfileError::HoistedDepGraph)?;
+            // Augment the live skip set with anything the walker
+            // newly skipped (optional + unsupported platform) so
+            // `.modules.yaml.skipped` reflects the union of the
+            // installability passes both paths ran.
+            for skipped_dep_path in &walker_result.skipped {
+                if let Ok(key) = skipped_dep_path.parse::<PackageKey>() {
+                    skipped.insert_installability(key);
+                }
+            }
+            // Empty CAS index → linker would refuse every
+            // non-optional node. Only happens when the install
+            // has no snapshots, in which case the linker is a no-op.
+            let cas_index =
+                cas_paths_by_pkg_id.expect("hoisted CreateVirtualStore populates cas_paths");
+            let link_opts = LinkHoistedModulesOpts {
+                graph: &walker_result.graph,
+                prev_graph: walker_result.prev_graph.as_ref(),
+                hierarchy: &walker_result.hierarchy,
+                cas_paths_by_pkg_id: &cas_index,
+                import_method: config.package_import_method,
+                logged_methods,
+                requester,
+            };
+            link_hoisted_modules::<R>(&link_opts)
+                .map_err(InstallFrozenLockfileError::LinkHoistedModules)?;
+            walker_result.hoisted_locations
+        } else {
+            BTreeMap::new()
+        };
 
         // Hoist transitive deps into `<virtual_store>/node_modules`
         // (private hoist) and/or `<root>/node_modules` (public hoist).
@@ -566,7 +725,18 @@ where
         // not the other, so the guard checks `is_some()` on the field
         // (not `Vec` length). With pacquet's defaults both sides are
         // `Some(non-empty)`, so the pass runs by default.
+        // Isolated-linker hoist pass: shamefully-hoist + private
+        // hoist into the virtual store. Skipped under hoisted —
+        // the hoisted linker materialized the project tree above
+        // and there's no virtual store to point hoist symlinks at.
+        // Mirrors upstream's behavior of leaving
+        // `newHoistedDependencies = opts.hoistedDependencies` (no
+        // new isolated-hoist results) under the hoisted linker
+        // when no `hoistPattern` / `publicHoistPattern` is
+        // configured: see
+        // [`installing/deps-restorer/src/index.ts:471-486`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-restorer/src/index.ts#L471-L486).
         let hoisted_dependencies = match (snapshots, packages) {
+            _ if is_hoisted => HoistedDependencies::new(),
             (Some(snaps), Some(pkgs))
                 if config.hoist_pattern.is_some() || config.public_hoist_pattern.is_some() =>
             {
@@ -785,28 +955,47 @@ where
             None => engine_name,
         };
 
-        let ignored_builds = BuildModules {
-            layout: &layout,
-            modules_dir: &config.modules_dir,
-            lockfile_dir: manifest_dir,
-            snapshots,
-            packages,
-            importers,
-            allow_build_policy: &allow_build_policy,
-            side_effects_maps_by_snapshot: Some(&side_effects_maps_by_snapshot),
-            engine_name: engine_name.as_deref(),
-            side_effects_cache: config.side_effects_cache_read(),
-            side_effects_cache_write: config.side_effects_cache_write(),
-            store_dir: Some(&config.store_dir),
-            store_index_writer: Some(&store_index_writer),
-            patches: patches.as_ref(),
-            scripts_prepend_node_path,
-            unsafe_perm: config.unsafe_perm,
-            child_concurrency: config.child_concurrency,
-            skipped: &skipped,
-        }
-        .run::<R>()
-        .map_err(InstallFrozenLockfileError::BuildModules)?;
+        // BuildModules walks the virtual-store layout to run
+        // `preinstall` / `install` / `postinstall` lifecycle scripts
+        // for each snapshot's slot. Under hoisted there's no
+        // virtual store: the build phase has to walk the
+        // `hoistedLocations` from the slice 4 walker instead, with
+        // `extraBinPaths` gathered from every `node_modules/.bin`
+        // up the ancestor chain (per upstream's `binDirsInAllParentDirs`
+        // helper at
+        // [`building/after-install/src/index.ts:357`](https://github.com/pnpm/pnpm/blob/94240bc046/building/after-install/src/index.ts#L357)).
+        // That retargeting is umbrella #438 slice 7; this slice
+        // skips the build phase entirely when `is_hoisted` so the
+        // install completes without trying to walk a virtual store
+        // that was never written. `ignored_builds` falls back to
+        // empty so the `pnpm:ignored-scripts` event below still
+        // fires with a consistent shape.
+        let ignored_builds = if is_hoisted {
+            Default::default()
+        } else {
+            BuildModules {
+                layout: &layout,
+                modules_dir: &config.modules_dir,
+                lockfile_dir: manifest_dir,
+                snapshots,
+                packages,
+                importers,
+                allow_build_policy: &allow_build_policy,
+                side_effects_maps_by_snapshot: Some(&side_effects_maps_by_snapshot),
+                engine_name: engine_name.as_deref(),
+                side_effects_cache: config.side_effects_cache_read(),
+                side_effects_cache_write: config.side_effects_cache_write(),
+                store_dir: Some(&config.store_dir),
+                store_index_writer: Some(&store_index_writer),
+                patches: patches.as_ref(),
+                scripts_prepend_node_path,
+                unsafe_perm: config.unsafe_perm,
+                child_concurrency: config.child_concurrency,
+                skipped: &skipped,
+            }
+            .run::<R>()
+            .map_err(InstallFrozenLockfileError::BuildModules)?
+        };
 
         // Mirrors upstream's single emit at the end of the build phase:
         // <https://github.com/pnpm/pnpm/blob/80037699fb/installing/deps-installer/src/install/index.ts#L414>.
@@ -838,22 +1027,30 @@ where
             ),
         }
 
-        Ok(InstallFrozenLockfileOutput { hoisted_dependencies, skipped })
+        Ok(InstallFrozenLockfileOutput { hoisted_dependencies, hoisted_locations, skipped })
     }
 }
 
-/// Two-field bundle returned by [`InstallFrozenLockfile::run`] so
-/// the caller can write both `.modules.yaml.hoistedDependencies`
-/// (slice tracked at pnpm/pacquet#435) and `.modules.yaml.skipped`
-/// (umbrella slice 3) from a single call. Defined as a `struct`
-/// rather than a tuple so future fields (the in-flight current
-/// lockfile in umbrella slice 6, etc.) can land without churning
-/// every call site.
+/// Bundle returned by [`InstallFrozenLockfile::run`] so the caller
+/// can drive a single `.modules.yaml` write from one frozen install.
+/// Defined as a `struct` rather than a tuple so future fields can
+/// land without churning every call site.
 #[derive(Debug)]
 pub struct InstallFrozenLockfileOutput {
-    /// Hoisted-dependencies map produced by the hoist pass — empty
-    /// when both hoist patterns are `None`.
+    /// Hoisted-dependencies map produced by the isolated-linker
+    /// hoist pass — empty when both hoist patterns are `None` and
+    /// always empty under `nodeLinker: hoisted` (the hoisted
+    /// linker writes the on-disk tree directly and does not need
+    /// the alias-to-`HoistKind` adapter shape).
     pub hoisted_dependencies: HoistedDependencies,
+    /// Per-depPath list of lockfile-relative directory paths the
+    /// hoisted linker placed each package at. Empty under the
+    /// isolated linker — the field is hoisted-only on disk and
+    /// only meaningful when `nodeLinker: hoisted`. Round-trips
+    /// through [`pacquet_modules_yaml::Modules::hoisted_locations`]
+    /// so a follow-up install (or rebuild) can locate every
+    /// package without re-running the walker.
+    pub hoisted_locations: BTreeMap<String, Vec<String>>,
     /// Install-time skip set produced by `compute_skipped_snapshots`,
     /// seeded from the previous install's `.modules.yaml.skipped`
     /// and augmented with snapshots that newly failed the

--- a/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/crates/package-manager/src/install_frozen_lockfile.rs
@@ -123,7 +123,7 @@ where
     ///
     /// Under [`NodeLinker::Hoisted`] the install pipeline routes
     /// through [`crate::lockfile_to_hoisted_dep_graph`] +
-    /// [`crate::link_hoisted_modules`] instead of the isolated
+    /// [`crate::link_hoisted_modules()`] instead of the isolated
     /// linker's [`crate::SymlinkDirectDependencies`] +
     /// [`crate::LinkVirtualStoreBins`] + [`crate::get_hoisted_dependencies`]
     /// chain. Mirrors upstream's
@@ -218,7 +218,7 @@ pub enum InstallFrozenLockfileError {
     #[diagnostic(transparent)]
     HoistedDepGraph(#[error(source)] HoistedDepGraphError),
 
-    /// Surfaces failures from [`crate::link_hoisted_modules`]
+    /// Surfaces failures from [`crate::link_hoisted_modules()`]
     /// while materializing the on-disk hoisted tree. Includes
     /// missing CAS-paths entries for required packages,
     /// hierarchy/graph mismatches, file-import I/O failures, and
@@ -612,7 +612,7 @@ where
             // (`CreateVirtualStore` skipped slot writes), and the
             // bin links go into `<parent>/node_modules/.bin` for
             // every hoist location instead. The hoisted linker
-            // ([`crate::link_hoisted_modules`], called below) does
+            // ([`crate::link_hoisted_modules()`], called below) does
             // its own per-`node_modules` bin pass while walking the
             // hierarchy. Mirrors upstream's `nodeLinker === 'hoisted'`
             // branch at
@@ -661,7 +661,7 @@ where
             let walker_opts = LockfileToHoistedDepGraphOptions {
                 lockfile_dir: workspace_root.to_path_buf(),
                 auto_install_peers: config.auto_install_peers,
-                skipped: walker_skipped,
+                skipped: walker_skipped.clone(),
                 force: false,
                 // Pacquet's [`Config`] does not yet expose
                 // `engineStrict` (tracked separately); default to
@@ -683,11 +683,22 @@ where
             let walker_result =
                 lockfile_to_hoisted_dep_graph(lockfile, current_lockfile, &walker_opts)
                     .map_err(InstallFrozenLockfileError::HoistedDepGraph)?;
-            // Augment the live skip set with anything the walker
-            // newly skipped (optional + unsupported platform) so
-            // `.modules.yaml.skipped` reflects the union of the
-            // installability passes both paths ran.
-            for skipped_dep_path in &walker_result.skipped {
+            // Augment the live skip set with the walker's *new*
+            // skips only — entries already in `walker_skipped` came
+            // from the input `SkippedSnapshots`, where each one
+            // already lives in its proper subset
+            // (installability / fetch-failed / optional-excluded).
+            // Re-inserting them as installability would promote
+            // transient `fetch_failed` / `optional_excluded`
+            // entries into the persisted-on-disk
+            // `.modules.yaml.skipped` set, which would survive into
+            // the next install — exactly the contract those
+            // subsets exist to prevent. Diffing against the input
+            // set keeps the persistence boundary intact: only
+            // walker-discovered installability skips (optional +
+            // unsupported platform) flow into
+            // [`SkippedSnapshots::insert_installability`].
+            for skipped_dep_path in walker_result.skipped.difference(&walker_skipped) {
                 if let Ok(key) = skipped_dep_path.parse::<PackageKey>() {
                     skipped.insert_installability(key);
                 }

--- a/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/crates/package-manager/src/install_package_by_snapshot.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use derive_more::{Display, Error};
 use miette::Diagnostic;
-use pacquet_config::Config;
+use pacquet_config::{Config, NodeLinker};
 use pacquet_executor::ScriptsPrependNodePath as ExecScriptsPrependNodePath;
 use pacquet_git_fetcher::{GitFetchOutput, GitFetcher, GitFetcherError, GitHostedTarballFetcher};
 use pacquet_graph_hasher::{host_arch, host_libc, host_platform};
@@ -68,6 +68,18 @@ pub struct InstallPackageBySnapshot<'a> {
     /// [`crate::InstallFrozenLockfile::run`] and threaded through
     /// [`crate::CreateVirtualStore`].
     pub allow_build_policy: &'a AllowBuildPolicy,
+    /// Selects between the isolated and hoisted install layouts.
+    /// `Isolated` runs [`CreateVirtualDirBySnapshot`] at the end of
+    /// the per-snapshot fetch to populate the virtual-store slot;
+    /// `Hoisted` skips that step because the hoisted linker
+    /// ([`crate::link_hoisted_modules`]) consumes the returned
+    /// `cas_paths` directly and writes them into project-tree
+    /// `node_modules/<alias>` directories. Either way the CAS files
+    /// land in the store, so this is purely about whether the
+    /// virtual-store slot gets materialized. Mirrors upstream's
+    /// [`nodeLinker === 'hoisted'`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-restorer/src/index.ts#L411-L425)
+    /// branch in `headlessInstall`.
+    pub node_linker: NodeLinker,
 }
 
 /// Error type of [`InstallPackageBySnapshot`].
@@ -157,8 +169,23 @@ pub enum InstallPackageBySnapshotError {
 }
 
 impl<'a> InstallPackageBySnapshot<'a> {
-    /// Execute the subroutine.
-    pub async fn run<R: Reporter>(self) -> Result<(), InstallPackageBySnapshotError> {
+    /// Execute the subroutine. Returns the CAS file index for the
+    /// fetched package — the map relative-archive-path →
+    /// absolute-store-path that downstream consumers use to either
+    /// populate a virtual-store slot (isolated) or import into a
+    /// hoisted `node_modules/<alias>/` directly (hoisted).
+    ///
+    /// Under [`NodeLinker::Isolated`] the slot has already been
+    /// materialized by the time this returns (via
+    /// [`CreateVirtualDirBySnapshot`]); the returned map is still
+    /// useful to the caller for assembling the
+    /// [`crate::CasPathsByPkgId`] index when a workspace mixes
+    /// linkers in the future. Under [`NodeLinker::Hoisted`] no slot
+    /// is created — the returned map is the only output the caller
+    /// gets, and it's threaded into [`crate::link_hoisted_modules`].
+    pub async fn run<R: Reporter>(
+        self,
+    ) -> Result<HashMap<String, PathBuf>, InstallPackageBySnapshotError> {
         let InstallPackageBySnapshot {
             http_client,
             config,
@@ -173,6 +200,7 @@ impl<'a> InstallPackageBySnapshot<'a> {
             metadata,
             snapshot,
             allow_build_policy,
+            node_linker,
         } = self;
 
         // TODO: skip when already exists in store?
@@ -386,20 +414,31 @@ impl<'a> InstallPackageBySnapshot<'a> {
             }
         };
 
-        CreateVirtualDirBySnapshot {
-            layout,
-            cas_paths: &cas_paths,
-            import_method: config.package_import_method,
-            logged_methods,
-            requester,
-            package_id: &package_id,
-            package_key,
-            snapshot,
+        // Under hoisted, the virtual-store slot would be unused —
+        // [`crate::link_hoisted_modules`] consumes the CAS paths
+        // directly to materialize project-tree `node_modules/`
+        // directories, so any slot we'd write here would only waste
+        // disk. Mirrors upstream's branch at
+        // <https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-restorer/src/index.ts#L411-L425>:
+        // hoisted skips both `linkAllModules` (slot symlinks) and
+        // `linkAllPkgs` (slot file imports), and runs
+        // `linkHoistedModules` over the CAS paths instead.
+        if matches!(node_linker, NodeLinker::Isolated | NodeLinker::Pnp) {
+            CreateVirtualDirBySnapshot {
+                layout,
+                cas_paths: &cas_paths,
+                import_method: config.package_import_method,
+                logged_methods,
+                requester,
+                package_id: &package_id,
+                package_key,
+                snapshot,
+            }
+            .run::<R>()
+            .map_err(InstallPackageBySnapshotError::CreateVirtualDir)?;
         }
-        .run::<R>()
-        .map_err(InstallPackageBySnapshotError::CreateVirtualDir)?;
 
-        Ok(())
+        Ok(cas_paths)
     }
 }
 

--- a/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/crates/package-manager/src/install_package_by_snapshot.rs
@@ -72,7 +72,7 @@ pub struct InstallPackageBySnapshot<'a> {
     /// `Isolated` runs [`CreateVirtualDirBySnapshot`] at the end of
     /// the per-snapshot fetch to populate the virtual-store slot;
     /// `Hoisted` skips that step because the hoisted linker
-    /// ([`crate::link_hoisted_modules`]) consumes the returned
+    /// ([`crate::link_hoisted_modules()`]) consumes the returned
     /// `cas_paths` directly and writes them into project-tree
     /// `node_modules/<alias>` directories. Either way the CAS files
     /// land in the store, so this is purely about whether the
@@ -182,7 +182,7 @@ impl<'a> InstallPackageBySnapshot<'a> {
     /// [`crate::CasPathsByPkgId`] index when a workspace mixes
     /// linkers in the future. Under [`NodeLinker::Hoisted`] no slot
     /// is created — the returned map is the only output the caller
-    /// gets, and it's threaded into [`crate::link_hoisted_modules`].
+    /// gets, and it's threaded into [`crate::link_hoisted_modules()`].
     pub async fn run<R: Reporter>(
         self,
     ) -> Result<HashMap<String, PathBuf>, InstallPackageBySnapshotError> {
@@ -415,7 +415,7 @@ impl<'a> InstallPackageBySnapshot<'a> {
         };
 
         // Under hoisted, the virtual-store slot would be unused —
-        // [`crate::link_hoisted_modules`] consumes the CAS paths
+        // [`crate::link_hoisted_modules()`] consumes the CAS paths
         // directly to materialize project-tree `node_modules/`
         // directories, so any slot we'd write here would only waste
         // disk. Mirrors upstream's branch at


### PR DESCRIPTION
## Summary

Slice 6 of #438. Plugs the existing slice 3-5 building blocks
(`real-hoist`, `lockfile_to_hoisted_dep_graph`, `link_hoisted_modules`)
into `Install::run` / `InstallFrozenLockfile::run` behind a branch on
`config.node_linker == Hoisted`. With this PR, `pacquet install
--frozen-lockfile --node-linker hoisted` produces a real-directory
\`node_modules/\` tree rooted at the project (no symlinks, no virtual
store), and `.modules.yaml.hoistedLocations` is persisted so a
follow-up install or rebuild can locate every package.

### Pipeline changes under hoisted

- `CreateVirtualStore` skips `CreateVirtualDirBySnapshot` for both warm
  and cold batches, collects each snapshot's CAS file index keyed by
  `PkgIdWithPatchHash` into a new `cas_paths_by_pkg_id` output field.
- `InstallPackageBySnapshot::run` now returns the per-package CAS map
  unconditionally and skips the virtual-store-slot write when its new
  `node_linker` field is `Hoisted`.
- `InstallFrozenLockfile::run` skips `SymlinkDirectDependencies`,
  `LinkVirtualStoreBins`, the isolated hoist pass, and `BuildModules`
  under hoisted; runs `lockfile_to_hoisted_dep_graph` +
  `link_hoisted_modules` in their place. Folds the walker's augmented
  skip set back into the install-time `SkippedSnapshots` so
  `.modules.yaml.skipped` reflects the union of both passes.
- `Install::run`'s `build_modules_manifest` now takes the walker's
  `hoisted_locations` and writes it through
  `Modules.hoisted_locations` (only when non-empty so the isolated
  path doesn't produce a hoisted-only key).

Mirrors upstream's hoisted branch in `headlessInstall` at
https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-restorer/src/index.ts#L369-L425.

### Out of scope (deferred to later slices)

- **Build phase under hoisted (slice 7).** Rebuild over
  \`hoistedLocations\` directories with \`extraBinPaths\` gathered from
  every ancestor \`node_modules/.bin\`. \`MISSING_HOISTED_LOCATIONS\`
  also lives there. Today's PR skips \`BuildModules\` under hoisted so
  the install completes without trying to walk a virtual store that
  was never written.
- **Workspace-aware hoisting (slice 9).** Single-importer only today —
  the walker rejects multi-importer lockfiles with
  \`HoistError::UnsupportedWorkspace\`.
- **\`hoistingLimits\` / \`externalDependencies\` (slice 10).** Walker
  inputs default to empty.
- **\`hoistedDependencies\` (the alias-to-public/private adapter
  field).** Left empty under hoisted because upstream's
  \`linkHoistedModules\` uses \`hoistedLocations\` directly; the
  isolated-mode adapter shape is unused under \`nodeLinker: hoisted\`
  and pacquet matches that.

## Test plan

- [x] \`just ready\` (1211 tests pass; lint, fmt, typos clean)
- [x] \`just dylint\` (perfectionist) clean
- [x] \`taplo format --check\` clean
- [x] New wiring tests in \`crates/package-manager/src/install/tests.rs\`:
  - \`hoisted_node_linker_empty_lockfile_writes_modules_yaml\` — pins
    \`Install::run\` → \`InstallFrozenLockfile::run\` → walker → linker
    composition against an empty lockfile, asserts
    \`.modules.yaml.nodeLinker == hoisted\` and
    \`hoisted_locations is None\` (the field drops to \`None\` when empty).
  - \`hoisted_node_linker_does_not_create_virtual_store_root\` — pins
    that \`<project>/node_modules/.pacquet\` is never created under
    hoisted.
- [ ] Real-package end-to-end coverage against the registry-mock —
  \`@pnpm.e2e/foo@100.0.0\` style fixture with hand-written lockfile.
  Tracked as a follow-up; the existing slice 4 / slice 5 unit tests
  already cover the underlying components and the slice 7 build-phase
  retargeting will benefit from the same fixture.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hoisted-mode install path supported with conditional link-time behavior and CAS path capture.
  * Persist hoisted installation location data into the modules manifest when applicable.

* **Refactor**
  * Virtual-store materialization and build-step execution now vary by selected linker mode.

* **Tests**
  * Added end-to-end tests for hoisted installs and unit tests ensuring manifest omits empty hoisted locations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pacquet/pull/518)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->