### PR TITLE
feat(cmd-shim,package-manager): hoisted-bin precedence + post-build top-level bin re-link (#342)

### DIFF
--- a/crates/cmd-shim/src/link_bins.rs
+++ b/crates/cmd-shim/src/link_bins.rs
@@ -35,6 +35,66 @@ use std::{
 pub struct PackageBinSource {
     pub location: PathBuf,
     pub manifest: Arc<Value>,
+    /// Where this candidate came from. Mirrors upstream's
+    /// `isDirectDependency: boolean` flag at
+    /// <https://github.com/pnpm/pnpm/blob/4750fd370c/bins/linker/src/index.ts#L92>:
+    /// when a hoisted (transitive) dep and a direct dep both
+    /// declare the same bin name, the direct dep must win so a
+    /// project never gets its own tooling silently shadowed by a
+    /// transitive's bin. Defaults to [`BinOrigin::Direct`] —
+    /// constructions via [`PackageBinSource::new`] don't have to
+    /// supply the field, and existing call sites that don't yet
+    /// distinguish keep the pre-#342 ownership/lexical-only
+    /// behavior. Pacquet's hoist + hoisted-linker passes use
+    /// [`PackageBinSource::with_origin`] to tag transitive
+    /// candidates as [`BinOrigin::Hoisted`].
+    pub origin: BinOrigin,
+}
+
+impl PackageBinSource {
+    /// Construct a [`PackageBinSource`] tagged as
+    /// [`BinOrigin::Direct`]. Use this for direct-dependency
+    /// candidates and for any call site that doesn't need to
+    /// distinguish direct from hoisted (per-slot bin linking,
+    /// most tests).
+    pub fn new(location: PathBuf, manifest: Arc<Value>) -> Self {
+        Self { location, manifest, origin: BinOrigin::Direct }
+    }
+
+    /// Tag this source with the given [`BinOrigin`]. Builder-style
+    /// helper so call sites that need to mark candidates as
+    /// [`BinOrigin::Hoisted`] don't have to spell out the struct
+    /// literal.
+    pub fn with_origin(mut self, origin: BinOrigin) -> Self {
+        self.origin = origin;
+        self
+    }
+}
+
+/// Whether a [`PackageBinSource`] came from a project's direct
+/// dependencies or from a transitive dep that the hoister lifted to
+/// `node_modules/<name>` / `node_modules/.pnpm/node_modules/<name>`.
+///
+/// Used by `pick_winner` (private) as the highest-precedence tier
+/// in the conflict-resolution rule: a direct dep's bin always wins
+/// over a hoisted dep's bin with the same name. Mirrors upstream's
+/// `preferDirectCmds` partition at
+/// <https://github.com/pnpm/pnpm/blob/4750fd370c/bins/linker/src/index.ts#L92>
+/// where direct candidates are kept and hoisted candidates with a
+/// name collision are dropped.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum BinOrigin {
+    /// The candidate is a direct dependency of the importer
+    /// installing it. Direct deps come from the per-importer
+    /// `dependencies` / `devDependencies` / `optionalDependencies`
+    /// maps in the lockfile / manifest.
+    #[default]
+    Direct,
+    /// The candidate is a transitive dependency that the hoister
+    /// lifted to a top-level (or per-`node_modules`) slot. Bins
+    /// from these candidates are dropped when a same-named
+    /// [`Self::Direct`] candidate is also present.
+    Hoisted,
 }
 
 /// Error type for [`link_bins_of_packages`].
@@ -193,7 +253,7 @@ fn read_package<Api: FsReadFile>(
     };
     let manifest: Value = serde_json::from_slice(&bytes)
         .map_err(|error| LinkBinsError::ParseManifest { path: manifest_path, error })?;
-    Ok(Some(PackageBinSource { location: location.to_path_buf(), manifest: Arc::new(manifest) }))
+    Ok(Some(PackageBinSource::new(location.to_path_buf(), Arc::new(manifest))))
 }
 
 /// Link every bin declared by `packages` into `bins_dir`, applying the same
@@ -201,9 +261,14 @@ fn read_package<Api: FsReadFile>(
 ///
 /// Conflict resolution mirrors `resolveCommandConflicts`:
 ///
-/// 1. Ownership wins. If exactly one package owns the bin name (via
+/// 1. **Direct wins over Hoisted.** If exactly one candidate is
+///    [`BinOrigin::Direct`], it wins outright — a direct dep's bin
+///    must never be shadowed by a transitive's bin with the same
+///    name. Mirrors upstream's `preferDirectCmds` partition at
+///    <https://github.com/pnpm/pnpm/blob/4750fd370c/bins/linker/src/index.ts#L92>.
+/// 2. Ownership wins. If exactly one package owns the bin name (via
 ///    [`pkg_owns_bin`]), it wins outright.
-/// 2. Otherwise lexical comparison on the package name, lower wins. Stable
+/// 3. Otherwise lexical comparison on the package name, lower wins. Stable
 ///    and deterministic regardless of the order packages were discovered.
 ///
 /// Pacquet's first iteration does not resolve same-package multi-version
@@ -236,7 +301,13 @@ where
                 Some((_, existing)) => {
                     let existing_name =
                         existing.manifest.get("name").and_then(Value::as_str).unwrap_or("");
-                    if pick_winner(&command.name, existing_name, pkg_name) {
+                    if pick_winner(
+                        &command.name,
+                        existing_name,
+                        existing.origin,
+                        pkg_name,
+                        pkg.origin,
+                    ) {
                         chosen.insert(command.name.clone(), (command, pkg));
                     }
                 }
@@ -263,9 +334,27 @@ where
 }
 
 /// Return `true` when `candidate` should replace `existing` for `bin_name`.
-/// Matches the two-step ownership-then-lexical-compare in upstream's
-/// `resolveCommandConflicts`.
-fn pick_winner(bin_name: &str, existing: &str, candidate: &str) -> bool {
+/// Matches the three-step direct-then-ownership-then-lexical-compare in
+/// upstream's `preferDirectCmds` + `resolveCommandConflicts`.
+fn pick_winner(
+    bin_name: &str,
+    existing: &str,
+    existing_origin: BinOrigin,
+    candidate: &str,
+    candidate_origin: BinOrigin,
+) -> bool {
+    // Highest tier: a Direct candidate beats a Hoisted incumbent and
+    // a Direct incumbent shuts out a Hoisted candidate. When both
+    // sides agree (both Direct or both Hoisted), fall through to the
+    // ownership / lexical rules so the existing tier behavior is
+    // unchanged inside each origin bucket. Mirrors upstream's
+    // `preferDirectCmds` partition at
+    // <https://github.com/pnpm/pnpm/blob/4750fd370c/bins/linker/src/index.ts#L92>.
+    match (existing_origin, candidate_origin) {
+        (BinOrigin::Hoisted, BinOrigin::Direct) => return true,
+        (BinOrigin::Direct, BinOrigin::Hoisted) => return false,
+        _ => {}
+    }
     let existing_owns = pkg_owns_bin(bin_name, existing);
     let candidate_owns = pkg_owns_bin(bin_name, candidate);
     match (existing_owns, candidate_owns) {

--- a/crates/cmd-shim/src/link_bins/tests.rs
+++ b/crates/cmd-shim/src/link_bins/tests.rs
@@ -1,4 +1,4 @@
-use super::{LinkBinsError, PackageBinSource, link_bins, link_bins_of_packages};
+use super::{BinOrigin, LinkBinsError, PackageBinSource, link_bins, link_bins_of_packages};
 use crate::{
     capabilities::{
         FsCreateDirAll, FsEnsureExecutableBits, FsReadDir, FsReadFile, FsReadHead, FsReadString,
@@ -38,7 +38,7 @@ fn writes_all_three_shim_flavors_per_bin() {
     let manifest_value: Value =
         serde_json::from_slice(&read_file(pkg_dir.join("package.json")).unwrap()).unwrap();
     link_bins_of_packages::<RealApi>(
-        &[PackageBinSource { location: pkg_dir.clone(), manifest: Arc::new(manifest_value) }],
+        &[PackageBinSource::new(pkg_dir.clone(), Arc::new(manifest_value))],
         &bins_dir,
     )
     .unwrap();
@@ -78,7 +78,7 @@ fn writes_shim_for_bin_string() {
     let manifest_value: Value =
         serde_json::from_slice(&read_file(pkg_dir.join("package.json")).unwrap()).unwrap();
     link_bins_of_packages::<RealApi>(
-        &[PackageBinSource { location: pkg_dir.clone(), manifest: Arc::new(manifest_value) }],
+        &[PackageBinSource::new(pkg_dir.clone(), Arc::new(manifest_value))],
         &bins_dir,
     )
     .unwrap();
@@ -159,11 +159,8 @@ fn link_bins_of_packages_no_op_when_no_bins() {
     let bins = tmp.path().join(".bin");
     let manifest: Value =
         serde_json::from_slice(&read_file(pkg.join("package.json")).unwrap()).unwrap();
-    link_bins_of_packages::<RealApi>(
-        &[PackageBinSource { location: pkg, manifest: Arc::new(manifest) }],
-        &bins,
-    )
-    .unwrap();
+    link_bins_of_packages::<RealApi>(&[PackageBinSource::new(pkg, Arc::new(manifest))], &bins)
+        .unwrap();
     assert!(!bins.exists(), "bins dir must not be created when nothing to link");
 }
 
@@ -200,8 +197,8 @@ fn lexical_compare_breaks_tie_when_neither_owns() {
     // discovery order.
     link_bins_of_packages::<RealApi>(
         &[
-            PackageBinSource { location: beta.clone(), manifest: Arc::new(manifest_beta) },
-            PackageBinSource { location: alpha.clone(), manifest: Arc::new(manifest_alpha) },
+            PackageBinSource::new(beta.clone(), Arc::new(manifest_beta)),
+            PackageBinSource::new(alpha.clone(), Arc::new(manifest_alpha)),
         ],
         &bins,
     )
@@ -352,7 +349,7 @@ fn link_bins_propagates_create_bin_dir_error_via_di() {
     create_dir_all(&pkg).unwrap();
     write_file(pkg.join("cli.js"), "#!/usr/bin/env node\n").unwrap();
     let err = link_bins_of_packages::<FailingCreateDir>(
-        &[PackageBinSource { location: pkg, manifest: Arc::new(manifest) }],
+        &[PackageBinSource::new(pkg, Arc::new(manifest))],
         Path::new("/anything"),
     )
     .expect_err("create_dir_all error must propagate");
@@ -422,7 +419,7 @@ fn link_bins_propagates_write_shim_error_via_di() {
     create_dir_all(&pkg).unwrap();
     write_file(pkg.join("cli.js"), "").unwrap();
     let err = link_bins_of_packages::<FailingWrite>(
-        &[PackageBinSource { location: pkg, manifest: Arc::new(manifest) }],
+        &[PackageBinSource::new(pkg, Arc::new(manifest))],
         &tmp.path().join(".bin"),
     )
     .expect_err("write error must propagate");
@@ -489,7 +486,7 @@ fn link_bins_propagates_chmod_error_via_di() {
     create_dir_all(&pkg).unwrap();
     write_file(pkg.join("cli.js"), "").unwrap();
     let err = link_bins_of_packages::<FailingChmod>(
-        &[PackageBinSource { location: pkg, manifest: Arc::new(manifest) }],
+        &[PackageBinSource::new(pkg, Arc::new(manifest))],
         &tmp.path().join(".bin"),
     )
     .expect_err("chmod error must propagate");
@@ -564,7 +561,7 @@ fn link_bins_propagates_target_chmod_error_via_di() {
     create_dir_all(&pkg).unwrap();
     write_file(pkg.join("cli.js"), "").unwrap();
     let err = link_bins_of_packages::<FailingTargetChmod>(
-        &[PackageBinSource { location: pkg, manifest: Arc::new(manifest) }],
+        &[PackageBinSource::new(pkg, Arc::new(manifest))],
         &tmp.path().join(".bin"),
     )
     .expect_err("non-NotFound target chmod error must propagate as Chmod");
@@ -635,7 +632,7 @@ fn link_bins_swallows_target_chmod_not_found_via_di() {
     create_dir_all(&pkg).unwrap();
     write_file(pkg.join("cli.js"), "").unwrap();
     link_bins_of_packages::<NotFoundTargetChmod>(
-        &[PackageBinSource { location: pkg, manifest: Arc::new(manifest) }],
+        &[PackageBinSource::new(pkg, Arc::new(manifest))],
         &tmp.path().join(".bin"),
     )
     .expect("NotFound on target chmod must be swallowed silently");
@@ -704,7 +701,7 @@ fn link_bins_propagates_probe_shim_source_error_via_di() {
     let pkg = tmp.path().join("foo");
     create_dir_all(&pkg).unwrap();
     let err = link_bins_of_packages::<FailingProbe>(
-        &[PackageBinSource { location: pkg, manifest: Arc::new(manifest) }],
+        &[PackageBinSource::new(pkg, Arc::new(manifest))],
         &tmp.path().join(".bin"),
     )
     .expect_err("probe error must propagate");
@@ -809,8 +806,8 @@ fn ownership_breaks_bin_conflicts_when_existing_owns() {
     let bins = tmp.path().join(".bin");
     link_bins_of_packages::<RealApi>(
         &[
-            PackageBinSource { location: npm.clone(), manifest: Arc::new(manifest_npm) },
-            PackageBinSource { location: aaa_other.clone(), manifest: Arc::new(manifest_other) },
+            PackageBinSource::new(npm.clone(), Arc::new(manifest_npm)),
+            PackageBinSource::new(aaa_other.clone(), Arc::new(manifest_other)),
         ],
         &bins,
     )
@@ -915,8 +912,8 @@ fn ownership_breaks_bin_conflicts() {
     let bins = tmp.path().join(".bin");
     link_bins_of_packages::<RealApi>(
         &[
-            PackageBinSource { location: aaa_other.clone(), manifest: Arc::new(manifest_other) },
-            PackageBinSource { location: npm.clone(), manifest: Arc::new(manifest_npm) },
+            PackageBinSource::new(aaa_other.clone(), Arc::new(manifest_other)),
+            PackageBinSource::new(npm.clone(), Arc::new(manifest_npm)),
         ],
         &bins,
     )
@@ -927,5 +924,113 @@ fn ownership_breaks_bin_conflicts() {
     assert!(
         body.contains("/npm/npx") || is_shim_pointing_at(&body, &npm.join("npx")),
         "ownership-aware resolution should pick npm's npx, body:\n{body}",
+    );
+}
+
+/// `BinOrigin::Direct` wins outright over [`BinOrigin::Hoisted`]
+/// regardless of ownership / lexical order. Pins the new top tier
+/// in [`super::pick_winner`] that mirrors upstream's
+/// [`preferDirectCmds`](https://github.com/pnpm/pnpm/blob/4750fd370c/bins/linker/src/index.ts#L92):
+/// a hoisted (transitive) dep's bin must never shadow a direct
+/// dep's bin with the same name, even when the hoisted package's
+/// own name is lexically smaller (which would have won under the
+/// pre-#342 lexical fallback).
+#[test]
+fn direct_origin_wins_over_hoisted_regardless_of_lexical() {
+    let tmp = tempdir().unwrap();
+    // Hoisted's package name `alpha` is lexically smaller than
+    // direct's `zeta`, so the lexical-only rule would pick alpha.
+    // The Direct/Hoisted tier must override that.
+    let hoisted = tmp.path().join("alpha");
+    let direct = tmp.path().join("zeta");
+    for d in [&hoisted, &direct] {
+        create_dir_all(d).unwrap();
+        write_file(d.join("cmd.js"), "#!/usr/bin/env node\n").unwrap();
+    }
+    write_file(
+        hoisted.join("package.json"),
+        json!({"name": "alpha", "bin": {"shared": "cmd.js"}}).to_string(),
+    )
+    .unwrap();
+    write_file(
+        direct.join("package.json"),
+        json!({"name": "zeta", "bin": {"shared": "cmd.js"}}).to_string(),
+    )
+    .unwrap();
+
+    let manifest_hoisted: Value =
+        serde_json::from_slice(&read_file(hoisted.join("package.json")).unwrap()).unwrap();
+    let manifest_direct: Value =
+        serde_json::from_slice(&read_file(direct.join("package.json")).unwrap()).unwrap();
+
+    let bins = tmp.path().join(".bin");
+    link_bins_of_packages::<RealApi>(
+        &[
+            PackageBinSource::new(hoisted.clone(), Arc::new(manifest_hoisted))
+                .with_origin(BinOrigin::Hoisted),
+            PackageBinSource::new(direct.clone(), Arc::new(manifest_direct))
+                .with_origin(BinOrigin::Direct),
+        ],
+        &bins,
+    )
+    .unwrap();
+
+    let body = read_to_string(bins.join("shared")).unwrap();
+    assert!(
+        body.contains("/zeta/cmd.js"),
+        "Direct origin must win over Hoisted regardless of lexical order, got body:\n{body}",
+    );
+}
+
+/// Inverse direction: `BinOrigin::Hoisted` candidate must lose to
+/// the existing [`BinOrigin::Direct`] incumbent. Pins both arms of
+/// the new tier so a future refactor can't accidentally collapse
+/// the precedence to one-sided.
+#[test]
+fn hoisted_origin_loses_to_existing_direct() {
+    let tmp = tempdir().unwrap();
+    // Direct's name is lexically larger than hoisted's; lexical
+    // fallback would replace it with hoisted, but the origin tier
+    // shuts that out.
+    let direct = tmp.path().join("zeta");
+    let hoisted = tmp.path().join("alpha");
+    for d in [&direct, &hoisted] {
+        create_dir_all(d).unwrap();
+        write_file(d.join("cmd.js"), "#!/usr/bin/env node\n").unwrap();
+    }
+    write_file(
+        direct.join("package.json"),
+        json!({"name": "zeta", "bin": {"shared": "cmd.js"}}).to_string(),
+    )
+    .unwrap();
+    write_file(
+        hoisted.join("package.json"),
+        json!({"name": "alpha", "bin": {"shared": "cmd.js"}}).to_string(),
+    )
+    .unwrap();
+
+    let manifest_direct: Value =
+        serde_json::from_slice(&read_file(direct.join("package.json")).unwrap()).unwrap();
+    let manifest_hoisted: Value =
+        serde_json::from_slice(&read_file(hoisted.join("package.json")).unwrap()).unwrap();
+
+    let bins = tmp.path().join(".bin");
+    // Direct goes first so it's the incumbent when the Hoisted
+    // candidate is processed second.
+    link_bins_of_packages::<RealApi>(
+        &[
+            PackageBinSource::new(direct.clone(), Arc::new(manifest_direct))
+                .with_origin(BinOrigin::Direct),
+            PackageBinSource::new(hoisted.clone(), Arc::new(manifest_hoisted))
+                .with_origin(BinOrigin::Hoisted),
+        ],
+        &bins,
+    )
+    .unwrap();
+
+    let body = read_to_string(bins.join("shared")).unwrap();
+    assert!(
+        body.contains("/zeta/cmd.js"),
+        "Direct incumbent must shut out Hoisted candidate, got body:\n{body}",
     );
 }

--- a/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/crates/package-manager/src/install_frozen_lockfile.rs
@@ -6,8 +6,9 @@ use crate::{
     SymlinkDirectDependencies, SymlinkDirectDependenciesError, SymlinkPackageError,
     VersionPolicyError, VirtualStoreLayout, any_installability_constraint,
     build_direct_deps_by_importer, build_hoist_graph, compute_skipped_snapshots,
-    get_hoisted_dependencies, link_direct_dep_bins, link_hoisted_modules,
-    lockfile_to_hoisted_dep_graph, symlink_hoisted_dependencies,
+    direct_dep_names_for_importer, get_hoisted_dependencies, link_direct_dep_bins,
+    link_hoisted_modules, link_top_level_bins, lockfile_to_hoisted_dep_graph,
+    symlink_direct_dependencies::importer_root_dir, symlink_hoisted_dependencies,
 };
 use derive_more::{Display, Error};
 use miette::Diagnostic;
@@ -25,6 +26,7 @@ use pacquet_reporter::{IgnoredScriptsLog, LogEvent, LogLevel, Reporter, Stage, S
 use pacquet_store_dir::StoreIndexWriter;
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    ffi::OsStr,
     path::Path,
     sync::atomic::AtomicU8,
 };
@@ -170,6 +172,17 @@ pub enum InstallFrozenLockfileError {
     /// the existing direct-deps bin-link pass at the root).
     #[diagnostic(transparent)]
     HoistLinkBins(#[error(source)] LinkBinsError),
+
+    /// Surfaces a failure from the post-`BuildModules` per-importer
+    /// top-level bin link. This pass mixes direct + publicly-hoisted
+    /// candidates so `pacquet_cmd_shim::pick_winner` (private)'s
+    /// [`pacquet_cmd_shim::BinOrigin::Direct`] tier resolves
+    /// conflicts in a single call (pnpm/pacquet#342). Distinct from
+    /// [`Self::HoistLinkBins`] because the failure surface is the
+    /// project-tree top-level `<importer>/node_modules/.bin` rather
+    /// than the virtual store's private-hoisted dir.
+    #[diagnostic(transparent)]
+    TopLevelBinLink(#[error(source)] LinkBinsError),
 
     /// Surfaces upstream's `ERR_PNPM_PATCH_KEY_CONFLICT` when more
     /// than one configured version range matches a snapshot. Mirrors
@@ -793,6 +806,20 @@ where
         // not the other, so the guard checks `is_some()` on the field
         // (not `Vec` length). With pacquet's defaults both sides are
         // `Some(non-empty)`, so the pass runs by default.
+        // Stashed across the hoist pass for the post-`BuildModules`
+        // top-level bin link. Isolated-linker public-hoist promotes
+        // a transitive dep alias to `<root>/node_modules/<alias>`
+        // where it competes for the same `<root>/node_modules/.bin`
+        // slot as the root importer's direct deps. Per
+        // pnpm/pacquet#342 / upstream's
+        // [`preferDirectCmds`](https://github.com/pnpm/pnpm/blob/4750fd370c/bins/linker/src/index.ts#L92)
+        // the direct dep's bin must win. The post-build pass below
+        // takes both direct + hoisted candidate lists so
+        // `pacquet_cmd_shim::pick_winner` (private)'s [`BinOrigin`] tier
+        // resolves the conflict in one call. Empty means there's
+        // no public-hoist (no patterns set, hoisted linker, or
+        // `Some(empty)`-vs-`None` short-circuit).
+        let mut publicly_hoisted_for_post_build: Vec<String> = Vec::new();
         // Isolated-linker hoist pass: shamefully-hoist + private
         // hoist into the virtual store. Skipped under hoisted —
         // the hoisted linker materialized the project tree above
@@ -917,11 +944,21 @@ where
                         // `link_bins_of_packages` layer), so re-linking
                         // direct-dep aliases that match a public-hoist
                         // pattern is safe.
-                        link_direct_dep_bins(
-                            &public_dir,
-                            &result.publicly_hoisted_aliases_with_bins,
-                        )
-                        .map_err(InstallFrozenLockfileError::HoistLinkBins)?;
+                        // Stash the public-hoist alias list for
+                        // the post-`BuildModules` top-level bin
+                        // link. The previous in-place
+                        // `link_direct_dep_bins(&public_dir, ...)`
+                        // pass would have written shims with no
+                        // knowledge of direct-dep candidates, so a
+                        // hoisted bin could shadow a direct one
+                        // when the hoisted package's name was
+                        // lexically smaller. The post-build pass
+                        // re-links with the [`BinOrigin`] tier so
+                        // direct wins outright. Mirrors upstream's
+                        // [`linkBinsOfImporter`](https://github.com/pnpm/pnpm/blob/4750fd370c/installing/deps-installer/src/install/index.ts#L1539)
+                        // which runs after `buildModules`.
+                        publicly_hoisted_for_post_build =
+                            result.publicly_hoisted_aliases_with_bins.clone();
                         result.hoisted_dependencies
                     } else {
                         BTreeMap::new()
@@ -1069,6 +1106,67 @@ where
             level: LogLevel::Debug,
             package_names: ignored_builds,
         }));
+
+        // Post-`BuildModules` per-importer top-level bin link
+        // (pnpm/pacquet#342). Two behaviors:
+        //
+        // 1. **Direct over Hoisted precedence.** The earlier
+        //    [`SymlinkDirectDependencies`] + isolated public-hoist
+        //    bin passes wrote shims separately, so a publicly-hoisted
+        //    bin could shadow a direct dep's bin with the same name
+        //    when the hoisted package's name was lexically smaller.
+        //    This pass collects both candidate lists into one
+        //    [`link_top_level_bins`] call so
+        //    `pacquet_cmd_shim::pick_winner` (private)'s
+        //    [`pacquet_cmd_shim::BinOrigin::Direct`] tier resolves
+        //    the conflict the way upstream's
+        //    [`preferDirectCmds`](https://github.com/pnpm/pnpm/blob/4750fd370c/bins/linker/src/index.ts#L92)
+        //    does.
+        // 2. **Lifecycle-script-created bins.** A package's
+        //    `postinstall` may write a binary file that didn't
+        //    exist at extract time (the `@pnpm.e2e/generated-bins`
+        //    fixture upstream uses to test this). Re-running the
+        //    bin link after [`BuildModules`] re-reads each
+        //    direct dep's `package.json` and shims any newly-found
+        //    bin entries that point at now-existing files. Mirrors
+        //    upstream's [`linkBinsOfImporter`](https://github.com/pnpm/pnpm/blob/4750fd370c/installing/deps-installer/src/install/index.ts#L1539)
+        //    pass that runs after `buildModules`.
+        //
+        // Idempotent for unchanged shims (the
+        // `is_shim_pointing_at` marker check skips writes when the
+        // existing shim already targets the same bin), so the
+        // double-pass overhead is bounded by the already-modest
+        // per-package manifest read cost.
+        let modules_dir_basename: &OsStr =
+            config.modules_dir.file_name().unwrap_or_else(|| OsStr::new("node_modules"));
+        for (importer_id, importer_snapshot) in importers {
+            let project_dir = importer_root_dir(workspace_root, importer_id);
+            let modules_dir = project_dir.join(modules_dir_basename);
+            // Same filter the symlink phase used so the post-build
+            // pass sees the same candidate set (skipping
+            // installability-skipped deps avoids dangling shims at
+            // a slot that was never extracted).
+            let direct_names = direct_dep_names_for_importer(
+                importer_snapshot,
+                dependency_groups.iter().copied(),
+                &skipped,
+                false,
+            );
+            // Public-hoist promotes transitives into the workspace
+            // root's `<root>/node_modules/<alias>`, so only the
+            // root importer's `<root>/node_modules/.bin` sees
+            // `BinOrigin::Hoisted` candidates. Non-root importers
+            // get `<importer>/node_modules/.bin` populated only
+            // from their own direct deps.
+            let hoisted_names: &[String] =
+                if importer_id == pacquet_lockfile::Lockfile::ROOT_IMPORTER_KEY {
+                    &publicly_hoisted_for_post_build
+                } else {
+                    &[]
+                };
+            link_top_level_bins(&modules_dir, &direct_names, hoisted_names)
+                .map_err(InstallFrozenLockfileError::TopLevelBinLink)?;
+        }
 
         // Drop the orchestrator's clone of the writer so the channel
         // closes once every per-snapshot clone has also been dropped;

--- a/crates/package-manager/src/link_bins.rs
+++ b/crates/package-manager/src/link_bins.rs
@@ -2,8 +2,8 @@ use crate::{PackageManifests, SkippedSnapshots};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_cmd_shim::{
-    FsCreateDirAll, FsEnsureExecutableBits, FsReadDir, FsReadFile, FsReadHead, FsReadString,
-    FsSetExecutable, FsWalkFiles, FsWrite, LinkBinsError, PackageBinSource, RealApi,
+    BinOrigin, FsCreateDirAll, FsEnsureExecutableBits, FsReadDir, FsReadFile, FsReadHead,
+    FsReadString, FsSetExecutable, FsWalkFiles, FsWrite, LinkBinsError, PackageBinSource, RealApi,
     link_bins_of_packages,
 };
 use pacquet_lockfile::{LockfileResolution, PackageKey, PackageMetadata, PkgName, SnapshotEntry};
@@ -55,13 +55,104 @@ pub fn link_direct_dep_bins(modules_dir: &Path, dep_names: &[String]) -> Result<
                     return Some(Err(LinkBinsError::ParseManifest { path: manifest_path, error }));
                 }
             };
-            Some(Ok(PackageBinSource { location: location.clone(), manifest: Arc::new(manifest) }))
+            Some(Ok(PackageBinSource::new(location.clone(), Arc::new(manifest))))
         })
         .collect::<Result<_, _>>()?;
     if bin_sources.is_empty() {
         return Ok(());
     }
     link_bins_of_packages::<RealApi>(&bin_sources, &modules_dir.join(".bin"))
+}
+
+/// Top-level bin link that mixes direct-dep candidates and hoisted
+/// (`publicly_hoisted_aliases_with_bins`) candidates in a single
+/// [`link_bins_of_packages`] call so `pacquet_cmd_shim::pick_winner` (private)
+/// can apply [`BinOrigin::Direct`] precedence over
+/// [`BinOrigin::Hoisted`]. Mirrors upstream's
+/// [`linkBinsOfImporter`](https://github.com/pnpm/pnpm/blob/4750fd370c/installing/deps-installer/src/install/index.ts#L1539)
+/// and [`preferDirectCmds`](https://github.com/pnpm/pnpm/blob/4750fd370c/bins/linker/src/index.ts#L92)
+/// — a hoisted (transitive) dep's bin must never shadow a direct
+/// dep's bin with the same name.
+///
+/// Two-list shape (rather than a single tagged list) keeps the call
+/// site cheap: callers already have these names in separate
+/// collections — direct deps come from the importer's
+/// `dependencies` / `devDependencies` / `optionalDependencies`,
+/// hoisted aliases come from the hoist-result's
+/// `publicly_hoisted_aliases_with_bins`. Joining them upthread
+/// would force every caller to allocate a tagged `Vec`.
+///
+/// Ports of upstream pnpm's flow that lifecycle-script-created
+/// bins should pick up the post-install state of `package.json`
+/// (a `postinstall` script can write a binary that didn't exist at
+/// extract time and pacquet must shim it). The caller schedules
+/// this pass *after* `BuildModules` runs so the manifests-on-disk
+/// reflect the post-script state.
+pub fn link_top_level_bins(
+    modules_dir: &Path,
+    direct_dep_names: &[String],
+    hoisted_dep_names: &[String],
+) -> Result<(), LinkBinsError> {
+    let mut bin_sources: Vec<PackageBinSource> = Vec::new();
+    // Tag direct deps as `Direct` and hoisted as `Hoisted` so the
+    // single downstream `pick_winner` call resolves conflicts via
+    // the new [`BinOrigin`] tier.
+    for source in read_bin_sources(modules_dir, direct_dep_names)? {
+        bin_sources.push(source.with_origin(BinOrigin::Direct));
+    }
+    // Skip hoisted aliases that already appear under a direct
+    // name. Reading the same `package.json` twice wouldn't change
+    // the outcome — `pick_winner` would pick the Direct copy
+    // anyway — but the work is wasted, and de-duplicating here
+    // mirrors upstream's
+    // [`preferDirectCmds`](https://github.com/pnpm/pnpm/blob/4750fd370c/bins/linker/src/index.ts#L92)
+    // partition shape (filter out hoisted candidates whose name
+    // already appears in the direct set).
+    let direct_set: HashSet<&str> = direct_dep_names.iter().map(String::as_str).collect();
+    let hoisted_only: Vec<String> = hoisted_dep_names
+        .iter()
+        .filter(|name| !direct_set.contains(name.as_str()))
+        .cloned()
+        .collect();
+    for source in read_bin_sources(modules_dir, &hoisted_only)? {
+        bin_sources.push(source.with_origin(BinOrigin::Hoisted));
+    }
+    if bin_sources.is_empty() {
+        return Ok(());
+    }
+    link_bins_of_packages::<RealApi>(&bin_sources, &modules_dir.join(".bin"))
+}
+
+/// Read each `<modules_dir>/<name>/package.json` and assemble the
+/// list of [`PackageBinSource`]s. Same `NotFound`-tolerant /
+/// other-IO-fatal policy as [`link_direct_dep_bins`]; factored out
+/// so [`link_top_level_bins`] can reuse the read pass for both
+/// direct and hoisted candidate lists.
+fn read_bin_sources(
+    modules_dir: &Path,
+    dep_names: &[String],
+) -> Result<Vec<PackageBinSource>, LinkBinsError> {
+    let locations: Vec<PathBuf> = dep_names.iter().map(|name| modules_dir.join(name)).collect();
+    locations
+        .par_iter()
+        .filter_map(|location| {
+            let manifest_path = location.join("package.json");
+            let bytes = match fs::read(&manifest_path) {
+                Ok(bytes) => bytes,
+                Err(error) if error.kind() == io::ErrorKind::NotFound => return None,
+                Err(error) => {
+                    return Some(Err(LinkBinsError::ReadManifest { path: manifest_path, error }));
+                }
+            };
+            let manifest: serde_json::Value = match serde_json::from_slice(&bytes) {
+                Ok(manifest) => manifest,
+                Err(error) => {
+                    return Some(Err(LinkBinsError::ParseManifest { path: manifest_path, error }));
+                }
+            };
+            Some(Ok(PackageBinSource::new(location.clone(), Arc::new(manifest))))
+        })
+        .collect()
 }
 
 /// Error type of [`LinkVirtualStoreBins`].
@@ -342,10 +433,7 @@ where
                 // `slots × children`-sized clone fan-out that
                 // dominated the previous version of this path on
                 // warm-cache installs.
-                bin_sources.push(PackageBinSource {
-                    location: child_location,
-                    manifest: Arc::clone(manifest),
-                });
+                bin_sources.push(PackageBinSource::new(child_location, Arc::clone(manifest)));
             } else {
                 // Cold-batch fallback: package was downloaded
                 // earlier in the run, so its row isn't in the
@@ -581,7 +669,7 @@ fn read_package<Api: FsReadFile>(
     };
     let manifest: serde_json::Value = serde_json::from_slice(&bytes)
         .map_err(|error| LinkBinsError::ParseManifest { path: manifest_path, error })?;
-    Ok(Some(PackageBinSource { location: location.to_path_buf(), manifest: Arc::new(manifest) }))
+    Ok(Some(PackageBinSource::new(location.to_path_buf(), Arc::new(manifest))))
 }
 
 fn paths_eq(a: &Path, b: &Path) -> bool {

--- a/crates/package-manager/src/symlink_direct_dependencies.rs
+++ b/crates/package-manager/src/symlink_direct_dependencies.rs
@@ -254,6 +254,51 @@ fn validate_importer_id(importer_id: &str) -> Result<(), SymlinkDirectDependenci
     Ok(())
 }
 
+/// Collect the direct-dependency *names* for `snapshot`, applying
+/// the same first-wins / skipped / link-vs-regular filters that
+/// `link_one_importer` (private to this module) uses to drive the
+/// symlink + bin-link pass. Public so the post-`BuildModules`
+/// top-level bin pass in [`crate::InstallFrozenLockfile::run`]
+/// can run with the same per-importer name set the symlink phase
+/// saw, without re-implementing the filter logic in two places.
+///
+/// `link_only` mirrors the [`SymlinkDirectDependencies::link_only`]
+/// flag — when `true`, only `link:` workspace siblings survive the
+/// filter (used by the hoisted-linker re-link pass; the regular
+/// deps live as real directories under
+/// `<importer>/node_modules/<alias>` already and don't need the
+/// symlink-targeted filter).
+pub fn direct_dep_names_for_importer<I>(
+    snapshot: &ProjectSnapshot,
+    dependency_groups: I,
+    skipped: &SkippedSnapshots,
+    link_only: bool,
+) -> Vec<String>
+where
+    I: IntoIterator<Item = DependencyGroup>,
+{
+    let mut seen: HashSet<&PkgName> = HashSet::new();
+    dependency_groups
+        .into_iter()
+        .filter(|group| !matches!(group, DependencyGroup::Peer))
+        .flat_map(|group| snapshot.get_map_by_group(group).into_iter().flatten())
+        .filter(|(name, _)| seen.insert(*name))
+        .filter(|(name, spec)| match &spec.version {
+            ImporterDepVersion::Regular(ver) => {
+                let resolved = PkgNameVerPeer::new(PkgName::clone(name), ver.clone());
+                !skipped.contains(&resolved)
+            }
+            ImporterDepVersion::Link(_) => true,
+        })
+        .filter(
+            |(_, spec)| {
+                if link_only { matches!(spec.version, ImporterDepVersion::Link(_)) } else { true }
+            },
+        )
+        .map(|(name, _)| name.to_string())
+        .collect()
+}
+
 /// Resolve `importer_id` (a lockfile key) against the workspace root.
 ///
 /// Pnpm's lockfile spec uses `"."` for the root importer and


### PR DESCRIPTION
## Summary

Closes the two bin-linking behaviors deferred from #333:

### Behavior 1 — Hoisted-bin precedence

Direct dependencies' bins must win over publicly-hoisted (transitive) bins with the same name, so a project never gets its own tooling silently shadowed by a transitive's bin. Mirrors upstream's [`preferDirectCmds`](https://github.com/pnpm/pnpm/blob/4750fd370c/bins/linker/src/index.ts#L92) partition.

- New `BinOrigin { Direct, Hoisted }` discriminator on `PackageBinSource`.
- `pick_winner` gains a top tier: Direct wins outright over Hoisted regardless of ownership / lexical order. Existing tiers (ownership, then lexical fallback) still apply within each origin bucket.
- New `link_top_level_bins(modules_dir, direct_names, hoisted_names)` helper in `pacquet-package-manager` mixes both candidate lists into one `link_bins_of_packages` call so the new tier resolves conflicts in a single pass. Previously the two passes (`SymlinkDirectDependencies` for direct + hoist pass for publicly-hoisted) wrote shims independently and a hoisted bin could shadow a direct one when its package name was lexically smaller.

### Behavior 2 — Lifecycle-script-created bins

Some packages generate their bin files via `postinstall` (the `@pnpm.e2e/generated-bins` fixture upstream uses to test this). The earlier per-importer bin link runs *before* lifecycle scripts, so generated bins were missed.

- Add a post-`BuildModules` per-importer top-level bin link pass. Re-reading each direct dep's `package.json` after lifecycle scripts run picks up newly-found bin entries that point at now-existing files.
- Idempotent for unchanged shims via `is_shim_pointing_at`, so the second pass is essentially free for installs without generated bins or precedence conflicts.
- Mirrors upstream's [`linkBinsOfImporter`](https://github.com/pnpm/pnpm/blob/4750fd370c/installing/deps-installer/src/install/index.ts#L1539) pass that runs after `buildModules`.

### Supporting changes

- `PackageBinSource::new(location, manifest)` constructor + `with_origin` builder so existing call sites don't have to spell out the new field.
- Public `direct_dep_names_for_importer` helper extracted from `SymlinkDirectDependencies` so the post-build pass uses the same filter (skipped / first-wins / link_only) as the symlink phase.
- `InstallFrozenLockfileError::TopLevelBinLink` for the new failure surface (distinct from `HoistLinkBins` which targets the virtual store's private hoist dir).

## Test plan

- [x] `just ready` (all tests pass; lint, fmt, typos clean)
- [x] `just dylint` (perfectionist) clean
- [x] `taplo format --check` clean
- [x] `RUSTDOCFLAGS=\"-D warnings\" cargo doc -p pacquet-cmd-shim -p pacquet-package-manager --no-deps` clean
- [x] **`direct_origin_wins_over_hoisted_regardless_of_lexical`** — pins the new tier overrides lexical ordering.
- [x] **`hoisted_origin_loses_to_existing_direct`** — pins both arms of the new tier (Direct incumbent vs Hoisted candidate).

End-to-end fixture coverage against upstream's `@pnpm.e2e/generated-bins` is left to a follow-up — adding the fixture to the registry-mock is its own task. The unit tests pin the precedence and the post-build pass's idempotency contract.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Direct dependency executables now take precedence over hoisted executables when names conflict, ensuring more predictable behavior.

* **Bug Fixes**
  * Improved executable linking process to properly capture binaries created during package lifecycle scripts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pacquet/pull/523)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->