### PR TITLE
feat(package-manager): BuildModules under hoisted node-linker (#438 slice 7)

### DIFF
--- a/crates/package-manager/src/build_modules.rs
+++ b/crates/package-manager/src/build_modules.rs
@@ -260,6 +260,31 @@ pub struct BuildModules<'a> {
     /// disk. Mirrors pnpm's `lockfileToDepGraph` flow where skipped
     /// snapshots never enter the build graph.
     pub skipped: &'a SkippedSnapshots,
+
+    /// Per-snapshot `pkgRoot` override, populated by the hoisted
+    /// linker with the slice 4 walker's
+    /// [`crate::DependenciesGraphNode::dir`] values. When `Some`,
+    /// every `pkgRoot` lookup goes through this map instead of the
+    /// virtual-store-layout slot computation; a missing entry means
+    /// the snapshot didn't make it into the hoisted graph (skipped
+    /// optional, etc.) and the build phase silently passes over it.
+    /// `None` for the isolated linker — its slot directories are
+    /// recovered from [`crate::VirtualStoreLayout::slot_dir`].
+    /// Mirrors upstream's two-mode `pkgRoots` selection at
+    /// [`building/after-install/src/index.ts`](https://github.com/pnpm/pnpm/blob/94240bc046/building/after-install/src/index.ts#L340-L350).
+    pub pkg_root_by_key: Option<&'a HashMap<PackageKey, PathBuf>>,
+
+    /// When `true`, compute per-snapshot `extra_bin_paths` via
+    /// `bin_dirs_in_all_parent_dirs` (private helper in this module)
+    /// so lifecycle scripts can resolve binaries from every ancestor `node_modules/.bin`
+    /// up to [`Self::lockfile_dir`]. Mirrors upstream's hoisted
+    /// branch at
+    /// [`after-install:357`](https://github.com/pnpm/pnpm/blob/94240bc046/building/after-install/src/index.ts#L357).
+    /// Always `false` under the isolated linker — its bins live in
+    /// the slot's own `<slot>/node_modules/.bin`, populated up-
+    /// front by [`crate::LinkVirtualStoreBins`], and the script
+    /// executor adds that path itself.
+    pub gather_ancestor_bin_paths: bool,
 }
 
 impl<'a> BuildModules<'a> {
@@ -289,12 +314,13 @@ impl<'a> BuildModules<'a> {
             unsafe_perm,
             child_concurrency,
             skipped,
+            pkg_root_by_key,
+            gather_ancestor_bin_paths,
         } = self;
 
         let Some(snapshots) = snapshots else { return Ok(Vec::new()) };
 
         let extra_env = HashMap::new();
-        let extra_bin_paths: Vec<PathBuf> = vec![];
 
         // Compute requires_build per snapshot from each extracted package
         // directory. Mirrors upstream where the worker computes
@@ -313,8 +339,16 @@ impl<'a> BuildModules<'a> {
             // optional fan-out.
             .filter(|key| !skipped.contains(key))
             .map(|key| {
-                let pkg_dir = virtual_store_dir_for_key(layout, key);
-                (key.clone(), pkg_requires_build(&pkg_dir))
+                // Hoisted snapshots without a recorded `pkgRoot` (the
+                // walker dropped them) get `requires_build = false`
+                // so they fall through both the script-runner and the
+                // patch-apply gates without a syscall, matching the
+                // isolated path's `pkg_dir.exists() == false` skip.
+                let requires = pkg_root_for_key(layout, pkg_root_by_key, key)
+                    .as_deref()
+                    .map(pkg_requires_build)
+                    .unwrap_or(false);
+                (key.clone(), requires)
             })
             .collect();
 
@@ -423,9 +457,10 @@ impl<'a> BuildModules<'a> {
                         &deps_state_cache,
                         &ignored_builds,
                         layout,
+                        pkg_root_by_key,
+                        gather_ancestor_bin_paths,
                         modules_dir,
                         lockfile_dir,
-                        &extra_bin_paths,
                         &extra_env,
                         scripts_prepend_node_path,
                         unsafe_perm,
@@ -469,9 +504,10 @@ fn build_one_snapshot<R: Reporter>(
     deps_state_cache: &Mutex<pacquet_graph_hasher::DepsStateCache<PackageKey>>,
     ignored_builds: &Mutex<BTreeSet<String>>,
     layout: &crate::VirtualStoreLayout,
+    pkg_root_by_key: Option<&HashMap<PackageKey, PathBuf>>,
+    gather_ancestor_bin_paths: bool,
     modules_dir: &Path,
     lockfile_dir: &Path,
-    extra_bin_paths: &[PathBuf],
     extra_env: &HashMap<String, String>,
     scripts_prepend_node_path: ScriptsPrependNodePath,
     unsafe_perm: bool,
@@ -597,10 +633,25 @@ fn build_one_snapshot<R: Reporter>(
         return Ok(());
     }
 
-    let pkg_dir = virtual_store_dir_for_key(layout, snapshot_key);
+    // Hoisted snapshots without a recorded `pkgRoot` (the walker
+    // dropped them — pre-skipped, optional skip, etc.) take the
+    // same exit as the isolated path's `!pkg_dir.exists()` skip.
+    let Some(pkg_dir) = pkg_root_for_key(layout, pkg_root_by_key, snapshot_key) else {
+        return Ok(());
+    };
     if !pkg_dir.exists() {
         return Ok(());
     }
+
+    // Per-snapshot `extra_bin_paths`. Isolated leaves it empty;
+    // hoisted gathers every ancestor's `node_modules/.bin` up to
+    // `lockfile_dir` so a lifecycle script invoked at a nested
+    // hoisted location can resolve bins added by parents.
+    let extra_bin_paths: Vec<PathBuf> = if gather_ancestor_bin_paths {
+        bin_dirs_in_all_parent_dirs(&pkg_dir, lockfile_dir)
+    } else {
+        Vec::new()
+    };
 
     let optional = snapshots.get(snapshot_key).is_some_and(|entry| entry.optional);
 
@@ -632,7 +683,7 @@ fn build_one_snapshot<R: Reporter>(
             pkg_root: &pkg_dir,
             root_modules_dir: modules_dir,
             init_cwd: lockfile_dir,
-            extra_bin_paths,
+            extra_bin_paths: &extra_bin_paths,
             extra_env,
             node_execpath: None,
             npm_execpath: None,
@@ -751,6 +802,70 @@ fn virtual_store_dir_for_key(layout: &crate::VirtualStoreLayout, key: &PackageKe
     let name = &name_version[..at_idx];
 
     layout.slot_dir(key).join("node_modules").join(name)
+}
+
+/// Resolve the on-disk package directory for a snapshot.
+///
+/// Two-mode lookup mirroring upstream's
+/// [`pkgRoots`](https://github.com/pnpm/pnpm/blob/94240bc046/building/after-install/src/index.ts#L340-L350)
+/// computation:
+///
+/// - **Isolated** (`pkg_root_by_key.is_none()`) — fall through to
+///   [`virtual_store_dir_for_key`], which routes through the
+///   install-scoped [`crate::VirtualStoreLayout`].
+/// - **Hoisted** (`pkg_root_by_key.is_some()`) — look the snapshot up
+///   in the per-key map populated from the slice 4 walker's
+///   [`crate::DependenciesGraphNode::dir`] values. `None` here means
+///   the snapshot is absent from the hoisted graph (pre-skipped, or
+///   the walker decided not to record it); the caller should treat
+///   that the same as the isolated `pkg_dir.exists() == false` skip.
+fn pkg_root_for_key(
+    layout: &crate::VirtualStoreLayout,
+    pkg_root_by_key: Option<&HashMap<PackageKey, PathBuf>>,
+    key: &PackageKey,
+) -> Option<PathBuf> {
+    match pkg_root_by_key {
+        Some(map) => map.get(key).cloned(),
+        None => Some(virtual_store_dir_for_key(layout, key)),
+    }
+}
+
+/// Mirrors upstream's
+/// [`binDirsInAllParentDirs`](https://github.com/pnpm/pnpm/blob/94240bc046/building/after-install/src/index.ts#L476-L487)
+/// — walk every ancestor `node_modules/.bin` from `pkg_root` up to
+/// (and including) `lockfile_dir`. Used as the per-snapshot
+/// `extra_bin_paths` under `nodeLinker: hoisted` so a lifecycle
+/// script invoked at a nested location can resolve bins added by
+/// any ancestor's `node_modules/.bin` — npm-style ancestor-chain
+/// resolution that the isolated layout doesn't need (every slot's
+/// children sit in its own `node_modules`, and bin-link writes are
+/// per-slot).
+///
+/// The `path.dirname(dir)[0] === '@'` check upstream skips
+/// pushing when `dir`'s parent path string starts with `@` — a
+/// guard for relative-path code paths in the upstream codebase.
+/// Mirrored here against the parent's path-string first character
+/// for byte-for-byte parity with upstream's output.
+///
+/// Non-existent ancestor `.bin` directories are harmless: they
+/// just don't contribute anything to lifecycle-script PATH lookup.
+fn bin_dirs_in_all_parent_dirs(pkg_root: &Path, lockfile_dir: &Path) -> Vec<PathBuf> {
+    let mut bin_dirs: Vec<PathBuf> = Vec::new();
+    let mut dir: PathBuf = pkg_root.to_path_buf();
+    loop {
+        let parent = dir.parent().unwrap_or(Path::new(""));
+        let parent_starts_with_at =
+            parent.to_str().and_then(|s| s.chars().next()).is_some_and(|c| c == '@');
+        if !parent_starts_with_at {
+            bin_dirs.push(dir.join("node_modules").join(".bin"));
+        }
+        dir = parent.to_path_buf();
+        if dir == *lockfile_dir || dir.as_os_str().is_empty() {
+            break;
+        }
+    }
+    bin_dirs.push(lockfile_dir.join("node_modules").join(".bin"));
+    bin_dirs
 }
 
 /// Parse `name` and `version` from a lockfile snapshot key like

--- a/crates/package-manager/src/build_modules/tests.rs
+++ b/crates/package-manager/src/build_modules/tests.rs
@@ -310,6 +310,8 @@ fn build_modules_collects_ignored_builds() {
         unsafe_perm: true,
         child_concurrency: 1,
         skipped: &SkippedSnapshots::default(),
+        pkg_root_by_key: None,
+        gather_ancestor_bin_paths: false,
     }
     .run::<SilentReporter>()
     .expect("run BuildModules");
@@ -377,6 +379,8 @@ fn build_modules_collects_ignored_builds_under_concurrency() {
         unsafe_perm: true,
         child_concurrency: 2,
         skipped: &SkippedSnapshots::default(),
+        pkg_root_by_key: None,
+        gather_ancestor_bin_paths: false,
     }
     .run::<SilentReporter>()
     .expect("run BuildModules under concurrency");
@@ -432,6 +436,8 @@ fn build_modules_excludes_explicit_deny_from_ignored() {
         unsafe_perm: true,
         child_concurrency: 1,
         skipped: &SkippedSnapshots::default(),
+        pkg_root_by_key: None,
+        gather_ancestor_bin_paths: false,
     }
     .run::<SilentReporter>()
     .expect("run BuildModules");
@@ -511,6 +517,8 @@ fn do_not_fail_on_optional_dep_with_failing_postinstall() {
         unsafe_perm: true,
         child_concurrency: 1,
         skipped: &SkippedSnapshots::default(),
+        pkg_root_by_key: None,
+        gather_ancestor_bin_paths: false,
     }
     .run::<RecordingReporter>()
     .expect("optional build failure must NOT abort the install");
@@ -641,6 +649,8 @@ fn using_side_effects_cache_skips_rebuild() {
         unsafe_perm: true,
         child_concurrency: 1,
         skipped: &SkippedSnapshots::default(),
+        pkg_root_by_key: None,
+        gather_ancestor_bin_paths: false,
     }
     .run::<RecordingReporter>()
     .expect("install must succeed when the cache hit skips the rebuild");
@@ -703,6 +713,8 @@ fn side_effects_cache_disabled_bypasses_the_gate() {
         unsafe_perm: true,
         child_concurrency: 1,
         skipped: &SkippedSnapshots::default(),
+        pkg_root_by_key: None,
+        gather_ancestor_bin_paths: false,
     }
     .run::<SilentReporter>()
     .expect_err("with cache disabled, the failing postinstall must run and the install must fail");
@@ -758,6 +770,8 @@ fn fail_when_failing_postinstall_is_required() {
         unsafe_perm: true,
         child_concurrency: 1,
         skipped: &SkippedSnapshots::default(),
+        pkg_root_by_key: None,
+        gather_ancestor_bin_paths: false,
     }
     .run::<SilentReporter>()
     .expect_err("required build failure must propagate");
@@ -990,6 +1004,8 @@ async fn write_path_populates_side_effects_row() {
         unsafe_perm: true,
         child_concurrency: 1,
         skipped: &SkippedSnapshots::default(),
+        pkg_root_by_key: None,
+        gather_ancestor_bin_paths: false,
     }
     .run::<SilentReporter>()
     .expect("build modules must complete cleanly");
@@ -1097,6 +1113,8 @@ async fn write_path_disabled_skips_upload() {
         unsafe_perm: true,
         child_concurrency: 1,
         skipped: &SkippedSnapshots::default(),
+        pkg_root_by_key: None,
+        gather_ancestor_bin_paths: false,
     }
     .run::<SilentReporter>()
     .expect("build modules must complete cleanly");
@@ -1213,6 +1231,8 @@ async fn upload_error_does_not_interrupt_install() {
         unsafe_perm: true,
         child_concurrency: 1,
         skipped: &SkippedSnapshots::default(),
+        pkg_root_by_key: None,
+        gather_ancestor_bin_paths: false,
     }
     .run::<SilentReporter>()
     .expect("upload failure must not propagate; install continues");
@@ -1439,6 +1459,8 @@ new file mode 100644
         unsafe_perm: true,
         child_concurrency: 1,
         skipped: &SkippedSnapshots::default(),
+        pkg_root_by_key: None,
+        gather_ancestor_bin_paths: false,
     }
     .run::<SilentReporter>()
     .expect("build modules must complete cleanly");
@@ -1543,6 +1565,8 @@ new file mode 100644
         unsafe_perm: true,
         child_concurrency: 1,
         skipped: &SkippedSnapshots::default(),
+        pkg_root_by_key: None,
+        gather_ancestor_bin_paths: false,
     }
     .run::<SilentReporter>()
     .expect("build modules must complete cleanly");
@@ -1618,6 +1642,8 @@ async fn missing_patch_file_path_errors_with_diagnostic() {
         unsafe_perm: true,
         child_concurrency: 1,
         skipped: &SkippedSnapshots::default(),
+        pkg_root_by_key: None,
+        gather_ancestor_bin_paths: false,
     }
     .run::<SilentReporter>()
     .expect_err("missing patch_file_path must surface as PatchFilePathMissing");
@@ -1626,4 +1652,149 @@ async fn missing_patch_file_path_errors_with_diagnostic() {
     let _ = writer_task.await;
 
     assert!(matches!(err, super::BuildModulesError::PatchFilePathMissing { .. }), "got: {err:?}");
+}
+
+// --- bin_dirs_in_all_parent_dirs ----------------------------------------
+
+/// Top-level hoisted package: the helper must produce one entry per
+/// ancestor `node_modules/.bin` from `pkg_root` up to (and including)
+/// `lockfile_dir`. Mirrors upstream's
+/// [`binDirsInAllParentDirs`](https://github.com/pnpm/pnpm/blob/94240bc046/building/after-install/src/index.ts#L476-L487):
+/// a `pkgRoot` of `<lockfile>/node_modules/foo` produces three paths
+/// — the package's own `node_modules/.bin`, the synthetic
+/// `<modules>/node_modules/.bin` from the dirname loop step, and the
+/// final `<lockfile>/node_modules/.bin` push after the loop exits.
+/// Synthetic entries don't exist on disk and are harmless to PATH
+/// lookup; pinning the literal list keeps pacquet byte-for-byte
+/// compatible with upstream's wire output.
+#[test]
+fn bin_dirs_top_level_hoisted_pkg() {
+    let lockfile_dir = PathBuf::from("/repo");
+    let pkg_root = PathBuf::from("/repo/node_modules/foo");
+    let dirs = super::bin_dirs_in_all_parent_dirs(&pkg_root, &lockfile_dir);
+    assert_eq!(
+        dirs,
+        vec![
+            PathBuf::from("/repo/node_modules/foo/node_modules/.bin"),
+            PathBuf::from("/repo/node_modules/node_modules/.bin"),
+            PathBuf::from("/repo/node_modules/.bin"),
+        ],
+    );
+}
+
+/// Conflict-nested package: a package living under
+/// `<lockfile>/node_modules/parent/node_modules/child` produces five
+/// entries — its own bin, parent's, the synthetic `<modules>/node_modules/.bin`,
+/// the synthetic intermediate (`<parent>/node_modules/node_modules/.bin`),
+/// and the final lockfile-root push. The two synthetic intermediates
+/// fall out of the dirname-loop's per-step push but never resolve to
+/// real directories.
+#[test]
+fn bin_dirs_nested_hoisted_pkg() {
+    let lockfile_dir = PathBuf::from("/repo");
+    let pkg_root = PathBuf::from("/repo/node_modules/parent/node_modules/child");
+    let dirs = super::bin_dirs_in_all_parent_dirs(&pkg_root, &lockfile_dir);
+    assert_eq!(
+        dirs,
+        vec![
+            PathBuf::from("/repo/node_modules/parent/node_modules/child/node_modules/.bin"),
+            PathBuf::from("/repo/node_modules/parent/node_modules/node_modules/.bin"),
+            PathBuf::from("/repo/node_modules/parent/node_modules/.bin"),
+            PathBuf::from("/repo/node_modules/node_modules/.bin"),
+            PathBuf::from("/repo/node_modules/.bin"),
+        ],
+    );
+}
+
+/// Scoped package: `<lockfile>/node_modules/@scope/pkg`. Upstream's
+/// `path.dirname(dir)[0] === '@'` guard never fires when paths are
+/// absolute (the dirname's leading char is `/`); we mirror that by
+/// pushing every step regardless of segment shape, including the
+/// scope slot's synthetic `<scope>/node_modules/.bin`. See the
+/// helper's doc-comment for the upstream rationale.
+#[test]
+fn bin_dirs_scoped_pkg_pushes_every_step() {
+    let lockfile_dir = PathBuf::from("/repo");
+    let pkg_root = PathBuf::from("/repo/node_modules/@scope/pkg");
+    let dirs = super::bin_dirs_in_all_parent_dirs(&pkg_root, &lockfile_dir);
+    assert_eq!(
+        dirs,
+        vec![
+            PathBuf::from("/repo/node_modules/@scope/pkg/node_modules/.bin"),
+            PathBuf::from("/repo/node_modules/@scope/node_modules/.bin"),
+            PathBuf::from("/repo/node_modules/node_modules/.bin"),
+            PathBuf::from("/repo/node_modules/.bin"),
+        ],
+    );
+}
+
+// --- pkg_root_for_key ---------------------------------------------------
+
+/// Without an override map (the isolated linker), the helper falls
+/// through to `virtual_store_dir_for_key` and returns
+/// `Some(<slot>/node_modules/<name>)`. Pinning the `Some` shape
+/// (rather than just the path) catches a future change that turns
+/// the isolated path optional too.
+#[test]
+fn pkg_root_for_key_isolated_uses_layout() {
+    let dir = tempdir().unwrap();
+    let mut config = Config::new();
+    config.store_dir = dir.path().join("store").into();
+    config.modules_dir = dir.path().join("node_modules");
+    config.virtual_store_dir = dir.path().join("node_modules/.pacquet");
+    let config = config.leak();
+    let layout = VirtualStoreLayout::new(config, None, None, None, None);
+
+    let key: PackageKey = "is-positive@1.0.0".parse().expect("parse key");
+    let result = super::pkg_root_for_key(&layout, None, &key).expect("isolated lookup hits");
+
+    assert!(
+        result.starts_with(&config.virtual_store_dir),
+        "isolated pkg_dir lives under the virtual store: {result:?}",
+    );
+    assert!(
+        result.ends_with("node_modules/is-positive"),
+        "trailing path is `node_modules/<name>`: {result:?}",
+    );
+}
+
+/// With an override map (the hoisted linker), the helper returns
+/// the override entry verbatim — no virtual-store layout lookup.
+#[test]
+fn pkg_root_for_key_hoisted_uses_override() {
+    let dir = tempdir().unwrap();
+    let mut config = Config::new();
+    config.store_dir = dir.path().join("store").into();
+    config.modules_dir = dir.path().join("node_modules");
+    config.virtual_store_dir = dir.path().join("node_modules/.pacquet");
+    let config = config.leak();
+    let layout = VirtualStoreLayout::new(config, None, None, None, None);
+
+    let key: PackageKey = "is-positive@1.0.0".parse().expect("parse key");
+    let hoisted_dir = PathBuf::from("/repo/node_modules/is-positive");
+    let map: HashMap<PackageKey, PathBuf> = [(key.clone(), hoisted_dir.clone())].into();
+
+    let result = super::pkg_root_for_key(&layout, Some(&map), &key).expect("override hits");
+    assert_eq!(result, hoisted_dir);
+}
+
+/// A snapshot key absent from the override map (the walker decided
+/// not to record it — pre-skipped, optional skip) returns `None` so
+/// `BuildModules`'s per-snapshot loop can short-circuit instead of
+/// attempting to `cd` into a path the caller never produced.
+#[test]
+fn pkg_root_for_key_hoisted_missing_returns_none() {
+    let dir = tempdir().unwrap();
+    let mut config = Config::new();
+    config.store_dir = dir.path().join("store").into();
+    config.modules_dir = dir.path().join("node_modules");
+    config.virtual_store_dir = dir.path().join("node_modules/.pacquet");
+    let config = config.leak();
+    let layout = VirtualStoreLayout::new(config, None, None, None, None);
+
+    let key: PackageKey = "absent@1.0.0".parse().expect("parse key");
+    let map: HashMap<PackageKey, PathBuf> = HashMap::new();
+
+    let result = super::pkg_root_for_key(&layout, Some(&map), &key);
+    assert!(result.is_none(), "absent key surfaces None, got {result:?}");
 }

--- a/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/crates/package-manager/src/install_frozen_lockfile.rs
@@ -648,7 +648,19 @@ where
         //
         // Mirrors upstream's hoisted branch at
         // [`installing/deps-restorer/src/index.ts:369-427`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-restorer/src/index.ts#L369-L427).
-        let hoisted_locations: BTreeMap<String, Vec<String>> = if is_hoisted {
+        // `pkg_root_by_key` is a per-snapshot override for
+        // `BuildModules`'s `pkgRoot` lookup. Populated from the
+        // walker's [`crate::DependenciesGraphNode::dir`] values so
+        // the build phase can `cd` into the on-disk hoisted
+        // directory instead of computing a virtual-store slot path
+        // that doesn't exist under hoisted. The first recorded
+        // location wins for snapshots the walker emitted multiple
+        // times (a single physical package nested under siblings),
+        // matching upstream's
+        // [`pkgRoots[0]`](https://github.com/pnpm/pnpm/blob/94240bc046/building/after-install/src/index.ts#L348)
+        // pick. `None` (and an empty `hoisted_locations`) for the
+        // isolated linker.
+        let HoistedLinkerOutput { hoisted_locations, hoisted_pkg_root_by_key } = if is_hoisted {
             // Walker installability inputs come straight from the
             // optional `host_node` we built earlier for the
             // `compute_skipped_snapshots` pass. When `host_node` is
@@ -719,9 +731,27 @@ where
             };
             link_hoisted_modules::<R>(&link_opts)
                 .map_err(InstallFrozenLockfileError::LinkHoistedModules)?;
-            walker_result.hoisted_locations
+            // Map snapshot key → first recorded directory. The
+            // walker can emit multiple [`crate::DependenciesGraphNode`]s
+            // with the same `dep_path` when the package nests under
+            // a sibling (version conflict). Postinstall scripts and
+            // the side-effects-cache key both depend only on the
+            // package contents (identical across locations), so
+            // running once at the first dir matches upstream's
+            // `pkgRoots[0]` pick at
+            // [`after-install:348`](https://github.com/pnpm/pnpm/blob/94240bc046/building/after-install/src/index.ts#L348).
+            let mut pkg_root_by_key: HashMap<PackageKey, std::path::PathBuf> = HashMap::new();
+            for node in walker_result.graph.values() {
+                if let Ok(key) = node.dep_path.as_str().parse::<PackageKey>() {
+                    pkg_root_by_key.entry(key).or_insert_with(|| node.dir.clone());
+                }
+            }
+            HoistedLinkerOutput {
+                hoisted_locations: walker_result.hoisted_locations,
+                hoisted_pkg_root_by_key: Some(pkg_root_by_key),
+            }
         } else {
-            BTreeMap::new()
+            HoistedLinkerOutput::default()
         };
 
         // Hoist transitive deps into `<virtual_store>/node_modules`
@@ -966,47 +996,43 @@ where
             None => engine_name,
         };
 
-        // BuildModules walks the virtual-store layout to run
-        // `preinstall` / `install` / `postinstall` lifecycle scripts
-        // for each snapshot's slot. Under hoisted there's no
-        // virtual store: the build phase has to walk the
-        // `hoistedLocations` from the slice 4 walker instead, with
-        // `extraBinPaths` gathered from every `node_modules/.bin`
-        // up the ancestor chain (per upstream's `binDirsInAllParentDirs`
-        // helper at
-        // [`building/after-install/src/index.ts:357`](https://github.com/pnpm/pnpm/blob/94240bc046/building/after-install/src/index.ts#L357)).
-        // That retargeting is umbrella #438 slice 7; this slice
-        // skips the build phase entirely when `is_hoisted` so the
-        // install completes without trying to walk a virtual store
-        // that was never written. `ignored_builds` falls back to
-        // empty so the `pnpm:ignored-scripts` event below still
-        // fires with a consistent shape.
-        let ignored_builds = if is_hoisted {
-            Default::default()
-        } else {
-            BuildModules {
-                layout: &layout,
-                modules_dir: &config.modules_dir,
-                lockfile_dir: manifest_dir,
-                snapshots,
-                packages,
-                importers,
-                allow_build_policy: &allow_build_policy,
-                side_effects_maps_by_snapshot: Some(&side_effects_maps_by_snapshot),
-                engine_name: engine_name.as_deref(),
-                side_effects_cache: config.side_effects_cache_read(),
-                side_effects_cache_write: config.side_effects_cache_write(),
-                store_dir: Some(&config.store_dir),
-                store_index_writer: Some(&store_index_writer),
-                patches: patches.as_ref(),
-                scripts_prepend_node_path,
-                unsafe_perm: config.unsafe_perm,
-                child_concurrency: config.child_concurrency,
-                skipped: &skipped,
-            }
-            .run::<R>()
-            .map_err(InstallFrozenLockfileError::BuildModules)?
-        };
+        // BuildModules walks per-snapshot package directories and
+        // runs `preinstall` / `install` / `postinstall` lifecycle
+        // scripts. Under isolated, the directories live under the
+        // virtual-store slot layout; under hoisted, they live at
+        // the project-tree paths the slice 4 walker assigned —
+        // threaded in via `pkg_root_by_key`. `gather_ancestor_bin_paths`
+        // additionally reroutes `extra_bin_paths` through
+        // `bin_dirs_in_all_parent_dirs` for the hoisted case so
+        // lifecycle scripts can resolve binaries from every
+        // ancestor `node_modules/.bin` up to `lockfile_dir` —
+        // mirrors upstream's
+        // [`after-install:357`](https://github.com/pnpm/pnpm/blob/94240bc046/building/after-install/src/index.ts#L357)
+        // call into `binDirsInAllParentDirs`.
+        let ignored_builds = BuildModules {
+            layout: &layout,
+            modules_dir: &config.modules_dir,
+            lockfile_dir: manifest_dir,
+            snapshots,
+            packages,
+            importers,
+            allow_build_policy: &allow_build_policy,
+            side_effects_maps_by_snapshot: Some(&side_effects_maps_by_snapshot),
+            engine_name: engine_name.as_deref(),
+            side_effects_cache: config.side_effects_cache_read(),
+            side_effects_cache_write: config.side_effects_cache_write(),
+            store_dir: Some(&config.store_dir),
+            store_index_writer: Some(&store_index_writer),
+            patches: patches.as_ref(),
+            scripts_prepend_node_path,
+            unsafe_perm: config.unsafe_perm,
+            child_concurrency: config.child_concurrency,
+            skipped: &skipped,
+            pkg_root_by_key: hoisted_pkg_root_by_key.as_ref(),
+            gather_ancestor_bin_paths: is_hoisted,
+        }
+        .run::<R>()
+        .map_err(InstallFrozenLockfileError::BuildModules)?;
 
         // Mirrors upstream's single emit at the end of the build phase:
         // <https://github.com/pnpm/pnpm/blob/80037699fb/installing/deps-installer/src/install/index.ts#L414>.
@@ -1067,6 +1093,25 @@ pub struct InstallFrozenLockfileOutput {
     /// and augmented with snapshots that newly failed the
     /// installability check.
     pub skipped: SkippedSnapshots,
+}
+
+/// Internal handoff between the hoisted-linker walker/linker pass
+/// and the downstream `BuildModules` + `.modules.yaml` writes. Bundled
+/// as a struct so the hoisted branch in [`InstallFrozenLockfile::run`]
+/// can return both fields in one binding without tripping
+/// `clippy::type_complexity`. Always [`Default`]-empty for the
+/// isolated linker.
+#[derive(Debug, Default)]
+struct HoistedLinkerOutput {
+    /// `LockfileToDepGraphResult::hoisted_locations` from the slice
+    /// 4 walker. Persisted into `.modules.yaml.hoisted_locations`
+    /// when non-empty.
+    hoisted_locations: BTreeMap<String, Vec<String>>,
+    /// Per-snapshot `pkgRoot` override for the build phase —
+    /// snapshot key → its first recorded directory in the hoisted
+    /// graph. `None` for the isolated linker (the layout-based
+    /// lookup in `BuildModules` is used instead).
+    hoisted_pkg_root_by_key: Option<HashMap<PackageKey, std::path::PathBuf>>,
 }
 
 /// Pull the leading major-version digits out of a semver string like


### PR DESCRIPTION
## Summary

Re-enables `BuildModules` under `nodeLinker: hoisted`. Slice 6 (#518) wired the hoisted install pipeline but skipped the build phase entirely because `BuildModules` walked virtual-store slot directories that don't exist under hoisted. Slice 7 routes the build phase through the slice 4 walker's per-node `dir` so postinstall scripts can run against the on-disk hoisted tree, with `extra_bin_paths` gathered from every ancestor `node_modules/.bin` up to the install root (npm-style ancestor resolution).

### Changes

- **`BuildModules`** gains two fields:
  - `pkg_root_by_key: Option<&HashMap<PackageKey, PathBuf>>` — overrides the per-snapshot `pkgRoot` lookup. Populated by the hoisted linker from `DependenciesGraphNode::dir`. `None` for isolated (the `VirtualStoreLayout::slot_dir` path is used).
  - `gather_ancestor_bin_paths: bool` — switches `extra_bin_paths` to the new `bin_dirs_in_all_parent_dirs` helper, a port of upstream's [`binDirsInAllParentDirs`](https://github.com/pnpm/pnpm/blob/94240bc046/building/after-install/src/index.ts#L476-L487).
- **`pkg_root_for_key` helper** routes between layout-based slot computation (isolated) and the override map (hoisted). Hoisted snapshots absent from the map (walker-dropped — pre-skipped, optional skip) take the same exit as the isolated `!pkg_dir.exists()` skip.
- **`InstallFrozenLockfile::run`** now builds a snapshot-key → first-recorded-dir map from `walker_result.graph.values()` and threads it (plus `gather_ancestor_bin_paths: true`) into `BuildModules` instead of skipping the phase. Multiple graph nodes with the same `dep_path` (a single physical package nested under siblings via version conflict) collapse to the first entry, matching upstream's [`pkgRoots[0]`](https://github.com/pnpm/pnpm/blob/94240bc046/building/after-install/src/index.ts#L348) pick.
- **`HoistedLinkerOutput` private struct** bundles `hoisted_locations` and `pkg_root_by_key` so the hoisted-branch return doesn't trip `clippy::type_complexity`.

### Out of scope

- **`MISSING_HOISTED_LOCATIONS`** — upstream's error fires when rebuild reads `.modules.yaml.hoistedLocations` and finds it absent. Pacquet has no `rebuild` command yet, so the install path always re-runs the walker and never consults the persisted field. Tracked as a follow-up for when `pacquet rebuild` lands.
- **Workspace-aware hoisting (slice 9)** and **`hoistingLimits` / `externalDependencies` (slice 10)** remain.

Side-effects-cache key shape is unchanged — it's keyed by `pkg_id_with_patch_hash` + dep-graph hash, both layout-independent (`crates/graph-hasher/src/dep_state.rs`).

## Test plan

- [x] `just ready` (1219 tests pass; lint, fmt, typos clean)
- [x] `just dylint` (perfectionist) clean
- [x] `taplo format --check` clean
- [x] `RUSTDOCFLAGS=\"-D warnings\" cargo doc -p pacquet-package-manager --no-deps` clean
- [x] New helper tests in `crates/package-manager/src/build_modules/tests.rs`:
  - `bin_dirs_top_level_hoisted_pkg`, `bin_dirs_nested_hoisted_pkg`, `bin_dirs_scoped_pkg_pushes_every_step` — pin the wire-format output of the upstream-mirroring helper.
  - `pkg_root_for_key_isolated_uses_layout`, `pkg_root_for_key_hoisted_uses_override`, `pkg_root_for_key_hoisted_missing_returns_none` — cover the isolated pass-through, the hoisted override hit, and the missing-snapshot short-circuit.

End-to-end coverage against the registry-mock with a real lifecycle-script package is left to a follow-up — same status as the slice 6 PR. The slice 6 wiring tests already prove the install-pipeline composition; the slice 7 helper tests prove the per-snapshot lookup contract.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hoisted package installation with enhanced package root resolution for lifecycle scripts.
  * Better bin-path discovery across package hierarchies during hoisted installs.
  * Fixed build module execution to correctly handle snapshot-specific configurations in hoisted environments.

* **Tests**
  * Added comprehensive unit tests for package path resolution and bin-directory discovery logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pacquet/pull/520)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->