### PR TITLE
feat(lockfile): support npm-alias importer dependency versions

### DIFF
--- a/crates/lockfile/src/resolved_dependency.rs
+++ b/crates/lockfile/src/resolved_dependency.rs
@@ -1,4 +1,4 @@
-use crate::{ParsePkgVerPeerError, PkgName, PkgVerPeer};
+use crate::{ParsePkgNameSuffixError, ParsePkgVerPeerError, PkgName, PkgNameVerPeer, PkgVerPeer};
 use derive_more::{Display, Error};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -24,10 +24,19 @@ pub struct ResolvedDependencySpec {
 /// Resolved `version` of an importer-level dependency.
 ///
 /// Importer dependencies (the values inside `importers.<id>.dependencies`
-/// in a pnpm v9 lockfile) carry one of two shapes for `version:`:
+/// in a pnpm v9 lockfile) carry one of three shapes for `version:`:
 ///
 /// - A bare semver-with-peer string like `4.0.0` or `17.0.2(react@17.0.2)`,
-///   meaning the dependency is in the shared virtual store.
+///   meaning the dependency is in the shared virtual store under a
+///   snapshot key built from the importer-map key and the version.
+/// - An npm-alias of the form `<target-name>@<version>` (with optional
+///   peer suffix), meaning the dependency resolves to a snapshot whose
+///   package name differs from the importer-map key. Pnpm writes this
+///   shape when a `catalog:` (or other) specifier resolves to an alias.
+///   Detection mirrors upstream's `refToRelative`
+///   (`deps/path/src/index.ts` at `pnpm/pnpm@8a80235c7b`): a reference
+///   is an alias when it begins with `@` or when the first `@` occurs
+///   before any `(` and `:`.
 /// - A `link:<path>` value, meaning the dependency is a workspace
 ///   sibling at `<path>` relative to the importer's `rootDir`. The
 ///   workspace project is not duplicated in the virtual store — pnpm
@@ -38,13 +47,20 @@ pub struct ResolvedDependencySpec {
 /// shape without re-parsing the raw string at every call site.
 ///
 /// Snapshot-level dependencies (the values inside `snapshots.*.dependencies`)
-/// use [`crate::SnapshotDepRef`] instead, which carries a different
-/// distinction (plain vs. alias) and never holds a `link:` value —
-/// `link:` only appears at the importer level.
+/// use [`crate::SnapshotDepRef`] instead, which carries the same
+/// plain/alias distinction but never holds a `link:` value — `link:`
+/// only appears at the importer level.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ImporterDepVersion {
-    /// Bare semver-with-peer; resolves to a snapshot in `snapshots:`.
+    /// Bare semver-with-peer; resolves to a snapshot in `snapshots:`
+    /// keyed by `(importer-map key, version)`.
     Regular(PkgVerPeer),
+
+    /// `<name>@<version-with-peer>`; resolves to a snapshot in
+    /// `snapshots:` keyed by `(alias.name, alias.suffix)`. The
+    /// importer-map key is only used as the directory name inside
+    /// `node_modules`.
+    Alias(PkgNameVerPeer),
 
     /// `link:<path>` value; resolves to a workspace sibling. The path
     /// is stored verbatim from the lockfile (relative to the
@@ -55,12 +71,28 @@ pub enum ImporterDepVersion {
 
 impl ImporterDepVersion {
     /// `Some(ver)` when this dependency resolves through the virtual
-    /// store; `None` when it's a `link:` sibling. Mirrors upstream's
-    /// `if (depPath.startsWith('link:'))` checks at the install layer.
+    /// store under the importer-map key (no alias rename); `None`
+    /// otherwise. Mirrors upstream's `if (depPath.startsWith('link:'))`
+    /// checks at the install layer.
+    ///
+    /// Use [`Self::resolved_key`] when you need a snapshot key that's
+    /// also correct for [`Self::Alias`] entries — `as_regular` returns
+    /// `None` for aliases, so callers that only handle the regular
+    /// branch would silently drop aliased deps.
     pub fn as_regular(&self) -> Option<&'_ PkgVerPeer> {
         match self {
             ImporterDepVersion::Regular(v) => Some(v),
-            ImporterDepVersion::Link(_) => None,
+            ImporterDepVersion::Alias(_) | ImporterDepVersion::Link(_) => None,
+        }
+    }
+
+    /// `Some(alias)` when this dependency resolves through the virtual
+    /// store under a name different from the importer-map key; `None`
+    /// otherwise.
+    pub fn as_alias(&self) -> Option<&'_ PkgNameVerPeer> {
+        match self {
+            ImporterDepVersion::Alias(alias) => Some(alias),
+            ImporterDepVersion::Regular(_) | ImporterDepVersion::Link(_) => None,
         }
     }
 
@@ -70,8 +102,36 @@ impl ImporterDepVersion {
     /// prefix.
     pub fn as_link_target(&self) -> Option<&'_ str> {
         match self {
-            ImporterDepVersion::Regular(_) => None,
+            ImporterDepVersion::Regular(_) | ImporterDepVersion::Alias(_) => None,
             ImporterDepVersion::Link(target) => Some(target.as_str()),
+        }
+    }
+
+    /// `Some(key)` with the snapshot-map key this dependency resolves
+    /// to; `None` for `link:` siblings. `importer_key` is the key of
+    /// the entry in `importers.<id>.dependencies` (the directory name
+    /// inside `node_modules`). For [`Self::Regular`] the resolved key
+    /// is `(importer_key, version)`; for [`Self::Alias`] it's the
+    /// alias's own `(name, suffix)` pair, mirroring upstream's
+    /// `refToRelative`.
+    pub fn resolved_key(&self, importer_key: &PkgName) -> Option<PkgNameVerPeer> {
+        match self {
+            ImporterDepVersion::Regular(ver) => {
+                Some(PkgNameVerPeer::new(importer_key.clone(), ver.clone()))
+            }
+            ImporterDepVersion::Alias(alias) => Some(alias.clone()),
+            ImporterDepVersion::Link(_) => None,
+        }
+    }
+
+    /// The version-with-peer portion of this dependency, or `None` for
+    /// `link:` siblings. For [`Self::Alias`] this returns the alias's
+    /// suffix, matching the version present in the snapshot key.
+    pub fn ver_peer(&self) -> Option<&'_ PkgVerPeer> {
+        match self {
+            ImporterDepVersion::Regular(ver) => Some(ver),
+            ImporterDepVersion::Alias(alias) => Some(&alias.suffix),
+            ImporterDepVersion::Link(_) => None,
         }
     }
 }
@@ -86,17 +146,52 @@ pub enum ParseImporterDepVersionError {
         #[error(source)]
         source: ParsePkgVerPeerError,
     },
+    #[display("Failed to parse importer dependency version {value:?}: {source}")]
+    ParseAlias {
+        value: String,
+        #[error(source)]
+        source: ParsePkgNameSuffixError<ParsePkgVerPeerError>,
+    },
+}
+
+/// Returns `true` when `value` is the npm-alias shape `<name>@<version>`
+/// rather than a bare semver-with-peer. Mirrors upstream's
+/// `refToRelative` (`deps/path/src/index.ts` at
+/// `pnpm/pnpm@8a80235c7b`, lines 96-110): an `@` before any `(` or `:`
+/// — or a leading `@` — means the reference is a full dep-path with
+/// the name encoded in front. The shared helper inside
+/// [`crate::SnapshotDepRef`] does the same check; the duplicated copy
+/// here keeps the two parsers self-contained.
+fn looks_like_alias(value: &str) -> bool {
+    if value.starts_with('@') {
+        return true;
+    }
+    let Some(at_idx) = value.find('@') else {
+        return false;
+    };
+    let before_paren = value.find('(').is_none_or(|idx| at_idx < idx);
+    let before_colon = value.find(':').is_none_or(|idx| at_idx < idx);
+    before_paren && before_colon
 }
 
 impl FromStr for ImporterDepVersion {
     type Err = ParseImporterDepVersionError;
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        // `link:` keeps the path verbatim; everything else parses as a
+        // `link:` keeps the path verbatim; the alias shape parses to
+        // `PkgNameVerPeer`; everything else parses as a bare
         // semver-with-peer. The `link:` discriminator is upstream's
         // own — pnpm itself looks for the literal `link:` prefix at
         // install time (see `installDepsResolve` / `lockfileToDepGraph`).
         if let Some(target) = value.strip_prefix("link:") {
             return Ok(ImporterDepVersion::Link(target.to_string()));
+        }
+        if looks_like_alias(value) {
+            return value.parse::<PkgNameVerPeer>().map(ImporterDepVersion::Alias).map_err(
+                |source| ParseImporterDepVersionError::ParseAlias {
+                    value: value.to_string(),
+                    source,
+                },
+            );
         }
         value.parse::<PkgVerPeer>().map(ImporterDepVersion::Regular).map_err(|source| {
             ParseImporterDepVersionError::Parse { value: value.to_string(), source }
@@ -115,6 +210,7 @@ impl From<ImporterDepVersion> for String {
     fn from(value: ImporterDepVersion) -> Self {
         match value {
             ImporterDepVersion::Regular(v) => v.to_string(),
+            ImporterDepVersion::Alias(alias) => alias.to_string(),
             ImporterDepVersion::Link(target) => format!("link:{target}"),
         }
     }
@@ -127,6 +223,7 @@ impl Serialize for ImporterDepVersion {
     {
         match self {
             ImporterDepVersion::Regular(v) => v.serialize(serializer),
+            ImporterDepVersion::Alias(alias) => serializer.serialize_str(&alias.to_string()),
             ImporterDepVersion::Link(target) => {
                 let formatted = format!("link:{target}");
                 serializer.serialize_str(&formatted)
@@ -151,10 +248,17 @@ impl From<PkgVerPeer> for ImporterDepVersion {
     }
 }
 
+impl From<PkgNameVerPeer> for ImporterDepVersion {
+    fn from(value: PkgNameVerPeer) -> Self {
+        ImporterDepVersion::Alias(value)
+    }
+}
+
 impl Display for ImporterDepVersion {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ImporterDepVersion::Regular(v) => Display::fmt(v, f),
+            ImporterDepVersion::Alias(alias) => Display::fmt(alias, f),
             ImporterDepVersion::Link(target) => write!(f, "link:{target}"),
         }
     }

--- a/crates/lockfile/src/resolved_dependency/tests.rs
+++ b/crates/lockfile/src/resolved_dependency/tests.rs
@@ -1,4 +1,5 @@
 use super::{ImporterDepVersion, ResolvedDependencySpec};
+use crate::PkgName;
 use pretty_assertions::assert_eq;
 
 /// Bare semver versions parse into `Regular` and round-trip through
@@ -54,4 +55,78 @@ fn resolved_spec_deserialize_regular() {
     let spec: ResolvedDependencySpec = serde_saphyr::from_str(yaml).unwrap();
     assert_eq!(spec.specifier, "^4.0.0");
     assert!(spec.version.as_regular().is_some());
+}
+
+/// A scoped npm-alias (`@scope/name@version`) parses into `Alias`,
+/// matching pnpm's `refToRelative` rule: a leading `@` always
+/// indicates a full dep-path. Regression for the
+/// `version: '@zkochan/js-yaml@0.0.11'` shape pnpm v11 writes for
+/// `catalog:` deps that resolve to a scoped alias.
+#[test]
+fn parses_scoped_alias_version() {
+    let parsed: ImporterDepVersion = "@zkochan/js-yaml@0.0.11".parse().unwrap();
+    let alias = parsed.as_alias().expect("alias variant");
+    assert_eq!(alias.name.to_string(), "@zkochan/js-yaml");
+    assert_eq!(alias.suffix.to_string(), "0.0.11");
+    assert!(parsed.as_regular().is_none());
+    assert!(parsed.as_link_target().is_none());
+    let serialized: String = parsed.into();
+    assert_eq!(serialized, "@zkochan/js-yaml@0.0.11");
+}
+
+/// An unscoped npm-alias parses into `Alias` when the first `@`
+/// appears before any `(` or `:` — the same discriminator pnpm uses.
+#[test]
+fn parses_unscoped_alias_version() {
+    let parsed: ImporterDepVersion = "string-width@4.2.3".parse().unwrap();
+    let alias = parsed.as_alias().expect("alias variant");
+    assert_eq!(alias.name.to_string(), "string-width");
+    assert_eq!(alias.suffix.to_string(), "4.2.3");
+}
+
+/// An alias with a peer suffix still parses into `Alias`; the peer
+/// suffix is preserved as part of the alias's version-with-peer.
+#[test]
+fn parses_alias_version_with_peer() {
+    let parsed: ImporterDepVersion = "react-dom@17.0.2(react@17.0.2)".parse().unwrap();
+    let alias = parsed.as_alias().expect("alias variant");
+    assert_eq!(alias.name.to_string(), "react-dom");
+    assert_eq!(alias.suffix.to_string(), "17.0.2(react@17.0.2)");
+    let serialized: String = parsed.into();
+    assert_eq!(serialized, "react-dom@17.0.2(react@17.0.2)");
+}
+
+/// A `ResolvedDependencySpec` with an aliased version round-trips
+/// through serde, the load path the lockfile reader uses. This is the
+/// exact YAML shape that previously failed to parse.
+#[test]
+fn resolved_spec_deserialize_alias() {
+    let yaml = "specifier: 'catalog:'\nversion: '@zkochan/js-yaml@0.0.11'\n";
+    let spec: ResolvedDependencySpec = serde_saphyr::from_str(yaml).unwrap();
+    assert_eq!(spec.specifier, "catalog:");
+    let alias = spec.version.as_alias().expect("alias variant");
+    assert_eq!(alias.name.to_string(), "@zkochan/js-yaml");
+    assert_eq!(alias.suffix.to_string(), "0.0.11");
+}
+
+/// `resolved_key` returns `(importer_key, version)` for `Regular`,
+/// the alias's own `(name, suffix)` for `Alias`, and `None` for
+/// `Link`. The snapshot lookup, skipped check, and reachability BFS
+/// all rely on this.
+#[test]
+fn resolved_key_returns_alias_name_for_alias_variant() {
+    let importer_key: PkgName = "js-yaml".parse().unwrap();
+
+    let regular: ImporterDepVersion = "4.0.0".parse().unwrap();
+    let regular_key = regular.resolved_key(&importer_key).expect("regular key");
+    assert_eq!(regular_key.name.to_string(), "js-yaml");
+    assert_eq!(regular_key.suffix.to_string(), "4.0.0");
+
+    let alias: ImporterDepVersion = "@zkochan/js-yaml@0.0.11".parse().unwrap();
+    let alias_key = alias.resolved_key(&importer_key).expect("alias key");
+    assert_eq!(alias_key.name.to_string(), "@zkochan/js-yaml");
+    assert_eq!(alias_key.suffix.to_string(), "0.0.11");
+
+    let link: ImporterDepVersion = "link:../shared".parse().unwrap();
+    assert!(link.resolved_key(&importer_key).is_none());
 }

--- a/crates/package-manager/src/build_sequence.rs
+++ b/crates/package-manager/src/build_sequence.rs
@@ -145,10 +145,11 @@ fn collect_root_dep_paths(
                 // `if (depPath.startsWith('link:')) continue` at
                 // build-time in
                 // <https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/src/install/index.ts>.
-                let Some(ver_peer) = spec.version.as_regular() else {
+                // For aliased deps, the snapshot key uses the alias's
+                // own (name, suffix), not the importer-map key.
+                let Some(key) = spec.version.resolved_key(name) else {
                     continue;
                 };
-                let key = PackageKey::new(name.clone(), ver_peer.clone());
                 if !snapshots.contains_key(&key) {
                     continue;
                 }

--- a/crates/package-manager/src/current_lockfile.rs
+++ b/crates/package-manager/src/current_lockfile.rs
@@ -130,11 +130,10 @@ fn filter_importer(
 /// siblings) survive — they don't live in the snapshot graph.
 fn retain_reachable(map: &mut ResolvedDependencyMap, reachable: &HashSet<PackageKey>) {
     map.retain(|name, spec| {
-        let Some(ver_peer) = spec.version.as_regular() else {
+        let Some(key) = spec.version.resolved_key(name) else {
             // Workspace `link:<path>` — no snapshot to check.
             return true;
         };
-        let key = PackageKey::new(name.clone(), ver_peer.clone());
         reachable.contains(&key)
     });
 }
@@ -172,8 +171,7 @@ fn collect_reachable(
         .flatten()
         {
             for (name, spec) in map {
-                let Some(ver_peer) = spec.version.as_regular() else { continue };
-                let key = PackageKey::new(name.clone(), ver_peer.clone());
+                let Some(key) = spec.version.resolved_key(name) else { continue };
                 if skipped.contains(&key) {
                     continue;
                 }

--- a/crates/package-manager/src/hoist.rs
+++ b/crates/package-manager/src/hoist.rs
@@ -18,9 +18,7 @@
 //! alias-list inputs that pass needs.
 
 use pacquet_config::matcher::Matcher;
-use pacquet_lockfile::{
-    PackageKey, PackageMetadata, PkgName, PkgNameVerPeer, ProjectSnapshot, SnapshotEntry,
-};
+use pacquet_lockfile::{PackageKey, PackageMetadata, PkgName, ProjectSnapshot, SnapshotEntry};
 use pacquet_modules_yaml::HoistKind;
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 
@@ -153,9 +151,11 @@ where
                 // in the snapshot graph and aren't candidates for the
                 // private/public hoist (upstream handles them via the
                 // separate `hoistedWorkspacePackages` shape, which is
-                // out of scope for this issue per #431).
-                let Some(ver) = spec.version.as_regular() else { continue };
-                let key = PkgNameVerPeer::new(name.clone(), ver.clone());
+                // out of scope for this issue per #431). For aliased
+                // deps, [`ImporterDepVersion::resolved_key`] returns
+                // the alias's own (name, suffix), matching the
+                // snapshot key under which the package lives.
+                let Some(key) = spec.version.resolved_key(name) else { continue };
                 // First-wins per alias: same precedence as
                 // `SymlinkDirectDependencies` (Prod beats Dev beats
                 // Optional with the CLI's group order).

--- a/crates/package-manager/src/hoisted_dep_graph.rs
+++ b/crates/package-manager/src/hoisted_dep_graph.rs
@@ -483,9 +483,11 @@ fn build_dep_graph(
         ] {
             let Some(dep_map) = dep_map else { continue };
             for (alias, spec) in dep_map {
-                let Some(ver_peer) = spec.version.as_regular() else { continue };
-                let dep_key =
-                    pacquet_lockfile::PkgNameVerPeer::new(alias.clone(), ver_peer.clone());
+                // For an aliased dep the snapshot key uses the
+                // alias's own (name, suffix); for a regular dep it's
+                // `(alias, version)`. `link:` deps are skipped — they
+                // don't live in the virtual store.
+                let Some(dep_key) = spec.version.resolved_key(alias) else { continue };
                 let dep_path = dep_key.to_string();
                 if let Some(locations) = pkg_locations_by_dep_path.get(&dep_path)
                     && let Some(first) = locations.first()

--- a/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/crates/package-manager/src/install_frozen_lockfile.rs
@@ -458,20 +458,15 @@ where
                 ] {
                     let Some(dep_map) = dep_map else { continue };
                     for (alias, spec) in dep_map {
-                        let Some(version) = spec.version.as_regular() else { continue };
-                        // Build the candidate snapshot key from
-                        // (alias, version). For non-aliased deps
-                        // this is the depPath verbatim; aliased
-                        // runtime deps (unusual) won't match
-                        // `packages` here, matching pnpm's lookup
-                        // by depPath rather than by alias.
-                        let candidate = format!("{alias}@{version}");
-                        if !candidate.contains("@runtime:") {
+                        // Build the candidate snapshot key. For
+                        // non-aliased deps this is `(alias, version)`;
+                        // for aliased deps it's the alias's own
+                        // (name, suffix). `link:` deps are skipped.
+                        // Matches pnpm's lookup by resolved depPath.
+                        let Some(key) = spec.version.resolved_key(alias) else { continue };
+                        if !key.to_string().contains("@runtime:") {
                             continue;
                         }
-                        let Ok(key) = candidate.parse::<pacquet_lockfile::PackageKey>() else {
-                            continue;
-                        };
                         if let Some(meta) = pkgs.get(&key)
                             && matches!(
                                 &meta.resolution,

--- a/crates/package-manager/src/symlink_direct_dependencies.rs
+++ b/crates/package-manager/src/symlink_direct_dependencies.rs
@@ -283,12 +283,11 @@ where
         .filter(|group| !matches!(group, DependencyGroup::Peer))
         .flat_map(|group| snapshot.get_map_by_group(group).into_iter().flatten())
         .filter(|(name, _)| seen.insert(*name))
-        .filter(|(name, spec)| match &spec.version {
-            ImporterDepVersion::Regular(ver) => {
-                let resolved = PkgNameVerPeer::new(PkgName::clone(name), ver.clone());
-                !skipped.contains(&resolved)
-            }
-            ImporterDepVersion::Link(_) => true,
+        .filter(|(name, spec)| match spec.version.resolved_key(name) {
+            Some(resolved) => !skipped.contains(&resolved),
+            // `link:` deps have no virtual-store slot and so cannot be
+            // in `skipped` — keep them.
+            None => true,
         })
         .filter(
             |(_, spec)| {
@@ -382,12 +381,11 @@ fn link_one_importer<R: Reporter>(
             // never participate in the virtual store, so they are
             // exempt from the skipped check (the resolved snapshot key
             // wouldn't exist in the set anyway).
-            .filter(|(name, spec, _)| match &spec.version {
-                ImporterDepVersion::Regular(ver) => {
-                    let resolved = PkgNameVerPeer::new(PkgName::clone(name), ver.clone());
-                    !skipped.contains(&resolved)
-                }
-                ImporterDepVersion::Link(_) => true,
+            .filter(|(name, spec, _)| match spec.version.resolved_key(name) {
+                Some(resolved) => !skipped.contains(&resolved),
+                // `link:` deps have no virtual-store slot and so
+                // cannot be in `skipped` — keep them.
+                None => true,
             })
             // Hoisted-mode filter: `link_only` keeps only `link:`
             // entries (workspace siblings) and drops every regular
@@ -430,6 +428,17 @@ fn link_one_importer<R: Reporter>(
                     // separately.
                     let dep_key = PkgNameVerPeer::new(PkgName::clone(name), ver_peer.clone());
                     layout.slot_dir(&dep_key).join("node_modules").join(&name_str)
+                }
+                ImporterDepVersion::Alias(alias) => {
+                    // For an alias, the snapshot key carries the
+                    // resolved package's real name + version-with-peer,
+                    // and the inner `node_modules/<real-name>` directory
+                    // is named after that real name (not the
+                    // importer-map key). The on-disk symlink at
+                    // `<modules_dir>/<importer-key>` still uses
+                    // `name_str` as the link name. Mirrors pnpm's
+                    // `linkDirectDeps` behavior for aliased deps.
+                    layout.slot_dir(alias).join("node_modules").join(alias.name.to_string())
                 }
                 ImporterDepVersion::Link(target) => {
                     // `link:<path>` values are relative to the
@@ -481,17 +490,23 @@ fn link_one_importer<R: Reporter>(
             // resolved `link:<path>` payload (re-prepended on the
             // wire) so reporters can render the link target. Pacquet
             // mirrors that here; for `Regular` deps we keep the
-            // semver-only formatting upstream uses on the wire.
+            // semver-only formatting upstream uses on the wire. For
+            // an `Alias`, the wire shape is the same as `Regular`
+            // (the version-without-peer of the alias's resolved
+            // suffix); the resolved package name surfaces via
+            // `real_name` below.
             let version = match &spec.version {
                 ImporterDepVersion::Regular(ver) => Some(ver.version().to_string()),
+                ImporterDepVersion::Alias(alias) => Some(alias.suffix.version().to_string()),
                 ImporterDepVersion::Link(target) => Some(format!("link:{target}")),
             };
-            // Pacquet's lockfile snapshot doesn't track the
-            // npm-alias key separately from the resolved package
-            // name at this layer, so `name` and `real_name` carry
-            // the same value. Clone the already-built string
-            // instead of formatting `name` a second time.
-            let real_name = name_str.clone();
+            // For aliases, `real_name` is the resolved package's true
+            // name (different from the importer-map key). For
+            // `Regular` and `Link` deps, the two match.
+            let real_name = match &spec.version {
+                ImporterDepVersion::Alias(alias) => alias.name.to_string(),
+                ImporterDepVersion::Regular(_) | ImporterDepVersion::Link(_) => name_str.clone(),
+            };
             R::emit(&LogEvent::Root(RootLog {
                 level: LogLevel::Debug,
                 message: RootMessage::Added {

--- a/crates/real-hoist/src/lib.rs
+++ b/crates/real-hoist/src/lib.rs
@@ -385,22 +385,20 @@ fn collect_importer_deps(
     let mut entries: Vec<_> = merged.into_iter().collect();
     entries.sort_by_key(|(alias, _)| alias.to_string());
     for (alias, spec) in entries {
-        // Pacquet's `ResolvedDependencySpec.version` doesn't carry an
-        // alternate package name, so importer-level npm-aliases
-        // aren't modelled here today — assume the alias is the
-        // registry name. Transitive npm-aliases (modelled via
-        // `SnapshotDepRef::Alias`) are handled in
-        // `collect_snapshot_deps`.
+        // For an aliased importer dep (`ImporterDepVersion::Alias`),
+        // the snapshot key is the alias's own (name, suffix);
+        // [`ImporterDepVersion::resolved_key`] returns that.
+        // Transitive npm-aliases (modelled via `SnapshotDepRef::Alias`)
+        // are handled in `collect_snapshot_deps`.
         //
         // `link:` deps (cross-importer `workspace:*` resolutions, see
         // [`ImporterDepVersion::Link`]) don't live in the virtual
         // store — they're directory symlinks materialised by
         // [`pacquet_package_manager::SymlinkDirectDependencies`] —
         // so they have no snapshot to hoist and we skip them here.
-        let Some(ver_peer) = spec.version.as_regular() else {
+        let Some(dep_key) = spec.version.resolved_key(alias) else {
             continue;
         };
-        let dep_key = PkgNameVerPeer::new(alias.clone(), ver_peer.clone());
         let node = build_dep_node(alias, &dep_key, lockfile, opts, nodes)?;
         out.insert(RcByPtr(node));
     }


### PR DESCRIPTION
## Summary

- Add an `Alias(PkgNameVerPeer)` variant to `ImporterDepVersion` so importer `version:` fields written as `<name>@<version>` (e.g. ``version: '@zkochan/js-yaml@0.0.11'``) parse correctly. Previously these lockfiles failed with `Failed to parse importer dependency version`.
- Introduce `ImporterDepVersion::resolved_key(importer_key)` and route every consumer through it — the snapshot lookup, skipped check, reachability BFS, runtime exclusion, build-sequence root walk, hoisted-dep-graph builder, and both hoist passes. For aliases the resolved key is the alias's own `(name, suffix)`, not `(importer-map key, version)`.
- For aliased direct deps, the on-disk symlink at `<modules_dir>/<importer-key>` now points to `<slot>/node_modules/<alias-real-name>` and the `pnpm:root added` event reports `realName` as the resolved package name.

Upstream reference: ``refToRelative`` in [pnpm/pnpm@8a80235c7b/deps/path/src/index.ts#L96-L110](https://github.com/pnpm/pnpm/blob/8a80235c7b/deps/path/src/index.ts#L96-L110).

## Test plan

- [x] `cargo nextest run -p pacquet-lockfile resolved_dependency` (11 tests including new alias parse + serde round-trip + `resolved_key` cases)
- [x] `cargo nextest run -p pacquet-lockfile -p pacquet-package-manager -p pacquet-real-hoist` (395 tests)
- [x] `just ready` (1237 tests, lint clean)
- [x] `taplo format --check` and `just dylint` clean
- [x] Built release binary and verified pacquet now parses the previously-failing pnpm v11 monorepo lockfile (the original ``--frozen-lockfile`` error is gone; a separate runtime-specifier check now fires, unrelated to this PR)

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive support for npm-alias dependencies in package resolution and lockfile management
  * Improved consistency in how aliased, regular, and linked dependencies are resolved across installation workflows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pacquet/pull/524)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->