### PR TITLE
fix: pacquet install --frozen-lockfile works against pnpm v11 repos

### DIFF
--- a/crates/lockfile/src/lib.rs
+++ b/crates/lockfile/src/lib.rs
@@ -16,6 +16,7 @@ mod save_lockfile;
 mod serialize_yaml;
 mod snapshot_dep_ref;
 mod snapshot_entry;
+mod yaml_documents;
 
 pub use comver::*;
 pub use freshness::*;
@@ -34,6 +35,7 @@ pub use resolved_dependency::*;
 pub use save_lockfile::*;
 pub use snapshot_dep_ref::*;
 pub use snapshot_entry::*;
+pub use yaml_documents::*;
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/crates/lockfile/src/load_lockfile.rs
+++ b/crates/lockfile/src/load_lockfile.rs
@@ -1,4 +1,4 @@
-use crate::Lockfile;
+use crate::{Lockfile, extract_main_document};
 use derive_more::{Display, Error};
 use pacquet_diagnostics::miette::{self, Diagnostic};
 use pipe_trait::Pipe;
@@ -59,6 +59,18 @@ impl Lockfile {
             Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
             Err(error) => return error.pipe(LoadLockfileError::ReadFile).pipe(Err),
         };
-        content.pipe_as_ref(serde_saphyr::from_str).map_err(LoadLockfileError::ParseYaml)
+        // Skip the env lockfile document if present (first document in
+        // pnpm v11's combined format). Mirrors upstream `_read` at
+        // <https://github.com/pnpm/pnpm/blob/31858c544b/lockfile/fs/src/read.ts#L103-L110>:
+        // an empty main document (env-only file) is treated as if the
+        // lockfile is absent.
+        let main = extract_main_document(&content);
+        if main.trim().is_empty() {
+            return Ok(None);
+        }
+        serde_saphyr::from_str(main).map(Some).map_err(LoadLockfileError::ParseYaml)
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/lockfile/src/load_lockfile/tests.rs
+++ b/crates/lockfile/src/load_lockfile/tests.rs
@@ -1,0 +1,110 @@
+use crate::Lockfile;
+use pretty_assertions::assert_eq;
+use tempfile::tempdir;
+use text_block_macros::text_block;
+
+/// Single-document lockfile body shared across the loader tests below.
+const MAIN_DOC: &str = text_block! {
+    "lockfileVersion: '9.0'"
+    ""
+    "settings:"
+    "  autoInstallPeers: true"
+    "  excludeLinksFromLockfile: false"
+    ""
+    "importers:"
+    ""
+    "  .:"
+    "    dependencies:"
+    "      react:"
+    "        specifier: ^17.0.2"
+    "        version: 17.0.2"
+    ""
+    "packages:"
+    ""
+    "  react@17.0.2:"
+    "    resolution: {integrity: sha512-TIE61hcgbI/SlJh/0c1sT1SZbBlpg7WiZcs65WPJhoIZQPhH1SCpcGA7LgrVXT15lwN3HV4GQM/MJ9aKEn3Qfg==}"
+    ""
+    "snapshots:"
+    ""
+    "  react@17.0.2: {}"
+};
+
+/// Env-document prelude pnpm v11 writes when `packageManager` /
+/// `devEngines.runtime` triggers a package-manager-bootstrap entry.
+/// Shape matches upstream's `EnvLockfile` at
+/// <https://github.com/pnpm/pnpm/blob/31858c544b/lockfile/types/src/index.ts#L187-L194>.
+const ENV_DOC: &str = text_block! {
+    "lockfileVersion: '9.0'"
+    ""
+    "importers:"
+    ""
+    "  .:"
+    "    configDependencies: {}"
+    "    packageManagerDependencies:"
+    "      pnpm:"
+    "        specifier: ^11.0.0"
+    "        version: 11.0.8"
+    ""
+    "packages:"
+    ""
+    "  pnpm@11.0.8:"
+    "    resolution: {integrity: sha512-TECX4d0tQjcsTn+lp5H/KPx1pITHrBkuZLHfD97xdZS6mC+bT+2a37PHV4RvVlt5mydj+zcz0d4by4LPRmhJEg==}"
+    "    hasBin: true"
+    ""
+    "snapshots:"
+    ""
+    "  pnpm@11.0.8: {}"
+};
+
+fn write_lockfile(content: &str) -> tempfile::TempDir {
+    let tmp = tempdir().expect("create tempdir");
+    let virtual_store_dir = tmp.path().join("node_modules").join(".pacquet");
+    std::fs::create_dir_all(&virtual_store_dir).expect("mkdir virtual_store_dir");
+    std::fs::write(virtual_store_dir.join(Lockfile::CURRENT_FILE_NAME), content)
+        .expect("write lock.yaml");
+    tmp
+}
+
+/// A pnpm v11 multi-document lockfile (env document + main document)
+/// must parse as the *second* document. The env document carries the
+/// package-manager bootstrap and is intentionally ignored by the
+/// install path. Mirrors upstream's
+/// [`_read`](https://github.com/pnpm/pnpm/blob/31858c544b/lockfile/fs/src/read.ts#L103-L110)
+/// which feeds the lockfile content through `extractMainDocument`
+/// before parsing.
+#[test]
+fn parses_main_document_from_combined_yaml() {
+    let combined = format!("---\n{ENV_DOC}\n---\n{MAIN_DOC}");
+    let tmp = write_lockfile(&combined);
+    let virtual_store_dir = tmp.path().join("node_modules").join(".pacquet");
+
+    let combined_loaded = Lockfile::load_current_from_virtual_store_dir(&virtual_store_dir)
+        .expect("load combined lockfile")
+        .expect("combined lockfile should be present");
+
+    // Same content parsed without the env prelude must produce an
+    // identical `Lockfile` — proves the env document was skipped and
+    // didn't bleed into the parsed structure.
+    let tmp_main = write_lockfile(MAIN_DOC);
+    let main_only_dir = tmp_main.path().join("node_modules").join(".pacquet");
+    let main_only_loaded = Lockfile::load_current_from_virtual_store_dir(&main_only_dir)
+        .expect("load main-only lockfile")
+        .expect("main-only lockfile should be present");
+
+    assert_eq!(combined_loaded, main_only_loaded);
+}
+
+/// An env-only lockfile (file starts with `---\n` but has no second
+/// document) reads back as `Ok(None)`, mirroring upstream's empty-main-
+/// document short-circuit at
+/// <https://github.com/pnpm/pnpm/blob/31858c544b/lockfile/fs/src/read.ts#L105-L110>.
+#[test]
+fn env_only_lockfile_loads_as_none() {
+    let env_only = format!("---\n{ENV_DOC}\n");
+    let tmp = write_lockfile(&env_only);
+    let virtual_store_dir = tmp.path().join("node_modules").join(".pacquet");
+
+    let result = Lockfile::load_current_from_virtual_store_dir(&virtual_store_dir)
+        .expect("env-only lockfile should not error");
+    assert!(result.is_none(), "expected None for env-only lockfile, got: {result:?}");
+}

--- a/crates/lockfile/src/yaml_documents.rs
+++ b/crates/lockfile/src/yaml_documents.rs
@@ -1,0 +1,64 @@
+//! Multi-document YAML helpers for `pnpm-lock.yaml`.
+//!
+//! Pnpm v11 writes the lockfile as a stream of up to two YAML
+//! documents: an optional first document records the package-manager
+//! bootstrap (the deps pulled in by `packageManager` / `devEngines`),
+//! and the second document is the regular project lockfile. Pacquet
+//! only consumes the second document, so this module mirrors
+//! upstream's
+//! [`extractMainDocument`](https://github.com/pnpm/pnpm/blob/31858c544b/lockfile/fs/src/yamlDocuments.ts#L57-L68)
+//! to strip the leading env document before handing the content to
+//! serde.
+
+/// Document-stream marker that ends one YAML document and starts the
+/// next. Matches upstream's
+/// [`YAML_DOCUMENT_SEPARATOR`](https://github.com/pnpm/pnpm/blob/31858c544b/lockfile/fs/src/yamlDocuments.ts#L6).
+const YAML_DOCUMENT_SEPARATOR: &str = "\n---\n";
+
+/// Document-stream marker at the very start of a file. Matches
+/// upstream's
+/// [`YAML_DOCUMENT_START`](https://github.com/pnpm/pnpm/blob/31858c544b/lockfile/fs/src/yamlDocuments.ts#L7).
+const YAML_DOCUMENT_START: &str = "---\n";
+
+/// Extract the main lockfile document (second YAML document) from a
+/// combined file. Mirrors upstream's
+/// [`extractMainDocument`](https://github.com/pnpm/pnpm/blob/31858c544b/lockfile/fs/src/yamlDocuments.ts#L63-L68):
+///
+/// - If the content starts with `---\n`, returns the slice after the
+///   next `\n---\n` separator. An empty slice (no second document
+///   present) means the file is env-only.
+/// - Otherwise the file is single-document and the input is returned
+///   verbatim.
+pub fn extract_main_document(content: &str) -> &str {
+    let Some(rest) = content.strip_prefix(YAML_DOCUMENT_START) else {
+        return content;
+    };
+    match rest.find(YAML_DOCUMENT_SEPARATOR) {
+        Some(idx) => &rest[idx + YAML_DOCUMENT_SEPARATOR.len()..],
+        None => "",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_main_document;
+
+    #[test]
+    fn returns_entire_content_when_it_does_not_start_with_separator() {
+        let content = "lockfileVersion: 9.0\npackages: {}\n";
+        assert_eq!(extract_main_document(content), content);
+    }
+
+    #[test]
+    fn returns_empty_string_when_content_starts_with_separator_but_has_no_second_separator() {
+        let content = "---\nfoo: bar\n";
+        assert_eq!(extract_main_document(content), "");
+    }
+
+    #[test]
+    fn returns_the_second_document_from_a_combined_file() {
+        let main = "lockfileVersion: 9.0\npackages: {}\n";
+        let combined = format!("---\nfoo: bar\n---\n{main}");
+        assert_eq!(extract_main_document(&combined), main);
+    }
+}

--- a/crates/package-manifest/src/lib.rs
+++ b/crates/package-manifest/src/lib.rs
@@ -97,7 +97,17 @@ impl PackageManifest {
 
     fn read_from_file(path: &Path) -> Result<Value, PackageManifestError> {
         let contents = fs::read_to_string(path)?;
-        serde_json::from_str(&contents).map_err(PackageManifestError::from)
+        let mut value: Value = serde_json::from_str(&contents)?;
+        // Mirror upstream pnpm's `convertManifestAfterRead` at
+        // <https://github.com/pnpm/pnpm/blob/9cad8274fd/workspace/project-manifest-reader/src/index.ts#L227-L231>:
+        // declarations under `devEngines.runtime` / `engines.runtime`
+        // with `onFail: "download"` are reified into the matching
+        // dependencies bucket so the lockfile entry the resolver writes
+        // (e.g. `node@runtime:24.6.0`) lines up with the manifest's
+        // flat-record view during the frozen-lockfile staleness check.
+        convert_engines_runtime_to_dependencies(&mut value, "devEngines", "devDependencies");
+        convert_engines_runtime_to_dependencies(&mut value, "engines", "dependencies");
+        Ok(value)
     }
 
     pub fn init(path: &Path) -> Result<(), PackageManifestError> {
@@ -233,6 +243,86 @@ impl PackageManifest {
         }
 
         if if_present { Ok(None) } else { Err(PackageManifestError::NoScript(command.to_string())) }
+    }
+}
+
+/// Runtime aliases recognised by pnpm's `devEngines.runtime` /
+/// `engines.runtime` reification. Matches upstream's
+/// [`RUNTIME_NAMES`](https://github.com/pnpm/pnpm/blob/9cad8274fd/pkg-manifest/utils/src/convertEnginesRuntimeToDependencies.ts#L8).
+const RUNTIME_NAMES: [&str; 3] = ["node", "deno", "bun"];
+
+/// Reify `devEngines.runtime` / `engines.runtime` entries with
+/// `onFail: "download"` into the matching `devDependencies` /
+/// `dependencies` slot as `runtime:<version>` specifiers.
+///
+/// Ports upstream's
+/// [`convertEnginesRuntimeToDependencies`](https://github.com/pnpm/pnpm/blob/9cad8274fd/pkg-manifest/utils/src/convertEnginesRuntimeToDependencies.ts#L10-L45)
+/// so the lockfile entry the resolver writes
+/// (`node@runtime:24.6.0`, etc.) is visible to the
+/// `satisfies_package_manifest` flat-record diff under the manifest's
+/// own dependency map. Without this step a manifest that declares its
+/// runtime exclusively through `devEngines.runtime` fails the frozen-
+/// lockfile staleness check as a spurious "dependency was removed".
+///
+/// Runtime entries are skipped when:
+/// - the target dependency slot already has an explicit entry (the
+///   user-declared specifier wins),
+/// - the runtime is declared with `onFail` other than `"download"` (the
+///   download is opt-in upstream), or
+/// - no `version` is set (upstream warns and skips; pacquet skips
+///   silently — the staleness check still surfaces the gap downstream).
+///
+/// WebContainer's "no runtime download" branch upstream is intentionally
+/// omitted: pacquet does not run in WebContainer.
+pub fn convert_engines_runtime_to_dependencies(
+    manifest: &mut Value,
+    engines_field: &str,
+    deps_field: &str,
+) {
+    // Collect first, mutate after — avoids a simultaneous shared+mutable
+    // borrow of the manifest while reading `engines_field` and writing
+    // `deps_field`.
+    let mut to_insert: Vec<(&'static str, String)> = Vec::new();
+    let Some(runtime_entry) =
+        manifest.get(engines_field).and_then(|engines| engines.get("runtime"))
+    else {
+        return;
+    };
+    for runtime_name in RUNTIME_NAMES {
+        if manifest.get(deps_field).and_then(|deps| deps.get(runtime_name)).is_some() {
+            continue;
+        }
+        let runtimes: &[Value] = match runtime_entry {
+            Value::Array(arr) => arr.as_slice(),
+            single @ Value::Object(_) => std::slice::from_ref(single),
+            _ => continue,
+        };
+        let Some(runtime) =
+            runtimes.iter().find(|r| r.get("name").and_then(Value::as_str) == Some(runtime_name))
+        else {
+            continue;
+        };
+        if runtime.get("onFail").and_then(Value::as_str) != Some("download") {
+            continue;
+        }
+        let Some(version) = runtime.get("version").and_then(Value::as_str) else {
+            continue;
+        };
+        to_insert.push((runtime_name, format!("runtime:{version}")));
+    }
+    if to_insert.is_empty() {
+        return;
+    }
+    let Some(manifest_obj) = manifest.as_object_mut() else {
+        return;
+    };
+    let deps =
+        manifest_obj.entry(deps_field.to_string()).or_insert_with(|| Value::Object(Map::new()));
+    let Some(deps_obj) = deps.as_object_mut() else {
+        return;
+    };
+    for (name, spec) in to_insert {
+        deps_obj.insert(name.to_string(), Value::String(spec));
     }
 }
 

--- a/crates/package-manifest/src/tests.rs
+++ b/crates/package-manifest/src/tests.rs
@@ -5,8 +5,9 @@ use pipe_trait::Pipe;
 use pretty_assertions::assert_eq;
 use tempfile::{NamedTempFile, tempdir};
 
-use super::{BundleDependencies, PackageManifest};
+use super::{BundleDependencies, PackageManifest, convert_engines_runtime_to_dependencies};
 use crate::DependencyGroup;
+use serde_json::json;
 use std::io::Write;
 
 #[test]
@@ -193,4 +194,163 @@ fn resolve_registry_dependency_picks_last_at_for_alias() {
         PackageManifest::resolve_registry_dependency("foo-rc", "npm:@scope/foo@1.0.0-rc.1",),
         ("@scope/foo", "1.0.0-rc.1"),
     );
+}
+
+/// `devEngines.runtime` with `onFail: "download"` and an explicit
+/// version is reified into `devDependencies` as `runtime:<version>`.
+/// This is the v11 install path: a manifest that declares its node
+/// version through `devEngines.runtime` must produce the same flat-
+/// record specifier set as the lockfile entry the resolver wrote.
+#[test]
+fn convert_engines_runtime_lifts_devengines_runtime_into_devdependencies() {
+    let mut manifest = json!({
+        "devEngines": {
+            "runtime": {
+                "name": "node",
+                "version": "24.6.0",
+                "onFail": "download",
+            },
+        },
+    });
+    convert_engines_runtime_to_dependencies(&mut manifest, "devEngines", "devDependencies");
+    assert_eq!(
+        manifest.get("devDependencies").and_then(|d| d.get("node")).and_then(|v| v.as_str()),
+        Some("runtime:24.6.0"),
+    );
+}
+
+/// Skip when no `version` is set. Upstream warns and skips; pacquet
+/// skips silently. The staleness check still surfaces the gap.
+/// Mirrors upstream's
+/// [`convertEnginesRuntimeToDependencies() skips runtime entries without a version`](https://github.com/pnpm/pnpm/blob/9cad8274fd/pkg-manifest/utils/test/convertEnginesRuntimeToDependencies.test.ts#L8-L21).
+#[test]
+fn convert_engines_runtime_skips_entries_without_a_version() {
+    let mut manifest = json!({
+        "devEngines": {
+            "runtime": {
+                "name": "node",
+                "onFail": "download",
+            },
+        },
+    });
+    convert_engines_runtime_to_dependencies(&mut manifest, "devEngines", "devDependencies");
+    assert!(manifest.get("devDependencies").is_none(), "manifest: {manifest}");
+}
+
+/// Skip when `onFail` is anything other than `"download"` (or absent).
+/// Upstream gates the runtime reification on that flag, so an `error`
+/// or `warn` setup must not silently morph into a `runtime:` dep.
+#[test]
+fn convert_engines_runtime_only_reifies_onfail_download() {
+    for on_fail in ["warn", "error", "ignore"] {
+        let mut manifest = json!({
+            "devEngines": {
+                "runtime": {
+                    "name": "node",
+                    "version": "24.6.0",
+                    "onFail": on_fail,
+                },
+            },
+        });
+        convert_engines_runtime_to_dependencies(&mut manifest, "devEngines", "devDependencies");
+        assert!(
+            manifest.get("devDependencies").is_none(),
+            "onFail={on_fail} should not reify; manifest: {manifest}",
+        );
+    }
+}
+
+/// An explicit user-declared entry in the target dependencies bucket
+/// wins over the reified runtime, matching upstream's
+/// [`manifest[dependenciesFieldName]?.[runtimeName]`](https://github.com/pnpm/pnpm/blob/9cad8274fd/pkg-manifest/utils/src/convertEnginesRuntimeToDependencies.ts#L17)
+/// short-circuit.
+#[test]
+fn convert_engines_runtime_preserves_explicit_user_dep() {
+    let mut manifest = json!({
+        "devDependencies": {
+            "node": "23.0.0",
+        },
+        "devEngines": {
+            "runtime": {
+                "name": "node",
+                "version": "24.6.0",
+                "onFail": "download",
+            },
+        },
+    });
+    convert_engines_runtime_to_dependencies(&mut manifest, "devEngines", "devDependencies");
+    assert_eq!(
+        manifest.get("devDependencies").and_then(|d| d.get("node")).and_then(|v| v.as_str()),
+        Some("23.0.0"),
+    );
+}
+
+/// `devEngines.runtime` accepts an array of entries (one per runtime
+/// alias). Each `RUNTIME_NAMES` entry is matched by `name` and reified
+/// independently — `node` and `bun` together is a valid declaration.
+#[test]
+fn convert_engines_runtime_handles_array_form_with_multiple_runtimes() {
+    let mut manifest = json!({
+        "devEngines": {
+            "runtime": [
+                { "name": "node", "version": "24.6.0", "onFail": "download" },
+                { "name": "bun", "version": "1.1.40", "onFail": "download" },
+            ],
+        },
+    });
+    convert_engines_runtime_to_dependencies(&mut manifest, "devEngines", "devDependencies");
+    let dev = manifest.get("devDependencies").expect("devDependencies inserted");
+    assert_eq!(dev.get("node").and_then(|v| v.as_str()), Some("runtime:24.6.0"));
+    assert_eq!(dev.get("bun").and_then(|v| v.as_str()), Some("runtime:1.1.40"));
+}
+
+/// `engines.runtime` (rather than `devEngines.runtime`) targets
+/// `dependencies` — upstream calls
+/// `convertEnginesRuntimeToDependencies(manifest, 'engines', 'dependencies')`
+/// alongside the `devEngines` pass.
+#[test]
+fn convert_engines_runtime_targets_dependencies_for_engines_field() {
+    let mut manifest = json!({
+        "engines": {
+            "runtime": {
+                "name": "node",
+                "version": "22.0.0",
+                "onFail": "download",
+            },
+        },
+    });
+    convert_engines_runtime_to_dependencies(&mut manifest, "engines", "dependencies");
+    assert_eq!(
+        manifest.get("dependencies").and_then(|d| d.get("node")).and_then(|v| v.as_str()),
+        Some("runtime:22.0.0"),
+    );
+}
+
+/// Reading a manifest with `devEngines.runtime` set must apply the
+/// reification automatically — that's the hook upstream wires into
+/// `convertManifestAfterRead`. Verifies the `from_path` end of the
+/// pipeline, not just the standalone function.
+#[test]
+fn from_path_applies_convert_engines_runtime() {
+    let dir = tempdir().unwrap();
+    let manifest_path = dir.path().join("package.json");
+    let raw = json!({
+        "name": "fixture",
+        "devEngines": {
+            "runtime": {
+                "name": "node",
+                "version": "24.6.0",
+                "onFail": "download",
+            },
+        },
+    });
+    std::fs::write(&manifest_path, serde_json::to_string_pretty(&raw).unwrap()).unwrap();
+
+    let manifest = PackageManifest::from_path(manifest_path).unwrap();
+    let node_spec = manifest
+        .value()
+        .get("devDependencies")
+        .and_then(|d| d.get("node"))
+        .and_then(|v| v.as_str());
+    assert_eq!(node_spec, Some("runtime:24.6.0"));
 }


### PR DESCRIPTION
## Summary

Two ports needed to make `pacquet install --frozen-lockfile` succeed against pnpm's own v11 repository (and any repo using the same pnpm-v11 conventions):

- **`fix(lockfile)`** — Port [`extractMainDocument`](https://github.com/pnpm/pnpm/blob/31858c544b/lockfile/fs/src/yamlDocuments.ts#L57-L68) so pacquet skips the env document in pnpm v11's combined `pnpm-lock.yaml`. Without this, `serde_saphyr::from_str` rejects the file with "multiple YAML documents detected".
- **`fix(package-manifest)`** — Port [`convertEnginesRuntimeToDependencies`](https://github.com/pnpm/pnpm/blob/9cad8274fd/pkg-manifest/utils/src/convertEnginesRuntimeToDependencies.ts#L10-L45) so `devEngines.runtime` (`onFail: "download"`) is reified into `devDependencies` as `runtime:<version>` after the manifest is read. Without this, the lockfile's `node@runtime:24.6.0` importer entry is flagged as a spurious "dependency was removed" by `satisfies_package_manifest`.

Together these unblock the v11 frozen-install path; the binary now exits 0 against `pnpm/pnpm` at the latest `main` commit (`8a80235c7b`).

## Test plan

- [x] `cargo nextest run -p pacquet-lockfile` — 119/119 pass, including 3 new `yaml_documents` tests and 2 new `load_lockfile/tests.rs` cases (combined-document and env-only paths)
- [x] `cargo nextest run -p pacquet-package-manifest` — 21/21 pass, including 7 new tests for `convert_engines_runtime_to_dependencies` (happy path, no-version skip, non-`download` `onFail`, explicit user dep wins, array-of-runtimes form, `engines` → `dependencies` variant, `from_path` integration)
- [x] `just ready` — 1249/1249 tests pass, `cargo fmt --check`, `cargo clippy -- --deny warnings`, `cargo check --locked`, typos all clean
- [x] `taplo format --check` — clean across all 26 `Cargo.toml` files
- [x] `just dylint` — clean
- [x] End-to-end: `cd /path/to/pnpm/pnpm && pacquet install --frozen-lockfile` exits 0

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for pnpm v11 multi-document lockfile format.
  * Implemented automatic conversion of runtime engine declarations to dependencies in package manifests.

* **Tests**
  * Added comprehensive test coverage for multi-document lockfile parsing and runtime engine declaration handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pacquet/pull/525)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->